### PR TITLE
feat: allow migrations to also read the config file

### DIFF
--- a/pkg/cmd/migrate.go
+++ b/pkg/cmd/migrate.go
@@ -29,6 +29,14 @@ func NewMigrateCommand() *cobra.Command {
 		RunE:  runMigration,
 	}
 
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+
+	configPaths := []string{"/etc/openfga", "$HOME/.openfga", "."}
+	for _, path := range configPaths {
+		viper.AddConfigPath(path)
+	}
+
 	viper.SetEnvPrefix("OPENFGA")
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 	viper.AutomaticEnv()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Allow the migrations to use the same config files as the running server. This way it allows re-using the same file for both which is a nice QoL improvement in case you're using the files.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] ~I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).~ Not possible for a pr coming from company fork.
- [ ] ~I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]~ Don't think this is necessary as it's already implied in the docs.
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
