### PR TITLE
chore: add missing config properties for ListObjects flags

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -20,6 +20,18 @@
             "type": "integer",
             "default": 25
         },
+        "listObjectsDeadline": {
+            "description": "The timeout deadline for serving ListObjects requests",
+            "type": "string",
+            "format": "duration",
+            "default": "3s"
+        },
+        "listObjectsMaxResults": {
+            "description": "The maximum results to return in ListObjects responses",
+            "type": "integer",
+            "minimum": 0,
+            "default": 1000
+        },
         "playground": {
             "type": "object",
             "properties": {

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -810,4 +810,12 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.Equal(t, val.Bool(), config.GRPC.TLS.Enabled)
 	require.Equal(t, val.Bool(), config.HTTP.TLS.Enabled)
+
+	val = res.Get("properties.listObjectsDeadline.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.String(), config.ListObjectsDeadline.String())
+
+	val = res.Get("properties.listObjectsMaxResults.default")
+	require.True(t, val.Exists())
+	require.EqualValues(t, val.Int(), config.ListObjectsMaxResults)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/openfga/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/openfga/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Some of the new ListObjects flags were missing in the config-schema.json definitions.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [X] The correct base branch is being used, if not `main`
