### PR TITLE
fix: change otel counters to gauges

### DIFF
--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -44,12 +44,12 @@ func NewCheckQuery(datastore storage.OpenFGADatastore, t trace.Tracer, m metric.
 
 // Execute the query in `checkRequest`, returning the response or an error.
 func (query *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckRequest) (*openfgapb.CheckResponse, error) {
-	statCheckResolutionDepth, _ := query.meter.SyncInt64().Counter(
+	statCheckResolutionDepth, _ := query.meter.AsyncInt64().Gauge(
 		"openfga.check.resolution.depth",
 		instrument.WithDescription("Number of recursive resolutions needed to execute check requests"),
 		instrument.WithUnit(unit.Dimensionless),
 	)
-	statCheckDBCalls, _ := query.meter.SyncInt64().Counter(
+	statCheckDBCalls, _ := query.meter.AsyncInt64().Gauge(
 		"openfga.check.db.calls",
 		instrument.WithDescription("Number of db queries needed to execute check requests"),
 		instrument.WithUnit(unit.Dimensionless),
@@ -87,10 +87,10 @@ func (query *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckReques
 
 	utils.LogDBStats(ctx, query.logger, "Check", rc.metadata.GetReadCalls(), 0)
 	if statCheckResolutionDepth != nil {
-		statCheckResolutionDepth.Add(ctx, int64(rc.metadata.GetResolve()))
+		statCheckResolutionDepth.Observe(ctx, int64(rc.metadata.GetResolve()))
 	}
 	if statCheckDBCalls != nil {
-		statCheckDBCalls.Add(ctx, int64(rc.metadata.GetReadCalls()))
+		statCheckDBCalls.Observe(ctx, int64(rc.metadata.GetReadCalls()))
 	}
 
 	return &openfgapb.CheckResponse{


### PR DESCRIPTION
**Counter**: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-counter

> reports [monotonically](https://wikipedia.org/wiki/Monotonic_function) increasing value(s) when the instrument is being observed. Example uses for Asynchronous Counter: [CPU time](https://wikipedia.org/wiki/CPU_time), which could be reported for each thread, each process or the entire system. For example "the CPU time for process A running in user mode, measured in seconds".

**Gauge**: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#asynchronous-gauge

> reports non-additive value(s) (e.g. the room temperature - it makes no sense to report the temperature value from multiple rooms and sum them up) when the instrument is being observed.

---

After this PR, for a `POST check`:

<img width="632" alt="image" src="https://user-images.githubusercontent.com/5374887/185248820-1e3bf948-7743-40d6-9747-93e997976f08.png">
