### PR TITLE
refactor: drop object in tuple_to_userset and computed_userset

### DIFF
--- a/server/commands/expand.go
+++ b/server/commands/expand.go
@@ -121,18 +121,15 @@ func (query *ExpandQuery) resolveThis(ctx context.Context, store string, tk *ope
 }
 
 // resolveComputedUserset builds a leaf node containing the result of resolving a ComputedUserset rewrite.
-func (query *ExpandQuery) resolveComputedUserset(ctx context.Context, userset *openfgapb.ObjectRelation, tk *openfgapb.TupleKey, metadata *utils.ResolutionMetadata) (*openfgapb.UsersetTree_Node, error) {
+func (query *ExpandQuery) resolveComputedUserset(ctx context.Context, computedUserset *openfgapb.ComputedUserset, tk *openfgapb.TupleKey, metadata *utils.ResolutionMetadata) (*openfgapb.UsersetTree_Node, error) {
 
 	var span trace.Span
 	_, span = query.tracer.Start(ctx, "resolveComputedUserset")
 	defer span.End()
 
 	computed := &openfgapb.TupleKey{
-		Object:   userset.GetObject(),
-		Relation: userset.GetRelation(),
-	}
-	if len(computed.Object) == 0 {
-		computed.Object = tk.Object
+		Object:   tk.GetObject(),
+		Relation: computedUserset.GetRelation(),
 	}
 	if len(computed.Relation) == 0 {
 		computed.Relation = tk.Relation
@@ -152,13 +149,13 @@ func (query *ExpandQuery) resolveComputedUserset(ctx context.Context, userset *o
 }
 
 // resolveTupleToUserset creates a new leaf node containing the result of expanding a TupleToUserset rewrite.
-func (query *ExpandQuery) resolveTupleToUserset(ctx context.Context, store string, userset *openfgapb.TupleToUserset, tk *openfgapb.TupleKey, metadata *utils.ResolutionMetadata) (*openfgapb.UsersetTree_Node, error) {
+func (query *ExpandQuery) resolveTupleToUserset(ctx context.Context, store string, tupleToUserset *openfgapb.TupleToUserset, tk *openfgapb.TupleKey, metadata *utils.ResolutionMetadata) (*openfgapb.UsersetTree_Node, error) {
 	ctx, span := query.tracer.Start(ctx, "resolveTupleToUserset")
 	defer span.End()
 
 	tsKey := &openfgapb.TupleKey{
 		Object:   tk.GetObject(),
-		Relation: userset.GetTupleset().GetRelation(),
+		Relation: tupleToUserset.GetTupleset().GetRelation(),
 	}
 	if tsKey.GetRelation() == "" {
 		tsKey.Relation = tk.GetRelation()
@@ -189,9 +186,9 @@ func (query *ExpandQuery) resolveTupleToUserset(ctx context.Context, store strin
 		// We only proceed in the case that tRelation == userset.GetComputedUserset().GetRelation().
 		// tRelation may be empty, and in this case, we set it to userset.GetComputedUserset().GetRelation().
 		if tRelation == "" {
-			tRelation = userset.GetComputedUserset().GetRelation()
+			tRelation = tupleToUserset.GetComputedUserset().GetRelation()
 		}
-		if tRelation != userset.GetComputedUserset().GetRelation() {
+		if tRelation != tupleToUserset.GetComputedUserset().GetRelation() {
 			continue
 		}
 		cs := &openfgapb.TupleKey{

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -147,13 +147,13 @@ var checkQueryTests = []checkQueryTest{
 			Relations: map[string]*openfgapb.Userset{
 				"reader": {
 					Userset: &openfgapb.Userset_ComputedUserset{
-						ComputedUserset: &openfgapb.ObjectRelation{
+						ComputedUserset: &openfgapb.ComputedUserset{
 							Relation: "writer",
 						},
 					}},
 				"writer": {
 					Userset: &openfgapb.Userset_ComputedUserset{
-						ComputedUserset: &openfgapb.ObjectRelation{
+						ComputedUserset: &openfgapb.ComputedUserset{
 							Relation: "reader",
 						},
 					}},
@@ -178,7 +178,7 @@ var checkQueryTests = []checkQueryTest{
 				},
 				"writer": {
 					Userset: &openfgapb.Userset_ComputedUserset{
-						ComputedUserset: &openfgapb.ObjectRelation{
+						ComputedUserset: &openfgapb.ComputedUserset{
 							Relation: "reader",
 						},
 					}},
@@ -210,7 +210,7 @@ var checkQueryTests = []checkQueryTest{
 								},
 								{
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "writer",
 										},
 									},
@@ -389,7 +389,7 @@ var checkQueryTests = []checkQueryTest{
 					Userset: &openfgapb.Userset_Union{
 						Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "owner",
 								},
 							}},
@@ -431,7 +431,7 @@ var checkQueryTests = []checkQueryTest{
 						Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_This{}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "writer",
 								},
 							}},
@@ -505,7 +505,7 @@ var checkQueryTests = []checkQueryTest{
 						Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_This{}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "writer",
 								},
 							}},
@@ -548,12 +548,12 @@ var checkQueryTests = []checkQueryTest{
 					Userset: &openfgapb.Userset_Intersection{
 						Intersection: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "create_user",
 								},
 							}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "write_organization",
 								},
 							}},
@@ -590,12 +590,12 @@ var checkQueryTests = []checkQueryTest{
 					Userset: &openfgapb.Userset_Intersection{
 						Intersection: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "create_user",
 								},
 							}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "write_organization",
 								},
 							}},
@@ -634,12 +634,12 @@ var checkQueryTests = []checkQueryTest{
 					Userset: &openfgapb.Userset_Intersection{
 						Intersection: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "create_user",
 								},
 							}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "write_organization",
 								},
 							}},
@@ -650,12 +650,12 @@ var checkQueryTests = []checkQueryTest{
 					Userset: &openfgapb.Userset_Intersection{
 						Intersection: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "create_user_a",
 								},
 							}},
 							{Userset: &openfgapb.Userset_ComputedUserset{
-								ComputedUserset: &openfgapb.ObjectRelation{
+								ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "create_user_b",
 								},
 							}},
@@ -698,7 +698,7 @@ var checkQueryTests = []checkQueryTest{
 								},
 								Subtract: &openfgapb.Userset{
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "banned",
 										},
 									},
@@ -738,7 +738,7 @@ var checkQueryTests = []checkQueryTest{
 								},
 								Subtract: &openfgapb.Userset{
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "banned",
 										},
 									},
@@ -775,11 +775,10 @@ var checkQueryTests = []checkQueryTest{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
 								{Userset: &openfgapb.Userset_TupleToUserset{TupleToUserset: &openfgapb.TupleToUserset{
-									Tupleset: &openfgapb.ObjectRelation{
+									Tupleset: &openfgapb.Tupleset{
 										Relation: "manager",
 									},
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Object:   "$TUPLE_USERSET_OBJECT",
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "repo_admin",
 									},
 								}}},
@@ -821,11 +820,10 @@ var checkQueryTests = []checkQueryTest{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
 								{Userset: &openfgapb.Userset_TupleToUserset{TupleToUserset: &openfgapb.TupleToUserset{
-									Tupleset: &openfgapb.ObjectRelation{
+									Tupleset: &openfgapb.Tupleset{
 										Relation: "manager",
 									},
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Object:   "$TUPLE_USERSET_OBJECT",
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "repo_admin",
 									},
 								}}},
@@ -836,7 +834,7 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "admin",
 								}}},
 							}},
@@ -846,15 +844,14 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "maintainer",
 								}}},
 								{Userset: &openfgapb.Userset_TupleToUserset{TupleToUserset: &openfgapb.TupleToUserset{
-									Tupleset: &openfgapb.ObjectRelation{
+									Tupleset: &openfgapb.Tupleset{
 										Relation: "manager",
 									},
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Object:   "$TUPLE_USERSET_OBJECT",
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "repo_writer",
 									},
 								}}},
@@ -865,7 +862,7 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "writer",
 								}}},
 							}},
@@ -875,15 +872,14 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "triager",
 								}}},
 								{Userset: &openfgapb.Userset_TupleToUserset{TupleToUserset: &openfgapb.TupleToUserset{
-									Tupleset: &openfgapb.ObjectRelation{
+									Tupleset: &openfgapb.Tupleset{
 										Relation: "manager",
 									},
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Object:   "$TUPLE_USERSET_OBJECT",
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "repo_reader",
 									},
 								}}},
@@ -925,7 +921,7 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "owner",
 								}}},
 							}},
@@ -935,15 +931,14 @@ var checkQueryTests = []checkQueryTest{
 						Userset: &openfgapb.Userset_Union{
 							Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 								{Userset: &openfgapb.Userset_This{}},
-								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{
+								{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{
 									Relation: "editor",
 								}}},
 								{Userset: &openfgapb.Userset_TupleToUserset{TupleToUserset: &openfgapb.TupleToUserset{
-									Tupleset: &openfgapb.ObjectRelation{
+									Tupleset: &openfgapb.Tupleset{
 										Relation: "parent",
 									},
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Object:   "$TUPLE_USERSET_OBJECT",
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "viewer",
 									},
 								}}},
@@ -1322,7 +1317,7 @@ func TestCheckQueryAuthorizationModelsVersioning(t *testing.T, datastore storage
 				Userset: &openfgapb.Userset_Union{
 					Union: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 						{Userset: &openfgapb.Userset_This{}},
-						{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ObjectRelation{Relation: "owner"}}},
+						{Userset: &openfgapb.Userset_ComputedUserset{ComputedUserset: &openfgapb.ComputedUserset{Relation: "owner"}}},
 					}},
 				},
 			},

--- a/server/test/expand.go
+++ b/server/test/expand.go
@@ -92,7 +92,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 							"admin": {},
 							"writer": {
 								Userset: &openfgapb.Userset_ComputedUserset{
-									ComputedUserset: &openfgapb.ObjectRelation{
+									ComputedUserset: &openfgapb.ComputedUserset{
 										Relation: "admin",
 									},
 								},
@@ -135,11 +135,10 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 							"admin": {
 								Userset: &openfgapb.Userset_TupleToUserset{
 									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
+										Tupleset: &openfgapb.Tupleset{
 											Relation: "manager",
 										},
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "$TUPLE_USERSET_OBJECT",
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "repo_admin",
 										},
 									},
@@ -206,11 +205,10 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 							"admin": {
 								Userset: &openfgapb.Userset_TupleToUserset{
 									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
+										Tupleset: &openfgapb.Tupleset{
 											Relation: "manager",
 										},
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "$TUPLE_USERSET_OBJECT",
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "repo_admin",
 										},
 									},
@@ -282,10 +280,10 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 							"admin": {
 								Userset: &openfgapb.Userset_TupleToUserset{
 									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
+										Tupleset: &openfgapb.Tupleset{
 											Relation: "manager",
 										},
-										ComputedUserset: &openfgapb.ObjectRelation{
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "repo_admin",
 										},
 									},
@@ -361,7 +359,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 											},
 											{
 												Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
+													ComputedUserset: &openfgapb.ComputedUserset{
 														Relation: "admin",
 													},
 												},
@@ -439,14 +437,14 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 									Difference: &openfgapb.Difference{
 										Base: &openfgapb.Userset{
 											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "admin",
 												},
 											},
 										},
 										Subtract: &openfgapb.Userset{
 											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "banned",
 												},
 											},
@@ -521,7 +519,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 											},
 											{
 												Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
+													ComputedUserset: &openfgapb.ComputedUserset{
 														Relation: "admin",
 													},
 												},
@@ -606,11 +604,10 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 														{
 															Userset: &openfgapb.Userset_TupleToUserset{
 																TupleToUserset: &openfgapb.TupleToUserset{
-																	Tupleset: &openfgapb.ObjectRelation{
+																	Tupleset: &openfgapb.Tupleset{
 																		Relation: "owner",
 																	},
-																	ComputedUserset: &openfgapb.ObjectRelation{
-																		Object:   "$TUPLE_USERSET_OBJECT",
+																	ComputedUserset: &openfgapb.ComputedUserset{
 																		Relation: "repo_writer",
 																	},
 																},
@@ -622,7 +619,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 										},
 										Subtract: &openfgapb.Userset{
 											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "banned_writer",
 												},
 											},

--- a/server/test/write_authzmodel.go
+++ b/server/test/write_authzmodel.go
@@ -112,8 +112,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 							Relations: map[string]*openfgapb.Userset{
 								"writer": {
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "",
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "owner",
 										},
 									},
@@ -137,12 +136,10 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 								"viewer": {
 									Userset: &openfgapb.Userset_TupleToUserset{
 										TupleToUserset: &openfgapb.TupleToUserset{
-											Tupleset: &openfgapb.ObjectRelation{
-												Object:   "",
+											Tupleset: &openfgapb.Tupleset{
 												Relation: "writer",
 											},
-											ComputedUserset: &openfgapb.ObjectRelation{
-												Object:   "$TUPLE_USERSET_OBJECT",
+											ComputedUserset: &openfgapb.ComputedUserset{
 												Relation: "owner",
 											},
 										},
@@ -170,8 +167,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 											Child: []*openfgapb.Userset{
 												{Userset: &openfgapb.Userset_This{}},
 												{Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
-														Object:   "",
+													ComputedUserset: &openfgapb.ComputedUserset{
 														Relation: "owner",
 													},
 												}},
@@ -199,14 +195,12 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 									Userset: &openfgapb.Userset_Difference{
 										Difference: &openfgapb.Difference{
 											Base: &openfgapb.Userset{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Object:   "",
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "writer",
 												},
 											}},
 											Subtract: &openfgapb.Userset{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Object:   "",
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "owner",
 												},
 											}},
@@ -233,14 +227,12 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 									Userset: &openfgapb.Userset_Difference{
 										Difference: &openfgapb.Difference{
 											Base: &openfgapb.Userset{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Object:   "",
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "owner",
 												},
 											}},
 											Subtract: &openfgapb.Userset{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Object:   "",
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "writer",
 												},
 											}},
@@ -266,12 +258,10 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 								"viewer": {
 									Userset: &openfgapb.Userset_TupleToUserset{
 										TupleToUserset: &openfgapb.TupleToUserset{
-											Tupleset: &openfgapb.ObjectRelation{
-												Object:   "",
+											Tupleset: &openfgapb.Tupleset{
 												Relation: "owner",
 											},
-											ComputedUserset: &openfgapb.ObjectRelation{
-												Object:   "$TUPLE_USERSET_OBJECT",
+											ComputedUserset: &openfgapb.ComputedUserset{
 												Relation: "from",
 											},
 										},
@@ -296,12 +286,10 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 								"viewer": {
 									Userset: &openfgapb.Userset_TupleToUserset{
 										TupleToUserset: &openfgapb.TupleToUserset{
-											Tupleset: &openfgapb.ObjectRelation{
-												Object:   "",
+											Tupleset: &openfgapb.Tupleset{
 												Relation: "writer",
 											},
-											ComputedUserset: &openfgapb.ObjectRelation{
-												Object:   "$TUPLE_USERSET_OBJECT",
+											ComputedUserset: &openfgapb.ComputedUserset{
 												Relation: "owner",
 											},
 										},
@@ -324,8 +312,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 							Relations: map[string]*openfgapb.Userset{
 								"writer": {
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "",
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "reader",
 										},
 									},
@@ -340,8 +327,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 							Relations: map[string]*openfgapb.Userset{
 								"owner": {
 									Userset: &openfgapb.Userset_ComputedUserset{
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "",
+										ComputedUserset: &openfgapb.ComputedUserset{
 											Relation: "writer",
 										},
 									},
@@ -368,8 +354,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 											Child: []*openfgapb.Userset{
 												{Userset: &openfgapb.Userset_This{}},
 												{Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
-														Object:   "",
+													ComputedUserset: &openfgapb.ComputedUserset{
 														Relation: "owner",
 													},
 												}},
@@ -397,8 +382,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 										Difference: &openfgapb.Difference{
 											Base: &openfgapb.Userset{Userset: &openfgapb.Userset_This{}},
 											Subtract: &openfgapb.Userset{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Object:   "",
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "viewer",
 												},
 											}},
@@ -426,7 +410,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 										Union: &openfgapb.Usersets{
 											Child: []*openfgapb.Userset{
 												{Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
+													ComputedUserset: &openfgapb.ComputedUserset{
 														Relation: "viewer",
 													},
 												}},
@@ -453,7 +437,7 @@ func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastor
 									Userset: &openfgapb.Userset_Intersection{
 										Intersection: &openfgapb.Usersets{Child: []*openfgapb.Userset{
 											{Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
+												ComputedUserset: &openfgapb.ComputedUserset{
 													Relation: "viewer",
 												},
 											}},

--- a/testdata/elsevier.json
+++ b/testdata/elsevier.json
@@ -26,7 +26,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "reader"
                                     }
                                 }

--- a/testdata/expenses.json
+++ b/testdata/expenses.json
@@ -15,7 +15,6 @@
                                         "relation": "manager"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "manager"
                                     }
                                 }
@@ -37,7 +36,6 @@
                             "relation": "submitter"
                         },
                         "computedUserset": {
-                            "object": "$TUPLE_USERSET_OBJECT",
                             "relation": "manager"
                         }
                     }

--- a/testdata/gdrive-fga.json
+++ b/testdata/gdrive-fga.json
@@ -26,7 +26,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "owner"
                                     }
                                 }
@@ -51,7 +50,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "writer"
                                     }
                                 }
@@ -76,7 +74,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "commenter"
                                     }
                                 }
@@ -101,7 +98,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "reader"
                                     }
                                 }

--- a/testdata/gdrive.json
+++ b/testdata/gdrive.json
@@ -15,7 +15,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "owner"
                                     }
                                 }
@@ -40,7 +39,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "writer"
                                     }
                                 }
@@ -65,7 +63,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "commenter"
                                     }
                                 }
@@ -90,7 +87,6 @@
                                         "relation": "parent"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "reader"
                                     }
                                 }

--- a/testdata/github-no-concentric.json
+++ b/testdata/github-no-concentric.json
@@ -15,7 +15,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_admin"
                                     }
                                 }
@@ -44,7 +43,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_writer"
                                     }
                                 }
@@ -73,7 +71,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_reader"
                                     }
                                 }
@@ -147,7 +144,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "owner"
                                     }
                                 }

--- a/testdata/github.json
+++ b/testdata/github.json
@@ -15,7 +15,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_admin"
                                     }
                                 }
@@ -54,7 +53,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_writer"
                                     }
                                 }
@@ -93,7 +91,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "repo_reader"
                                     }
                                 }
@@ -177,7 +174,6 @@
                                         "relation": "owner"
                                     },
                                     "computedUserset": {
-                                        "object": "$TUPLE_USERSET_OBJECT",
                                         "relation": "owner"
                                     }
                                 }

--- a/testdata/unix.json
+++ b/testdata/unix.json
@@ -60,7 +60,6 @@
                             "relation": "parent"
                         },
                         "computedUserset": {
-                            "object": "$TUPLE_USERSET_OBJECT",
                             "relation": "executor"
                         }
                     }
@@ -130,7 +129,6 @@
                                                     "relation": "parent"
                                                 },
                                                 "computedUserset": {
-                                                    "object": "$TUPLE_USERSET_OBJECT",
                                                     "relation": "executor"
                                                 }
                                             }


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Related to https://github.com/openfga/api/pull/26.

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
