### PR TITLE
chore: simplify coverage and suppress verbose coverpkg output

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - id: go-cache-paths
         run: |
-          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
 
       # Cache go build cache, used to speedup go test
       - uses: actions/cache@v3
@@ -66,8 +66,8 @@ jobs:
 
         - id: go-cache-paths
           run: |
-            echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-            echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+            echo "::set-output name=go-build::$(go env GOCACHE)"
+            echo "::set-output name=go-mod::$(go env GOMODCACHE)"
 
         # Cache go build and go mod cache, used to speedup go test
         - uses: actions/cache@v3
@@ -88,13 +88,6 @@ jobs:
 
         - name: Functional Tests
           run: make functional-test
-
-        - name: upload coverage to codecov
-          uses: codecov/codecov-action@v3
-          with:
-            files: ./coveragefunctional.out
-            verbose: true
-            fail_ci_if_error: false 
 
   go-bench:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR changes the way we report coverage by running `go test` on all packages and then stripping away all of the cover profiles that cover mocks. It leads to the same report, but it avoids the verbose comma-separate list of `coverpkg` which makes it hard to read the test output.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
