### PR TITLE
feat: add configurable pprof profiling support

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -35,6 +35,21 @@
                 }
             }
         },
+        "profiler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "Enabled/disable pprof profiling.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "addr": {
+                    "description": "The host:port address to serve the pprof profiler server on.",
+                    "type": "string",
+                    "default": ":3001"
+                }
+            }
+        },
         "datastore": {
             "type": "object",
             "properties": {

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ In the event that a port other than the default port is required, the `--playgro
 ./openfga run --playground-enabled --playground-port 3001
 ```
 
+## Profiler (pprof)
+Profiling through pprof can be enabled on the OpenFGA server by providing the `--profiler-enabled` flag.
+
+```sh
+./openfga run --profiler-enabled
+```
+
+If you need to serve the profiler on a different address than the default `:3001`, you can do so by specifying the `--profiler-addr` flag. For example,
+
+```sh
+./openfga run --profiler-enabled --profiler-addr :3002
+```
+
 ## Next Steps
 
 Take a look at examples of how to:

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -123,6 +123,12 @@ type OpenFGAConfig struct {
 	ResolveNodeLimit uint32
 }
 
+// ProfilerConfig defines server configurations specific to pprof profiling.
+type ProfilerConfig struct {
+	Enabled bool
+	Addr    string
+}
+
 type Config struct {
 	// If you change any of these settings, please update the documentation at https://github.com/openfga/openfga.dev/blob/main/docs/content/intro/setup-openfga.mdx
 
@@ -133,6 +139,7 @@ type Config struct {
 	Authn      AuthnConfig
 	Log        LogConfig
 	Playground PlaygroundConfig
+	Profiler   ProfilerConfig
 }
 
 // DefaultConfig returns the OpenFGA server default configurations.
@@ -172,6 +179,10 @@ func DefaultConfig() *Config {
 		Playground: PlaygroundConfig{
 			Enabled: true,
 			Port:    3000,
+		},
+		Profiler: ProfilerConfig{
+			Enabled: false,
+			Addr:    ":3001",
 		},
 	}
 }

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -766,6 +766,14 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), config.Playground.Port)
 
+	val = res.Get("properties.profiler.properties.enabled.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.Bool(), config.Profiler.Enabled)
+
+	val = res.Get("properties.profiler.properties.addr.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.String(), config.Profiler.Addr)
+
 	val = res.Get("properties.authn.properties.method.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), config.Authn.Method)


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This adds configurable pprof profiling support to the OpenFGA server.

## References
Closes #110 

Documentation: https://github.com/openfga/openfga.dev/pull/170

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
