### PR TITLE
fix streaming list objects API returning more objects than it should

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ go-generate: install-tools
 
 .PHONY: unit-test
 unit-test: go-generate ## Run unit tests
-	go test $(gotest_extra_flags) -v \
+	go test $(gotest_extra_flags) -race -v \
 			-coverprofile=coverageunit.out \
 			-coverpkg=$(COVERPKG) \
 			-covermode=atomic -race \

--- a/server/commands/list_objects.go
+++ b/server/commands/list_objects.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -31,6 +32,7 @@ type ListObjectsQuery struct {
 	ListObjectsDeadline   time.Duration
 	ListObjectsMaxResults uint32
 	ResolveNodeLimit      uint32
+	mutex                 sync.Mutex
 }
 
 // Execute the ListObjectsQuery, returning a list of object IDs
@@ -233,10 +235,13 @@ func (q *ListObjectsQuery) internalCheck(ctx context.Context, obj *openfgapb.Obj
 		q.Logger.ErrorWithContext(ctx, "check_error", logger.Error(err))
 		return nil
 	}
-
-	if resp.Allowed && atomic.LoadUint32(objectsFound) < q.ListObjectsMaxResults {
-		resultsChan <- obj.Id
-		atomic.AddUint32(objectsFound, 1)
+	if resp.Allowed {
+		q.mutex.Lock()
+		defer q.mutex.Unlock()
+		if atomic.LoadUint32(objectsFound) < q.ListObjectsMaxResults {
+			resultsChan <- obj.Id
+			atomic.AddUint32(objectsFound, 1)
+		}
 	}
 
 	return nil

--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -187,7 +187,7 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 			require.ErrorIs(t, err, test.expectedError)
 
 			if len(streamedObjectIds) > defaultListObjectsMaxResults {
-				t.Errorf("expected a maximum of %d results but got %d:", defaultListObjectsMaxResults, len(streamedObjectIds))
+				t.Errorf("expected a maximum of %d results but got %d", defaultListObjectsMaxResults, len(streamedObjectIds))
 			}
 			if !subset(streamedObjectIds, test.expectedResult) {
 				if diff := cmp.Diff(streamedObjectIds, test.expectedResult, cmpopts.EquateEmpty(), cmpopts.SortSlices(sortFn)); diff != "" {

--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/openfga/openfga/pkg/id"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
@@ -156,7 +154,6 @@ func (x *mockStreamServer) Send(m *openfgapb.StreamedListObjectsResponse) error 
 }
 
 func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObjectsTestCase, listObjectsQuery *commands.ListObjectsQuery) {
-	sortFn := func(a, b string) bool { return a < b }
 
 	for _, test := range testCases {
 		t.Run(test.name+"/streaming", func(t *testing.T) {
@@ -185,15 +182,8 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 			<-done
 
 			require.ErrorIs(t, err, test.expectedError)
-
-			if len(streamedObjectIds) > defaultListObjectsMaxResults {
-				t.Errorf("expected a maximum of %d results but got %d", defaultListObjectsMaxResults, len(streamedObjectIds))
-			}
-			if !subset(streamedObjectIds, test.expectedResult) {
-				if diff := cmp.Diff(streamedObjectIds, test.expectedResult, cmpopts.EquateEmpty(), cmpopts.SortSlices(sortFn)); diff != "" {
-					t.Errorf("object ID mismatch (-got +want):\n%s", diff)
-				}
-			}
+			require.LessOrEqual(t, len(streamedObjectIds), defaultListObjectsMaxResults)
+			require.Subset(t, test.expectedResult, streamedObjectIds)
 		})
 
 		t.Run(test.name, func(t *testing.T) {
@@ -206,15 +196,8 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 			require.ErrorIs(t, err, test.expectedError)
 
 			if res != nil {
-				if len(res.ObjectIds) > defaultListObjectsMaxResults {
-					t.Errorf("expected a maximum of %d results but got %d:", defaultListObjectsMaxResults, len(res.ObjectIds))
-				}
-				if !subset(res.ObjectIds, test.expectedResult) {
-					if diff := cmp.Diff(res.ObjectIds, test.expectedResult, cmpopts.EquateEmpty(), cmpopts.SortSlices(sortFn)); diff != "" {
-						t.Errorf("object ID mismatch (-got +want):\n%s", diff)
-					}
-				}
-
+				require.LessOrEqual(t, len(res.ObjectIds), defaultListObjectsMaxResults)
+				require.Subset(t, test.expectedResult, res.ObjectIds)
 			}
 		})
 	}
@@ -244,20 +227,4 @@ func setupTestListObjects(store string, datastore storage.OpenFGADatastore) (con
 	}
 
 	return ctx, datastore, modelID, nil
-}
-
-// subset returns true if the first slice is a subset of second
-func subset(first, second []string) bool {
-	set := make(map[string]bool)
-	for _, value := range second {
-		set[value] = true
-	}
-
-	for _, value := range first {
-		if _, found := set[value]; !found {
-			return false
-		}
-	}
-
-	return true
 }


### PR DESCRIPTION
When we read the value of `objectsFound` and then increment it, we need to put a lock around this entire block of code, otherwise a data race can occur.

Alternatively, read and increment `objectsFound` in one operation :D 