### PR TITLE
refactor: add start-postgres-container to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,11 +37,11 @@ start-postgres-container:
 .PHONY: migrate-postgres
 migrate-postgres: build
 	# nosemgrep: detected-username-and-password-in-uri
-	./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres?sslmode=disable'
+	./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres'
 
 .PHONY: run-postgres
 run-postgres: build
-	./openfga run --datastore-engine postgres --datastore-uri postgres://postgres:password@localhost:5432/postgres?sslmode=disable
+	./openfga run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres'
 
 .PHONY: go-generate
 go-generate: install-tools

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ run: build ## Run the OpenFGA server with in-memory storage
 .PHONY: start-postgres-container
 start-postgres-container:
 	docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14
+	@echo \> use \'postgres://postgres:password@localhost:5432/postgres\' to connect to postgres
 
 .PHONY: migrate-postgres
 migrate-postgres: build

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ build: ## Build/compile the OpenFGA service
 run: build ## Run the OpenFGA server with in-memory storage
 	./openfga run
 
+
+.PHONY: start-postgres-container
+start-postgres-container:
+	docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14
+
 .PHONY: migrate-postgres
 migrate-postgres: build
 	# nosemgrep: detected-username-and-password-in-uri
@@ -65,8 +70,3 @@ functional-test:
 .PHONY: bench
 bench: go-generate
 	go test ./... -bench=. -run=XXX -benchmem
-
-.PHONY: initialize-db
-initialize-db: go-generate
-    #TODO wait for docker postgres container to be healthy
-	go clean -testcache; $(test_backend) go test ./storage/postgres -run TestReadTypeDefinition; \


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Now that we are adding [other storage engines](https://github.com/openfga/openfga/pull/210), I think it would be useful to have commands in the Makefile that help with the local development of OpenFGA for these engines. Previously to start Postgres we could rely on the docker-compose file, but I don't suppose this will be the case with MySQL. So to keep things consistent, this PR adds a `start-postgres-container` command to the Makefile which can be used with the `migrate-postgres` and `run-postgres` commands. I envision we will have similar commands for MySQL.



## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
