### PR TITLE
fix: log internal errors at the grpc layer

### DIFF
--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -315,6 +315,7 @@ func BuildService(config *Config, logger logger.Logger) (*service, error) {
 
 	interceptors := []grpc.UnaryServerInterceptor{
 		grpc_auth.UnaryServerInterceptor(middleware.AuthFunc(authenticator)),
+		middleware.NewErrorLoggingInterceptor(logger),
 	}
 
 	openFgaServer, err := server.New(&server.Dependencies{

--- a/server/middleware/logging.go
+++ b/server/middleware/logging.go
@@ -1,0 +1,27 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/openfga/openfga/pkg/logger"
+	serverErrors "github.com/openfga/openfga/server/errors"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+func NewErrorLoggingInterceptor(logger logger.Logger) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		resp, err := handler(ctx, req)
+		if err != nil {
+			var e error
+			if internalError, ok := err.(serverErrors.InternalError); ok {
+				e = internalError.Internal()
+			}
+			logger.Error("grpc_error", zap.Error(e), zap.String("public_error", err.Error()))
+
+			return nil, err
+		}
+
+		return resp, nil
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -136,10 +136,6 @@ func New(dependencies *Dependencies, config *Config) (*Server, error) {
 		defaultServeMuxOpts: []runtime.ServeMuxOption{
 			runtime.WithForwardResponseOption(httpmiddleware.HTTPResponseModifier),
 			runtime.WithErrorHandler(func(c context.Context, sr *runtime.ServeMux, mm runtime.Marshaler, w http.ResponseWriter, r *http.Request, e error) {
-				if internalError, ok := e.(serverErrors.InternalError); ok {
-					e = internalError.Internal()
-				}
-				dependencies.Logger.ErrorWithContext(c, "grpc_error", logger.Error(e), logger.String("request_url", r.URL.String()))
 				actualCode := serverErrors.ConvertToEncodedErrorCode(status.Convert(e))
 				httpmiddleware.CustomHTTPErrorHandler(c, w, r, serverErrors.NewEncodedError(actualCode, e.Error()))
 			}),

--- a/storage/postgres/utils.go
+++ b/storage/postgres/utils.go
@@ -203,5 +203,6 @@ func handlePostgresError(err error, args ...interface{}) error {
 		}
 		return openfgaerrors.ErrorWithStack(storage.ErrCollision)
 	}
-	return openfgaerrors.ErrorWithStack(err)
+
+	return errors.WrapPrefix(err, "postgres error", 0)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Previously we were trying to log internal errors at the HTTP layer, but at this point the error had already been converted to a status type error and the internal error had been lost. So, in this PR, we move this logging to the gRPC layer.

Another benefit of this change is that if you are using the gRPC endpoint you will actually generate this log, whereas previously you would not have.






## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
