### PR TITLE
fix: correcting TLS certificates config path

### DIFF
--- a/pkg/cmd/service/service.go
+++ b/pkg/cmd/service/service.go
@@ -69,8 +69,8 @@ type HTTPConfig struct {
 // TLSConfig defines configuration specific to Transport Layer Security (TLS) settings.
 type TLSConfig struct {
 	Enabled  bool
-	CertPath string
-	KeyPath  string
+	CertPath string `mapstructure:"cert"`
+	KeyPath  string `mapstructure:"key"`
 }
 
 // AuthnConfig defines OpenFGA server configurations for authentication specific settings.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
In [config schema](https://github.com/openfga/openfga/blob/main/.config-schema.json) is this config path described: `grpc.tls.cert` and `grpc.tls.key`. Neither runtime flags `--grpc-tls-cert`/`--grpc-tls-key` nor yaml configs `grpc.tls.cert` and `grpc.tls.key` are mapped correctly.
Mismatch is done by:

https://github.com/openfga/openfga/blob/0999404bfb1ef7846b2ca12469ef049cb6c6f8e9/pkg/cmd/service/service.go#L70-L74

Fields `cert` and `key` cannot be mapped to `CertPath` and `KeyPath` without `mapstructure` tag.

## Description
<!-- Provide a detailed description of the changes -->
fixes #284 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
