### PR TITLE
chore: fix app build info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,11 @@ builds:
       - linux
       - windows
       - darwin
+    ldflags:
+      - "-s -w"
+      - "-X github.com/openfga/openfga/internal/build.Version=v{{ .Version }}"
+      - "-X github.com/openfga/openfga/internal/build.Commit={{.Commit}}"
+      - "-X github.com/openfga/openfga/internal/build.Date={{.Date}}"
 
 dockers:
   -

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -1,0 +1,15 @@
+// Package build provides build information that is linked into the application. Other
+// packages within this project can use this information in logs etc..
+package build
+
+var (
+
+	// Version is the build version of the app (e.g. v0.1.0)
+	Version = "dev"
+
+	// Commit is the sha of the git commit the app was built against.
+	Commit = "none"
+
+	// Date is the date when the app was built.
+	Date = "unknown"
+)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -8,17 +8,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/pkg/cmd/service"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-)
-
-const (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
 )
 
 func NewRunCommand() *cobra.Command {
@@ -48,9 +43,9 @@ func run(_ *cobra.Command, _ []string) {
 
 	logger.Info(
 		"🚀 starting openfga service...",
-		zap.String("version", version),
-		zap.String("date", date),
-		zap.String("commit", commit),
+		zap.String("version", build.Version),
+		zap.String("date", build.Date),
+		zap.String("commit", build.Commit),
 		zap.String("go-version", runtime.Version()),
 	)
 
@@ -85,8 +80,8 @@ func buildLogger(logFormat string) (logger.Logger, error) {
 			return nil, err
 		}
 		openfgaLogger.With(
-			zap.String("build.version", version),
-			zap.String("build.commit", commit),
+			zap.String("build.version", build.Version),
+			zap.String("build.commit", build.Commit),
 		)
 	}
 


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes our app build information. It was broken when we introduced the CLI. These changes make sure that we get the build version, commit, and date linked into the final binary.


## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
