### PR TITLE
fix: ListObjects streaming tests

### DIFF
--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -161,6 +161,17 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 	for _, test := range testCases {
 		t.Run(test.name+"/streaming", func(t *testing.T) {
 			server := NewMockStreamServer(len(test.expectedResult))
+
+			done := make(chan struct{})
+			var streamedObjectIds []string
+			go func() {
+				for x := range server.channel {
+					streamedObjectIds = append(streamedObjectIds, x)
+				}
+
+				done <- struct{}{}
+			}()
+
 			err := listObjectsQuery.ExecuteStreamed(ctx, &openfgapb.StreamedListObjectsRequest{
 				StoreId:              test.request.StoreId,
 				AuthorizationModelId: test.request.AuthorizationModelId,
@@ -169,12 +180,12 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 				User:                 test.request.User,
 				ContextualTuples:     test.request.ContextualTuples,
 			}, server)
+
 			close(server.channel)
+			<-done
+
 			require.ErrorIs(t, err, test.expectedError)
-			streamedObjectIds := make([]string, 0, len(test.expectedResult))
-			for x := range server.channel {
-				streamedObjectIds = append(streamedObjectIds, x)
-			}
+
 			if len(streamedObjectIds) > defaultListObjectsMaxResults {
 				t.Errorf("expected a maximum of %d results but got %d:", defaultListObjectsMaxResults, len(streamedObjectIds))
 			}
@@ -184,6 +195,7 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 				}
 			}
 		})
+
 		t.Run(test.name, func(t *testing.T) {
 			res, err := listObjectsQuery.Execute(ctx, test.request)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes the flaky StreamedListObjects tests that were not waiting on full consumption of the result channel.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
