### PR TITLE
fix: remove arrows in codeblocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ You can install from source using Go modules (make sure `$GOBIN` is on your shel
 
 ```bash
 export PATH=$PATH:$(go env GOBIN)
+```
+
+Then:
+
+```bash
 go install github.com/openfga/openfga/cmd/openfga
 ```
 


### PR DESCRIPTION
Remove ➜ characters from README.md codeblocks

## Description
* removed styling characters so that codeblocks copy-pasted to terminal wouldn't error
* syntax highlighted codeblocks
* separated commands so that they could be copied and pasted sequentially - documentation should always ask users to do things one step at a time wherever possible.

Before:
![Screen Shot 2022-06-16 at 10 20 34 AM](https://user-images.githubusercontent.com/6372810/174079085-6652ae9f-5892-4b78-9e90-37a795bbbe6a.png)

After:
![Screen Shot 2022-06-16 at 10 20 13 AM](https://user-images.githubusercontent.com/6372810/174079045-d724b73a-18f6-4a39-acfe-30b95d295891.png)

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
