### PR TITLE
feat: wire up support for env variables

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -41,23 +41,26 @@
             }
         },
         "datastore": {
-            "engine": {
-                "description": "The datastore engine that will be used for persistence.",
-                "type": "string",
-                "enum": ["memory", "postgres"],
-                "default": "memory"
-            },
-            "uri": {
-                "description": "The connection uri to use to connect to the datastore (for any engine other than 'memory').",
-                "type": "string",
-                "examples": [
-                    "postgres://user:pass@host:port/datastore?opts"
-                ]
-            },
-            "maxCacheSize": {
-                "description": "The maximum number of cache keys that the storage cache can store before evicting old keys.",
-                "type": "integer",
-                "default": 100000
+            "type": "object",
+            "properties": {
+                "engine": {
+                    "description": "The datastore engine that will be used for persistence.",
+                    "type": "string",
+                    "enum": ["memory", "postgres"],
+                    "default": "memory"
+                },
+                "uri": {
+                    "description": "The connection uri to use to connect to the datastore (for any engine other than 'memory').",
+                    "type": "string",
+                    "examples": [
+                        "postgres://user:pass@host:port/datastore?opts"
+                    ]
+                },
+                "maxCacheSize": {
+                    "description": "The maximum number of cache keys that the storage cache can store before evicting old keys.",
+                    "type": "integer",
+                    "default": 100000
+                }
             }
         },
         "authn": {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
 	github.com/stretchr/testify v1.8.0
+	github.com/tidwall/gjson v1.14.1
 	go.buf.build/openfga/go/openfga/api v1.1.21
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.33.0
 	go.opentelemetry.io/otel v1.8.0
@@ -67,6 +68,8 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	go.buf.build/openfga/go/envoyproxy/protoc-gen-validate v1.1.6 // indirect
 	go.buf.build/openfga/go/grpc-ecosystem/grpc-gateway v1.1.43 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -340,6 +340,12 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=
+github.com/tidwall/gjson v1.14.1 h1:iymTbGkQBhveq21bEvAQ81I0LEBork8BFe1CUZXdyuo=
+github.com/tidwall/gjson v1.14.1/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -189,6 +190,8 @@ func GetServiceConfig() (*Config, error) {
 	for _, path := range configPaths {
 		viper.AddConfigPath(path)
 	}
+	viper.SetEnvPrefix("OPENFGA")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
 	err := viper.ReadInConfig()


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The adds support for env variables to the list of optional ways to configure the OpenFGA server. Configuration is loaded according to the default behavior of the spf13/viper package. That is,

> Viper uses the following precedence order. Each item takes precedence over the item below it:
> 
> explicit call to Set
> flag
> env
> config
> key/value store
> default

Each config property is mapped to an env variable by translating the config to all uppercase and replacing any usage of `.` with `_` and attaching the `OPENFGA_` prefix to it. For example, `http.enabled` becomes `OPENFGA_HTTP_ENABLED` and `authn.preshared.keys` becomes `OPENFGA_AUTHN_PRESHARED_KEYS` etc..

## References
https://github.com/spf13/viper#why-viper

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
