### PR TITLE
feat: content styling clarity to changelog header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
+
 ## [Unreleased]
 
 ## [0.1.7] - 2022-07-29


### PR DESCRIPTION
Brief content guidance for the top of the changelog.

## Description
In an effort to make sure our changelog is easy to skim, searchable, and serves the humans that will read it - without crossing into full documentation territory - this added guidance means to steer contributors toward the simplest possible changelog additions while leaving more intensive description, justification, and implementation help to the project's full documentation site.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
