### PR TITLE
fix: correct order of unit test assert messages

### DIFF
--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -234,7 +234,7 @@ func TestSettingCORS(t *testing.T) {
 	corsAllowedOrigins := GetServiceConfig().CORSAllowedOrigins
 	expectedCORSAllowedOrigins := []string{"http://openfga.dev", "http://localhost"}
 	if !reflect.DeepEqual(corsAllowedOrigins, expectedCORSAllowedOrigins) {
-		t.Fatalf("Unexpected CORSAllowedOrigin expected %v, actual %v", corsAllowedOrigins, expectedCORSAllowedOrigins)
+		t.Fatalf("Unexpected CORSAllowedOrigin expected %v, actual %v", expectedCORSAllowedOrigins, corsAllowedOrigins)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
## Description
Fix parameter in unit test

## References
https://github.com/openfga/openfga/pull/65#discussion_r902918343


## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [ ] The correct base branch is being used, if not `main`
