### PR TITLE
chore: change playground enable default

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -31,7 +31,7 @@
                 "enabled": {
                     "description": "Enable/disable the OpenFGA Playground.",
                     "type": "boolean",
-                    "default": false
+                    "default": true
                 },
                 "port": {
                     "description": "The port to serve the local OpenFGA Playground on.",

--- a/README.md
+++ b/README.md
@@ -152,12 +152,12 @@ If everything is running correctly, you should get a response with information a
 ```
 
 ## Playground
-The Playground facilitates rapid development by allowing you to visualize and model your application's authorization model(s) and manage relationship tuples with a locally running OpenFGA instace.
+The Playground facilitates rapid development by allowing you to visualize and model your application's authorization model(s) and manage relationship tuples with a locally running OpenFGA instance.
 
-To run OpenFGA with the Playground enabled, provide the `--playground-enabled` flag.
+To run OpenFGA with the Playground disabled, provide the `--playground-enabled=false` flag.
 
 ```
-./bin/openfga run --playground-enabled
+./bin/openfga run --playground-enabled=false
 ```
 Once OpenFGA is running, by default, the Playground can be accessed at [http://localhost:3000/playground](http://localhost:3000/playground).
 

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -170,7 +170,7 @@ func DefaultConfig() *Config {
 			Format: "text",
 		},
 		Playground: PlaygroundConfig{
-			Enabled: false,
+			Enabled: true,
 			Port:    3000,
 		},
 	}


### PR DESCRIPTION
## Description
Update default so that playground is enabled by default. Also update corresponding README

## References
Close https://github.com/openfga/openfga/issues/102

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
