### PR TITLE
fix: throw error if config.http.upstreamTimeout is lower than config.listObjectsDeadline

### DIFF
--- a/pkg/cmd/service/service_test.go
+++ b/pkg/cmd/service/service_test.go
@@ -214,6 +214,16 @@ type authTest struct {
 	expectedStatusCode    int
 }
 
+func TestBuildServiceWithIncompatibleTimeouts(t *testing.T) {
+	config, err := GetServiceConfig()
+	require.NoError(t, err)
+	config.ListObjectsDeadline = 5 * time.Minute
+	config.HTTP.UpstreamTimeout = 2 * time.Second
+
+	_, err = BuildService(config, logger.NewNoopLogger())
+	require.EqualError(t, err, "config 'http.upstreamTimeout' (2s) cannot be lower than 'listObjectsDeadline' config (5m0s)")
+}
+
 func TestBuildServiceWithNoAuth(t *testing.T) {
 	config, err := GetServiceConfig()
 	require.NoError(t, err)


### PR DESCRIPTION
Throw an error if attempting to run the server and `config.http.upstreamTimeout` and `config.listObjectsDeadline`.

## References
https://github.com/openfga/openfga/issues/314

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
