### PR TITLE
fix: make grpc server and http server bind addr configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ COPY . .
 RUN go build -o ./openfga ./cmd/openfga
 
 FROM alpine as final
-EXPOSE 8081
-EXPOSE 8080
-EXPOSE 3000
 COPY --from=builder /app/openfga /app/openfga
 COPY --from=builder /app/static /app/static
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY . .
 RUN go build -o ./openfga ./cmd/openfga
 
 FROM alpine as final
+EXPOSE 8081
+EXPOSE 8080
+EXPOSE 3000
 COPY --from=builder /app/openfga /app/openfga
 COPY --from=builder /app/static /app/static
 WORKDIR /app

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -80,7 +80,7 @@ func run(_ *cobra.Command, _ []string) {
 					err = tmpl.Execute(w, struct {
 						HTTPServerURL string
 					}{
-						HTTPServerURL: fmt.Sprintf("localhost:%d", config.HTTPPort),
+						HTTPServerURL: config.HTTPAddr,
 					})
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html/template"
 	"log"
+	"net"
 	"net/http"
 	"os/signal"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/pkg/cmd/service"
 	"github.com/openfga/openfga/pkg/logger"
@@ -72,6 +74,21 @@ func run(_ *cobra.Command, _ []string) {
 
 		fileServer := http.FileServer(http.Dir("./static"))
 
+		policy := backoff.NewExponentialBackOff()
+		policy.MaxElapsedTime = 3 * time.Second
+
+		var conn net.Conn
+		err = backoff.Retry(
+			func() error {
+				conn, err = net.Dial("tcp", config.HTTPAddr)
+				return err
+			},
+			policy,
+		)
+		if err != nil {
+			logger.Fatal("failed to establish Playground connection to HTTP server", zap.Error(err))
+		}
+
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -80,7 +97,7 @@ func run(_ *cobra.Command, _ []string) {
 					err = tmpl.Execute(w, struct {
 						HTTPServerURL string
 					}{
-						HTTPServerURL: config.HTTPAddr,
+						HTTPServerURL: conn.RemoteAddr().String(),
 					})
 					if err != nil {
 						w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -34,8 +34,8 @@ type Config struct {
 	DatastoreConnectionURI        string `split_words:"true"`
 	DatastoreMaxCacheSize         int    `default:"100000" split_words:"true"`
 	ServiceName                   string `default:"openfga" split_words:"true"`
-	HTTPPort                      int    `default:"8080" split_words:"true"`
-	RPCPort                       int    `default:"8081" split_words:"true"`
+	HTTPAddr                      string `default:":8080" split_words:"true"`
+	GRPCAddr                      string `default:":8081" split_words:"true"`
 	MaxTuplesPerWrite             int    `default:"100" split_words:"true"`
 	MaxTypesPerAuthorizationModel int    `default:"100" split_words:"true"`
 	// ChangelogHorizonOffset is an offset in minutes from the current time. Changes that occur after this offset will not be included in the response of ReadChanges.
@@ -184,11 +184,11 @@ func BuildService(config Config, logger logger.Logger) (*service, error) {
 	}, &server.Config{
 		ServiceName: config.ServiceName,
 		GRPCServer: server.GRPCServerConfig{
-			Addr:      config.RPCPort,
+			Addr:      config.GRPCAddr,
 			TLSConfig: grpcTLSConfig,
 		},
 		HTTPServer: server.HTTPServerConfig{
-			Addr:               config.HTTPPort,
+			Addr:               config.HTTPAddr,
 			TLSConfig:          httpTLSConfig,
 			CORSAllowedOrigins: config.CORSAllowedOrigins,
 			CORSAllowedHeaders: config.CORSAllowedHeaders,

--- a/server/server.go
+++ b/server/server.go
@@ -81,12 +81,12 @@ type Config struct {
 }
 
 type GRPCServerConfig struct {
-	Addr      int
+	Addr      string
 	TLSConfig *TLSConfig
 }
 
 type HTTPServerConfig struct {
-	Addr               int
+	Addr               string
 	TLSConfig          *TLSConfig
 	CORSAllowedOrigins []string
 	CORSAllowedHeaders []string
@@ -426,7 +426,7 @@ func (s *Server) Run(ctx context.Context) error {
 	grpcServer := grpc.NewServer(opts...)
 	openfgapb.RegisterOpenFGAServiceServer(grpcServer, s)
 
-	rpcAddr := fmt.Sprintf("localhost:%d", s.config.GRPCServer.Addr)
+	rpcAddr := s.config.GRPCServer.Addr
 	lis, err := net.Listen("tcp", rpcAddr)
 	if err != nil {
 		return err
@@ -475,7 +475,7 @@ func (s *Server) Run(ctx context.Context) error {
 	}
 
 	httpServer := &http.Server{
-		Addr: fmt.Sprintf(":%d", s.config.HTTPServer.Addr),
+		Addr: s.config.HTTPServer.Addr,
 		Handler: cors.New(cors.Options{
 			AllowedOrigins:   s.config.HTTPServer.CORSAllowedOrigins,
 			AllowCredentials: true,


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
These changes allow the developer to run OpenFGA on a configurable `host:port` address, thus allowing the servers bind to a host address other than "localhost" of the running container.

The defaults still remain `:8080` (for the HTTP server) and `:8081` (for the grpc server), so it behaves identically under default conditions, but if you want to bind to a different host and port address you now can.

## References
Closes #74 

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
