### PR TITLE
bug: wait for connection to postgres before starting

### DIFF
--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -89,7 +89,7 @@ func NewPostgresDatastore(uri string, opts ...PostgresOption) (*Postgres, error)
 
 	pool, err := pgxpool.New(context.Background(), uri)
 	if err != nil {
-		return nil, err
+		return nil, errors.Errorf("failed to connect to Postgres: %v", err)
 	}
 
 	policy := backoff.NewExponentialBackOff()

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -87,13 +87,16 @@ func NewPostgresDatastore(uri string, opts ...PostgresOption) (*Postgres, error)
 		p.maxTypesInTypeDefinition = defaultMaxTypesInDefinition
 	}
 
+	pool, err := pgxpool.New(context.Background(), uri)
+	if err != nil {
+		return nil, err
+	}
+
 	policy := backoff.NewExponentialBackOff()
 	policy.MaxElapsedTime = 1 * time.Minute
-	var pool *pgxpool.Pool
 	attempt := 1
-	err := backoff.Retry(func() error {
-		var err error
-		pool, err = pgxpool.New(context.Background(), uri)
+	err = backoff.Retry(func() error {
+		err = pool.Ping(context.Background())
 		if err != nil {
 			p.logger.Info("waiting for Postgres", zap.Int("attempt", attempt))
 			attempt++


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Sigh... pgx v5 must have changed how `New` works so that it is now quite similar to `sql.Open`. Anyway, this change is to ensure we connect to Postgres before starting.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
