### PR TITLE
fix: correct link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Take a look at examples of how to:
 * [Check Relationships](https://openfga.dev/api/service/#/Relationship%20Queries/Check)
 * [Add authentication](https://openfga.dev/intro/setup-openfga#configuring-authentication)
 
-Don't hesitate to browse the official [Documentation][https://openfga.dev/], [API Reference][https://openfga.dev/api/service], and [Examples][examples].
+Don't hesitate to browse the official [Documentation](https://openfga.dev/), [API Reference](https://openfga.dev/api/service).
 
 # Production Readiness
 The core [OpenFGA](https://github.com/openfga/openfga) service is used by [Auth0 FGA](https://fga.dev), and it has been used in production since December 2021. 


### PR DESCRIPTION

## Description
Remove examples for now until the docs have examples section.


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
