### PR TITLE
fix: skip malformed tuples involving tuple to userset definitions

### DIFF
--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -425,11 +425,12 @@ func (query *CheckQuery) resolveTupleToUserset(ctx context.Context, rc *resoluti
 			break // the user was resolved already, avoid launching extra lookups
 		}
 
-		if !tupleUtils.IsValidObject(tuple.GetUser()) && !tupleUtils.IsObjectRelation(tuple.GetUser()) {
+		userObj, userRel := tupleUtils.SplitObjectRelation(tuple.GetUser())
+
+		if !tupleUtils.IsValidObject(userObj) {
 			continue // TupleToUserset tuplesets should be of the form 'objectType:id' or 'objectType:id#relation' but are not guaranteed to be because it is neither a user or userset
 		}
 
-		userObj, userRel := tupleUtils.SplitObjectRelation(tuple.GetUser())
 		usersetRel := node.TupleToUserset.GetComputedUserset().GetRelation()
 
 		// userRel may be empty, and in this case we set it to usersetRel.

--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -425,6 +425,10 @@ func (query *CheckQuery) resolveTupleToUserset(ctx context.Context, rc *resoluti
 			break // the user was resolved already, avoid launching extra lookups
 		}
 
+		if !tupleUtils.IsValidObject(tuple.GetUser()) && !tupleUtils.IsObjectRelation(tuple.GetUser()) {
+			continue // TupleToUserset tuplesets should be of the form 'objectType:id' or 'objectType:id#relation' but are not guaranteed to be because it is neither a user or userset
+		}
+
 		userObj, userRel := tupleUtils.SplitObjectRelation(tuple.GetUser())
 		usersetRel := node.TupleToUserset.GetComputedUserset().GetRelation()
 

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1252,10 +1252,72 @@ var checkQueryTests = []checkQueryTest{
 		},
 	},
 	{
+		name:             "CheckUsersetAsUser_WithContextualTuples",
+		resolveNodeLimit: defaultResolveNodeLimit,
+		request: &openfgapb.CheckRequest{
+			TupleKey: tuple.NewTupleKey("team:iam", "member", "org:openfga#member"),
+			ContextualTuples: &openfgapb.ContextualTupleKeys{
+				TupleKeys: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("team:iam", "member", "team:engineering#member"),
+					tuple.NewTupleKey("team:engineering", "member", "org:openfga#member"),
+				},
+			},
+		},
+		typeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "team",
+				Relations: map[string]*openfgapb.Userset{
+					"member": {Userset: &openfgapb.Userset_This{}},
+				},
+			},
+			{
+				Type: "org",
+				Relations: map[string]*openfgapb.Userset{
+					"member": {Userset: &openfgapb.Userset_This{}},
+				},
+			},
+		},
+		tuples: []*openfgapb.TupleKey{},
+		response: &openfgapb.CheckResponse{
+			Allowed: true,
+		},
+	},
+	{
+		name:             "CheckUsersetAsUser_WithContextualTuples",
+		resolveNodeLimit: defaultResolveNodeLimit,
+		request: &openfgapb.CheckRequest{
+			TupleKey: tuple.NewTupleKey("team:iam", "member", "org:openfga#member"),
+			ContextualTuples: &openfgapb.ContextualTupleKeys{
+				TupleKeys: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("team:iam", "member", "team:engineering#member"),
+					tuple.NewTupleKey("team:engineering", "member", "org:openfga#member"),
+				},
+			},
+		},
+		typeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "team",
+				Relations: map[string]*openfgapb.Userset{
+					"member": {Userset: &openfgapb.Userset_This{}},
+				},
+			},
+			{
+				Type: "org",
+				Relations: map[string]*openfgapb.Userset{
+					"member": {Userset: &openfgapb.Userset_This{}},
+				},
+			},
+		},
+		tuples: []*openfgapb.TupleKey{},
+		response: &openfgapb.CheckResponse{
+			Allowed: true,
+		},
+	},
+	{
 		name:             "Check with TupleToUserset involving no object or userset",
 		resolveNodeLimit: defaultResolveNodeLimit,
 		request: &openfgapb.CheckRequest{
-			TupleKey: tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+			TupleKey: tuple.NewTupleKey("document:doc1", "viewer", "anne"),
 		},
 		typeDefinitions: []*openfgapb.TypeDefinition{
 			{
@@ -1285,9 +1347,51 @@ var checkQueryTests = []checkQueryTest{
 		},
 		tuples: []*openfgapb.TupleKey{
 			tuple.NewTupleKey("document:doc1", "parent", "folder1"), // folder1 isn't an object or userset
+			tuple.NewTupleKey("folder:folder1", "viewer", "anne"),
 		},
 		response: &openfgapb.CheckResponse{
 			Allowed: false,
+		},
+	},
+	{
+		name:             "TupleToUserset Check Passes when at least one tupleset relation resolves",
+		resolveNodeLimit: defaultResolveNodeLimit,
+		request: &openfgapb.CheckRequest{
+			TupleKey: tuple.NewTupleKey("document:doc1", "viewer", "anne"),
+		},
+		typeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "document",
+				Relations: map[string]*openfgapb.Userset{
+					"parent": {
+						Userset: &openfgapb.Userset_This{},
+					},
+					"viewer": {
+						Userset: &openfgapb.Userset_TupleToUserset{
+							TupleToUserset: &openfgapb.TupleToUserset{
+								Tupleset:        &openfgapb.ObjectRelation{Relation: "parent"},
+								ComputedUserset: &openfgapb.ObjectRelation{Relation: "viewer"},
+							},
+						},
+					},
+				},
+			},
+			{
+				Type: "folder",
+				Relations: map[string]*openfgapb.Userset{
+					"viewer": {
+						Userset: &openfgapb.Userset_This{},
+					},
+				},
+			},
+		},
+		tuples: []*openfgapb.TupleKey{
+			tuple.NewTupleKey("document:doc1", "parent", "folder1"), // folder1 isn't an object or userset
+			tuple.NewTupleKey("document:doc1", "parent", "folder:folder1"),
+			tuple.NewTupleKey("folder:folder1", "viewer", "anne"),
+		},
+		response: &openfgapb.CheckResponse{
+			Allowed: true,
 		},
 	},
 }

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1251,6 +1251,45 @@ var checkQueryTests = []checkQueryTest{
 			Allowed: true,
 		},
 	},
+	{
+		name:             "Check with TupleToUserset involving no object or userset",
+		resolveNodeLimit: defaultResolveNodeLimit,
+		request: &openfgapb.CheckRequest{
+			TupleKey: tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+		},
+		typeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "document",
+				Relations: map[string]*openfgapb.Userset{
+					"parent": {
+						Userset: &openfgapb.Userset_This{},
+					},
+					"viewer": {
+						Userset: &openfgapb.Userset_TupleToUserset{
+							TupleToUserset: &openfgapb.TupleToUserset{
+								Tupleset:        &openfgapb.ObjectRelation{Relation: "parent"},
+								ComputedUserset: &openfgapb.ObjectRelation{Relation: "viewer"},
+							},
+						},
+					},
+				},
+			},
+			{
+				Type: "folder",
+				Relations: map[string]*openfgapb.Userset{
+					"viewer": {
+						Userset: &openfgapb.Userset_This{},
+					},
+				},
+			},
+		},
+		tuples: []*openfgapb.TupleKey{
+			tuple.NewTupleKey("document:doc1", "parent", "folder1"), // folder1 isn't an object or userset
+		},
+		response: &openfgapb.CheckResponse{
+			Allowed: false,
+		},
+	},
 }
 
 func TestCheckQuery(t *testing.T, datastore storage.OpenFGADatastore) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes the bug reported in https://discord.com/channels/759188666072825867/920359187949707305/1019251304251523112

## References
(https://discord.com/channels/759188666072825867/920359187949707305/1019251304251523112)

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
