### PR TITLE
fix: need basic syntax validation on deletes

### DIFF
--- a/pkg/tuple/validation.go
+++ b/pkg/tuple/validation.go
@@ -54,7 +54,7 @@ func (i *RelationNotFoundError) Error() string {
 // ValidateUser returns whether the user is valid.  If not, return error
 func ValidateUser(tk *openfgapb.TupleKey) error {
 	if !IsValidUser(tk.GetUser()) {
-		return &InvalidTupleError{Reason: "missing user", TupleKey: tk}
+		return &InvalidTupleError{Reason: "the 'user' field must be a non-empty string", TupleKey: tk}
 	}
 	return nil
 }

--- a/pkg/tuple/validation.go
+++ b/pkg/tuple/validation.go
@@ -51,10 +51,18 @@ func (i *RelationNotFoundError) Error() string {
 	return fmt.Sprintf("Relation '%s' not found in type definition '%s' for tuple (%s)", i.Relation, i.TypeName, i.TupleKey.String())
 }
 
+// ValidateUser returns whether the user is valid.  If not, return error
+func ValidateUser(tk *openfgapb.TupleKey) error {
+	if !IsValidUser(tk.GetUser()) {
+		return &InvalidTupleError{Reason: "missing user", TupleKey: tk}
+	}
+	return nil
+}
+
 // ValidateTuple returns whether a *openfgapb.TupleKey is valid
 func ValidateTuple(ctx context.Context, backend storage.TypeDefinitionReadBackend, store, authorizationModelID string, tk *openfgapb.TupleKey, dbCallsCounter utils.DBCallCounter) (*openfgapb.Userset, error) {
-	if !IsValidUser(tk.GetUser()) {
-		return nil, &InvalidTupleError{Reason: "missing user", TupleKey: tk}
+	if err := ValidateUser(tk); err != nil {
+		return nil, err
 	}
 	return ValidateObjectsRelations(ctx, backend, store, authorizationModelID, tk, dbCallsCounter)
 }

--- a/server/commands/write.go
+++ b/server/commands/write.go
@@ -65,6 +65,13 @@ func (c *WriteCommand) validateTuplesets(ctx context.Context, req *openfgapb.Wri
 		}
 	}
 
+	for _, tk := range deletes {
+		// For delete, we only need to ensure it is well form but no need to validate whether relation exists
+		if err := tupleUtils.ValidateUser(tk); err != nil {
+			return serverErrors.HandleTupleValidateError(err)
+		}
+	}
+
 	if err := c.validateNoDuplicatesAndCorrectSize(deletes, writes); err != nil {
 		return err
 	}

--- a/server/commands/write_test.go
+++ b/server/commands/write_test.go
@@ -127,16 +127,16 @@ func TestValidateWriteTuples(t *testing.T) {
 			expectedError: serverErrors.InvalidWriteInput,
 		},
 		{
-			name:          "validation on tuples against write",
+			name:          "write failure with invalid user",
 			deletes:       []*openfgapb.TupleKey{},
 			writes:        []*openfgapb.TupleKey{badItem},
-			expectedError: serverErrors.InvalidTuple("missing user", badItem),
+			expectedError: serverErrors.InvalidTuple("the 'user' field must be a non-empty string", badItem),
 		},
 		{
-			name:          "validation on tuples against delete",
+			name:          "delete failure with invalid user",
 			deletes:       []*openfgapb.TupleKey{badItem},
 			writes:        []*openfgapb.TupleKey{},
-			expectedError: serverErrors.InvalidTuple("missing user", badItem),
+			expectedError: serverErrors.InvalidTuple("the 'user' field must be a non-empty string", badItem),
 		},
 	}
 

--- a/server/commands/write_test.go
+++ b/server/commands/write_test.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -9,12 +10,13 @@ import (
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/utils"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	mockstorage "github.com/openfga/openfga/storage/mocks"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-func TestValidateWriteTuples(t *testing.T) {
+func TestValidateNoDuplicatesAndCorrectSize(t *testing.T) {
 	type test struct {
 		name          string
 		deletes       []*openfgapb.TupleKey
@@ -83,6 +85,71 @@ func TestValidateWriteTuples(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := cmd.validateNoDuplicatesAndCorrectSize(test.deletes, test.writes)
+			if !reflect.DeepEqual(err, test.expectedError) {
+				t.Errorf("Expected error %v, got %v", test.expectedError, err)
+			}
+		})
+	}
+}
+
+func TestValidateWriteTuples(t *testing.T) {
+	type test struct {
+		name          string
+		deletes       []*openfgapb.TupleKey
+		writes        []*openfgapb.TupleKey
+		expectedError error
+	}
+
+	tracer := telemetry.NewNoopTracer()
+	logger := logger.NewNoopLogger()
+	dbCounter := utils.NewDBCallCounter()
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	maxTuplesInWriteOp := 10
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+	mockDatastore.EXPECT().MaxTuplesInWriteOperation().AnyTimes().Return(maxTuplesInWriteOp)
+
+	badItem := &openfgapb.TupleKey{
+		Object:   fmt.Sprintf("%s:1", testutils.CreateRandomString(459)),
+		Relation: testutils.CreateRandomString(50),
+		User:     "",
+	}
+
+	cmd := NewWriteCommand(mockDatastore, tracer, logger)
+
+	tests := []test{
+		{
+			name:          "nil for deletes and writes",
+			deletes:       nil,
+			writes:        nil,
+			expectedError: serverErrors.InvalidWriteInput,
+		},
+		{
+			name:          "validation on tuples against write",
+			deletes:       []*openfgapb.TupleKey{},
+			writes:        []*openfgapb.TupleKey{badItem},
+			expectedError: serverErrors.InvalidTuple("missing user", badItem),
+		},
+		{
+			name:          "validation on tuples against delete",
+			deletes:       []*openfgapb.TupleKey{badItem},
+			writes:        []*openfgapb.TupleKey{},
+			expectedError: serverErrors.InvalidTuple("missing user", badItem),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			req := &openfgapb.WriteRequest{
+				StoreId: "abcd123",
+				Writes:  &openfgapb.TupleKeys{TupleKeys: test.writes},
+				Deletes: &openfgapb.TupleKeys{TupleKeys: test.deletes},
+			}
+
+			err := cmd.validateTuplesets(ctx, req, dbCounter)
 			if !reflect.DeepEqual(err, test.expectedError) {
 				t.Errorf("Expected error %v, got %v", test.expectedError, err)
 			}

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -144,7 +144,7 @@ var writeCommandTests = []writeCommandTest{
 			}}},
 		},
 		// output
-		err: serverErrors.InvalidTuple("missing user", &openfgapb.TupleKey{Object: "repo:auth0", Relation: "owner"}),
+		err: serverErrors.InvalidTuple("the 'user' field must be a non-empty string", &openfgapb.TupleKey{Object: "repo:auth0", Relation: "owner"}),
 	},
 	{
 		_name: "ExecuteWithWriteTupleWithMissingObjectError",


### PR DESCRIPTION
## Description

Even though we should allow deleting tuples where there is no current
relation / authorization model not exist, etc.  We should nevertheless
ensure the tuple itself is valid in syntax (i.e., the user is defined).


## References

- Close https://github.com/openfga/openfga/issues/132

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
