### PR TITLE
chore: ignore 2 semgrep violations since they are false positives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ run: build ## Run the OpenFGA server with in-memory storage
 
 .PHONY: run-postgres
 run-postgres: build ## Run the OpenFGA server with Postgres
+	# nosemgrep: detected-username-and-password-in-uri
 	OPENFGA_DATASTORE_ENGINE=postgres OPENFGA_DATASTORE_CONNECTION_URI='postgres://postgres:password@localhost:5432/postgres?sslmode=disable' make run
 
 .PHONY: go-generate

--- a/server/server.go
+++ b/server/server.go
@@ -423,6 +423,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		opts = append(opts, grpc.Creds(creds))
 	}
+	// nosemgrep: grpc-server-insecure-connection
 	grpcServer := grpc.NewServer(opts...)
 	openfgapb.RegisterOpenFGAServiceServer(grpcServer, s)
 


### PR DESCRIPTION
## Description
Mark the 2 high severity violations reported by semgrep as false positives.

- The command in the Makefile contains parameters meant for local development and should be overridden for a production deployment.
- The server configuration contains an option to include credentials.

## References
 https://semgrep.dev/orgs/auth0/findings?tab=open&dedup=true&severity=2&repo=openfga%2Fopenfga

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
