### PR TITLE
fix: minor changes to ListObjects

### DIFF
--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -14,6 +14,8 @@ type tupleIterator struct {
 	rows pgx.Rows
 }
 
+var _ storage.TupleIterator = (*tupleIterator)(nil)
+
 func (t *tupleIterator) next() (*tupleRecord, error) {
 	if !t.rows.Next() {
 		t.Stop()


### PR DESCRIPTION
Addressing some comments from https://github.com/openfga/openfga/pull/145#issuecomment-1211066407

Also fixing the case where this

```
case genericError := <-errChan:
		return nil, genericError
	}
```

returns `nil, nil`.

See https://go.dev/play/p/I07S9PTkann. [We don't need to call `close(errChan)`](https://stackoverflow.com/a/8593986)