### PR TITLE
chore: store the schema version

### DIFF
--- a/assets/migrations/postgres/002_add_authorization_model_version.sql
+++ b/assets/migrations/postgres/002_add_authorization_model_version.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-ALTER TABLE authorization_model ADD COLUMN schema_version INT DEFAULT 1;
+ALTER TABLE authorization_model ADD COLUMN schema_version INT NOT NULL DEFAULT 1;
 
 -- +goose Down
 ALTER TABLE authorization_model DROP COLUMN schema_version;

--- a/assets/migrations/postgres/002_add_authorization_model_version.sql
+++ b/assets/migrations/postgres/002_add_authorization_model_version.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE authorization_model ADD COLUMN version INT DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE authorization_model DROP COLUMN version;

--- a/assets/migrations/postgres/002_add_authorization_model_version.sql
+++ b/assets/migrations/postgres/002_add_authorization_model_version.sql
@@ -1,5 +1,5 @@
 -- +goose Up
-ALTER TABLE authorization_model ADD COLUMN version INT DEFAULT 1;
+ALTER TABLE authorization_model ADD COLUMN schema_version INT DEFAULT 1;
 
 -- +goose Down
-ALTER TABLE authorization_model DROP COLUMN version;
+ALTER TABLE authorization_model DROP COLUMN schema_version;

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -7,7 +7,7 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-type SchemaVersion int
+type SchemaVersion int32
 
 const (
 	SchemaVersionUnspecified SchemaVersion = 0

--- a/server/commands/write_authzmodel.go
+++ b/server/commands/write_authzmodel.go
@@ -35,12 +35,12 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 		return nil, serverErrors.ExceededEntityLimit("type definitions in an authorization model", w.backend.MaxTypesInTypeDefinition())
 	}
 
-	schemaVersion, err := typesystem.NewSchemaVersion(req.GetSchemaVersion())
+	version, err := typesystem.NewSchemaVersion(req.GetSchemaVersion())
 	if err != nil {
 		return nil, serverErrors.UnsupportedSchemaVersion
 	}
 
-	typeSystem := typesystem.NewTypeSystem(schemaVersion, req.GetTypeDefinitions())
+	typeSystem := typesystem.NewTypeSystem(version, req.GetTypeDefinitions())
 	if len(typeSystem.TypeDefinitions) != len(req.GetTypeDefinitions()) {
 		return nil, serverErrors.CannotAllowDuplicateTypesInOneRequest
 	}
@@ -55,7 +55,7 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 	}
 
 	utils.LogDBStats(ctx, w.logger, "WriteAuthzModel", 0, 1)
-	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, typeSystem.GetTypeDefinitions()); err != nil {
+	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, version, typeSystem.GetTypeDefinitions()); err != nil {
 		return nil, serverErrors.NewInternalError("Error writing authorization model configuration", err)
 	}
 

--- a/server/commands/write_authzmodel.go
+++ b/server/commands/write_authzmodel.go
@@ -35,12 +35,12 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 		return nil, serverErrors.ExceededEntityLimit("type definitions in an authorization model", w.backend.MaxTypesInTypeDefinition())
 	}
 
-	version, err := typesystem.NewSchemaVersion(req.GetSchemaVersion())
+	schemaVersion, err := typesystem.NewSchemaVersion(req.GetSchemaVersion())
 	if err != nil {
 		return nil, serverErrors.UnsupportedSchemaVersion
 	}
 
-	typeSystem := typesystem.NewTypeSystem(version, req.GetTypeDefinitions())
+	typeSystem := typesystem.NewTypeSystem(schemaVersion, req.GetTypeDefinitions())
 	if len(typeSystem.TypeDefinitions) != len(req.GetTypeDefinitions()) {
 		return nil, serverErrors.CannotAllowDuplicateTypesInOneRequest
 	}
@@ -55,7 +55,7 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 	}
 
 	utils.LogDBStats(ctx, w.logger, "WriteAuthzModel", 0, 1)
-	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, version, typeSystem.GetTypeDefinitions()); err != nil {
+	if err := w.backend.WriteAuthorizationModel(ctx, req.GetStoreId(), id, schemaVersion, typeSystem.GetTypeDefinitions()); err != nil {
 		return nil, serverErrors.NewInternalError("Error writing authorization model configuration", err)
 	}
 

--- a/server/test/expand.go
+++ b/server/test/expand.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -21,7 +22,7 @@ import (
 func setUp(ctx context.Context, store string, datastore storage.OpenFGADatastore, typeDefinitions []*openfgapb.TypeDefinition, tuples []*openfgapb.TupleKey) (string, error) {
 	modelID := id.Must(id.New()).String()
 
-	if err := datastore.WriteAuthorizationModel(ctx, store, modelID, typeDefinitions); err != nil {
+	if err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, typeDefinitions); err != nil {
 		return "", err
 	}
 

--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -219,7 +220,7 @@ func setupTestListObjects(store string, datastore storage.OpenFGADatastore) (con
 	}
 
 	modelID := id.Must(id.New()).String()
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, gitHubTypeDefinitions.GetTypeDefinitions())
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, gitHubTypeDefinitions.GetTypeDefinitions())
 	if err != nil {
 		return nil, nil, "", err
 	}

--- a/server/test/read.go
+++ b/server/test/read.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -553,7 +554,7 @@ func TestReadQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 			store := id.Must(id.New()).String()
 			modelID := id.Must(id.New()).String()
 
-			err := datastore.WriteAuthorizationModel(ctx, store, modelID, test.typeDefinitions)
+			err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, test.typeDefinitions)
 			require.NoError(err)
 
 			if test.tuples != nil {

--- a/server/test/read_authzmodel.go
+++ b/server/test/read_authzmodel.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -64,7 +65,7 @@ func TestReadAuthorizationModelByIDAndOneTypeDefinitionReturnsAuthorizationModel
 	store := id.Must(id.New()).String()
 	modelID := id.Must(id.New()).String()
 
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID, state)
+	err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, state)
 	require.NoError(err)
 
 	query := commands.NewReadAuthorizationModelQuery(datastore, logger)
@@ -86,7 +87,7 @@ func TestReadAuthorizationModelByIDAndTypeDefinitionsReturnsError(t *testing.T, 
 	store := id.Must(id.New()).String()
 	modelID := id.Must(id.New()).String()
 
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{})
+	err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, []*openfgapb.TypeDefinition{})
 	require.NoError(err)
 
 	query := commands.NewReadAuthorizationModelQuery(datastore, logger)

--- a/server/test/read_authzmodel.go
+++ b/server/test/read_authzmodel.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/openfga/openfga/pkg/id"
@@ -14,6 +13,84 @@ import (
 	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
+
+func TestSuccessfulReadAuthorizationModelQuery(t *testing.T, datastore storage.OpenFGADatastore) {
+	var tests = []struct {
+		name            string
+		storeID         string
+		modelID         string
+		schemaVersion   typesystem.SchemaVersion
+		typeDefinitions []*openfgapb.TypeDefinition
+	}{
+		{
+			name:          "write and read a 1.0 model",
+			storeID:       id.Must(id.New()).String(),
+			modelID:       id.Must(id.New()).String(),
+			schemaVersion: typesystem.SchemaVersion1_0,
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "user",
+				},
+				{
+					Type: "document",
+					Relations: map[string]*openfgapb.Userset{
+						"reader": {
+							Userset: &openfgapb.Userset_This{},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "write and read an empty 1.1 model",
+			storeID:       id.Must(id.New()).String(),
+			modelID:       id.Must(id.New()).String(),
+			schemaVersion: typesystem.SchemaVersion1_1,
+			typeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "user",
+				},
+				{
+					Type: "document",
+					Relations: map[string]*openfgapb.Userset{
+						"reader": {
+							Userset: &openfgapb.Userset_This{},
+						},
+					},
+					Metadata: &openfgapb.Metadata{
+						Relations: map[string]*openfgapb.RelationMetadata{
+							"reader": {
+								DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+									{
+										Type: "user",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+	logger := logger.NewNoopLogger()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := datastore.WriteAuthorizationModel(ctx, test.storeID, test.modelID, test.schemaVersion, test.typeDefinitions)
+			require.NoError(t, err)
+
+			resp, err := commands.NewReadAuthorizationModelQuery(datastore, logger).Execute(ctx, &openfgapb.ReadAuthorizationModelRequest{
+				StoreId: test.storeID,
+				Id:      test.modelID,
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.modelID, resp.GetAuthorizationModel().GetId())
+			require.Equal(t, test.schemaVersion.String(), resp.GetAuthorizationModel().GetSchemaVersion())
+		})
+	}
+}
 
 func TestReadAuthorizationModelQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 	type readAuthorizationModelQueryTest struct {
@@ -37,46 +114,11 @@ func TestReadAuthorizationModelQueryErrors(t *testing.T, datastore storage.OpenF
 	logger := logger.NewNoopLogger()
 
 	for _, test := range tests {
-		query := commands.NewReadAuthorizationModelQuery(datastore, logger)
-		if _, err := query.Execute(ctx, test.request); !errors.Is(test.expectedError, err) {
-			t.Errorf("[%s] Expected error '%s', actual '%s'", test._name, test.expectedError, err)
-			continue
-		}
+		t.Run(test._name, func(t *testing.T) {
+			_, err := commands.NewReadAuthorizationModelQuery(datastore, logger).Execute(ctx, test.request)
+			require.ErrorIs(t, err, test.expectedError)
+		})
 	}
-}
-
-func TestReadAuthorizationModelByIDAndOneTypeDefinitionReturnsAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastore) {
-
-	require := require.New(t)
-	ctx := context.Background()
-	logger := logger.NewNoopLogger()
-
-	state := []*openfgapb.TypeDefinition{
-		{
-			Type: "repo",
-			Relations: map[string]*openfgapb.Userset{
-				"viewer": {
-					Userset: &openfgapb.Userset_This{},
-				},
-			},
-		},
-	}
-
-	store := id.Must(id.New()).String()
-	modelID := id.Must(id.New()).String()
-
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, state)
-	require.NoError(err)
-
-	query := commands.NewReadAuthorizationModelQuery(datastore, logger)
-	actualResponse, actualError := query.Execute(ctx, &openfgapb.ReadAuthorizationModelRequest{
-		StoreId: store,
-		Id:      modelID,
-	})
-
-	require.NotNil(actualResponse)
-	require.Equal(actualResponse.AuthorizationModel.Id, modelID)
-	require.Nil(actualError)
 }
 
 func TestReadAuthorizationModelByIDAndTypeDefinitionsReturnsError(t *testing.T, datastore storage.OpenFGADatastore) {

--- a/server/test/read_authzmodel.go
+++ b/server/test/read_authzmodel.go
@@ -42,7 +42,7 @@ func TestSuccessfulReadAuthorizationModelQuery(t *testing.T, datastore storage.O
 			},
 		},
 		{
-			name:          "write and read an empty 1.1 model",
+			name:          "write and read an 1.1 model",
 			storeID:       id.Must(id.New()).String(),
 			modelID:       id.Must(id.New()).String(),
 			schemaVersion: typesystem.SchemaVersion1_1,

--- a/server/test/read_tuples.go
+++ b/server/test/read_tuples.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -29,7 +30,7 @@ func TestReadTuplesQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 
 	tds := []*openfgapb.TypeDefinition{{Type: "repo"}}
 
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID, tds)
+	err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, tds)
 	require.NoError(err)
 
 	writes := []*openfgapb.TupleKey{
@@ -107,7 +108,7 @@ func TestReadTuplesQueryInvalidContinuationToken(t *testing.T, datastore storage
 	store := testutils.CreateRandomString(10)
 	modelID := id.Must(id.New()).String()
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{{Type: "repo"}})
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, []*openfgapb.TypeDefinition{{Type: "repo"}})
 	require.NoError(err)
 
 	q := commands.NewReadTuplesQuery(datastore, logger, encoder)

--- a/server/test/server.go
+++ b/server/test/server.go
@@ -14,11 +14,7 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestCheckQuery", func(t *testing.T) { TestCheckQuery(t, ds) })
 	t.Run("TestReadAuthorizationModelQueryErrors", func(t *testing.T) { TestReadAuthorizationModelQueryErrors(t, ds) })
-	t.Run("TestReadAuthorizationModelByIDAndOneTypeDefinitionReturnsAuthorizationModel",
-		func(t *testing.T) {
-			TestReadAuthorizationModelByIDAndOneTypeDefinitionReturnsAuthorizationModel(t, ds)
-		},
-	)
+	t.Run("TestSuccessfulReadAuthorizationModelQuery", func(t *testing.T) { TestSuccessfulReadAuthorizationModelQuery(t, ds) })
 	t.Run("TestReadAuthorizationModelByIDAndTypeDefinitionsReturnsError",
 		func(t *testing.T) {
 			TestReadAuthorizationModelByIDAndTypeDefinitionsReturnsError(t, ds)

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
@@ -746,7 +747,7 @@ func TestWriteCommand(t *testing.T, datastore storage.OpenFGADatastore) {
 			modelID := id.Must(id.New()).String()
 
 			if test.typeDefinitions != nil {
-				err := datastore.WriteAuthorizationModel(ctx, store, modelID, test.typeDefinitions)
+				err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, test.typeDefinitions)
 				require.NoError(err)
 			}
 

--- a/server/test/write_authzmodel.go
+++ b/server/test/write_authzmodel.go
@@ -15,6 +15,7 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
+// TODO: update these to SchemaVersion1_1 models
 func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastore) {
 	storeID, err := id.NewString()
 	require.NoError(t, err)

--- a/server/test/write_authzmodel.go
+++ b/server/test/write_authzmodel.go
@@ -15,7 +15,6 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-// TODO: update these to SchemaVersion1_1 models
 func TestWriteAuthorizationModel(t *testing.T, datastore storage.OpenFGADatastore) {
 	storeID, err := id.NewString()
 	require.NoError(t, err)

--- a/storage/caching/caching_test.go
+++ b/storage/caching/caching_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/openfga/openfga/pkg/id"
+	"github.com/openfga/openfga/pkg/telemetry"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/storage/memory"
 	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
-	"go.opentelemetry.io/otel"
 )
 
 const store = "openfga"
@@ -42,11 +43,11 @@ var readTypeDefinitionTests = []readTypeDefinitionTest{
 func TestReadTypeDefinition(t *testing.T) {
 	for _, test := range readTypeDefinitionTests {
 		ctx := context.Background()
-		memoryBackend := memory.New(otel.Tracer("noop"), 10000, 10000)
+		memoryBackend := memory.New(telemetry.NewNoopTracer(), 10000, 10000)
 		cachingBackend := NewCachedOpenFGADatastore(memoryBackend, 5)
 
 		modelID := id.Must(id.New()).String()
-		err := memoryBackend.WriteAuthorizationModel(ctx, store, modelID, test.dbState)
+		err := memoryBackend.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, test.dbState)
 		require.NoError(t, err)
 
 		td, actualError := cachingBackend.ReadTypeDefinition(ctx, test.store, modelID, test.name)

--- a/storage/mocks/mock_storage.go
+++ b/storage/mocks/mock_storage.go
@@ -10,6 +10,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+	typesystem "github.com/openfga/openfga/pkg/typesystem"
 	storage "github.com/openfga/openfga/storage"
 	openfgav1 "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
@@ -352,17 +353,17 @@ func (mr *MockTypeDefinitionWriteBackendMockRecorder) MaxTypesInTypeDefinition()
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockTypeDefinitionWriteBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
+func (m *MockTypeDefinitionWriteBackend) WriteAuthorizationModel(ctx context.Context, store, id string, schemaVersion typesystem.SchemaVersion, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
+	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, schemaVersion, tds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteAuthorizationModel indicates an expected call of WriteAuthorizationModel.
-func (mr *MockTypeDefinitionWriteBackendMockRecorder) WriteAuthorizationModel(ctx, store, id, tds interface{}) *gomock.Call {
+func (mr *MockTypeDefinitionWriteBackendMockRecorder) WriteAuthorizationModel(ctx, store, id, schemaVersion, tds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockTypeDefinitionWriteBackend)(nil).WriteAuthorizationModel), ctx, store, id, tds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockTypeDefinitionWriteBackend)(nil).WriteAuthorizationModel), ctx, store, id, schemaVersion, tds)
 }
 
 // MockAuthorizationModelBackend is a mock of AuthorizationModelBackend interface.
@@ -464,17 +465,17 @@ func (mr *MockAuthorizationModelBackendMockRecorder) ReadTypeDefinition(ctx, sto
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockAuthorizationModelBackend) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
+func (m *MockAuthorizationModelBackend) WriteAuthorizationModel(ctx context.Context, store, id string, schemaVersion typesystem.SchemaVersion, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
+	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, schemaVersion, tds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteAuthorizationModel indicates an expected call of WriteAuthorizationModel.
-func (mr *MockAuthorizationModelBackendMockRecorder) WriteAuthorizationModel(ctx, store, id, tds interface{}) *gomock.Call {
+func (mr *MockAuthorizationModelBackendMockRecorder) WriteAuthorizationModel(ctx, store, id, schemaVersion, tds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockAuthorizationModelBackend)(nil).WriteAuthorizationModel), ctx, store, id, tds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockAuthorizationModelBackend)(nil).WriteAuthorizationModel), ctx, store, id, schemaVersion, tds)
 }
 
 // MockStoresBackend is a mock of StoresBackend interface.
@@ -1004,15 +1005,15 @@ func (mr *MockOpenFGADatastoreMockRecorder) WriteAssertions(ctx, store, modelID,
 }
 
 // WriteAuthorizationModel mocks base method.
-func (m *MockOpenFGADatastore) WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgav1.TypeDefinition) error {
+func (m *MockOpenFGADatastore) WriteAuthorizationModel(ctx context.Context, store, id string, schemaVersion typesystem.SchemaVersion, tds []*openfgav1.TypeDefinition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, tds)
+	ret := m.ctrl.Call(m, "WriteAuthorizationModel", ctx, store, id, schemaVersion, tds)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteAuthorizationModel indicates an expected call of WriteAuthorizationModel.
-func (mr *MockOpenFGADatastoreMockRecorder) WriteAuthorizationModel(ctx, store, id, tds interface{}) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) WriteAuthorizationModel(ctx, store, id, schemaVersion, tds interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockOpenFGADatastore)(nil).WriteAuthorizationModel), ctx, store, id, tds)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAuthorizationModel", reflect.TypeOf((*MockOpenFGADatastore)(nil).WriteAuthorizationModel), ctx, store, id, schemaVersion, tds)
 }

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -326,8 +326,8 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 		return nil, storage.ErrNotFound
 	}
 
-	// Update the schema version lazily
-	if version == typesystem.SchemaVersionUnspecified {
+	// Update the schema version lazily if it is not a valid typesystem.SchemaVersion.
+	if version != typesystem.SchemaVersion1_0 && version != typesystem.SchemaVersion1_1 {
 		version = typesystem.SchemaVersion1_0
 		_, err = p.pool.Exec(ctx, "UPDATE authorization_model SET schema_version = $1 WHERE store = $2 AND authorization_model_id = $3", version, store, modelID)
 		if err != nil {

--- a/storage/postgres/postgres_test.go
+++ b/storage/postgres/postgres_test.go
@@ -1,20 +1,46 @@
-package postgres_test
+package postgres
 
 import (
+	"context"
 	"testing"
 
 	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
-	"github.com/openfga/openfga/storage/postgres"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/storage/test"
 	"github.com/stretchr/testify/require"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPostgresDatastore(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
 	uri := testDatastore.GetConnectionURI()
-	ds, err := postgres.NewPostgresDatastore(uri)
+	ds, err := NewPostgresDatastore(uri)
 	require.NoError(t, err)
 
 	test.RunAllTests(t, ds)
+}
+
+func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI()
+	ds, err := NewPostgresDatastore(uri)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	store := "store"
+	modelID := "foo"
+	schemaVersion := 4 // which is not an enum value... yet.
+
+	bytes, err := proto.Marshal(&openfgapb.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+
+	_, err = ds.pool.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition) VALUES ($1, $2, $3, $4, $5)", store, modelID, schemaVersion, "document", bytes)
+	require.NoError(t, err)
+
+	model, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+	require.NoError(t, err)
+	require.Equal(t, typesystem.SchemaVersion1_0.String(), model.SchemaVersion)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
@@ -278,7 +279,7 @@ type TypeDefinitionWriteBackend interface {
 
 	// WriteAuthorizationModel writes an authorization model for the given store.
 	// It is expected that the number of type definitions is less than or equal to 24
-	WriteAuthorizationModel(ctx context.Context, store, id string, tds []*openfgapb.TypeDefinition) error
+	WriteAuthorizationModel(ctx context.Context, store, id string, schemaVersion typesystem.SchemaVersion, tds []*openfgapb.TypeDefinition) error
 }
 
 // AuthorizationModelBackend provides an R/W interface for managing type definition.

--- a/storage/test/authz_models.go
+++ b/storage/test/authz_models.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/storage"
 	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
@@ -33,7 +34,7 @@ func TestWriteAndReadAuthorizationModel(t *testing.T, datastore storage.OpenFGAD
 		},
 	}
 
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID, expectedModel)
+	err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, expectedModel)
 	require.NoError(t, err)
 
 	model, err := datastore.ReadAuthorizationModel(ctx, store, modelID)
@@ -74,7 +75,7 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 		},
 	}
 
-	err := datastore.WriteAuthorizationModel(ctx, store, modelID1, tds1)
+	err := datastore.WriteAuthorizationModel(ctx, store, modelID1, typesystem.SchemaVersion1_0, tds1)
 	require.NoError(t, err)
 
 	modelID2 := id.Must(id.New()).String()
@@ -91,7 +92,7 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 		},
 	}
 
-	err = datastore.WriteAuthorizationModel(ctx, store, modelID2, tds2)
+	err = datastore.WriteAuthorizationModel(ctx, store, modelID2, typesystem.SchemaVersion1_0, tds2)
 	require.NoError(t, err)
 
 	cmpOpts := []cmp.Option{
@@ -143,7 +144,7 @@ func FindLatestAuthorizationModelIDTest(t *testing.T, datastore storage.OpenFGAD
 		now := time.Now()
 
 		oldModelID := id.Must(id.NewFromTime(now)).String()
-		err := datastore.WriteAuthorizationModel(ctx, store, oldModelID, []*openfgapb.TypeDefinition{
+		err := datastore.WriteAuthorizationModel(ctx, store, oldModelID, typesystem.SchemaVersion1_0, []*openfgapb.TypeDefinition{
 			{
 				Type: "folder",
 				Relations: map[string]*openfgapb.Userset{
@@ -156,7 +157,7 @@ func FindLatestAuthorizationModelIDTest(t *testing.T, datastore storage.OpenFGAD
 		require.NoError(t, err)
 
 		newModelID := id.Must(id.NewFromTime(now)).String()
-		err = datastore.WriteAuthorizationModel(ctx, store, newModelID, []*openfgapb.TypeDefinition{
+		err = datastore.WriteAuthorizationModel(ctx, store, newModelID, typesystem.SchemaVersion1_0, []*openfgapb.TypeDefinition{
 			{
 				Type: "folder",
 				Relations: map[string]*openfgapb.Userset{
@@ -199,7 +200,7 @@ func ReadTypeDefinitionTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 		}
 
-		err := datastore.WriteAuthorizationModel(ctx, store, modelID, []*openfgapb.TypeDefinition{expectedTypeDef})
+		err := datastore.WriteAuthorizationModel(ctx, store, modelID, typesystem.SchemaVersion1_0, []*openfgapb.TypeDefinition{expectedTypeDef})
 		require.NoError(t, err)
 
 		typeDef, err := datastore.ReadTypeDefinition(ctx, store, modelID, "folder")


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Store the schema version in our datastore.

One thing I don't like there is that our signatures have grown a bit unwieldy. Do we prefer to combine the `version SchemaVersion, typeDefinitions []*openfgapb.TypeDefinition` into a `typeSystem *typesystem.Typesystem`. There is a bit of subtlety here as a `TypeSystem` contains a `map[string]*openfgapb.TypeDefinition` rather than an `[]*openfgapb.TypeDefinition`.

You know, we could even add the model id to the `TypeSystem`. Then, in checks, we simply read the entire model rather than a type at a time. WDYT?




## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
