### PR TITLE
fix(makefile): warning: no packages being tested depend on matches for pattern

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-COVERPKG := $(shell eval go list ./... | grep -v mocks | tr '\n' ',')
+COVERPKG := $(shell eval go list ./... | grep -v mocks | tr '\n' ',' | rev | cut -c 2- | rev)
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := help
-COVERPKG := $(shell eval go list ./... | grep -v mocks | tr '\n' ',' | rev | cut -c 2- | rev)
+COVERPKG := $(shell eval go list ./... | grep -v mocks |  paste -sd "," -)
 
 .PHONY: help
 help:


### PR DESCRIPTION
## Description

https://github.com/golang/go/blob/78b722d8c2f764c3048c6f0344e9ebcd2687813d/src/cmd/go/internal/test/test.go#L852

Fix warning by trimming the last `,` from the `COVERPKG` variable

## References
n/a

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
