### PR TITLE
feat: optimized ListObjects with reverse expansion

### DIFF
--- a/assets/migrations/mysql/003_add_reverse_lookup_index.sql
+++ b/assets/migrations/mysql/003_add_reverse_lookup_index.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+CREATE INDEX idx_reverse_lookup_user on tuple (store, object_type, relation, _user);
+
+-- +goose Down
+DROP INDEX  idx_reverse_lookup_user;

--- a/assets/migrations/postgres/003_add_reverse_lookup_index.sql
+++ b/assets/migrations/postgres/003_add_reverse_lookup_index.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+CREATE INDEX idx_reverse_lookup_user on tuple (store, object_type, relation, _user);
+
+-- +goose Down
+DROP INDEX  idx_reverse_lookup_user;

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.33.0
 	go.opentelemetry.io/otel/trace v1.11.1
 	go.uber.org/zap v1.23.0
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
+	golang.org/x/sync v0.1.0
 	google.golang.org/grpc v1.50.1
 	google.golang.org/protobuf v1.28.1
 )
@@ -52,7 +52,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
-	github.com/jackc/puddle/v2 v2.0.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,6 @@ github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHF
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgx/v5 v5.0.4 h1:r5O6y84qHX/z/HZV40JBdx2obsHz7/uRj5b+CcYEdeY=
 github.com/jackc/pgx/v5 v5.0.4/go.mod h1:U0ynklHtgg43fue9Ly30w3OCSTDPlXjig9ghrNGaguQ=
-github.com/jackc/puddle/v2 v2.0.0 h1:Kwk/AlLigcnZsDssc3Zun1dk1tAtQNPaBBxBHWn0Mjc=
-github.com/jackc/puddle/v2 v2.0.0/go.mod h1:itE7ZJY8xnoo0JqJEpSMprN0f+NQkMCuEV/N9j8h0oc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/karlseguin/ccache/v2 v2.0.8 h1:lT38cE//uyf6KcFok0rlgXtGFBWxkI6h/qg4tbFyDnA=
@@ -511,8 +509,9 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -14,8 +14,12 @@ const (
 )
 
 var (
-	ErrDuplicateTypes       = errors.New("an authorization model cannot contain duplicate types")
-	ErrInvalidSchemaVersion = errors.New("invalid schema version")
+	ErrDuplicateTypes        = errors.New("an authorization model cannot contain duplicate types")
+	ErrInvalidSchemaVersion  = errors.New("invalid schema version")
+	ErrInvalidModel          = errors.New("invalid authorization model encountered")
+	ErrRelationUndefined     = errors.New("undefined relation")
+	ErrObjectTypeUndefined   = errors.New("undefined object type")
+	ErrInvalidUsersetRewrite = errors.New("invalid userset rewrite definition")
 )
 
 func RelationReference(objectType, relation string) *openfgapb.RelationReference {
@@ -121,10 +125,13 @@ func (t *TypeSystem) GetTypeDefinition(objectType string) (*openfgapb.TypeDefini
 	return nil, false
 }
 
-func (t *TypeSystem) GetRelations(objectType string) (map[string]*openfgapb.Relation, bool) {
+func (t *TypeSystem) GetRelations(objectType string) (map[string]*openfgapb.Relation, error) {
 	td, ok := t.typeDefinitions[objectType]
 	if !ok {
-		return nil, false
+		return nil, &ObjectTypeUndefinedError{
+			ObjectType: objectType,
+			Err:        ErrObjectTypeUndefined,
+		}
 	}
 
 	relations := map[string]*openfgapb.Relation{}
@@ -143,42 +150,231 @@ func (t *TypeSystem) GetRelations(objectType string) (map[string]*openfgapb.Rela
 		relations[relation] = r
 	}
 
-	return relations, true
+	return relations, nil
 }
 
-func (t *TypeSystem) GetRelation(objectType, relation string) (*openfgapb.Relation, bool) {
-	relations, ok := t.GetRelations(objectType)
-	if !ok {
-		return nil, false
+func (t *TypeSystem) GetRelation(objectType, relation string) (*openfgapb.Relation, error) {
+	relations, err := t.GetRelations(objectType)
+	if err != nil {
+		return nil, err
 	}
 
 	r, ok := relations[relation]
 	if !ok {
-		return nil, false
-	}
-
-	return r, true
-}
-
-func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) []*openfgapb.RelationReference {
-	if r, ok := t.GetRelation(objectType, relation); ok {
-		return r.GetTypeInfo().GetDirectlyRelatedUserTypes()
-	}
-
-	return nil
-}
-
-// IsDirectlyRelated determines whether the type of the target RelationReference contains the source RelationReference.
-func (t *TypeSystem) IsDirectlyRelated(target *openfgapb.RelationReference, source *openfgapb.RelationReference) bool {
-	if relation, ok := t.GetRelation(target.GetType(), target.GetRelation()); ok {
-		for _, relationReference := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
-			if source.GetType() == relationReference.GetType() && source.GetRelation() == relationReference.GetRelation() {
-				return true
-			}
+		return nil, &RelationUndefinedError{
+			ObjectType: objectType,
+			Relation:   relation,
+			Err:        ErrRelationUndefined,
 		}
 	}
 
-	return false
+	return r, nil
+}
+
+func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([]*openfgapb.RelationReference, error) {
+
+	r, err := t.GetRelation(objectType, relation)
+	if err != nil {
+		return nil, err
+	}
+
+	return r.GetTypeInfo().GetDirectlyRelatedUserTypes(), nil
+}
+
+// IsDirectlyRelated determines whether the type of the target RelationReference contains the source RelationReference.
+func (t *TypeSystem) IsDirectlyRelated(target *openfgapb.RelationReference, source *openfgapb.RelationReference) (bool, error) {
+
+	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
+	if err != nil {
+		return false, err
+	}
+
+	for _, relationReference := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+		if source.GetType() == relationReference.GetType() && source.GetRelation() == relationReference.GetRelation() {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (t *TypeSystem) HasTypeInfo(objectType, relation string) (bool, error) {
+	r, err := t.GetRelation(objectType, relation)
+	if err != nil {
+		return false, err
+	}
+
+	if t.GetSchemaVersion() == SchemaVersion1_1 && r.GetTypeInfo() != nil {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// RelationInvolvesIntersection returns true if the provided relation's userset rewrite
+// is defined by one or more direct or indirect intersections.
+func (t *TypeSystem) RelationInvolvesIntersection(objectType, relation string) (bool, error) {
+
+	rel, err := t.GetRelation(objectType, relation)
+	if err != nil {
+		return false, err
+	}
+
+	rewrite := rel.GetRewrite()
+
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgapb.Userset_This:
+		return false, nil
+	case *openfgapb.Userset_ComputedUserset:
+		rewrittenRelation := rw.ComputedUserset.GetRelation()
+		rewritten, err := t.GetRelation(objectType, rewrittenRelation)
+		if err != nil {
+			return false, err
+		}
+
+		return t.RelationInvolvesIntersection(objectType, rewritten.GetName())
+	case *openfgapb.Userset_TupleToUserset:
+		tupleset := rw.TupleToUserset.GetTupleset().GetRelation()
+		rewrittenRelation := rw.TupleToUserset.ComputedUserset.GetRelation()
+
+		tuplesetRel, err := t.GetRelation(objectType, tupleset)
+		if err != nil {
+			return false, err
+		}
+
+		directlyRelatedTypes := tuplesetRel.GetTypeInfo().GetDirectlyRelatedUserTypes()
+		for _, relatedType := range directlyRelatedTypes {
+			// must be of the form 'objectType' by this point since we disallow `tupleset` relations of the form `objectType:id#relation`
+			r := relatedType.GetRelation()
+			if r != "" {
+				return false, fmt.Errorf(
+					"invalid type restriction '%s#%s' specified on tupleset relation '%s#%s': %w",
+					relatedType.GetType(),
+					relatedType.GetRelation(),
+					objectType,
+					tupleset,
+					ErrInvalidModel,
+				)
+			}
+
+			rel, err := t.GetRelation(relatedType.GetType(), rewrittenRelation)
+			if err != nil {
+				if errors.Is(err, ErrObjectTypeUndefined) || errors.Is(err, ErrRelationUndefined) {
+					continue
+				}
+
+				return false, err
+			}
+
+			containsIntersection, err := t.RelationInvolvesIntersection(relatedType.GetType(), rel.GetName())
+			if err != nil {
+				return false, err
+			}
+
+			if containsIntersection {
+				return true, nil
+			}
+		}
+
+	case *openfgapb.Userset_Intersection:
+		return true, nil
+	case *openfgapb.Userset_Union:
+		for _, child := range rw.Union.GetChild() {
+			if RewriteContainsIntersection(child) {
+				return true, nil
+			}
+		}
+	case *openfgapb.Userset_Difference:
+		difference := rw.Difference
+		if RewriteContainsIntersection(difference.GetBase()) || RewriteContainsIntersection(difference.GetSubtract()) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// RelationInvolvesExclusion returns true if the provided relation's userset rewrite
+// is defined by one or more direct or indirect exclusions.
+func (t *TypeSystem) RelationInvolvesExclusion(objectType, relation string) (bool, error) {
+	rel, err := t.GetRelation(objectType, relation)
+	if err != nil {
+		return false, err
+	}
+
+	rewrite := rel.GetRewrite()
+
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgapb.Userset_This:
+		return false, nil
+	case *openfgapb.Userset_ComputedUserset:
+		rewrittenRelation := rw.ComputedUserset.GetRelation()
+		rewritten, err := t.GetRelation(objectType, rewrittenRelation)
+		if err != nil {
+			return false, err
+		}
+
+		return t.RelationInvolvesExclusion(objectType, rewritten.GetName())
+	case *openfgapb.Userset_TupleToUserset:
+		tupleset := rw.TupleToUserset.GetTupleset().GetRelation()
+		rewrittenRelation := rw.TupleToUserset.ComputedUserset.GetRelation()
+
+		tuplesetRel, err := t.GetRelation(objectType, tupleset)
+		if err != nil {
+			return false, err
+		}
+
+		directlyRelatedTypes := tuplesetRel.GetTypeInfo().GetDirectlyRelatedUserTypes()
+		for _, relatedType := range directlyRelatedTypes {
+			// must be of the form 'objectType' by this point since we disallow `tupleset` relations of the form `objectType:id#relation`
+			r := relatedType.GetRelation()
+			if r != "" {
+				return false, fmt.Errorf(
+					"invalid type restriction '%s#%s' specified on tupleset relation '%s#%s': %w",
+					relatedType.GetType(),
+					relatedType.GetRelation(),
+					objectType,
+					tupleset,
+					ErrInvalidModel,
+				)
+			}
+
+			rel, err := t.GetRelation(relatedType.GetType(), rewrittenRelation)
+			if err != nil {
+				if errors.Is(err, ErrObjectTypeUndefined) || errors.Is(err, ErrRelationUndefined) {
+					continue
+				}
+
+				return false, err
+			}
+
+			containsExclusion, err := t.RelationInvolvesExclusion(relatedType.GetType(), rel.GetName())
+			if err != nil {
+				return false, err
+			}
+
+			if containsExclusion {
+				return true, nil
+			}
+		}
+
+	case *openfgapb.Userset_Intersection:
+		for _, child := range rw.Intersection.GetChild() {
+			if RewriteContainsExclusion(child) {
+				return true, nil
+			}
+		}
+	case *openfgapb.Userset_Union:
+		for _, child := range rw.Union.GetChild() {
+			if RewriteContainsExclusion(child) {
+				return true, nil
+			}
+		}
+	case *openfgapb.Userset_Difference:
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Validate validates an *openfgapb.AuthorizationModel according to the following rules:
@@ -287,24 +483,24 @@ func isUsersetRewriteValid(
 	rewrite *openfgapb.Userset,
 ) error {
 	if rewrite.GetUserset() == nil {
-		return InvalidRelationError(objectType, relation)
+		return &InvalidRelationError{ObjectType: objectType, Relation: relation, Cause: ErrInvalidUsersetRewrite}
 	}
 
 	switch t := rewrite.GetUserset().(type) {
 	case *openfgapb.Userset_ComputedUserset:
 		computedUserset := t.ComputedUserset.GetRelation()
 		if computedUserset == relation {
-			return InvalidRelationError(objectType, relation)
+			return &InvalidRelationError{ObjectType: objectType, Relation: relation, Cause: ErrInvalidUsersetRewrite}
 		}
 		if _, ok := relationsOnType[computedUserset]; !ok {
-			return RelationDoesNotExistError(objectType, computedUserset)
+			return &RelationUndefinedError{ObjectType: objectType, Relation: computedUserset, Err: ErrRelationUndefined}
 		}
 	case *openfgapb.Userset_TupleToUserset:
 		tupleset := t.TupleToUserset.GetTupleset().GetRelation()
 
 		tuplesetRelation, ok := relationsOnType[tupleset]
 		if !ok {
-			return RelationDoesNotExistError(objectType, tupleset)
+			return &RelationUndefinedError{ObjectType: objectType, Relation: tupleset, Err: ErrRelationUndefined}
 		}
 
 		// tupleset relations must only be direct relationships, no rewrites
@@ -316,7 +512,7 @@ func isUsersetRewriteValid(
 
 		computedUserset := t.TupleToUserset.GetComputedUserset().GetRelation()
 		if _, ok := allRelations[computedUserset]; !ok {
-			return RelationDoesNotExistError("", computedUserset)
+			return &RelationUndefinedError{ObjectType: "", Relation: computedUserset, Err: ErrRelationUndefined}
 		}
 	case *openfgapb.Userset_Union:
 		for _, child := range t.Union.GetChild() {
@@ -351,9 +547,9 @@ func validateRelationTypeRestrictions(model *openfgapb.AuthorizationModel) error
 	t := New(model)
 
 	for objectType := range t.typeDefinitions {
-		relations, ok := t.GetRelations(objectType)
-		if !ok {
-			return InvalidRelationError(objectType, "")
+		relations, err := t.GetRelations(objectType)
+		if err != nil {
+			return err
 		}
 
 		for name, relation := range relations {
@@ -372,12 +568,12 @@ func validateRelationTypeRestrictions(model *openfgapb.AuthorizationModel) error
 				relatedObjectType := related.GetType()
 				relatedRelation := related.GetRelation()
 
-				if _, ok := t.GetRelations(relatedObjectType); !ok {
+				if _, err := t.GetRelations(relatedObjectType); err != nil {
 					return InvalidRelationTypeError(objectType, name, relatedObjectType, relatedRelation)
 				}
 
 				if relatedRelation != "" {
-					if _, ok := t.GetRelation(relatedObjectType, relatedRelation); !ok {
+					if _, err := t.GetRelation(relatedObjectType, relatedRelation); err != nil {
 						return InvalidRelationTypeError(objectType, name, relatedObjectType, relatedRelation)
 					}
 				}
@@ -391,28 +587,30 @@ func validateRelationTypeRestrictions(model *openfgapb.AuthorizationModel) error
 func (t *TypeSystem) IsDirectlyAssignable(relation *openfgapb.Relation) bool {
 	rewrite := relation.GetRewrite()
 
-	return ContainsSelf(rewrite)
+	return RewriteContainsSelf(rewrite)
 }
 
-func ContainsSelf(rewrite *openfgapb.Userset) bool {
+// RewriteContainsSelf returns true if the provided userset rewrite
+// is defined by one or more self referencing definitions.
+func RewriteContainsSelf(rewrite *openfgapb.Userset) bool {
 	switch rw := rewrite.GetUserset().(type) {
 	case *openfgapb.Userset_This:
 		return true
 	case *openfgapb.Userset_Union:
 		for _, child := range rw.Union.GetChild() {
-			if ContainsSelf(child) {
+			if RewriteContainsSelf(child) {
 				return true
 			}
 		}
 	case *openfgapb.Userset_Intersection:
 		for _, child := range rw.Intersection.GetChild() {
-			if ContainsSelf(child) {
+			if RewriteContainsSelf(child) {
 				return true
 			}
 		}
 	case *openfgapb.Userset_Difference:
 		difference := rw.Difference
-		if ContainsSelf(difference.GetBase()) || ContainsSelf(difference.GetSubtract()) {
+		if RewriteContainsSelf(difference.GetBase()) || RewriteContainsSelf(difference.GetSubtract()) {
 			return true
 		}
 	}
@@ -420,22 +618,95 @@ func ContainsSelf(rewrite *openfgapb.Userset) bool {
 	return false
 }
 
-func InvalidRelationError(objectType, relation string) error {
-	return fmt.Errorf("the definition of relation '%s' in object type '%s' is invalid", relation, objectType)
-}
-
-func ObjectTypeDoesNotExistError(objectType string) error {
-	return fmt.Errorf("object type '%s' does not exist", objectType)
-}
-
-// RelationDoesNotExistError may have an empty objectType, but must have a relation
-// (otherwise the error won't make much sense).
-func RelationDoesNotExistError(objectType, relation string) error {
-	msg := fmt.Sprintf("relation '%s'", relation)
-	if objectType != "" {
-		msg = fmt.Sprintf("%s in object type '%s'", msg, objectType)
+// RewriteContainsIntersection returns true if the provided userset rewrite
+// is defined by one or more direct or indirect intersections.
+func RewriteContainsIntersection(rewrite *openfgapb.Userset) bool {
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgapb.Userset_Intersection:
+		return true
+	case *openfgapb.Userset_Union:
+		for _, child := range rw.Union.GetChild() {
+			if RewriteContainsIntersection(child) {
+				return true
+			}
+		}
+	case *openfgapb.Userset_Difference:
+		difference := rw.Difference
+		if RewriteContainsIntersection(difference.GetBase()) || RewriteContainsIntersection(difference.GetSubtract()) {
+			return true
+		}
 	}
-	return fmt.Errorf("%s does not exist", msg)
+
+	return false
+}
+
+// RewriteContainsExclusion returns true if the provided userset rewrite
+// is defined by one or more direct or indirect exclusions.
+func RewriteContainsExclusion(rewrite *openfgapb.Userset) bool {
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgapb.Userset_Intersection:
+		for _, child := range rw.Intersection.GetChild() {
+			if RewriteContainsExclusion(child) {
+				return true
+			}
+		}
+	case *openfgapb.Userset_Union:
+		for _, child := range rw.Union.GetChild() {
+			if RewriteContainsExclusion(child) {
+				return true
+			}
+		}
+	case *openfgapb.Userset_Difference:
+		return true
+	}
+
+	return false
+}
+
+type InvalidRelationError struct {
+	ObjectType string
+	Relation   string
+	Cause      error
+}
+
+func (e *InvalidRelationError) Error() string {
+	return fmt.Sprintf("the definition of relation '%s' in object type '%s' is invalid", e.Relation, e.ObjectType)
+}
+
+func (e *InvalidRelationError) Unwrap() error {
+	return e.Cause
+}
+
+type ObjectTypeUndefinedError struct {
+	ObjectType string
+	Err        error
+}
+
+func (e *ObjectTypeUndefinedError) Error() string {
+	return fmt.Sprintf("'%s' is an undefined object type", e.ObjectType)
+}
+
+func (e *ObjectTypeUndefinedError) Unwrap() error {
+	return e.Err
+}
+
+type RelationUndefinedError struct {
+	ObjectType string
+	Relation   string
+	Err        error
+}
+
+func (e *RelationUndefinedError) Error() string {
+
+	if e.ObjectType != "" {
+		return fmt.Sprintf("'%s#%s' relation is undefiend", e.ObjectType, e.Relation)
+	}
+
+	return fmt.Sprintf("'%s' relation is undefined", e.Relation)
+}
+
+func (e *RelationUndefinedError) Unwrap() error {
+	return e.Err
 }
 
 func AssignableRelationError(objectType, relation string) error {

--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -148,9 +148,15 @@ func (query *CheckQuery) resolveNode(ctx context.Context, rc *resolutionContext,
 		tupleset := usType.TupleToUserset.GetTupleset().GetRelation()
 
 		objectType, _ := tupleUtils.SplitObject(rc.tk.Object)
-		relation, ok := typesys.GetRelation(objectType, tupleset)
-		if !ok {
-			return serverErrors.RelationNotFound(tupleset, objectType, tupleUtils.NewTupleKey(rc.tk.Object, tupleset, rc.tk.User))
+		relation, err := typesys.GetRelation(objectType, tupleset)
+		if err != nil {
+			if errors.Is(err, typesystem.ErrObjectTypeUndefined) {
+				return serverErrors.TypeNotFound(objectType)
+			}
+
+			if errors.Is(err, typesystem.ErrRelationUndefined) {
+				return serverErrors.RelationNotFound(tupleset, objectType, tupleUtils.NewTupleKey(rc.tk.Object, tupleset, rc.tk.User))
+			}
 		}
 
 		tuplesetRewrite := relation.GetRewrite().GetUserset()

--- a/server/commands/connected_objects.go
+++ b/server/commands/connected_objects.go
@@ -1,0 +1,350 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	serverErrors "github.com/openfga/openfga/server/errors"
+
+	"github.com/openfga/openfga/internal/graph"
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+	"github.com/openfga/openfga/storage"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"golang.org/x/sync/errgroup"
+)
+
+type ConnectedObjectsRequest struct {
+	StoreID          string
+	ObjectType       string
+	Relation         string
+	User             *openfgapb.ObjectRelation
+	ContextualTuples []*openfgapb.TupleKey
+}
+
+type ConnectedObjectsCommand struct {
+	Datastore        storage.OpenFGADatastore
+	Typesystem       *typesystem.TypeSystem
+	ResolveNodeLimit uint32
+
+	// Limit limits the results yielded by the ConnectedObjects API.
+	Limit uint32
+}
+
+func (c *ConnectedObjectsCommand) streamedConnectedObjects(
+	ctx context.Context,
+	req *ConnectedObjectsRequest,
+	resultChan chan<- string,
+	foundObjectsMap *sync.Map,
+	foundCount *uint32,
+) error {
+
+	depth, ok := graph.ResolutionDepthFromContext(ctx)
+	if !ok {
+		ctx = graph.ContextWithResolutionDepth(ctx, 0)
+	} else {
+		if depth >= c.ResolveNodeLimit {
+			return serverErrors.AuthorizationModelResolutionTooComplex
+		}
+
+		ctx = graph.ContextWithResolutionDepth(ctx, depth+1)
+	}
+
+	storeID := req.StoreID
+
+	targetUserType, _ := tuple.SplitObject(req.User.Object)
+
+	targetUserRef := &openfgapb.RelationReference{
+		Type:     targetUserType,
+		Relation: req.User.Relation,
+	}
+
+	sourceObjRef := &openfgapb.RelationReference{
+		Type:     req.ObjectType,
+		Relation: req.Relation,
+	}
+
+	// build the graph of possible edges between object types in the graph based on the authz model's type info
+	g := graph.BuildConnectedObjectGraph(c.Typesystem)
+
+	// find the possible incoming edges (ingresses) between the target user reference and the source (object, relation) reference
+	ingresses, err := g.RelationshipIngresses(sourceObjRef, targetUserRef)
+	if err != nil {
+		return err
+	}
+
+	for _, ingress := range ingresses {
+
+		r := &reverseExpandRequest{
+			storeID:          storeID,
+			ingress:          ingress,
+			sourceObjectRef:  sourceObjRef,
+			targetUserRef:    req.User,
+			contextualTuples: req.ContextualTuples,
+		}
+
+		var err error
+		switch ingress.Type {
+		case graph.DirectIngress:
+			err = c.reverseExpandDirect(ctx, r, resultChan, foundObjectsMap, foundCount)
+		case graph.TupleToUsersetIngress:
+			err = c.reverseExpandTupleToUserset(ctx, r, resultChan, foundObjectsMap, foundCount)
+		default:
+			return fmt.Errorf("unsupported ingress type")
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// StreamedConnectedObjects yields all of the objects of the provided objectType that
+// the given user has a specific relation with. The results will be limited by the request
+// limit. If a 0 limit is provided then all objects of the provided objectType will be
+// returned.
+func (c *ConnectedObjectsCommand) StreamedConnectedObjects(
+	ctx context.Context,
+	req *ConnectedObjectsRequest,
+	resultChan chan<- string, // object string (e.g. document:1)
+) error {
+
+	var foundCount *uint32
+	if c.Limit > 0 {
+		foundCount = new(uint32)
+	}
+
+	var foundObjects sync.Map
+	return c.streamedConnectedObjects(ctx, req, resultChan, &foundObjects, foundCount)
+}
+
+type reverseExpandRequest struct {
+	storeID          string
+	ingress          *graph.RelationshipIngress
+	sourceObjectRef  *openfgapb.RelationReference
+	targetUserRef    *openfgapb.ObjectRelation
+	contextualTuples []*openfgapb.TupleKey
+}
+
+func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
+	ctx context.Context,
+	req *reverseExpandRequest,
+	resultChan chan<- string,
+	foundObjectsMap *sync.Map,
+	foundCount *uint32,
+) error {
+
+	store := req.storeID
+
+	ingress := req.ingress.Ingress
+
+	sourceObjectType := req.sourceObjectRef.GetType()
+	sourceObjectRel := req.sourceObjectRef.GetRelation()
+
+	tuplesetRelation := req.ingress.TuplesetRelation.GetRelation()
+
+	var tuples []*openfgapb.Tuple
+	for _, t := range req.contextualTuples {
+
+		object := t.GetObject()
+		objectType, _ := tuple.SplitObject(object)
+		if objectType != ingress.GetType() {
+			continue
+		}
+
+		if t.GetRelation() != tuplesetRelation {
+			continue
+		}
+
+		targetUserStr := req.targetUserRef.GetObject()
+
+		userObj, _ := tuple.SplitObjectRelation(t.GetUser())
+		if userObj == targetUserStr || userObj == Wildcard {
+			tuples = append(tuples, &openfgapb.Tuple{Key: t})
+		}
+	}
+	iter1 := storage.NewStaticTupleIterator(tuples)
+
+	iter2, err := c.Datastore.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
+		ObjectType: req.ingress.Ingress.GetType(),
+		Relation:   tuplesetRelation,
+		UserFilter: []*openfgapb.ObjectRelation{
+			{Object: req.targetUserRef.Object},
+			{Object: Wildcard},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	iter := storage.NewCombinedIterator(iter1, iter2)
+
+	g := errgroup.Group{}
+	g.SetLimit(100) // set some concurrency limit
+
+	for {
+		t, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, storage.ErrIteratorDone) {
+				break
+			}
+
+			return err
+		}
+
+		tk := t.GetKey()
+
+		foundObject := tk.GetObject()
+		foundObjectType, _ := tuple.SplitObject(foundObject)
+
+		userObj, _ := tuple.SplitObjectRelation(tk.GetUser())
+
+		if userObj == Wildcard {
+
+			return serverErrors.InvalidTuple(
+				fmt.Sprintf("unexpected wildcard evaluated on relation '%s#%s'", foundObjectType, tuplesetRelation),
+				tuple.NewTupleKey(foundObject, tuplesetRelation, Wildcard),
+			)
+		}
+
+		if _, ok := foundObjectsMap.Load(foundObject); ok {
+			// todo(jon-whit): we could optimize this by avoiding reading this
+			// from the database in the first place
+
+			// if we've already evaluated/found the object, then continue
+			continue
+		}
+
+		if foundObjectType == sourceObjectType {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+				break
+			}
+
+			resultChan <- foundObject
+			foundObjectsMap.Store(foundObject, struct{}{})
+		}
+
+		g.Go(func() error {
+			return c.streamedConnectedObjects(ctx, &ConnectedObjectsRequest{
+				StoreID:          store,
+				ObjectType:       sourceObjectType,
+				Relation:         sourceObjectRel,
+				User:             &openfgapb.ObjectRelation{Object: foundObject, Relation: req.targetUserRef.Relation},
+				ContextualTuples: req.contextualTuples,
+			}, resultChan, foundObjectsMap, foundCount)
+		})
+	}
+
+	return g.Wait()
+}
+
+func (c *ConnectedObjectsCommand) reverseExpandDirect(
+	ctx context.Context,
+	req *reverseExpandRequest,
+	resultChan chan<- string,
+	foundObjectsMap *sync.Map,
+	foundCount *uint32,
+) error {
+
+	store := req.storeID
+
+	ingress := req.ingress.Ingress
+
+	sourceObjectType := req.sourceObjectRef.GetType()
+	sourceObjectRel := req.sourceObjectRef.GetRelation()
+
+	var tuples []*openfgapb.Tuple
+	for _, t := range req.contextualTuples {
+
+		object := t.GetObject()
+		objectType, _ := tuple.SplitObject(object)
+		if objectType != ingress.GetType() {
+			continue
+		}
+
+		if t.GetRelation() != ingress.GetRelation() {
+			continue
+		}
+
+		targetUserStr := req.targetUserRef.GetObject()
+		if req.targetUserRef.GetRelation() != "" {
+			targetUserStr = fmt.Sprintf("%s#%s", targetUserStr, req.targetUserRef.GetRelation())
+		}
+
+		if t.GetUser() == targetUserStr || t.GetUser() == Wildcard {
+			tuples = append(tuples, &openfgapb.Tuple{Key: t})
+		}
+	}
+	iter1 := storage.NewStaticTupleIterator(tuples)
+
+	iter2, err := c.Datastore.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
+		ObjectType: ingress.GetType(),
+		Relation:   ingress.GetRelation(),
+		UserFilter: []*openfgapb.ObjectRelation{
+			req.targetUserRef,
+			{Object: Wildcard},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	iter := storage.NewCombinedIterator(iter1, iter2)
+
+	g := errgroup.Group{}
+	g.SetLimit(100) // set some concurrency limit
+
+	for {
+		t, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, storage.ErrIteratorDone) {
+				break
+			}
+
+			return err
+		}
+
+		tk := t.GetKey()
+
+		foundObject := tk.GetObject()
+		foundObjectType, _ := tuple.SplitObject(foundObject)
+
+		if _, ok := foundObjectsMap.Load(foundObject); ok {
+			// todo(jon-whit): we could optimize this by avoiding reading this
+			// from the database in the first place
+
+			// if we've already evaluated/found the object, then continue
+			continue
+		}
+
+		if foundObjectType == sourceObjectType {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+				break
+			}
+
+			resultChan <- foundObject
+			foundObjectsMap.Store(foundObject, struct{}{})
+		}
+
+		user := &openfgapb.ObjectRelation{Object: foundObject}
+		if tk.GetRelation() != "" {
+			user.Relation = tk.GetRelation()
+		}
+
+		g.Go(func() error {
+			return c.streamedConnectedObjects(ctx, &ConnectedObjectsRequest{
+				StoreID:          store,
+				ObjectType:       sourceObjectType,
+				Relation:         sourceObjectRel,
+				User:             user,
+				ContextualTuples: req.contextualTuples,
+			}, resultChan, foundObjectsMap, foundCount)
+		})
+	}
+
+	return g.Wait()
+}

--- a/server/commands/list_objects.go
+++ b/server/commands/list_objects.go
@@ -3,11 +3,13 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/openfga/openfga/storage"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
@@ -16,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/unit"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -31,14 +34,102 @@ type ListObjectsQuery struct {
 	ListObjectsDeadline   time.Duration
 	ListObjectsMaxResults uint32
 	ResolveNodeLimit      uint32
+	ConnectedObjects      func(ctx context.Context, req *ConnectedObjectsRequest, results chan<- string) error
+}
+
+type listObjectsRequest interface {
+	GetStoreId() string
+	GetAuthorizationModelId() string
+	GetType() string
+	GetRelation() string
+	GetUser() string
+	GetContextualTuples() *openfgapb.ContextualTupleKeys
+}
+
+func (q *ListObjectsQuery) handler(
+	ctx context.Context,
+	req listObjectsRequest,
+	resolvedChan chan<- struct{},
+	resultsChan chan<- string,
+	errChan chan<- error,
+) error {
+
+	targetObjectType := req.GetType()
+	targetRelation := req.GetRelation()
+
+	model, err := q.Datastore.ReadAuthorizationModel(ctx, req.GetStoreId(), req.GetAuthorizationModelId())
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return serverErrors.AuthorizationModelNotFound(req.GetAuthorizationModelId())
+		}
+		return err
+	}
+
+	typesys := typesystem.New(model)
+
+	hasTypeInfo, err := typesys.HasTypeInfo(targetObjectType, targetRelation)
+	if err != nil {
+		q.Logger.WarnWithContext(
+			ctx, fmt.Sprintf("failed to lookup type info for relation '%s'", targetRelation),
+			zap.String("store_id", req.GetStoreId()),
+			zap.String("object_type", targetObjectType),
+		)
+	}
+
+	handler := func() {
+		q.performChecks(ctx, req, resultsChan, errChan, resolvedChan)
+	}
+
+	_, err = typesys.GetRelation(targetObjectType, targetRelation)
+	if err != nil {
+		if errors.Is(err, typesystem.ErrObjectTypeUndefined) {
+			return serverErrors.TypeNotFound(targetObjectType)
+		}
+
+		if errors.Is(err, typesystem.ErrRelationUndefined) {
+			return serverErrors.RelationNotFound(targetRelation, targetObjectType, nil)
+		}
+
+		return serverErrors.HandleError("", err)
+	}
+
+	containsIntersection, _ := typesys.RelationInvolvesIntersection(targetObjectType, targetRelation)
+	containsExclusion, _ := typesys.RelationInvolvesExclusion(targetObjectType, targetRelation)
+
+	// ConnectedObjects currently only supports models that do not include intersection and exclusion,
+	// and the model must include type info for ConnectedObjects to work.
+	if !containsIntersection && !containsExclusion && hasTypeInfo {
+
+		userObj, userRel := tuple.SplitObjectRelation(req.GetUser())
+
+		handler = func() {
+			err = q.ConnectedObjects(ctx, &ConnectedObjectsRequest{
+				StoreID:          req.GetStoreId(),
+				ObjectType:       targetObjectType,
+				Relation:         targetRelation,
+				User:             &openfgapb.ObjectRelation{Object: userObj, Relation: userRel},
+				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
+			}, resultsChan)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			close(resolvedChan)
+			close(resultsChan)
+		}
+	}
+
+	go handler()
+
+	return nil
 }
 
 // Execute the ListObjectsQuery, returning a list of object IDs
-func (q *ListObjectsQuery) Execute(ctx context.Context, req *openfgapb.ListObjectsRequest) (*openfgapb.ListObjectsResponse, error) {
-	err := q.validateInput(ctx, req.StoreId, req.Type, req.AuthorizationModelId, req.Relation)
-	if err != nil {
-		return nil, err
-	}
+func (q *ListObjectsQuery) Execute(
+	ctx context.Context,
+	req *openfgapb.ListObjectsRequest,
+) (*openfgapb.ListObjectsResponse, error) {
 
 	listObjectsGauge, err := q.Meter.AsyncInt64().Gauge(
 		"openfga.listObjects.results",
@@ -49,7 +140,11 @@ func (q *ListObjectsQuery) Execute(ctx context.Context, req *openfgapb.ListObjec
 		return nil, serverErrors.NewInternalError("", err)
 	}
 
-	resultsChan := make(chan string, q.ListObjectsMaxResults)
+	resultsChan := make(chan string, 1)
+	if q.ListObjectsMaxResults > 0 {
+		resultsChan = make(chan string, q.ListObjectsMaxResults)
+	}
+
 	errChan := make(chan error)
 	resolvedChan := make(chan struct{})
 
@@ -60,16 +155,10 @@ func (q *ListObjectsQuery) Execute(ctx context.Context, req *openfgapb.ListObjec
 		defer cancel()
 	}
 
-	go func() {
-		q.performChecks(timeoutCtx, &PerformChecksInput{
-			storeID:     req.StoreId,
-			authModelID: req.AuthorizationModelId,
-			objectType:  req.Type,
-			relation:    req.Relation,
-			user:        req.User,
-			ctxTuples:   req.ContextualTuples,
-		}, resultsChan, errChan, resolvedChan)
-	}()
+	err = q.handler(timeoutCtx, req, resolvedChan, resultsChan, errChan)
+	if err != nil {
+		return nil, err
+	}
 
 	attributes := make([]attribute.KeyValue, 1)
 
@@ -94,13 +183,17 @@ func (q *ListObjectsQuery) Execute(ctx context.Context, req *openfgapb.ListObjec
 	}, nil
 }
 
-func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgapb.StreamedListObjectsRequest, srv openfgapb.OpenFGAService_StreamedListObjectsServer) error {
-	err := q.validateInput(ctx, req.StoreId, req.Type, req.AuthorizationModelId, req.Relation)
-	if err != nil {
-		return err
+func (q *ListObjectsQuery) ExecuteStreamed(
+	ctx context.Context,
+	req *openfgapb.StreamedListObjectsRequest,
+	srv openfgapb.OpenFGAService_StreamedListObjectsServer,
+) error {
+
+	resultsChan := make(chan string, 1)
+	if q.ListObjectsMaxResults > 0 {
+		resultsChan = make(chan string, q.ListObjectsMaxResults)
 	}
 
-	resultsChan := make(chan string, q.ListObjectsMaxResults)
 	errChan := make(chan error)
 	resolvedChan := make(chan struct{})
 
@@ -111,16 +204,10 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgapb.S
 		defer cancel()
 	}
 
-	go func() {
-		q.performChecks(timeoutCtx, &PerformChecksInput{
-			storeID:     req.StoreId,
-			authModelID: req.AuthorizationModelId,
-			objectType:  req.Type,
-			relation:    req.Relation,
-			user:        req.User,
-			ctxTuples:   req.ContextualTuples,
-		}, resultsChan, errChan, resolvedChan)
-	}()
+	err := q.handler(timeoutCtx, req, resolvedChan, resultsChan, errChan)
+	if err != nil {
+		return err
+	}
 
 	for {
 		select {
@@ -130,6 +217,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgapb.S
 			if !ok {
 				return nil //channel was closed
 			}
+
 			if err := srv.Send(&openfgapb.StreamedListObjectsResponse{
 				ObjectId: objectID,
 			}); err != nil {
@@ -143,38 +231,20 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgapb.S
 	}
 }
 
-func (q *ListObjectsQuery) validateInput(ctx context.Context, storeID string, targetObjectType string, authModelID string, relation string) error {
-	definition, err := q.Datastore.ReadTypeDefinition(ctx, storeID, authModelID, targetObjectType)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return serverErrors.TypeNotFound(targetObjectType)
-		}
-		return err
-	}
-	_, ok := definition.Relations[relation]
-	if !ok {
-		return serverErrors.RelationNotFound(relation, targetObjectType, nil)
-	}
-	return nil
-}
-
-type PerformChecksInput struct {
-	storeID     string
-	authModelID string
-	objectType  string
-	relation    string
-	user        string
-	ctxTuples   *openfgapb.ContextualTupleKeys
-}
-
-func (q *ListObjectsQuery) performChecks(timeoutCtx context.Context, input *PerformChecksInput, resultsChan chan<- string, errChan chan<- error, resolvedChan chan<- struct{}) {
+func (q *ListObjectsQuery) performChecks(
+	ctx context.Context,
+	req listObjectsRequest,
+	resultsChan chan<- string,
+	errChan chan<- error,
+	resolvedChan chan<- struct{},
+) {
 	g := new(errgroup.Group)
 	g.SetLimit(maximumConcurrentChecks)
 	var objectsFound = new(uint32)
 
-	iter1 := storage.NewTupleKeyObjectIterator(input.ctxTuples.GetTupleKeys())
+	iter1 := storage.NewTupleKeyObjectIterator(req.GetContextualTuples().GetTupleKeys())
 
-	iter2, err := q.Datastore.ListObjectsByType(timeoutCtx, input.storeID, input.objectType)
+	iter2, err := q.Datastore.ListObjectsByType(ctx, req.GetStoreId(), req.GetType())
 	if err != nil {
 		errChan <- err
 		return
@@ -204,7 +274,7 @@ func (q *ListObjectsQuery) performChecks(timeoutCtx context.Context, input *Perf
 		}
 
 		checkFunction := func() error {
-			return q.internalCheck(timeoutCtx, object, input, objectsFound, resultsChan)
+			return q.internalCheck(ctx, object, req, objectsFound, resultsChan)
 		}
 
 		g.Go(checkFunction)
@@ -219,14 +289,20 @@ func (q *ListObjectsQuery) performChecks(timeoutCtx context.Context, input *Perf
 	close(resolvedChan)
 }
 
-func (q *ListObjectsQuery) internalCheck(ctx context.Context, obj *openfgapb.Object, input *PerformChecksInput, objectsFound *uint32, resultsChan chan<- string) error {
+func (q *ListObjectsQuery) internalCheck(
+	ctx context.Context,
+	obj *openfgapb.Object,
+	req listObjectsRequest,
+	objectsFound *uint32,
+	resultsChan chan<- string,
+) error {
 	query := NewCheckQuery(q.Datastore, q.Tracer, q.Meter, q.Logger, q.ResolveNodeLimit)
 
 	resp, err := query.Execute(ctx, &openfgapb.CheckRequest{
-		StoreId:              input.storeID,
-		AuthorizationModelId: input.authModelID,
-		TupleKey:             tuple.NewTupleKey(tuple.ObjectKey(obj), input.relation, input.user),
-		ContextualTuples:     input.ctxTuples,
+		StoreId:              req.GetStoreId(),
+		AuthorizationModelId: req.GetAuthorizationModelId(),
+		TupleKey:             tuple.NewTupleKey(tuple.ObjectKey(obj), req.GetRelation(), req.GetUser()),
+		ContextualTuples:     req.GetContextualTuples(),
 	})
 	if err != nil {
 		// ignore the error. we don't want to abort everything if one of the checks failed.

--- a/server/commands/write.go
+++ b/server/commands/write.go
@@ -80,7 +80,7 @@ func (c *WriteCommand) validateTuplesets(ctx context.Context, req *openfgapb.Wri
 		}
 
 		// Validate that we are not trying to write to an indirect-only relationship
-		if !typesystem.ContainsSelf(tupleUserset) {
+		if !typesystem.RewriteContainsSelf(tupleUserset) {
 			return serverErrors.HandleTupleValidateError(&tupleUtils.IndirectWriteError{Reason: IndirectWriteErrorReason, TupleKey: tk})
 		}
 

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1740,7 +1740,7 @@ var tuples = []*openfgapb.TupleKey{
 }
 
 // Used to avoid compiler optimizations (see https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)
-var result *openfgapb.CheckResponse //nolint
+var checkResponse *openfgapb.CheckResponse //nolint
 
 func BenchmarkCheckWithoutTrace(b *testing.B, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
@@ -1785,10 +1785,10 @@ func BenchmarkCheckWithoutTrace(b *testing.B, datastore storage.OpenFGADatastore
 		})
 	}
 
-	result = r
+	checkResponse = r
 }
 
-func BenchmarkWithTrace(b *testing.B, datastore storage.OpenFGADatastore) {
+func BenchmarkCheckWithTrace(b *testing.B, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 	tracer := telemetry.NewNoopTracer()
 	meter := telemetry.NewNoopMeter()
@@ -1832,5 +1832,5 @@ func BenchmarkWithTrace(b *testing.B, datastore storage.OpenFGADatastore) {
 		})
 	}
 
-	result = r
+	checkResponse = r
 }

--- a/server/test/connected_objects.go
+++ b/server/test/connected_objects.go
@@ -1,0 +1,600 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+	"github.com/openfga/openfga/server/commands"
+	serverErrors "github.com/openfga/openfga/server/errors"
+	"github.com/openfga/openfga/storage"
+	"github.com/stretchr/testify/require"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+)
+
+func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
+
+	tests := []struct {
+		name             string
+		model            *openfgapb.AuthorizationModel
+		tuples           []*openfgapb.TupleKey
+		request          *commands.ConnectedObjectsRequest
+		resolveNodeLimit uint32
+		limit            uint32
+		expectedObjects  []string
+		expectedError    error
+	}{
+		{
+			name: "Direct relations and TTU relations with wildcard",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "folder",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+				ContextualTuples: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("folder:folderX", "parent", "*"),
+				},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.Union(
+								typesystem.This(),
+								typesystem.TupleToUserset("parent", "viewer"),
+							),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+			},
+			expectedError: serverErrors.InvalidTuple(
+				fmt.Sprintf("unexpected wildcard evaluated on relation '%s#%s'", "folder", "parent"),
+				tuple.NewTupleKey("folder:folderX", "parent", commands.Wildcard),
+			),
+		},
+		{
+			name: "Direct relations and TTU relations with strictly contextual tuples",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "folder",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+				ContextualTuples: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+					tuple.NewTupleKey("folder:folderX", "parent", "*"),
+				},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.Union(
+								typesystem.This(),
+								typesystem.TupleToUserset("parent", "viewer"),
+							),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{},
+			expectedError: serverErrors.InvalidTuple(
+				fmt.Sprintf("unexpected wildcard evaluated on relation '%s#%s'", "folder", "parent"),
+				tuple.NewTupleKey("folder:folderX", "parent", commands.Wildcard),
+			),
+		},
+		{
+			name: "Restrict results based on limit",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:          ulid.Make().String(),
+				ObjectType:       "folder",
+				Relation:         "viewer",
+				User:             &openfgapb.ObjectRelation{Object: "user:jon"},
+				ContextualTuples: []*openfgapb.TupleKey{},
+			},
+			limit: 2,
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+				tuple.NewTupleKey("folder:folder2", "viewer", "user:jon"),
+				tuple.NewTupleKey("folder:folder3", "viewer", "user:jon"),
+			},
+			expectedObjects: []string{"folder:folder1", "folder:folder2"},
+		},
+		{
+			name: "Resolve direct relationships with tuples and contextual tuples",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "document",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+				ContextualTuples: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("document:doc2", "viewer", "user:bob"),
+					tuple.NewTupleKey("document:doc3", "viewer", "user:jon"),
+				},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+			},
+			expectedObjects: []string{"document:doc1", "document:doc3"},
+		},
+		{
+			name: "Direct relations involving relationships with users and usersets",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "document",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgapb.Userset{
+							"member": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+										{Type: "group", Relation: "member"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+				tuple.NewTupleKey("document:doc2", "viewer", "user:bob"),
+				tuple.NewTupleKey("document:doc3", "viewer", "group:openfga#member"),
+				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			},
+			expectedObjects: []string{"document:doc1", "document:doc3"},
+		},
+		{
+			name: "Success with direct relationships and computed usersets",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "document",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgapb.Userset{
+							"member": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"owner":  typesystem.This(),
+							"viewer": typesystem.ComputedUserset("owner"),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"owner": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+										{Type: "group", Relation: "member"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("document:doc1", "owner", "user:jon"),
+				tuple.NewTupleKey("document:doc2", "owner", "user:bob"),
+				tuple.NewTupleKey("document:doc3", "owner", "group:openfga#member"),
+				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			},
+			expectedObjects: []string{"document:doc1", "document:doc3"},
+		},
+		{
+			name: "Success with many tuples",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "document",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgapb.Userset{
+							"member": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+										{Type: "group", Relation: "member"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.Union(
+								typesystem.This(),
+								typesystem.TupleToUserset("parent", "viewer"),
+							),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+										{Type: "group", Relation: "member"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.TupleToUserset("parent", "viewer"),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
+				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
+				tuple.NewTupleKey("folder:folder4", "viewer", "group:eng#member"),
+				tuple.NewTupleKey("folder:folder5", "parent", "folder:folder4"),
+				tuple.NewTupleKey("folder:folder6", "viewer", "user:bob"),
+
+				tuple.NewTupleKey("document:doc1", "parent", "folder:folder3"),
+				tuple.NewTupleKey("document:doc2", "parent", "folder:folder5"),
+				tuple.NewTupleKey("document:doc3", "parent", "folder:folder6"),
+
+				tuple.NewTupleKey("group:eng", "member", "group:openfga#member"),
+				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			},
+			expectedObjects: []string{"document:doc1", "document:doc2"},
+		},
+		{
+			name: "Resolve objects involved in recursive hierarchy",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "folder",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.Union(
+								typesystem.This(),
+								typesystem.TupleToUserset("parent", "viewer"),
+							),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
+				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
+			},
+			expectedObjects: []string{"folder:folder1", "folder:folder2", "folder:folder3"},
+		},
+		{
+			name: "Resolution Depth Exceeded Failure",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "folder",
+				Relation:   "viewer",
+				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+			},
+			resolveNodeLimit: 2,
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "folder",
+						Relations: map[string]*openfgapb.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.Union(
+								typesystem.This(),
+								typesystem.TupleToUserset("parent", "viewer"),
+							),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "folder"},
+									},
+								},
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
+				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
+				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
+			},
+			expectedError: serverErrors.AuthorizationModelResolutionTooComplex,
+		},
+		{
+			name: "Objects connected to a userset",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "group",
+				Relation:   "member",
+				User:       &openfgapb.ObjectRelation{Object: "group:iam", Relation: "member"},
+			},
+			model: &openfgapb.AuthorizationModel{
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgapb.Userset{
+							"member": typesystem.This(),
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{Type: "group", Relation: "member"},
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("group:auth0", "member", "group:eng#member"),
+				tuple.NewTupleKey("group:eng", "member", "group:iam#member"),
+				tuple.NewTupleKey("group:iam", "member", "user:jon"),
+			},
+			expectedObjects: []string{"group:auth0", "group:eng"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			ctx := context.Background()
+			store := ulid.Make().String()
+			test.request.StoreID = store
+
+			err := ds.WriteAuthorizationModel(ctx, store, test.model)
+			require.NoError(err)
+
+			err = ds.Write(ctx, store, nil, test.tuples)
+			require.NoError(err)
+
+			if test.resolveNodeLimit == 0 {
+				test.resolveNodeLimit = defaultResolveNodeLimit
+			}
+
+			connectedObjectsCmd := commands.ConnectedObjectsCommand{
+				Datastore:        ds,
+				Typesystem:       typesystem.New(test.model),
+				ResolveNodeLimit: test.resolveNodeLimit,
+				Limit:            test.limit,
+			}
+
+			resultChan := make(chan string, 100)
+			done := make(chan struct{})
+
+			var results []string
+			go func() {
+				for result := range resultChan {
+					results = append(results, result)
+				}
+
+				done <- struct{}{}
+			}()
+
+			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			go func() {
+				err = connectedObjectsCmd.StreamedConnectedObjects(timeoutCtx, test.request, resultChan)
+				require.ErrorIs(err, test.expectedError)
+				close(resultChan)
+			}()
+
+			select {
+			case <-timeoutCtx.Done():
+				require.FailNow("timed out waiting for response")
+			case <-done:
+			}
+
+			if test.expectedError == nil {
+				sort.Strings(results)
+				sort.Strings(test.expectedObjects)
+
+				require.Equal(test.expectedObjects, results)
+			}
+		})
+	}
+}

--- a/server/test/list_objects.go
+++ b/server/test/list_objects.go
@@ -2,14 +2,16 @@ package test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/server/commands"
@@ -51,24 +53,44 @@ func newListObjectsRequest(store, objectType, relation, user, modelID string, co
 	}
 }
 
-func TestListObjects(t *testing.T, datastore storage.OpenFGADatastore) {
-	store := testutils.CreateRandomString(10)
-	tracer := telemetry.NewNoopTracer()
-	ctx, backend, modelID, err := setupTestListObjects(store, datastore)
-	require.NoError(t, err)
+func ListObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 
-	t.Run("list objects", func(t *testing.T) {
+	ctx := context.Background()
+	tracer := telemetry.NewNoopTracer()
+
+	t.Run("Github without TypeInfo", func(t *testing.T) {
+		store := ulid.Make().String()
+
+		data, err := os.ReadFile(gitHubTestDataFile)
+		require.NoError(t, err)
+
+		var gitHubTypeDefinitions openfgapb.WriteAuthorizationModelRequest
+		err = protojson.Unmarshal(data, &gitHubTypeDefinitions)
+		require.NoError(t, err)
+
+		model := &openfgapb.AuthorizationModel{
+			Id:              ulid.Make().String(),
+			SchemaVersion:   typesystem.SchemaVersion1_0,
+			TypeDefinitions: gitHubTypeDefinitions.GetTypeDefinitions(),
+		}
+		err = ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err)
+
+		writes := []*openfgapb.TupleKey{tKAllAdminsRepo6, tkAnnaRepo1, tkAnnaRepo2, tkAnnaRepo3, tkAnnaRepo4, tkBobRepo2}
+		err = ds.Write(ctx, store, nil, writes)
+		require.NoError(t, err)
+
 		testCases := []listObjectsTestCase{
 			{
 				name:           "does not return duplicates",
-				request:        newListObjectsRequest(store, "repo", "admin", "anna", modelID, nil),
+				request:        newListObjectsRequest(store, "repo", "admin", "anna", model.Id, nil),
 				expectedResult: []string{"1", "2", "3", "4", "6"},
 				expectedError:  nil,
 			},
 
 			{
 				name: "respects max results",
-				request: newListObjectsRequest(store, "repo", "admin", "anna", modelID, &openfgapb.ContextualTupleKeys{
+				request: newListObjectsRequest(store, "repo", "admin", "anna", model.Id, &openfgapb.ContextualTupleKeys{
 					TupleKeys: []*openfgapb.TupleKey{{
 						User:     "anna",
 						Relation: "admin",
@@ -79,13 +101,13 @@ func TestListObjects(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 			{
 				name:           "performs correct checks",
-				request:        newListObjectsRequest(store, "repo", "admin", "bob", modelID, nil),
+				request:        newListObjectsRequest(store, "repo", "admin", "bob", model.Id, nil),
 				expectedResult: []string{"2", "6"},
 				expectedError:  nil,
 			},
 			{
 				name: "includes contextual tuples in the checks",
-				request: newListObjectsRequest(store, "repo", "admin", "bob", modelID, &openfgapb.ContextualTupleKeys{
+				request: newListObjectsRequest(store, "repo", "admin", "bob", model.Id, &openfgapb.ContextualTupleKeys{
 					TupleKeys: []*openfgapb.TupleKey{{
 						User:     "bob",
 						Relation: "admin",
@@ -100,7 +122,7 @@ func TestListObjects(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 			{
 				name: "ignores irrelevant contextual tuples in the checks",
-				request: newListObjectsRequest(store, "repo", "admin", "bob", modelID, &openfgapb.ContextualTupleKeys{
+				request: newListObjectsRequest(store, "repo", "admin", "bob", model.Id, &openfgapb.ContextualTupleKeys{
 					TupleKeys: []*openfgapb.TupleKey{{
 						User:     "bob",
 						Relation: "member",
@@ -111,26 +133,141 @@ func TestListObjects(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 			{
 				name:           "returns error if unknown type",
-				request:        newListObjectsRequest(store, "unknown", "admin", "anna", modelID, nil),
+				request:        newListObjectsRequest(store, "unknown", "admin", "anna", model.Id, nil),
 				expectedResult: nil,
 				expectedError:  serverErrors.TypeNotFound("unknown"),
 			},
 			{
 				name:           "returns error if unknown relation",
-				request:        newListObjectsRequest(store, "repo", "unknown", "anna", modelID, nil),
+				request:        newListObjectsRequest(store, "repo", "unknown", "anna", model.Id, nil),
 				expectedResult: nil,
 				expectedError:  serverErrors.RelationNotFound("unknown", "repo", nil),
 			},
 		}
 
 		listObjectsQuery := &commands.ListObjectsQuery{
-			Datastore:             backend,
+			Datastore:             ds,
 			Logger:                logger.NewNoopLogger(),
 			Tracer:                tracer,
 			Meter:                 telemetry.NewNoopMeter(),
 			ListObjectsDeadline:   defaultListObjectsDeadline,
 			ListObjectsMaxResults: defaultListObjectsMaxResults,
 			ResolveNodeLimit:      defaultResolveNodeLimit,
+		}
+
+		runListObjectsTests(t, ctx, testCases, listObjectsQuery)
+	})
+
+	t.Run("Github with TypeInfo", func(t *testing.T) {
+		store := ulid.Make().String()
+
+		data, err := os.ReadFile("testdata/github/typedefs.json")
+		require.NoError(t, err)
+
+		var gitHubTypeDefinitions openfgapb.WriteAuthorizationModelRequest
+		err = protojson.Unmarshal(data, &gitHubTypeDefinitions)
+		require.NoError(t, err)
+
+		model := &openfgapb.AuthorizationModel{
+			Id:              ulid.Make().String(),
+			SchemaVersion:   typesystem.SchemaVersion1_1,
+			TypeDefinitions: gitHubTypeDefinitions.GetTypeDefinitions(),
+		}
+
+		err = ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err)
+
+		data, err = os.ReadFile("testdata/github/tuples.json")
+		require.NoError(t, err)
+
+		var writes []*openfgapb.TupleKey
+		err = json.Unmarshal(data, &writes)
+		require.NoError(t, err)
+
+		err = ds.Write(ctx, store, nil, writes)
+		require.NoError(t, err)
+
+		testCases := []listObjectsTestCase{
+			{
+				name:           "does not return duplicates",
+				request:        newListObjectsRequest(store, "repo", "admin", "anna", model.Id, nil),
+				expectedResult: []string{"1", "2", "3", "4", "6"},
+				expectedError:  nil,
+			},
+
+			{
+				name: "respects max results",
+				request: newListObjectsRequest(store, "repo", "admin", "anna", model.Id, &openfgapb.ContextualTupleKeys{
+					TupleKeys: []*openfgapb.TupleKey{{
+						User:     "anna",
+						Relation: "admin",
+						Object:   "repo:7",
+					}}}),
+				expectedResult: []string{"1", "2", "3", "4", "6", "7"},
+				expectedError:  nil,
+			},
+			{
+				name:           "performs correct checks",
+				request:        newListObjectsRequest(store, "repo", "admin", "bob", model.Id, nil),
+				expectedResult: []string{"2", "6"},
+				expectedError:  nil,
+			},
+			{
+				name: "includes contextual tuples in the checks",
+				request: newListObjectsRequest(store, "repo", "admin", "bob", model.Id, &openfgapb.ContextualTupleKeys{
+					TupleKeys: []*openfgapb.TupleKey{{
+						User:     "bob",
+						Relation: "admin",
+						Object:   "repo:5",
+					}, {
+						User:     "bob",
+						Relation: "admin",
+						Object:   "repo:7",
+					}}}),
+				expectedResult: []string{"2", "5", "6", "7"},
+				expectedError:  nil,
+			},
+			{
+				name: "ignores irrelevant contextual tuples in the checks",
+				request: newListObjectsRequest(store, "repo", "admin", "bob", model.Id, &openfgapb.ContextualTupleKeys{
+					TupleKeys: []*openfgapb.TupleKey{{
+						User:     "bob",
+						Relation: "member",
+						Object:   "team:abc",
+					}}}),
+				expectedResult: []string{"2", "6"},
+				expectedError:  nil,
+			},
+			{
+				name:           "returns error if unknown type",
+				request:        newListObjectsRequest(store, "unknown", "admin", "anna", model.Id, nil),
+				expectedResult: nil,
+				expectedError:  serverErrors.TypeNotFound("unknown"),
+			},
+			{
+				name:           "returns error if unknown relation",
+				request:        newListObjectsRequest(store, "repo", "unknown", "anna", model.Id, nil),
+				expectedResult: nil,
+				expectedError:  serverErrors.RelationNotFound("unknown", "repo", nil),
+			},
+		}
+
+		connectedObjectsCmd := commands.ConnectedObjectsCommand{
+			Datastore:        ds,
+			Typesystem:       typesystem.New(model),
+			ResolveNodeLimit: defaultResolveNodeLimit,
+			Limit:            defaultListObjectsMaxResults,
+		}
+
+		listObjectsQuery := &commands.ListObjectsQuery{
+			Datastore:             ds,
+			Logger:                logger.NewNoopLogger(),
+			Tracer:                tracer,
+			Meter:                 telemetry.NewNoopMeter(),
+			ListObjectsDeadline:   defaultListObjectsDeadline,
+			ListObjectsMaxResults: defaultListObjectsMaxResults,
+			ResolveNodeLimit:      defaultResolveNodeLimit,
+			ConnectedObjects:      connectedObjectsCmd.StreamedConnectedObjects,
 		}
 
 		runListObjectsTests(t, ctx, testCases, listObjectsQuery)
@@ -203,33 +340,145 @@ func runListObjectsTests(t *testing.T, ctx context.Context, testCases []listObje
 	}
 }
 
-func setupTestListObjects(store string, datastore storage.OpenFGADatastore) (context.Context, storage.OpenFGADatastore, string, error) {
-	ctx := context.Background()
-	data, err := os.ReadFile(gitHubTestDataFile)
-	if err != nil {
-		return nil, nil, "", err
-	}
+// Used to avoid compiler optimizations (see https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)
+var listObjectsResponse *openfgapb.ListObjectsResponse //nolint
 
-	var gitHubTypeDefinitions openfgapb.WriteAuthorizationModelRequest
-	if err := protojson.Unmarshal(data, &gitHubTypeDefinitions); err != nil {
-		return nil, nil, "", err
-	}
+func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatastore) {
+
+	ctx := context.Background()
+	store := ulid.Make().String()
 
 	model := &openfgapb.AuthorizationModel{
-		Id:              ulid.Make().String(),
-		SchemaVersion:   typesystem.SchemaVersion1_0,
-		TypeDefinitions: gitHubTypeDefinitions.GetTypeDefinitions(),
+		Id:            ulid.Make().String(),
+		SchemaVersion: typesystem.SchemaVersion1_1,
+		TypeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "user",
+			},
+			{
+				Type: "document",
+				Relations: map[string]*openfgapb.Userset{
+					"viewer": typesystem.This(),
+				},
+				Metadata: &openfgapb.Metadata{
+					Relations: map[string]*openfgapb.RelationMetadata{
+						"viewer": {
+							DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+								typesystem.RelationReference("user", ""),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
-	err = datastore.WriteAuthorizationModel(ctx, store, model)
-	if err != nil {
-		return nil, nil, "", err
+	err := ds.WriteAuthorizationModel(ctx, store, model)
+	require.NoError(b, err)
+
+	n := 0
+	for i := 0; i < 100; i++ {
+		var tuples []*openfgapb.TupleKey
+
+		for j := 0; j < ds.MaxTuplesInWriteOperation(); j++ {
+			obj := fmt.Sprintf("document:%s", strconv.Itoa(n))
+			user := fmt.Sprintf("user:%s", strconv.Itoa(n))
+
+			tuples = append(tuples, tuple.NewTupleKey(obj, "viewer", user))
+
+			n += 1
+		}
+
+		err = ds.Write(ctx, store, nil, tuples)
+		require.NoError(b, err)
 	}
 
-	writes := []*openfgapb.TupleKey{tKAllAdminsRepo6, tkAnnaRepo1, tkAnnaRepo2, tkAnnaRepo3, tkAnnaRepo4, tkBobRepo2}
-	err = datastore.Write(ctx, store, []*openfgapb.TupleKey{}, writes)
-	if err != nil {
-		return nil, nil, "", err
+	connectedObjCmd := commands.ConnectedObjectsCommand{
+		Datastore:        ds,
+		Typesystem:       typesystem.New(model),
+		ResolveNodeLimit: defaultResolveNodeLimit,
 	}
 
-	return ctx, datastore, model.Id, nil
+	listObjectsQuery := commands.ListObjectsQuery{
+		Datastore:        ds,
+		Logger:           logger.NewNoopLogger(),
+		Tracer:           telemetry.NewNoopTracer(),
+		Meter:            telemetry.NewNoopMeter(),
+		ResolveNodeLimit: defaultResolveNodeLimit,
+		ConnectedObjects: connectedObjCmd.StreamedConnectedObjects,
+	}
+
+	var r *openfgapb.ListObjectsResponse
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, _ = listObjectsQuery.Execute(ctx, &openfgapb.ListObjectsRequest{
+			StoreId:              store,
+			AuthorizationModelId: model.Id,
+			Type:                 "document",
+			Relation:             "viewer",
+			User:                 "user:999",
+		})
+	}
+
+	listObjectsResponse = r
+}
+
+func BenchmarkListObjectsWithConcurrentChecks(b *testing.B, ds storage.OpenFGADatastore) {
+	ctx := context.Background()
+	store := ulid.Make().String()
+
+	model := &openfgapb.AuthorizationModel{
+		Id:            ulid.Make().String(),
+		SchemaVersion: typesystem.SchemaVersion1_0,
+		TypeDefinitions: []*openfgapb.TypeDefinition{
+			{
+				Type: "document",
+				Relations: map[string]*openfgapb.Userset{
+					"viewer": typesystem.This(),
+				},
+			},
+		},
+	}
+	err := ds.WriteAuthorizationModel(ctx, store, model)
+	require.NoError(b, err)
+
+	n := 0
+	for i := 0; i < 100; i++ {
+		var tuples []*openfgapb.TupleKey
+
+		for j := 0; j < ds.MaxTuplesInWriteOperation(); j++ {
+			obj := fmt.Sprintf("document:%s", strconv.Itoa(n))
+			user := fmt.Sprintf("user:%s", strconv.Itoa(n))
+
+			tuples = append(tuples, tuple.NewTupleKey(obj, "viewer", user))
+
+			n += 1
+		}
+
+		err = ds.Write(ctx, store, nil, tuples)
+		require.NoError(b, err)
+	}
+
+	listObjectsQuery := commands.ListObjectsQuery{
+		Datastore:        ds,
+		Logger:           logger.NewNoopLogger(),
+		Tracer:           telemetry.NewNoopTracer(),
+		Meter:            telemetry.NewNoopMeter(),
+		ResolveNodeLimit: defaultResolveNodeLimit,
+	}
+
+	var r *openfgapb.ListObjectsResponse
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		r, _ = listObjectsQuery.Execute(ctx, &openfgapb.ListObjectsRequest{
+			StoreId:              store,
+			AuthorizationModelId: model.Id,
+			Type:                 "document",
+			Relation:             "viewer",
+			User:                 "user:999",
+		})
+	}
+
+	listObjectsResponse = r
 }

--- a/server/test/server.go
+++ b/server/test/server.go
@@ -54,7 +54,8 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadChangesReturnsSameContTokenWhenNoChanges",
 		func(t *testing.T) { TestReadChangesReturnsSameContTokenWhenNoChanges(t, ds) },
 	)
-	t.Run("TestListObjects", func(t *testing.T) { TestListObjects(t, ds) })
+
+	t.Run("TestListObjects", func(t *testing.T) { ListObjectsTest(t, ds) })
 }
 
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
@@ -63,13 +64,20 @@ func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestWriteAssertions", func(t *testing.T) { TestWriteAssertions(t, ds) })
 	t.Run("TestCreateStore", func(t *testing.T) { TestCreateStore(t, ds) })
 	t.Run("TestDeleteStore", func(t *testing.T) { TestDeleteStore(t, ds) })
+	t.Run("TestConnectedObjects", func(t *testing.T) { ConnectedObjectsTest(t, ds) })
 }
 
 func RunAllBenchmarks(b *testing.B, ds storage.OpenFGADatastore) {
 	RunCheckBenchmarks(b, ds)
+	RunListObjectsBenchmarks(b, ds)
 }
 
 func RunCheckBenchmarks(b *testing.B, ds storage.OpenFGADatastore) {
 	b.Run("BenchmarkCheckWithoutTrace", func(b *testing.B) { BenchmarkCheckWithoutTrace(b, ds) })
-	b.Run("BenchmarkWithTrace", func(b *testing.B) { BenchmarkWithTrace(b, ds) })
+	b.Run("BenchmarkCheckWithTrace", func(b *testing.B) { BenchmarkCheckWithTrace(b, ds) })
+}
+
+func RunListObjectsBenchmarks(b *testing.B, ds storage.OpenFGADatastore) {
+	b.Run("BenchmarkListObjectsWithReverseExpand", func(b *testing.B) { BenchmarkListObjectsWithReverseExpand(b, ds) })
+	b.Run("BenchmarkListObjectsWithConcurrentChecks", func(b *testing.B) { BenchmarkListObjectsWithConcurrentChecks(b, ds) })
 }

--- a/server/test/write_authzmodel.go
+++ b/server/test/write_authzmodel.go
@@ -166,7 +166,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.InvalidRelationError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInComputedUserset",
@@ -188,7 +188,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInTupleToUserset",
@@ -215,7 +215,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInUnion",
@@ -250,7 +250,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInDifferenceBaseArgument",
@@ -285,7 +285,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInDifferenceSubtractArgument",
@@ -320,7 +320,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInTupleToUsersetTupleset",
@@ -349,7 +349,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInTupleToUsersetComputedUserset",
@@ -378,7 +378,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfTupleToUsersetReferencesUnknownRelation",
@@ -414,7 +414,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("bar", "writer")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "bar", Relation: "writer"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnknownRelationInIntersection",
@@ -447,7 +447,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.RelationDoesNotExistError("repo", "owner")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.RelationUndefinedError{ObjectType: "repo", Relation: "owner"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfDifferenceIncludesSameRelationTwice",
@@ -477,7 +477,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.InvalidRelationError("repo", "viewer")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{ObjectType: "repo", Relation: "viewer"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfUnionIncludesSameRelationTwice",
@@ -504,7 +504,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.InvalidRelationError("repo", "viewer")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{ObjectType: "repo", Relation: "viewer"}),
 		},
 		{
 			name: "ExecuteWriteFailsIfIntersectionIncludesSameRelationTwice",
@@ -530,7 +530,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-			err: serverErrors.InvalidAuthorizationModelInput(typesystem.InvalidRelationError("repo", "viewer")),
+			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{ObjectType: "repo", Relation: "viewer"}),
 		},
 		{
 			name: "Union Rewrite Contains Repeated Definitions",

--- a/testdata/github/tuples.json
+++ b/testdata/github/tuples.json
@@ -1,0 +1,7 @@
+[
+    {"object":  "repo:1", "relation":  "admin", "user":  "user:anna"},
+    {"object":  "repo:2", "relation":  "admin", "user":  "user:anna"},
+    {"object":  "repo:3", "relation":  "admin", "user":  "user:anna"},
+    {"object":  "repo:4", "relation":  "admin", "user":  "user:anna"},
+    {"object":  "repo:6", "relation":  "admin", "user":  "*"}
+]

--- a/testdata/github/typedefs.json
+++ b/testdata/github/typedefs.json
@@ -1,0 +1,293 @@
+{
+  "type_definitions": [
+    {
+      "type": "user",
+      "relations": {}
+    },
+    {
+      "type": "team",
+      "relations": {
+        "member": {
+          "this": {}
+        }
+      },
+      "metadata": {
+        "relations": {
+          "member": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "repo",
+      "relations": {
+        "admin": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "tupleToUserset": {
+                  "tupleset": {
+                    "object": "",
+                    "relation": "owner"
+                  },
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "repo_admin"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "maintainer": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "object": "",
+                  "relation": "admin"
+                }
+              }
+            ]
+          }
+        },
+        "owner": {
+          "this": {}
+        },
+        "reader": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "object": "",
+                  "relation": "triager"
+                }
+              },
+              {
+                "tupleToUserset": {
+                  "tupleset": {
+                    "object": "",
+                    "relation": "owner"
+                  },
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "repo_reader"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "triager": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "object": "",
+                  "relation": "writer"
+                }
+              }
+            ]
+          }
+        },
+        "writer": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "object": "",
+                  "relation": "maintainer"
+                }
+              },
+              {
+                "tupleToUserset": {
+                  "tupleset": {
+                    "object": "",
+                    "relation": "owner"
+                  },
+                  "computedUserset": {
+                    "object": "",
+                    "relation": "repo_writer"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "relations": {
+          "admin": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          },
+          "maintainer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          },
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "organization"
+              }
+            ]
+          },
+          "reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          },
+          "triager": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          },
+          "writer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "organization",
+      "relations": {
+        "member": {
+          "union": {
+            "child": [
+              {
+                "this": {}
+              },
+              {
+                "computedUserset": {
+                  "object": "",
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "owner": {
+          "this": {}
+        },
+        "repo_admin": {
+          "this": {}
+        },
+        "repo_reader": {
+          "this": {}
+        },
+        "repo_writer": {
+          "this": {}
+        }
+      },
+      "metadata": {
+        "relations": {
+          "member": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              }
+            ]
+          },
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              }
+            ]
+          },
+          "repo_admin": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "organization",
+                "relation": "member"
+              }
+            ]
+          },
+          "repo_reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "organization",
+                "relation": "member"
+              }
+            ]
+          },
+          "repo_writer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "organization",
+                "relation": "member"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR introduces a new internal API called the `ConnectedObjects` API. This API is used to reverse expand relationship tuples between some source user and some target `object#relation`. We use this ConnectedObjects API in an improved version of ListObjects for any models other than those exhibiting intersection or exclusion rewrites (support for improved intersection and exclusion coming soon).

## References
https://github.com/openfga/roadmap/issues/8

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
