### PR TITLE
fix: db_reads log when calling Check API

### DIFF
--- a/server/commands/list_objects.go
+++ b/server/commands/list_objects.go
@@ -227,7 +227,7 @@ func (q *ListObjectsQuery) performChecks(timeoutCtx context.Context, input *Perf
 
 func (q *ListObjectsQuery) internalCheck(ctx context.Context, object string, input *PerformChecksInput, objectsFound *uint32, resultsChan chan<- string) error {
 	_, objectID := tuple.SplitObject(object)
-	query := NewCheckQuery(q.Datastore, q.Tracer, q.Meter, q.Logger, q.ResolveNodeLimit)
+	query := NewCheckQuery(q.Datastore, q.Tracer, q.Meter, q.Logger, q.ResolveNodeLimit, "listObjects")
 
 	resp, err := query.Execute(ctx, &openfgapb.CheckRequest{
 		StoreId:              input.storeID,

--- a/server/server.go
+++ b/server/server.go
@@ -295,7 +295,7 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 	}
 	span.SetAttributes(attribute.KeyValue{Key: "authorization-model-id", Value: attribute.StringValue(modelID)})
 
-	q := commands.NewCheckQuery(s.datastore, s.tracer, s.meter, s.logger, s.config.ResolveNodeLimit)
+	q := commands.NewCheckQuery(s.datastore, s.tracer, s.meter, s.logger, s.config.ResolveNodeLimit, "check")
 
 	res, err := q.Execute(ctx, &openfgapb.CheckRequest{
 		StoreId:              store,

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1543,7 +1543,7 @@ func TestCheckQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 				}
 			}
 
-			cmd := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, test.resolveNodeLimit)
+			cmd := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, test.resolveNodeLimit, "check")
 			test.request.StoreId = store
 			test.request.AuthorizationModelId = modelID
 			resp, gotErr := cmd.Execute(ctx, test.request)
@@ -1626,7 +1626,7 @@ func TestCheckQueryAuthorizationModelsVersioning(t *testing.T, datastore storage
 		t.Fatalf("failed to write test tuple: %v", err)
 	}
 
-	originalCheckQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit)
+	originalCheckQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit, "check")
 	originalNSResponse, err := originalCheckQuery.Execute(ctx, &openfgapb.CheckRequest{
 		StoreId:              store,
 		AuthorizationModelId: originalModelID,
@@ -1644,7 +1644,7 @@ func TestCheckQueryAuthorizationModelsVersioning(t *testing.T, datastore storage
 		t.Errorf("[%s] Expected allowed '%t', actual '%t'", "originalNS", true, originalNSResponse.Allowed)
 	}
 
-	updatedCheckQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit)
+	updatedCheckQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit, "check")
 	updatedNSResponse, err := updatedCheckQuery.Execute(ctx, &openfgapb.CheckRequest{
 		StoreId:              store,
 		AuthorizationModelId: updatedModelID,
@@ -1709,7 +1709,7 @@ func BenchmarkCheckWithoutTrace(b *testing.B, datastore storage.OpenFGADatastore
 		b.Fatal(err)
 	}
 
-	checkQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit)
+	checkQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit, "check")
 
 	var r *openfgapb.CheckResponse
 
@@ -1758,7 +1758,7 @@ func BenchmarkWithTrace(b *testing.B, datastore storage.OpenFGADatastore) {
 		b.Fatal(err)
 	}
 
-	checkQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit)
+	checkQuery := commands.NewCheckQuery(datastore, tracer, telemetry.NewNoopMeter(), logger, defaultResolveNodeLimit, "check")
 
 	var r *openfgapb.CheckResponse
 


### PR DESCRIPTION
When we call List Objects API, the logs say "check", because internally List Objects is calling Check.

```
2022-08-19T20:01:41.068Z	INFO	db_stats	{"method": "Check", "reads": 7, "writes": 0}
```