### PR TITLE
ci: remove `ghcr.io` container tags from goreleaser releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,13 +49,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,11 +29,6 @@ dockers:
       - "openfga/openfga:v{{ .Major }}"
       - "openfga/openfga:v{{ .Major }}.{{ .Minor }}"
       - "openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
-      - "ghcr.io/openfga/openfga:{{ .Tag }}"
-      - "ghcr.io/openfga/openfga:v{{ .Version }}"
-      - "ghcr.io/openfga/openfga:v{{ .Major }}"
-      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}"
-      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
 
 release:
   github:


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Choosing to not release container images to Github Container Registry for now.

## References
N/A

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
