### PR TITLE
chore: rename references of gRPC or GRPC to simply grpc

### DIFF
--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -127,9 +127,9 @@ func BuildService(config Config, logger logger.Logger) (*service, error) {
 			CertPath: config.GRPCTLSCertPath,
 			KeyPath:  config.GRPCTLSKeyPath,
 		}
-		logger.Info("GRPC TLS enabled, serving connections using the provided certificate")
+		logger.Info("TLS is enabled, serving grpc connections using the provided certificate")
 	} else {
-		logger.Warn("GRPC TLS is disabled, falling back to insecure plaintext")
+		logger.Warn("TLS is disabled, serving grpc connections using insecure plaintext")
 	}
 
 	var httpTLSConfig *server.TLSConfig

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -442,7 +442,7 @@ func TestHTTPServingTLS(t *testing.T) {
 func TestGRPCServingTLS(t *testing.T) {
 	logger := logger.NewNoopLogger()
 
-	t.Run("enable gRPC TLS is false, even with keys set, will serve plaintext", func(t *testing.T) {
+	t.Run("enable grpc TLS is false, even with keys set, will serve plaintext", func(t *testing.T) {
 		createKeys(t)
 		require.NoError(t, os.Setenv(grpcTLSEnabledEnvVar, "false"), "failed to set env var") // override
 		defer os.Clearenv()
@@ -471,7 +471,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		require.NoError(t, service.Close(ctx))
 	})
 
-	t.Run("enable gRPC TLS is true will serve gRPC TLS", func(t *testing.T) {
+	t.Run("enable grpc TLS is true will serve grpc TLS", func(t *testing.T) {
 		certFile := createKeys(t)
 		defer os.Clearenv()
 

--- a/server/server.go
+++ b/server/server.go
@@ -130,7 +130,7 @@ func New(dependencies *Dependencies, config *Config) (*Server, error) {
 			runtime.WithErrorHandler(func(c context.Context, sr *runtime.ServeMux, mm runtime.Marshaler, w http.ResponseWriter, r *http.Request, e error) {
 				actualCode := serverErrors.ConvertToEncodedErrorCode(status.Convert(e))
 				if serverErrors.IsValidEncodedError(actualCode) {
-					dependencies.Logger.ErrorWithContext(c, "gRPC error", logger.Error(e), logger.String("request_url", r.URL.String()))
+					dependencies.Logger.ErrorWithContext(c, "grpc error", logger.Error(e), logger.String("request_url", r.URL.String()))
 				}
 
 				httpmiddleware.CustomHTTPErrorHandler(c, w, r, serverErrors.NewEncodedError(actualCode, e.Error()))
@@ -426,7 +426,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}()
 
-	s.logger.Info(fmt.Sprintf("gRPC server listening on '%s'...", rpcAddr))
+	s.logger.Info(fmt.Sprintf("grpc server listening on '%s'...", rpcAddr))
 
 	// Set a request timeout.
 	runtime.DefaultContextTimeout = s.config.RequestTimeout

--- a/server/test/read.go
+++ b/server/test/read.go
@@ -27,7 +27,7 @@ func TestReadQuery(t *testing.T, dbTester teststorage.DatastoreTester[storage.Op
 		response        *openfgapb.ReadResponse
 	}
 
-	// TODO: review which of these tests should be moved to validation/types in gRPC rather than execution. e.g.: invalid relation in authorizationmodel is fine, but tuple without authorizationmodel is should be required before. see issue: https://github.com/auth0/sandcastle/issues/13
+	// TODO: review which of these tests should be moved to validation/types in grpc rather than execution. e.g.: invalid relation in authorizationmodel is fine, but tuple without authorizationmodel is should be required before. see issue: https://github.com/auth0/sandcastle/issues/13
 	var tests = []readQueryTest{
 		{
 			_name: "ExecuteErrorsIfOneTupleKeyHasNeitherUserObjectNorRelation",


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
I noticed we're using `gRPC`, `GRPC`, and `grpc` in various places. I'm submitting this to change these references to simply `grpc`, which is a bit more pretty to read than the other two.


## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
