### PR TITLE
chore(ci): only run semgrep, fossa & snyk on branches owned by openfga org

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   fossa:
     runs-on: ubuntu-latest
-    if: (github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
+    if: (github.repository_owner == 'openfga')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,15 +1,17 @@
 name: Semgrep
 on:
+  pull_request:
   push:
     branches:
       - main
+      - master
 jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep
-    if: (github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
+    if: (github.repository_owner == 'openfga' && github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
     steps:
     - uses: actions/checkout@v3
     - run: semgrep ci

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    if: (github.repository_owner == 'openfga' && github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

These checks will always fail for external contributors, this change only makes them run on branches coming in from within the org, we will have to rely on the weaker webhook integration for outside PRs (these checks will still run on merge to main).

## Description
<!-- Please provide a detailed description of the changes here -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
