### PR TITLE
fix: add Playground artifact to the goreleaser build artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,7 +8,7 @@ before:
 builds:
   - 
     main: ./cmd/openfga
-    binary: bin/openfga
+    binary: openfga
     env:
       - CGO_ENABLED=0
     goos:
@@ -51,6 +51,8 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+    files:
+      - static/playground
 
 checksum:
   name_template: 'checksums.txt'

--- a/Makefile
+++ b/Makefile
@@ -19,20 +19,20 @@ lint:  ## Lint Go source files
 
 .PHONY: clean
 clean: ## Clean files
-	rm ./bin/openfga
+	rm ./openfga
 
 .PHONY: build
 build: ## Build/compile the OpenFGA service
-	go build -o ./bin/openfga ./cmd/openfga
+	go build -o ./openfga ./cmd/openfga
 
 .PHONY: run
 run: build ## Run the OpenFGA server with in-memory storage
-	./bin/openfga run
+	./openfga run
 
 .PHONY: run-postgres
 run-postgres: build ## Run the OpenFGA server with Postgres
 	# nosemgrep: detected-username-and-password-in-uri
-	./bin/openfga run --datastore-engine postgres --datastore-uri postgres://postgres:password@localhost:5432/postgres?sslmode=disable
+	./openfga run --datastore-engine postgres --datastore-uri postgres://postgres:password@localhost:5432/postgres?sslmode=disable
 
 .PHONY: go-generate
 go-generate: install-tools

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Download your platform's [latest release](https://github.com/openfga/openfga/rel
 with the command:
 
 ```bash
-./bin/openfga run
+./openfga run
 ```
 
 ### Building from Source

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ The Playground facilitates rapid development by allowing you to visualize and mo
 To run OpenFGA with the Playground disabled, provide the `--playground-enabled=false` flag.
 
 ```
-./bin/openfga run --playground-enabled=false
+./openfga run --playground-enabled=false
 ```
 Once OpenFGA is running, by default, the Playground can be accessed at [http://localhost:3000/playground](http://localhost:3000/playground).
 
 In the event that a port other than the default port is required, the `--playground-port` flag can be set to change it. For example,
 
 ```sh
-./bin/openfga run --playground-enabled --playground-port 3001
+./openfga run --playground-enabled --playground-port 3001
 ```
 
 ## Next Steps

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"os/signal"
+	"path"
 	"runtime"
 	"strings"
 	"syscall"
@@ -22,6 +24,15 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
+
+func init() {
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "../..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+}
 
 func NewRunCommand() *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes the issue with the Playground assets not being included with our build artifacts generated by goreleaser.

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
