### PR TITLE
chore: rename database -> datastore in flags and config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ run: build ## Run the OpenFGA server with in-memory storage
 .PHONY: run-postgres
 run-postgres: build ## Run the OpenFGA server with Postgres
 	# nosemgrep: detected-username-and-password-in-uri
-	OPENFGA_DATASTORE_ENGINE=postgres OPENFGA_DATASTORE_CONNECTION_URI='postgres://postgres:password@localhost:5432/postgres?sslmode=disable' make run
+	./bin/openfga run --datastore-engine postgres --datastore-uri postgres://postgres:password@localhost:5432/postgres?sslmode=disable
 
 .PHONY: go-generate
 go-generate: install-tools

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ docker compose up -d postgres
 make run-postgres
 ```
 
-This should start a Postgres container, run database schema migrations, and start the OpenFGA server.
+This should start a Postgres container, run migrations, and start the OpenFGA server.
 
 When you are done you can stop the Postgres container with:
 

--- a/config-schema.json
+++ b/config-schema.json
@@ -40,18 +40,18 @@
                 }
             }
         },
-        "database": {
+        "datastore": {
             "engine": {
-                "description": "The database engine that will be used for persistence.",
+                "description": "The datastore engine that will be used for persistence.",
                 "type": "string",
                 "enum": ["memory", "postgres"],
                 "default": "memory"
             },
             "uri": {
-                "description": "The connection uri to use to connect to the database (for any engine other than 'memory').",
+                "description": "The connection uri to use to connect to the datastore (for any engine other than 'memory').",
                 "type": "string",
                 "examples": [
-                    "postgres://user:pass@host:port/database?opts"
+                    "postgres://user:pass@host:port/datastore?opts"
                 ]
             },
             "maxCacheSize": {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -239,10 +239,10 @@ func bindFlags(cmd *cobra.Command) {
 	cmd.Flags().String("authn-oidc-issuer", defaultConfig.Authn.Issuer, "the OIDC issuer (authorization server) signing the tokens")
 	cmdutil.MustBindPFlag("authn.oidc.issuer", cmd.Flags().Lookup("authn-oidc-issuer"))
 
-	cmd.Flags().String("database-engine", defaultConfig.Database.Engine, "the database engine that will be used for persistence")
-	cmdutil.MustBindPFlag("database.engine", cmd.Flags().Lookup("database-engine"))
-	cmd.Flags().String("database-uri", defaultConfig.Database.URI, "the connection uri to use to connect to the database (for any engine other than 'memory')")
-	cmdutil.MustBindPFlag("database.uri", cmd.Flags().Lookup("database-uri"))
+	cmd.Flags().String("datastore-engine", defaultConfig.Datastore.Engine, "the datastore engine that will be used for persistence")
+	cmdutil.MustBindPFlag("datastore.engine", cmd.Flags().Lookup("datastore-engine"))
+	cmd.Flags().String("datastore-uri", defaultConfig.Datastore.URI, "the connection uri to use to connect to the datastore (for any engine other than 'memory')")
+	cmdutil.MustBindPFlag("datastore.uri", cmd.Flags().Lookup("datastore-uri"))
 
 	cmd.Flags().Bool("playground-enabled", defaultConfig.Playground.Enabled, "enable/disable the OpenFGA Playground")
 	cmdutil.MustBindPFlag("playground.enabled", cmd.Flags().Lookup("playground-enabled"))

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -11,7 +11,7 @@ import (
 // generated from a TestStorageBuilder
 type InitFunc[T any] func(engine, uri string) T
 
-// RunningEngineForTest represents an instance of a database engine running with its backing
+// RunningEngineForTest represents an instance of a datastore engine running with its backing
 // database/service, expressly for testing.
 type RunningEngineForTest[T any] interface {
 


### PR DESCRIPTION

<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

Generally, we have been calling our storage a datastore, e.g., OpenFGADatastore. This PR is to keep us consistent. 

And fix the make command `run-postgres`.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
