### PR TITLE
fix: correct authentication link in Next Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Take a look at examples of how to:
 * [Write an Authorization Model](https://openfga.dev/api/service/#/Authorization%20Models/WriteAuthorizationModel)
 * [Write Relationship Tuples](https://openfga.dev/api/service/#/Relationship%20Tuples/Write)
 * [Check Relationships](https://openfga.dev/api/service/#/Relationship%20Queries/Check)
-* [Add authentication](https://openfga.dev/intro/setup-openfga#configuring-authentication)
+* [Add authentication](https://openfga.dev/docs/getting-started/setup-openfga#configuring-authentication)
 
 Don't hesitate to browse the official [Documentation](https://openfga.dev/), [API Reference](https://openfga.dev/api/service).
 


### PR DESCRIPTION
Fix to correct Add Authentiction link in README.md to new docs link structure.

## References
Closes #30 

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
