### PR TITLE
ci: drop auto changelog release notes temporarily until we can resolve

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,20 +24,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate Release Changes
-        id: changelog_reader
-        uses: mindsers/changelog-reader-action@v2
-        with:
-          version: ${{ steps.tag_name.outputs.current_version }}
-
-      - name: Generate Release Notes
-        id: release_notes
-        run: |
-          export NOTES=$(mktemp)
-          echo ::set-output name=notes::$NOTES
-          printf '${{ steps.changelog_reader.outputs.changes }}' > $NOTES
-        shell: bash
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The `v0.1.5` CHANGELOG release notes have richer Markdown text (with special characters etc..) that cause issues with bash shell escape sequences. Prior releases didn't have such characters and consequently did not have the same issues. The purpose of this PR is to drop the automatic changelog release notes generator until we can fix this is a more elegant (automated) way. For now this will unblock us from releasing the latest `v0.1.5` release.

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
