### PR TITLE
ci: tidy up the Dockerfile and add the `latest` tag to releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,7 @@ dockers:
     dockerfile: Dockerfile.goreleaser
 
     image_templates:
+      - "openfga/openfga:latest"
       - "openfga/openfga:{{ .Tag }}"
       - "openfga/openfga:v{{ .Version }}"
       - "openfga/openfga:v{{ .Major }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,11 @@
 FROM golang:1.18-alpine AS builder
 
-RUN apk update && apk --no-cache add make
-
-RUN mkdir /app
 WORKDIR /app
 
 COPY . .
-RUN make build
-RUN cp ./bin/openfga /app
+RUN go build -o ./openfga ./cmd/openfga
 
 FROM alpine as final
 EXPOSE 8080
-RUN mkdir /app
-COPY --from=builder /app/openfga /app
+COPY --from=builder /app/openfga /app/openfga
 ENTRYPOINT ["/app/openfga"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM golang:1.18-alpine AS builder
 
-RUN mkdir /app && mkdir /app/bin
-RUN apk update && apk --no-cache add make curl git gcc build-base
+RUN apk update && apk --no-cache add make
 
-WORKDIR $GOPATH/src/github.com/openfga/openfga
+RUN mkdir /app
+WORKDIR /app
 
 COPY . .
 RUN make build
-RUN cp ./bin/openfga /app/bin/
+RUN cp ./bin/openfga /app
 
 FROM alpine as final
 EXPOSE 8080
-RUN mkdir /app && mkdir /app/bin
-COPY --from=builder /app/bin/openfga /app/bin
-ENTRYPOINT ["/app/bin/openfga"]
+RUN mkdir /app
+COPY --from=builder /app/openfga /app
+ENTRYPOINT ["/app/openfga"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,9 +17,7 @@ services:
       retries: 5
 
   openfga:
-    build:
-      context: ./
-      dockerfile: ./Dockerfile
+    image: openfga/openfga:latest
     container_name: openfga
     networks:
       - default


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This adds `openfga/openfga:latest` tags to the goreleaser release process and it cleans up the Dockerfile by removing some packages that are not needed in the built image.

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
