### PR TITLE
feat: allow specifying CORS allowed origins

### DIFF
--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -65,6 +65,9 @@ type Config struct {
 
 	// Logging. Possible options: text,json
 	LogFormat string `default:"text" split_words:"true"`
+
+	// CORS Allowed Origins
+	CORSAllowedOrigins []string `default:"*" split_words:"true"`
 }
 
 func GetServiceConfig() Config {
@@ -181,8 +184,9 @@ func BuildService(config Config, logger logger.Logger) (*service, error) {
 			TLSConfig: grpcTLSConfig,
 		},
 		HTTPServer: server.HTTPServerConfig{
-			Addr:      config.HTTPPort,
-			TLSConfig: httpTLSConfig,
+			Addr:               config.HTTPPort,
+			TLSConfig:          httpTLSConfig,
+			CORSAllowedOrigins: config.CORSAllowedOrigins,
 		},
 		ResolveNodeLimit:       config.ResolveNodeLimit,
 		ChangelogHorizonOffset: config.ChangelogHorizonOffset,

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -222,6 +223,18 @@ func TestBuildServerWithPresharedKeyAuthentication(t *testing.T) {
 	cancel()
 	require.NoError(t, g.Wait())
 	require.NoError(t, service.Close(ctx))
+}
+
+func TestSettingCORSAllowedOrigins(t *testing.T) {
+	os.Setenv("OPENFGA_AUTH_METHOD", "preshared")
+	os.Setenv("OPENFGA_AUTH_PRESHARED_KEYS", "KEYONE,KEYTWO")
+	os.Setenv("OPENFGA_CORS_ALLOWED_ORIGINS", "http://openfga.dev,http://localhost")
+
+	corsAllowedOrigins := GetServiceConfig().CORSAllowedOrigins
+	expectedCORSAllowedOrigins := []string{"http://openfga.dev", "http://localhost"}
+	if !reflect.DeepEqual(corsAllowedOrigins, expectedCORSAllowedOrigins) {
+		t.Fatalf("Unexpected CORSAllowedOrigin expected %v, actual %v", corsAllowedOrigins, expectedCORSAllowedOrigins)
+	}
 }
 
 func TestBuildServerWithOidcAuthentication(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -86,8 +86,9 @@ type GRPCServerConfig struct {
 }
 
 type HTTPServerConfig struct {
-	Addr      int
-	TLSConfig *TLSConfig
+	Addr               int
+	TLSConfig          *TLSConfig
+	CORSAllowedOrigins []string
 }
 
 type TLSConfig struct {
@@ -475,7 +476,7 @@ func (s *Server) Run(ctx context.Context) error {
 	httpServer := &http.Server{
 		Addr: fmt.Sprintf(":%d", s.config.HTTPServer.Addr),
 		Handler: cors.New(cors.Options{
-			AllowedOrigins:   []string{"*"},
+			AllowedOrigins:   s.config.HTTPServer.CORSAllowedOrigins,
 			AllowCredentials: true,
 			AllowedHeaders:   []string{"*"},
 			AllowedMethods: []string{http.MethodGet, http.MethodPost,


### PR DESCRIPTION
## Description
Allow overriding the default CORS allowed origins via variable `OPENFGA_CORS_ALLOWED_ORIGINS`

## References
Close https://github.com/openfga/openfga/issues/64

The corresponding docs change is  https://github.com/openfga/openfga.dev/pull/114

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
