### PR TITLE
fix: erroneous test message

### DIFF
--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -131,18 +131,11 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		}
 
 		err := datastore.Write(ctx, store, nil, []*openfgapb.TupleKey{tk1, tk2})
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		changes, continuationToken, err := datastore.ReadChanges(ctx, store, "folder", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 0)
-		if err != nil {
-			t.Errorf("expected no error but got '%v'", err)
-		}
-
-		if len(continuationToken) == 0 {
-			t.Errorf("expected empty token but got '%s'", continuationToken)
-		}
+		require.NoError(t, err)
+		require.NotEmpty(t, continuationToken)
 
 		expectedChanges := []*openfgapb.TupleChange{
 			{


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

Fix erroneous test message pointed out by @MidasLamb in discord. Thank you!

Also part of a general push to move to using `require` more.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
