### PR TITLE
chore: minor Health server touch ups

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -668,7 +668,7 @@ func (o *openfgaHealthServer) Check(ctx context.Context, req *healthv1pb.HealthC
 		return &healthv1pb.HealthCheckResponse{Status: healthv1pb.HealthCheckResponse_SERVING}, nil
 	}
 
-	return nil, status.Error(codes.NotFound, "")
+	return nil, status.Errorf(codes.NotFound, "service '%s' is not registered with the Health server", service)
 }
 
 func (o *openfgaHealthServer) Watch(req *healthv1pb.HealthCheckRequest, server healthv1pb.Health_WatchServer) error {


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This changes our Health check implementation slightly so that it is inline with the grpc Health Check protocol.

> The server should register all the services manually and set the individual status, including an empty service name and its status. For each request received, if the service name can be found in the registry, a response must be sent back with an OK status and the status field should be set to SERVING or NOT_SERVING accordingly. If the service name is not registered, the server returns a NOT_FOUND GRPC status.
> 
> The server should use an empty string as the key for server's overall health status, so that a client not interested in a specific service can query the server's status with an empty request. 

More specifically, we only return a status if the request is made with a service field that is the empty string "" or the service name matching the OpenFGA service (`openfga.v1.OpenFGAService`).

## References
https://github.com/grpc/grpc/blob/master/doc/health-checking.md

## Review Checklist
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
