### PR TITLE
chore: fix host:port mapping with unspecified host

### DIFF
--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -364,12 +364,30 @@ func BuildService(config *Config, logger logger.Logger) (*service, error) {
 		middleware.NewErrorLoggingInterceptor(logger),
 	}
 
-	grpcAddr, err := netip.ParseAddrPort(config.GRPC.Addr)
+	grpcHostAddr, grpcHostPort, err := net.SplitHostPort(config.GRPC.Addr)
+	if err != nil {
+		return nil, errors.Errorf("`grpc.addr` config must be in the form [host]:port")
+	}
+
+	if grpcHostAddr == "" {
+		grpcHostAddr = "0.0.0.0"
+	}
+
+	grpcAddr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%s", grpcHostAddr, grpcHostPort))
 	if err != nil {
 		return nil, errors.Errorf("failed to parse the 'grpc.addr' config: %v", err)
 	}
 
-	httpAddr, err := netip.ParseAddrPort(config.HTTP.Addr)
+	httpHostAddr, httpHostPort, err := net.SplitHostPort(config.HTTP.Addr)
+	if err != nil {
+		return nil, errors.Errorf("`http.addr` config must be in the form [host]:port")
+	}
+
+	if httpHostAddr == "" {
+		httpHostAddr = "0.0.0.0"
+	}
+
+	httpAddr, err := netip.ParseAddrPort(fmt.Sprintf("%s:%s", httpHostAddr, httpHostPort))
 	if err != nil {
 		return nil, errors.Errorf("failed to parse the 'http.addr' config: %v", err)
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
We used to support an unspecified host in the `grpc.addr` and `http.addr` config. That is, you could provide `:8080` as a host and port address. We accidentally broke this in a recent release, and so this fixes it. 

## References
Fixes #274

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
