### PR TITLE
doc: remove grpc enabled config 

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -109,11 +109,6 @@
         "grpc": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "description": "Enables or disables the OpenFGA grpc server. If 'http.enabled' is set to true, then this must be set to true.",
-                    "type": "boolean",
-                    "default": true
-                },
                 "addr": {
                     "description": "The host:port address to serve the grpc server on.",
                     "type": "string",

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -164,7 +164,7 @@ func run(_ *cobra.Command, _ []string) {
 
 		g.Go(func() error {
 
-			var errCh chan (error)
+			var errCh chan error
 
 			go func() {
 				err = playground.ListenAndServe()
@@ -228,9 +228,6 @@ func buildLogger(logFormat string) (logger.Logger, error) {
 func bindRunFlags(cmd *cobra.Command) {
 
 	defaultConfig := service.DefaultConfig()
-
-	cmd.Flags().Bool("grpc-enabled", defaultConfig.GRPC.Enabled, "enable/disable the OpenFGA grpc server")
-	cmdutil.MustBindPFlag("grpc.enabled", cmd.Flags().Lookup("grpc-enabled"))
 
 	cmd.Flags().String("grpc-addr", defaultConfig.GRPC.Addr, "the host:port address to serve the grpc server on")
 	cmdutil.MustBindPFlag("grpc.addr", cmd.Flags().Lookup("grpc-addr"))

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -269,14 +269,12 @@ func (s *service) Run(ctx context.Context) error {
 	return s.server.Run(ctx)
 }
 
-// GetHTTPPort returns the configured or auto-assigned port that the underlying HTTP service is running
-// on.
+// GetHTTPAddrPort returns the configured or auto-assigned port that the underlying HTTP service is running on.
 func (s *service) GetHTTPAddrPort() netip.AddrPort {
 	return s.httpAddr
 }
 
-// GetGRPCPort returns the configured or auto-assigned port that the underlying grpc service is running
-// on.
+// GetGRPCAddrPort returns the configured or auto-assigned port that the underlying grpc service is running on.
 func (s *service) GetGRPCAddrPort() netip.AddrPort {
 	return s.grpcAddr
 }

--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -48,9 +48,8 @@ type DatastoreConfig struct {
 
 // GRPCConfig defines OpenFGA server configurations for grpc server specific settings.
 type GRPCConfig struct {
-	Enabled bool
-	Addr    string
-	TLS     TLSConfig
+	Addr string
+	TLS  TLSConfig
 }
 
 // HTTPConfig defines OpenFGA server configurations for HTTP server specific settings.
@@ -187,9 +186,8 @@ func DefaultConfig() *Config {
 			MaxCacheSize: 100000,
 		},
 		GRPC: GRPCConfig{
-			Enabled: true,
-			Addr:    "0.0.0.0:8081",
-			TLS:     TLSConfig{Enabled: false},
+			Addr: "0.0.0.0:8081",
+			TLS:  TLSConfig{Enabled: false},
 		},
 		HTTP: HTTPConfig{
 			Enabled:            true,

--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -739,10 +739,6 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), config.Datastore.MaxCacheSize)
 
-	val = res.Get("properties.grpc.properties.enabled.default")
-	require.True(t, val.Exists())
-	require.Equal(t, val.Bool(), config.GRPC.Enabled)
-
 	val = res.Get("properties.grpc.properties.addr.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), config.GRPC.Addr)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

There is no situation in which we would not enable gRPC. Remove this config option.

We also have two GRPCConfig and HTTPConfig structs. It would be nice to refactor this. And we use `service` to wrap a `server` and store a bunch of data that is in the server redundantly. This is a bit confusing and would also be nice to refactor.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
