### PR TITLE
fix: read usersets in check

### DIFF
--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -85,12 +85,6 @@ func IsObjectRelation(userset string) bool {
 	return GetType(userset) != "" && GetRelation(userset) != ""
 }
 
-// IsType returns true if the given string contains just a type.
-func IsType(object string) bool {
-	t, id := SplitObject(object)
-	return t != "" && id == ""
-}
-
 // ToObjectRelationString formats an object/relation pair as an object#relation string. This is the inverse of
 // SplitObjectRelation.
 func ToObjectRelationString(object, relation string) string {
@@ -99,7 +93,8 @@ func ToObjectRelationString(object, relation string) string {
 
 // GetUserTypeFromUser returns the type of user (userset or user).
 func GetUserTypeFromUser(user string) UserType {
-	if IsObjectRelation(user) || user == "*" {
+	userObj, _ := SplitObjectRelation(user)
+	if IsValidObject(userObj) || user == "*" {
 		return UserSet
 	}
 	return User

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -280,7 +280,7 @@ func TestGetUsertypeFromUser(t *testing.T) {
 		},
 		{
 			name: "document:10",
-			want: User,
+			want: UserSet,
 		},
 		{
 			name: "*",

--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -402,7 +402,7 @@ func (query *CheckQuery) resolveTupleToUserset(ctx context.Context, rc *resoluti
 		relation = rc.tk.GetRelation()
 	}
 	tracer := rc.tracer.AppendTupleToUserset().AppendString(tupleUtils.ToObjectRelationString(rc.tk.GetObject(), relation))
-	nestedRC := rc.fork(&openfgapb.TupleKey{Object: rc.tk.GetObject(), Relation: relation}, rc.tracer, false)
+	nestedRC := rc.fork(&openfgapb.TupleKey{Object: rc.tk.GetObject(), Relation: relation}, tracer, false)
 	iter, err := nestedRC.readUsersetTuples(ctx, query.datastore)
 	if err != nil {
 		return serverErrors.HandleError("", err)

--- a/server/commands/check_utils.go
+++ b/server/commands/check_utils.go
@@ -362,26 +362,8 @@ func (rc *resolutionContext) readUsersetTuples(ctx context.Context, backend stor
 	return storage.NewCombinedIterator(iter1, iter2), nil
 }
 
-func (rc *resolutionContext) read(ctx context.Context, backend storage.TupleBackend, tk *openfgapb.TupleKey) (storage.TupleKeyIterator, error) {
-	cTuples := rc.contextualTuples.read(tk)
-	rc.metadata.AddReadCall()
-	tuples, err := backend.Read(ctx, rc.store, tk)
-	if err != nil {
-		return nil, err
-	}
-
-	iter1 := storage.NewStaticTupleKeyIterator(cTuples)
-	iter2 := storage.NewTupleKeyIteratorFromTupleIterator(tuples)
-
-	return storage.NewCombinedIterator(iter1, iter2), nil
-}
-
 type contextualTuples struct {
 	usersets map[string][]*openfgapb.TupleKey
-}
-
-func (c *contextualTuples) read(tk *openfgapb.TupleKey) []*openfgapb.TupleKey {
-	return c.usersets[tupleUtils.ToObjectRelationString(tk.GetObject(), tk.GetRelation())]
 }
 
 func (c *contextualTuples) readUserTuple(tk *openfgapb.TupleKey) (*openfgapb.TupleKey, bool) {

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1209,9 +1209,9 @@ func TestCheckQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				if test.response.Allowed {
-					require.Equal(t, test.response.Resolution, resp.Resolution)
-				}
+				//if test.response.Allowed {
+				//	require.Equal(t, test.response.Resolution, resp.Resolution)
+				//}
 			}
 		})
 	}
@@ -1342,9 +1342,9 @@ func TestCheckQueryAgainstGitHubModel(t *testing.T, datastore storage.OpenFGADat
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				if test.response.Allowed {
-					require.Equal(t, test.response.Resolution, resp.Resolution)
-				}
+				//if test.response.Allowed {
+				//	require.Equal(t, test.response.Resolution, resp.Resolution)
+				//}
 			}
 		})
 	}
@@ -1535,9 +1535,9 @@ func TestCheckQueryWithContextualTuplesAgainstGitHubModel(t *testing.T, datastor
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				if test.response.Allowed {
-					require.Equal(t, test.response.Resolution, resp.Resolution)
-				}
+				//if test.response.Allowed {
+				//	require.Equal(t, test.response.Resolution, resp.Resolution)
+				//}
 			}
 		})
 	}

--- a/server/test/check.go
+++ b/server/test/check.go
@@ -1209,9 +1209,9 @@ func TestCheckQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				//if test.response.Allowed {
-				//	require.Equal(t, test.response.Resolution, resp.Resolution)
-				//}
+				if test.response.Allowed {
+					require.Equal(t, test.response.Resolution, resp.Resolution)
+				}
 			}
 		})
 	}
@@ -1342,9 +1342,9 @@ func TestCheckQueryAgainstGitHubModel(t *testing.T, datastore storage.OpenFGADat
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				//if test.response.Allowed {
-				//	require.Equal(t, test.response.Resolution, resp.Resolution)
-				//}
+				if test.response.Allowed {
+					require.Equal(t, test.response.Resolution, resp.Resolution)
+				}
 			}
 		})
 	}
@@ -1535,9 +1535,9 @@ func TestCheckQueryWithContextualTuplesAgainstGitHubModel(t *testing.T, datastor
 
 				require.Equal(t, test.response.Allowed, resp.Allowed)
 
-				//if test.response.Allowed {
-				//	require.Equal(t, test.response.Resolution, resp.Resolution)
-				//}
+				if test.response.Allowed {
+					require.Equal(t, test.response.Resolution, resp.Resolution)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

`object:id` in the user part of a tuple is a userset.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
