### PR TITLE
refactor: write auth models to take an array of type definitions

### DIFF
--- a/server/commands/write_authzmodel.go
+++ b/server/commands/write_authzmodel.go
@@ -29,7 +29,9 @@ func NewWriteAuthorizationModelCommand(
 
 // Execute the command using the supplied request.
 func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openfgapb.WriteAuthorizationModelRequest) (*openfgapb.WriteAuthorizationModelResponse, error) {
-	if err := w.validateAuthorizationModel(req.GetTypeDefinitions().GetTypeDefinitions()); err != nil {
+	typeDefinitions := req.GetTypeDefinitions().GetTypeDefinitions()
+
+	if err := w.validateAuthorizationModel(typeDefinitions); err != nil {
 		return nil, err
 	}
 
@@ -39,7 +41,7 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 	}
 
 	utils.LogDBStats(ctx, w.logger, "WriteAuthzModel", 0, 1)
-	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, req.GetTypeDefinitions()); err != nil {
+	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, typeDefinitions); err != nil {
 		return nil, serverErrors.HandleError("Error writing authorization model configuration", err)
 	}
 

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1272,9 +1272,9 @@ func TestCheckQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 			require.NoError(t, err)
 
 			if test.useGitHubTypeDefinition {
-				err = datastore.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{TypeDefinitions: gitHubTypeDefinitions.GetTypeDefinitions()})
+				err = datastore.WriteAuthorizationModel(ctx, store, modelID, gitHubTypeDefinitions.GetTypeDefinitions())
 			} else {
-				err = datastore.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{TypeDefinitions: test.typeDefinitions})
+				err = datastore.WriteAuthorizationModel(ctx, store, modelID, test.typeDefinitions)
 			}
 			require.NoError(t, err)
 
@@ -1341,13 +1341,13 @@ func TestCheckQueryAuthorizationModelsVersioning(t *testing.T, datastore storage
 	originalModelID, err := id.NewString()
 	require.NoError(t, err)
 
-	err = datastore.WriteAuthorizationModel(ctx, store, originalModelID, &openfgapb.TypeDefinitions{TypeDefinitions: originalTD})
+	err = datastore.WriteAuthorizationModel(ctx, store, originalModelID, originalTD)
 	require.NoError(t, err)
 
 	updatedModelID, err := id.NewString()
 	require.NoError(t, err)
 
-	err = datastore.WriteAuthorizationModel(ctx, store, updatedModelID, &openfgapb.TypeDefinitions{TypeDefinitions: updatedTD})
+	err = datastore.WriteAuthorizationModel(ctx, store, updatedModelID, updatedTD)
 	require.NoError(t, err)
 
 	err = datastore.Write(ctx, store, []*openfgapb.TupleKey{}, []*openfgapb.TupleKey{{Object: "repo:openfgapb", Relation: "owner", User: "yenkel"}})
@@ -1408,7 +1408,7 @@ func BenchmarkCheckWithoutTrace(b *testing.B, datastore storage.OpenFGADatastore
 	modelID, err := id.NewString()
 	require.NoError(b, err)
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, &gitHubTypeDefinitions)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, gitHubTypeDefinitions.GetTypeDefinitions())
 	require.NoError(b, err)
 
 	err = datastore.Write(ctx, store, []*openfgapb.TupleKey{}, tuples)
@@ -1451,7 +1451,7 @@ func BenchmarkWithTrace(b *testing.B, datastore storage.OpenFGADatastore) {
 	modelID, err := id.NewString()
 	require.NoError(b, err)
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, &gitHubTypeDefinitions)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, gitHubTypeDefinitions.GetTypeDefinitions())
 	require.NoError(b, err)
 
 	err = datastore.Write(ctx, store, []*openfgapb.TupleKey{}, tuples)

--- a/server/test/expand.go
+++ b/server/test/expand.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
-func setUp(ctx context.Context, store string, datastore storage.OpenFGADatastore, typeDefinitions *openfgapb.TypeDefinitions, tuples []*openfgapb.TupleKey) (string, error) {
+func setUp(ctx context.Context, store string, datastore storage.OpenFGADatastore, typeDefinitions []*openfgapb.TypeDefinition, tuples []*openfgapb.TupleKey) (string, error) {
 	modelID, err := id.NewString()
 	if err != nil {
 		return "", err
@@ -35,20 +35,18 @@ func setUp(ctx context.Context, store string, datastore storage.OpenFGADatastore
 func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 	tests := []struct {
 		name            string
-		typeDefinitions *openfgapb.TypeDefinitions
+		typeDefinitions []*openfgapb.TypeDefinition
 		tuples          []*openfgapb.TupleKey
 		request         *openfgapb.ExpandRequest
 		expected        *openfgapb.ExpandResponse
 	}{
 		{
 			name: "simple direct",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {},
-						},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {},
 					},
 				},
 			},
@@ -84,17 +82,15 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "computed userset",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {},
-							"writer": {
-								Userset: &openfgapb.Userset_ComputedUserset{
-									ComputedUserset: &openfgapb.ObjectRelation{
-										Relation: "admin",
-									},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {},
+						"writer": {
+							Userset: &openfgapb.Userset_ComputedUserset{
+								ComputedUserset: &openfgapb.ObjectRelation{
+									Relation: "admin",
 								},
 							},
 						},
@@ -127,32 +123,30 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "tuple to userset",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {
-								Userset: &openfgapb.Userset_TupleToUserset{
-									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
-											Relation: "manager",
-										},
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "$TUPLE_USERSET_OBJECT",
-											Relation: "repo_admin",
-										},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {
+							Userset: &openfgapb.Userset_TupleToUserset{
+								TupleToUserset: &openfgapb.TupleToUserset{
+									Tupleset: &openfgapb.ObjectRelation{
+										Relation: "manager",
+									},
+									ComputedUserset: &openfgapb.ObjectRelation{
+										Object:   "$TUPLE_USERSET_OBJECT",
+										Relation: "repo_admin",
 									},
 								},
 							},
-							"manager": {},
 						},
+						"manager": {},
 					},
-					{
-						Type: "org",
-						Relations: map[string]*openfgapb.Userset{
-							"repo_admin": {},
-						},
+				},
+				{
+					Type: "org",
+					Relations: map[string]*openfgapb.Userset{
+						"repo_admin": {},
 					},
 				},
 			},
@@ -198,32 +192,30 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "tuple to userset II",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {
-								Userset: &openfgapb.Userset_TupleToUserset{
-									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
-											Relation: "manager",
-										},
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Object:   "$TUPLE_USERSET_OBJECT",
-											Relation: "repo_admin",
-										},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {
+							Userset: &openfgapb.Userset_TupleToUserset{
+								TupleToUserset: &openfgapb.TupleToUserset{
+									Tupleset: &openfgapb.ObjectRelation{
+										Relation: "manager",
+									},
+									ComputedUserset: &openfgapb.ObjectRelation{
+										Object:   "$TUPLE_USERSET_OBJECT",
+										Relation: "repo_admin",
 									},
 								},
 							},
-							"manager": {},
 						},
+						"manager": {},
 					},
-					{
-						Type: "org",
-						Relations: map[string]*openfgapb.Userset{
-							"repo_admin": {},
-						},
+				},
+				{
+					Type: "org",
+					Relations: map[string]*openfgapb.Userset{
+						"repo_admin": {},
 					},
 				},
 			},
@@ -274,31 +266,29 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "tuple to userset implicit",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {
-								Userset: &openfgapb.Userset_TupleToUserset{
-									TupleToUserset: &openfgapb.TupleToUserset{
-										Tupleset: &openfgapb.ObjectRelation{
-											Relation: "manager",
-										},
-										ComputedUserset: &openfgapb.ObjectRelation{
-											Relation: "repo_admin",
-										},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {
+							Userset: &openfgapb.Userset_TupleToUserset{
+								TupleToUserset: &openfgapb.TupleToUserset{
+									Tupleset: &openfgapb.ObjectRelation{
+										Relation: "manager",
+									},
+									ComputedUserset: &openfgapb.ObjectRelation{
+										Relation: "repo_admin",
 									},
 								},
 							},
-							"manager": {},
 						},
+						"manager": {},
 					},
-					{
-						Type: "org",
-						Relations: map[string]*openfgapb.Userset{
-							"repo_admin": {},
-						},
+				},
+				{
+					Type: "org",
+					Relations: map[string]*openfgapb.Userset{
+						"repo_admin": {},
 					},
 				},
 			},
@@ -344,26 +334,24 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "simple union",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {},
-							"writer": {
-								Userset: &openfgapb.Userset_Union{
-									Union: &openfgapb.Usersets{
-										Child: []*openfgapb.Userset{
-											{
-												Userset: &openfgapb.Userset_This{
-													This: &openfgapb.DirectUserset{},
-												},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {},
+						"writer": {
+							Userset: &openfgapb.Userset_Union{
+								Union: &openfgapb.Usersets{
+									Child: []*openfgapb.Userset{
+										{
+											Userset: &openfgapb.Userset_This{
+												This: &openfgapb.DirectUserset{},
 											},
-											{
-												Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
-														Relation: "admin",
-													},
+										},
+										{
+											Userset: &openfgapb.Userset_ComputedUserset{
+												ComputedUserset: &openfgapb.ObjectRelation{
+													Relation: "admin",
 												},
 											},
 										},
@@ -427,28 +415,26 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "simple difference",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin":  {},
-							"banned": {},
-							"active_admin": {
-								Userset: &openfgapb.Userset_Difference{
-									Difference: &openfgapb.Difference{
-										Base: &openfgapb.Userset{
-											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Relation: "admin",
-												},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin":  {},
+						"banned": {},
+						"active_admin": {
+							Userset: &openfgapb.Userset_Difference{
+								Difference: &openfgapb.Difference{
+									Base: &openfgapb.Userset{
+										Userset: &openfgapb.Userset_ComputedUserset{
+											ComputedUserset: &openfgapb.ObjectRelation{
+												Relation: "admin",
 											},
 										},
-										Subtract: &openfgapb.Userset{
-											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Relation: "banned",
-												},
+									},
+									Subtract: &openfgapb.Userset{
+										Userset: &openfgapb.Userset_ComputedUserset{
+											ComputedUserset: &openfgapb.ObjectRelation{
+												Relation: "banned",
 											},
 										},
 									},
@@ -503,27 +489,25 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "simple intersection",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						// Writers must be both directly in 'writers', and in 'admins'
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin": {},
-							"writer": {
-								Userset: &openfgapb.Userset_Intersection{
-									Intersection: &openfgapb.Usersets{
-										Child: []*openfgapb.Userset{
-											{
-												Userset: &openfgapb.Userset_This{
-													This: &openfgapb.DirectUserset{},
-												},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					// Writers must be both directly in 'writers', and in 'admins'
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin": {},
+						"writer": {
+							Userset: &openfgapb.Userset_Intersection{
+								Intersection: &openfgapb.Usersets{
+									Child: []*openfgapb.Userset{
+										{
+											Userset: &openfgapb.Userset_This{
+												This: &openfgapb.DirectUserset{},
 											},
-											{
-												Userset: &openfgapb.Userset_ComputedUserset{
-													ComputedUserset: &openfgapb.ObjectRelation{
-														Relation: "admin",
-													},
+										},
+										{
+											Userset: &openfgapb.Userset_ComputedUserset{
+												ComputedUserset: &openfgapb.ObjectRelation{
+													Relation: "admin",
 												},
 											},
 										},
@@ -581,38 +565,36 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "complex tree",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				// Users can write if they are direct members of writers, or repo_writers
-				// in the org, unless they are also in banned_writers
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-						Relations: map[string]*openfgapb.Userset{
-							"admin":         {},
-							"owner":         {},
-							"banned_writer": {},
-							"writer": {
-								Userset: &openfgapb.Userset_Difference{
-									Difference: &openfgapb.Difference{
-										Base: &openfgapb.Userset{
-											Userset: &openfgapb.Userset_Union{
-												Union: &openfgapb.Usersets{
-													Child: []*openfgapb.Userset{
-														{
-															Userset: &openfgapb.Userset_This{
-																This: &openfgapb.DirectUserset{},
-															},
+			// Users can write if they are direct members of writers, or repo_writers
+			// in the org, unless they are also in banned_writers
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
+					Relations: map[string]*openfgapb.Userset{
+						"admin":         {},
+						"owner":         {},
+						"banned_writer": {},
+						"writer": {
+							Userset: &openfgapb.Userset_Difference{
+								Difference: &openfgapb.Difference{
+									Base: &openfgapb.Userset{
+										Userset: &openfgapb.Userset_Union{
+											Union: &openfgapb.Usersets{
+												Child: []*openfgapb.Userset{
+													{
+														Userset: &openfgapb.Userset_This{
+															This: &openfgapb.DirectUserset{},
 														},
-														{
-															Userset: &openfgapb.Userset_TupleToUserset{
-																TupleToUserset: &openfgapb.TupleToUserset{
-																	Tupleset: &openfgapb.ObjectRelation{
-																		Relation: "owner",
-																	},
-																	ComputedUserset: &openfgapb.ObjectRelation{
-																		Object:   "$TUPLE_USERSET_OBJECT",
-																		Relation: "repo_writer",
-																	},
+													},
+													{
+														Userset: &openfgapb.Userset_TupleToUserset{
+															TupleToUserset: &openfgapb.TupleToUserset{
+																Tupleset: &openfgapb.ObjectRelation{
+																	Relation: "owner",
+																},
+																ComputedUserset: &openfgapb.ObjectRelation{
+																	Object:   "$TUPLE_USERSET_OBJECT",
+																	Relation: "repo_writer",
 																},
 															},
 														},
@@ -620,11 +602,11 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 												},
 											},
 										},
-										Subtract: &openfgapb.Userset{
-											Userset: &openfgapb.Userset_ComputedUserset{
-												ComputedUserset: &openfgapb.ObjectRelation{
-													Relation: "banned_writer",
-												},
+									},
+									Subtract: &openfgapb.Userset{
+										Userset: &openfgapb.Userset_ComputedUserset{
+											ComputedUserset: &openfgapb.ObjectRelation{
+												Relation: "banned_writer",
 											},
 										},
 									},
@@ -632,11 +614,11 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 							},
 						},
 					},
-					{
-						Type: "org",
-						Relations: map[string]*openfgapb.Userset{
-							"repo_writer": {},
-						},
+				},
+				{
+					Type: "org",
+					Relations: map[string]*openfgapb.Userset{
+						"repo_writer": {},
 					},
 				},
 			},
@@ -747,7 +729,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 func TestExpandQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 	tests := []struct {
 		name            string
-		typeDefinitions *openfgapb.TypeDefinitions
+		typeDefinitions []*openfgapb.TypeDefinition
 		tuples          []*openfgapb.TupleKey
 		request         *openfgapb.ExpandRequest
 		expected        error
@@ -808,11 +790,9 @@ func TestExpandQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 		{
 			name: "relation not found",
-			typeDefinitions: &openfgapb.TypeDefinitions{
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "repo",
-					},
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repo",
 				},
 			},
 			request: &openfgapb.ExpandRequest{

--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -221,7 +221,7 @@ func setupTestListObjects(store string, datastore storage.OpenFGADatastore) (con
 	if err != nil {
 		return nil, nil, "", err
 	}
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, &gitHubTypeDefinitions)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, gitHubTypeDefinitions.GetTypeDefinitions())
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/server/test/read.go
+++ b/server/test/read.go
@@ -555,7 +555,7 @@ func TestReadQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 			modelID, err := id.NewString()
 			require.NoError(err)
 
-			err = datastore.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{TypeDefinitions: test.typeDefinitions})
+			err = datastore.WriteAuthorizationModel(ctx, store, modelID, test.typeDefinitions)
 			require.NoError(err)
 
 			if test.tuples != nil {

--- a/server/test/read_authzmodel.go
+++ b/server/test/read_authzmodel.go
@@ -51,14 +51,12 @@ func TestReadAuthorizationModelByIDAndOneTypeDefinitionReturnsAuthorizationModel
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
 
-	state := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "repo",
-				Relations: map[string]*openfgapb.Userset{
-					"viewer": {
-						Userset: &openfgapb.Userset_This{},
-					},
+	state := []*openfgapb.TypeDefinition{
+		{
+			Type: "repo",
+			Relations: map[string]*openfgapb.Userset{
+				"viewer": {
+					Userset: &openfgapb.Userset_This{},
 				},
 			},
 		},
@@ -87,15 +85,11 @@ func TestReadAuthorizationModelByIDAndTypeDefinitionsReturnsError(t *testing.T, 
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
 
-	emptyState := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{},
-	}
-
 	store := testutils.CreateRandomString(10)
 	modelID, err := id.NewString()
 	require.NoError(err)
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, emptyState)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{})
 	require.NoError(err)
 
 	query := commands.NewReadAuthorizationModelQuery(datastore, logger)

--- a/server/test/read_authzmodels.go
+++ b/server/test/read_authzmodels.go
@@ -27,7 +27,7 @@ func TestReadAuthorizationModelsWithoutPaging(t *testing.T, datastore storage.Op
 
 	tests := []struct {
 		name                      string
-		backendState              map[string]*openfgapb.TypeDefinitions
+		backendState              map[string][]*openfgapb.TypeDefinition
 		request                   *openfgapb.ReadAuthorizationModelsRequest
 		expectedNumModelsReturned int
 	}{
@@ -40,10 +40,8 @@ func TestReadAuthorizationModelsWithoutPaging(t *testing.T, datastore storage.Op
 		},
 		{
 			name: "empty for requested store",
-			backendState: map[string]*openfgapb.TypeDefinitions{
-				"another-store": {
-					TypeDefinitions: []*openfgapb.TypeDefinition{},
-				},
+			backendState: map[string][]*openfgapb.TypeDefinition{
+				"another-store": {},
 			},
 			request: &openfgapb.ReadAuthorizationModelsRequest{
 				StoreId: store,
@@ -52,12 +50,10 @@ func TestReadAuthorizationModelsWithoutPaging(t *testing.T, datastore storage.Op
 		},
 		{
 			name: "multiple type definitions",
-			backendState: map[string]*openfgapb.TypeDefinitions{
+			backendState: map[string][]*openfgapb.TypeDefinition{
 				store: {
-					TypeDefinitions: []*openfgapb.TypeDefinition{
-						{
-							Type: "ns1",
-						},
+					{
+						Type: "ns1",
 					},
 				},
 			},
@@ -95,13 +91,7 @@ func TestReadAuthorizationModelsWithPaging(t *testing.T, datastore storage.OpenF
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
 
-	tds := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "ns1",
-			},
-		},
-	}
+	tds := []*openfgapb.TypeDefinition{{Type: "repo"}}
 
 	store := testutils.CreateRandomString(10)
 	modelID1, err := id.NewString()
@@ -170,13 +160,7 @@ func TestReadAuthorizationModelsInvalidContinuationToken(t *testing.T, datastore
 	modelID, err := id.NewString()
 	require.NoError(err)
 
-	tds := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "repo",
-			},
-		},
-	}
+	tds := []*openfgapb.TypeDefinition{{Type: "repo"}}
 
 	err = datastore.WriteAuthorizationModel(ctx, store, modelID, tds)
 	require.NoError(err)

--- a/server/test/read_tuples.go
+++ b/server/test/read_tuples.go
@@ -28,15 +28,9 @@ func TestReadTuplesQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 	modelID, err := id.NewString()
 	require.NoError(err)
 
-	backendState := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "ns1",
-			},
-		},
-	}
+	tds := []*openfgapb.TypeDefinition{{Type: "repo"}}
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, backendState)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, tds)
 	require.NoError(err)
 
 	writes := []*openfgapb.TupleKey{
@@ -115,15 +109,7 @@ func TestReadTuplesQueryInvalidContinuationToken(t *testing.T, datastore storage
 	modelID, err := id.NewString()
 	require.NoError(err)
 
-	state := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "repo",
-			},
-		},
-	}
-
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, state)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{{Type: "repo"}})
 	require.NoError(err)
 
 	q := commands.NewReadTuplesQuery(datastore, logger, encoder)

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -517,7 +517,7 @@ func TestWriteCommand(t *testing.T, datastore storage.OpenFGADatastore) {
 			require.NoError(err)
 
 			if test.typeDefinitions != nil {
-				err = datastore.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{TypeDefinitions: test.typeDefinitions})
+				err = datastore.WriteAuthorizationModel(ctx, store, modelID, test.typeDefinitions)
 				require.NoError(err)
 			}
 

--- a/storage/caching/caching_test.go
+++ b/storage/caching/caching_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/storage/memory"
+	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 	"go.opentelemetry.io/otel"
 )
@@ -45,12 +46,10 @@ func TestReadTypeDefinition(t *testing.T) {
 		cachingBackend := NewCachedOpenFGADatastore(memoryBackend, 5)
 
 		modelID, err := id.NewString()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := memoryBackend.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{TypeDefinitions: test.dbState}); err != nil {
-			t.Fatalf("%s: WriteAuthorizationModel: err was %v, want nil", test._name, err)
-		}
+		require.NoError(t, err)
+
+		err = memoryBackend.WriteAuthorizationModel(ctx, store, modelID, test.dbState)
+		require.NoError(t, err)
 
 		td, actualError := cachingBackend.ReadTypeDefinition(ctx, test.store, modelID, test.name)
 

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -566,7 +566,7 @@ func (s *MemoryBackend) ReadTypeDefinition(ctx context.Context, store, id, objec
 }
 
 // WriteAuthorizationModel See storage.TypeDefinitionWriteBackend.WriteAuthorizationModel
-func (s *MemoryBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds *openfgapb.TypeDefinitions) error {
+func (s *MemoryBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgapb.TypeDefinition) error {
 	_, span := s.tracer.Start(ctx, "memory.WriteAuthorizationModel")
 	defer span.End()
 
@@ -584,7 +584,7 @@ func (s *MemoryBackend) WriteAuthorizationModel(ctx context.Context, store, id s
 	s.authorizationModels[store][id] = &AuthorizationModelEntry{
 		model: &openfgapb.AuthorizationModel{
 			Id:              id,
-			TypeDefinitions: tds.GetTypeDefinitions(),
+			TypeDefinitions: tds,
 		},
 		latest: true,
 	}

--- a/storage/mocks/mock_storage.go
+++ b/storage/mocks/mock_storage.go
@@ -352,7 +352,7 @@ func (mr *MockTypeDefinitionWriteBackendMockRecorder) MaxTypesInTypeDefinition()
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockTypeDefinitionWriteBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds *openfgav1.TypeDefinitions) error {
+func (m *MockTypeDefinitionWriteBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
 	ret0, _ := ret[0].(error)
@@ -464,7 +464,7 @@ func (mr *MockAuthorizationModelBackendMockRecorder) ReadTypeDefinition(ctx, sto
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockAuthorizationModelBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds *openfgav1.TypeDefinitions) error {
+func (m *MockAuthorizationModelBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
 	ret0, _ := ret[0].(error)
@@ -1004,7 +1004,7 @@ func (mr *MockOpenFGADatastoreMockRecorder) WriteAssertions(ctx, store, modelID,
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockOpenFGADatastore) WriteAuthorizationModel(ctx context.Context, store, id string, tds *openfgav1.TypeDefinitions) error {
+func (m *MockOpenFGADatastore) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
 	ret0, _ := ret[0].(error)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -278,7 +278,7 @@ type TypeDefinitionWriteBackend interface {
 
 	// WriteAuthorizationModel writes an authorization model for the given store.
 	// It is expected that the number of type definitions is less than or equal to 24
-	WriteAuthorizationModel(ctx context.Context, store, id string, tds *openfgapb.TypeDefinitions) error
+	WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgapb.TypeDefinition) error
 }
 
 // AuthorizationModelBackend provides an R/W interface for managing type definition.

--- a/storage/test/authz_models.go
+++ b/storage/test/authz_models.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/storage"
+	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
@@ -20,32 +20,26 @@ func TestWriteAndReadAuthorizationModel(t *testing.T, datastore storage.OpenFGAD
 
 	store := testutils.CreateRandomString(10)
 	modelID, err := id.NewString()
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedModel := &openfgapb.TypeDefinitions{
-		TypeDefinitions: []*openfgapb.TypeDefinition{
-			{
-				Type: "folder",
-				Relations: map[string]*openfgapb.Userset{
-					"viewer": {
-						Userset: &openfgapb.Userset_This{
-							This: &openfgapb.DirectUserset{},
-						},
+	require.NoError(t, err)
+
+	expectedModel := []*openfgapb.TypeDefinition{
+		{
+			Type: "folder",
+			Relations: map[string]*openfgapb.Userset{
+				"viewer": {
+					Userset: &openfgapb.Userset_This{
+						This: &openfgapb.DirectUserset{},
 					},
 				},
 			},
 		},
 	}
 
-	if err := datastore.WriteAuthorizationModel(ctx, store, modelID, expectedModel); err != nil {
-		t.Errorf("failed to write authorization model: %v", err)
-	}
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, expectedModel)
+	require.NoError(t, err)
 
 	model, err := datastore.ReadAuthorizationModel(ctx, store, modelID)
-	if err != nil {
-		t.Errorf("failed to read authorization model: %v", err)
-	}
+	require.NoError(t, err)
 
 	cmpOpts := []cmp.Option{
 		cmpopts.IgnoreUnexported(
@@ -56,25 +50,21 @@ func TestWriteAndReadAuthorizationModel(t *testing.T, datastore storage.OpenFGAD
 		),
 	}
 
-	if diff := cmp.Diff(expectedModel.TypeDefinitions, model.TypeDefinitions, cmpOpts...); diff != "" {
+	if diff := cmp.Diff(expectedModel, model.TypeDefinitions, cmpOpts...); diff != "" {
 		t.Errorf("mismatch (-got +want):\n%s", diff)
 	}
 
 	_, err = datastore.ReadAuthorizationModel(ctx, "undefined", modelID)
-	if !errors.Is(err, storage.ErrNotFound) {
-		t.Errorf("got error '%v', want '%v'", err, storage.ErrNotFound)
-	}
+	require.ErrorIs(t, err, storage.ErrNotFound)
 }
 
 func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 
 	store := testutils.CreateRandomString(10)
 	modelID1, err := id.NewString()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tds1 := []*openfgapb.TypeDefinition{
 		{
 			Type: "folder",
@@ -87,15 +77,13 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 			},
 		},
 	}
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID1, &openfgapb.TypeDefinitions{TypeDefinitions: tds1})
-	if err != nil {
-		t.Fatalf("failed to write authorization model: %v", err)
-	}
+
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID1, tds1)
+	require.NoError(t, err)
 
 	modelID2, err := id.NewString()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	tds2 := []*openfgapb.TypeDefinition{
 		{
 			Type: "folder",
@@ -108,10 +96,9 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 			},
 		},
 	}
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID2, &openfgapb.TypeDefinitions{TypeDefinitions: tds2})
-	if err != nil {
-		t.Fatalf("failed to write authorization model: %v", err)
-	}
+
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID2, tds2)
+	require.NoError(t, err)
 
 	cmpOpts := []cmp.Option{
 		cmpopts.IgnoreUnexported(
@@ -125,132 +112,94 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 	models, continuationToken, err := datastore.ReadAuthorizationModels(ctx, store, storage.PaginationOptions{
 		PageSize: 1,
 	})
-	if err != nil {
-		t.Fatalf("expected no error but got '%v'", err)
-	}
-	if len(models) != 1 {
-		t.Fatalf("expected 1, got %d", len(models))
-	}
-	if modelID2 != models[0].Id {
-		t.Fatalf("expected '%s', got '%s", modelID2, models[0].Id)
-	}
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	require.Equal(t, modelID2, models[0].Id)
+	require.NotEmpty(t, continuationToken)
+
 	if diff := cmp.Diff(tds2, models[0].TypeDefinitions, cmpOpts...); diff != "" {
 		t.Fatalf("mismatch (-got +want):\n%s", diff)
-	}
-	if len(continuationToken) == 0 {
-		t.Fatalf("expected non-empty continuation token")
 	}
 
 	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store, storage.PaginationOptions{
 		PageSize: 2,
 		From:     string(continuationToken),
 	})
-	if err != nil {
-		t.Fatalf("expected no error but got '%v'", err)
-	}
-	if len(models) != 1 {
-		t.Fatalf("expected 1, got %d", len(models))
-	}
-	if modelID1 != models[0].Id {
-		t.Fatalf("expected '%s', got '%s", modelID1, models[0].Id)
-	}
+	require.NoError(t, err)
+	require.Len(t, models, 1)
+	require.Equal(t, modelID1, models[0].Id)
+	require.Empty(t, continuationToken)
+
 	if diff := cmp.Diff(tds1, models[0].TypeDefinitions, cmpOpts...); diff != "" {
 		t.Fatalf("mismatch (-got +want):\n%s", diff)
-	}
-	if len(continuationToken) != 0 {
-		t.Fatalf("expected empty continuation token but got '%v'", string(continuationToken))
 	}
 }
 
 func FindLatestAuthorizationModelIDTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 
 	t.Run("find latest authorization model should return not found when no models", func(t *testing.T) {
 		store := testutils.CreateRandomString(10)
 		_, err := datastore.FindLatestAuthorizationModelID(ctx, store)
-		if !errors.Is(err, storage.ErrNotFound) {
-			t.Errorf("got error '%v', want '%v'", err, storage.ErrNotFound)
-		}
+		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
 	t.Run("find latests authorization model should succeed", func(t *testing.T) {
 		store := testutils.CreateRandomString(10)
 		now := time.Now()
 		oldModelID, err := id.NewStringFromTime(now)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = datastore.WriteAuthorizationModel(ctx, store, oldModelID, &openfgapb.TypeDefinitions{
-			TypeDefinitions: []*openfgapb.TypeDefinition{
-				{
-					Type: "folder",
-					Relations: map[string]*openfgapb.Userset{
-						"viewer": {
-							Userset: &openfgapb.Userset_This{},
-						},
+		require.NoError(t, err)
+
+		err = datastore.WriteAuthorizationModel(ctx, store, oldModelID, []*openfgapb.TypeDefinition{
+			{
+				Type: "folder",
+				Relations: map[string]*openfgapb.Userset{
+					"viewer": {
+						Userset: &openfgapb.Userset_This{},
 					},
 				},
 			},
 		})
-		if err != nil {
-			t.Errorf("failed to write authorization model: %v", err)
-		}
+		require.NoError(t, err)
 
 		newModelID, err := id.NewStringFromTime(now)
-		if err != nil {
-			t.Fatal(err)
-		}
-		err = datastore.WriteAuthorizationModel(ctx, store, newModelID, &openfgapb.TypeDefinitions{
-			TypeDefinitions: []*openfgapb.TypeDefinition{
-				{
-					Type: "folder",
-					Relations: map[string]*openfgapb.Userset{
-						"reader": {
-							Userset: &openfgapb.Userset_This{},
-						},
+		require.NoError(t, err)
+
+		err = datastore.WriteAuthorizationModel(ctx, store, newModelID, []*openfgapb.TypeDefinition{
+			{
+				Type: "folder",
+				Relations: map[string]*openfgapb.Userset{
+					"reader": {
+						Userset: &openfgapb.Userset_This{},
 					},
 				},
 			},
 		})
-		if err != nil {
-			t.Errorf("failed to write authorization model: %v", err)
-		}
+		require.NoError(t, err)
 
 		latestID, err := datastore.FindLatestAuthorizationModelID(ctx, store)
-		if err != nil {
-			t.Errorf("failed to read latest authorization model: %v", err)
-		}
-
-		if latestID != newModelID {
-			t.Errorf("got '%s', want '%s'", latestID, newModelID)
-		}
+		require.NoError(t, err)
+		require.Equal(t, newModelID, latestID)
 	})
 }
 
 func ReadTypeDefinitionTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 
 	t.Run("read type definition of nonexistent type should return not found", func(t *testing.T) {
 		store := testutils.CreateRandomString(10)
 		modelID, err := id.NewString()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		_, err = datastore.ReadTypeDefinition(ctx, store, modelID, "folder")
-		if !errors.Is(err, storage.ErrNotFound) {
-			t.Errorf("got error '%v', want '%v'", err, storage.ErrNotFound)
-		}
+		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
 	t.Run("read type definition should succeed", func(t *testing.T) {
 		store := testutils.CreateRandomString(10)
 		modelID, err := id.NewString()
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
+
 		expectedTypeDef := &openfgapb.TypeDefinition{
 			Type: "folder",
 			Relations: map[string]*openfgapb.Userset{
@@ -262,19 +211,11 @@ func ReadTypeDefinitionTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 		}
 
-		err = datastore.WriteAuthorizationModel(ctx, store, modelID, &openfgapb.TypeDefinitions{
-			TypeDefinitions: []*openfgapb.TypeDefinition{
-				expectedTypeDef,
-			},
-		})
-		if err != nil {
-			t.Errorf("failed to write authorization model: %v", err)
-		}
+		err = datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{expectedTypeDef})
+		require.NoError(t, err)
 
 		typeDef, err := datastore.ReadTypeDefinition(ctx, store, modelID, "folder")
-		if err != nil {
-			t.Errorf("expected no error but got '%v'", err)
-		}
+		require.NoError(t, err)
 
 		cmpOpts := []cmp.Option{
 			cmpopts.IgnoreUnexported(


### PR DESCRIPTION
<!-- Thanks for opening a PR!  Here are some quick tips for you:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Please provide a detailed description of the changes here -->

Refactor `WriteAuthorizationModel` to take an array of `*openfgapb.TypeDefinition`s rather than an `*openfgapb.TypeDefinitions`. Currently every implementation starts off by extracting the underlying `*openfgapb.TypeDefinition` array from `*openfgapb.TypeDefinitions` so why not just make it explicit in the function.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
