### PR TITLE
chore(ci): only run snyk, fossa and semgrep on pushes to main

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,10 +1,8 @@
 name: FOSSA
 on:
-  pull_request:
   push:
     branches:
       - main
-      - master
 
 jobs:
   fossa:

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,10 +1,9 @@
 name: Semgrep
 on:
-  pull_request:
   push:
     branches:
       - main
-      - master
+
 jobs:
   semgrep:
     name: Scan

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -1,10 +1,8 @@
 name: Snyk
 on:
-  pull_request:
   push:
     branches:
       - main
-      - master
 
 jobs:
   security:


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

This is because external contributors do not have access to the required
secrets necessary for running these workflows, causing them to fail.

This causes external contributors confusion where they believe the failure
was triggered by a change they made.

Instead for FOSSA and snyk we will rely on the github integration which
does not need access to defined secrets, though does detect less issues.

These workflows are kept in main so that we are able to detect any issues
missed by the integration.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
