### PR TITLE
docs(readme): use pwd when downloading release from github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 
 coverage*.out
 *.swp
+
+openfga

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following section aims to help you get started quickly. Please look at our o
 
 ## Setup and Installation
 
-> ℹ️ The following sections setup an OpenFGA server using the default configuration values. These are for rapid development and not for a production environment.
+> ℹ️ The following sections set up an OpenFGA server using the default configuration values. These are for rapid development and not for a production environment.
 >
 > For more information on how to configure the OpenFGA server, please take a look at our official documentation on [Configuring OpenFGA](https://openfga.dev/docs/getting-started/setup-openfga#configuring-the-server) or our [Production Checklist](https://openfga.dev/docs/getting-started/setup-openfga#production-checklist).
 
@@ -38,7 +38,6 @@ If you haven't cloned the repository you can get the `docker-compose.yaml` file 
 
 ```bash
 curl -LO https://openfga.dev/docker-compose.yaml
-
 ```
 
 ### Pre-compiled Binaries
@@ -47,7 +46,7 @@ Download your platform's [latest release](https://github.com/openfga/openfga/rel
 with the command:
 
 ```bash
-./bin/openfga
+./openfga
 ```
 
 ### Source


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

When downloading the binary from github, assume it's on PWD since the user is not creating a ./bin directory. 

When downloading it (or compiling from source) the binary should be ignored from the repo.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
