### PR TITLE
fix: explicitly close client connection in grpc tests

### DIFF
--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -447,11 +447,10 @@ func TestGRPCServingTLS(t *testing.T) {
 		require.NoError(t, os.Setenv(grpcTLSEnabledEnvVar, "false"), "failed to set env var") // override
 		defer os.Clearenv()
 
-		ctx, cancel := context.WithCancel(context.Background())
-
 		service, err := BuildService(GetServiceConfig(), logger)
 		require.NoError(t, err)
 
+		ctx, cancel := context.WithCancel(context.Background())
 		g := new(errgroup.Group)
 		g.Go(func() error {
 			return service.Run(ctx)
@@ -460,12 +459,12 @@ func TestGRPCServingTLS(t *testing.T) {
 		opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 		conn, err := grpc.Dial("localhost:8081", opts...)
 		require.NoError(t, err)
-		defer conn.Close()
 
 		client := openfgapb.NewOpenFGAServiceClient(conn)
 		_, err = client.ListStores(ctx, &openfgapb.ListStoresRequest{})
 		require.NoError(t, err)
 
+		conn.Close()
 		cancel()
 		require.NoError(t, g.Wait())
 		require.NoError(t, service.Close(ctx))
@@ -475,11 +474,10 @@ func TestGRPCServingTLS(t *testing.T) {
 		certFile := createKeys(t)
 		defer os.Clearenv()
 
-		ctx, cancel := context.WithCancel(context.Background())
-
 		service, err := BuildService(GetServiceConfig(), logger)
 		require.NoError(t, err)
 
+		ctx, cancel := context.WithCancel(context.Background())
 		g := new(errgroup.Group)
 		g.Go(func() error {
 			return service.Run(ctx)
@@ -491,12 +489,12 @@ func TestGRPCServingTLS(t *testing.T) {
 		opts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
 		conn, err := grpc.Dial("localhost:8081", opts...)
 		require.NoError(t, err)
-		defer conn.Close()
 
 		client := openfgapb.NewOpenFGAServiceClient(conn)
 		_, err = client.ListStores(ctx, &openfgapb.ListStoresRequest{})
 		require.NoError(t, err)
 
+		conn.Close()
 		cancel()
 		require.NoError(t, g.Wait())
 		require.NoError(t, service.Close(ctx))


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [ ] The correct base branch is being used, if not `main`
