### PR TITLE
fix: run test on a different port

### DIFF
--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -444,14 +444,14 @@ func TestGRPCServingTLS(t *testing.T) {
 
 	t.Run("enable grpc TLS is false, even with keys set, will serve plaintext", func(t *testing.T) {
 		createKeys(t)
-		require.NoError(t, os.Setenv(grpcTLSEnabledEnvVar, "false"), "failed to set env var") // override
 		defer os.Clearenv()
 
-		ctx, cancel := context.WithCancel(context.Background())
-
-		service, err := BuildService(GetServiceConfig(), logger)
+		config := GetServiceConfig()
+		config.GRPCTLSEnabled = false
+		service, err := BuildService(config, logger)
 		require.NoError(t, err)
 
+		ctx, cancel := context.WithCancel(context.Background())
 		g := new(errgroup.Group)
 		g.Go(func() error {
 			return service.Run(ctx)
@@ -475,11 +475,12 @@ func TestGRPCServingTLS(t *testing.T) {
 		certFile := createKeys(t)
 		defer os.Clearenv()
 
-		ctx, cancel := context.WithCancel(context.Background())
-
-		service, err := BuildService(GetServiceConfig(), logger)
+		config := GetServiceConfig()
+		config.RPCPort = 8082
+		service, err := BuildService(config, logger)
 		require.NoError(t, err)
 
+		ctx, cancel := context.WithCancel(context.Background())
 		g := new(errgroup.Group)
 		g.Go(func() error {
 			return service.Run(ctx)
@@ -489,7 +490,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		require.NoError(t, err)
 
 		opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-		conn, err := grpc.Dial("localhost:8081", opts...)
+		conn, err := grpc.Dial("localhost:8082", opts...)
 		require.NoError(t, err)
 		defer conn.Close()
 


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

Running the TLS test on the same port as the server usually runs on sometimes causes an error as it probably tries to interact with a server that is still running from another test. In the future I think we will dockerize the tests and the server will run on a random port, but until then, have the problematic test run on a different port.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [ ] The correct base branch is being used, if not `main`
