### PR TITLE
feat: add basic CLI flags to the `run` command

### DIFF
--- a/cmd/openfga/openfga.go
+++ b/cmd/openfga/openfga.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"log"
+	"os"
 
 	"github.com/openfga/openfga/pkg/cmd"
 )
@@ -13,6 +13,6 @@ func main() {
 	rootCmd.AddCommand(runCmd)
 
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		os.Exit(1)
 	}
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -18,17 +18,22 @@ import (
 	"github.com/openfga/openfga/pkg/cmd/service"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
 func NewRunCommand() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "run",
 		Short: "Run the OpenFGA server",
 		Long:  "Run the OpenFGA server.",
 		Run:   run,
 	}
+
+	bindFlags(cmd)
+
+	return cmd
 }
 
 func run(_ *cobra.Command, _ []string) {
@@ -182,4 +187,54 @@ func buildLogger(logFormat string) (logger.Logger, error) {
 	}
 
 	return openfgaLogger, err
+}
+
+// bindFlags binds the cobra cmd flags to the equivalent config value being managed
+// by viper. This bridges the config between cobra flags and viper flags.
+func bindFlags(cmd *cobra.Command) {
+	cmd.Flags().Bool("grpc-enabled", true, "enable/disable the OpenFGA grpc server")
+	viper.BindPFlag("grpc.enabled", cmd.Flags().Lookup("grpc-enabled"))
+	cmd.Flags().String("grpc-addr", ":8081", "the host:port address to serve the grpc server on")
+	viper.BindPFlag("grpc.addr", cmd.Flags().Lookup("grpc-addr"))
+	cmd.Flags().Bool("grpc-tls-enabled", false, "enable/disable transport layer security (TLS)")
+	viper.BindPFlag("grpc.tls.enabled", cmd.Flags().Lookup("grpc-tls-enabled"))
+	cmd.Flags().String("grpc-tls-cert", "", "the (absolute) file path of the certificate to use for the TLS connection")
+	viper.BindPFlag("grpc.tls.cert", cmd.Flags().Lookup("grpc-tls-cert"))
+	cmd.Flags().String("grpc-tls-key", "", "the (absolute) file path of the TLS key that should be used for the TLS connection")
+	viper.BindPFlag("grpc.tls.key", cmd.Flags().Lookup("grpc-tls-key"))
+	cmd.MarkFlagsRequiredTogether("grpc-tls-enabled", "grpc-tls-cert", "grpc-tls-key")
+
+	cmd.Flags().Bool("http-enabled", true, "enable/disable the OpenFGA HTTP server")
+	viper.BindPFlag("http.enabled", cmd.Flags().Lookup("http-enabled"))
+	cmd.Flags().String("http-addr", ":8080", "the host:port address to serve the HTTP server on")
+	viper.BindPFlag("http.addr", cmd.Flags().Lookup("http-addr"))
+	cmd.Flags().Bool("http-tls-enabled", false, "enable/disable transport layer security (TLS)")
+	viper.BindPFlag("http.tls.enabled", cmd.Flags().Lookup("http-tls-enabled"))
+	cmd.Flags().String("http-tls-cert", "", "the (absolute) file path of the certificate to use for the TLS connection")
+	viper.BindPFlag("http.tls.cert", cmd.Flags().Lookup("http-tls-cert"))
+	cmd.Flags().String("http-tls-key", "", "the (absolute) file path of the TLS key that should be used for the TLS connection")
+	viper.BindPFlag("http.tls.key", cmd.Flags().Lookup("http-tls-key"))
+	cmd.MarkFlagsRequiredTogether("http-tls-enabled", "http-tls-cert", "http-tls-key")
+
+	cmd.Flags().String("authn-method", "none", "the authentication method to use")
+	viper.BindPFlag("authn.method", cmd.Flags().Lookup("authn-method"))
+	cmd.Flags().StringSlice("authn-presharedkeys", nil, "one or more preshared keys to use for authentication")
+	viper.BindPFlag("authn.preshared.keys", cmd.Flags().Lookup("authn-presharedkeys"))
+	cmd.Flags().String("authn-oidc-audience", "", "the OIDC audience of the tokens being signed by the authorization server")
+	viper.BindPFlag("authn.oidc.audience", cmd.Flags().Lookup("authn-oidc-audience"))
+	cmd.Flags().String("authn-oidc-issuer", "", "the OIDC issuer (authorization server) signing the tokens")
+	viper.BindPFlag("authn.oidc.issuer", cmd.Flags().Lookup("authn-oidc-issuer"))
+
+	cmd.Flags().String("database-engine", "memory", "the database engine that will be used for persistence")
+	viper.BindPFlag("database.engine", cmd.Flags().Lookup("database-engine"))
+	cmd.Flags().String("database-uri", "", "the connection uri to use to connect to the database (for any engine other than 'memory')")
+	viper.BindPFlag("database.uri", cmd.Flags().Lookup("database-uri"))
+
+	cmd.Flags().Bool("playground-enabled", false, "enable/disable the OpenFGA Playground")
+	viper.BindPFlag("playground.enabled", cmd.Flags().Lookup("playground-enabled"))
+	cmd.Flags().Int("playground-port", 3000, "the port to serve the local OpenFGA Playground on")
+	viper.BindPFlag("playground.port", cmd.Flags().Lookup("playground-port"))
+
+	cmd.Flags().String("log-format", "text", "the log format to output logs in")
+	viper.BindPFlag("log.format", cmd.Flags().Lookup("log-format"))
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This adds some CLI flags for the `run` command to wire up basic options that you can provide at the command-line. The changes herein wire up the cobra command flags with the config being managed by viper. 

## References
Part of #91 

* Design inspired by the spf13/cobra [User Guide](https://github.com/spf13/cobra/blob/master/user_guide.md)

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
