### PR TITLE
chore: refactor postgres to use `database/sql`

### DIFF
--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -289,6 +289,8 @@ func TestBuildServiceWithNoAuth(t *testing.T) {
 		}
 	}()
 
+	ensureServiceUp(t, cfg.GRPC.Addr, cfg.HTTP.Addr, nil, true)
+
 	conn, err := grpc.Dial(cfg.GRPC.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	require.NoError(t, err)
 	defer conn.Close()

--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -1,16 +1,16 @@
 package postgres
 
 import (
+	"database/sql"
 	"encoding/json"
 	"errors"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/openfga/openfga/storage"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
 type tupleIterator struct {
-	rows pgx.Rows
+	rows *sql.Rows
 }
 
 var _ storage.TupleIterator = (*tupleIterator)(nil)
@@ -81,7 +81,7 @@ func (t *tupleIterator) Stop() {
 }
 
 type objectIterator struct {
-	rows pgx.Rows
+	rows *sql.Rows
 }
 
 var _ storage.ObjectIterator = (*objectIterator)(nil)

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -514,13 +514,13 @@ func (p *Postgres) WriteAuthorizationModel(ctx context.Context, store string, mo
 		return storage.ExceededMaxTypeDefinitionsLimitError(p.maxTypesInTypeDefinition)
 	}
 
-	sqlbuilder := squirrel.
-		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
-		Insert("authorization_model").Columns("store", "authorization_model_id", "schema_version", "type", "type_definition")
-
 	if len(typeDefinitions) < 1 {
 		return nil
 	}
+
+	sqlbuilder := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Insert("authorization_model").Columns("store", "authorization_model_id", "schema_version", "type", "type_definition")
 
 	for _, td := range typeDefinitions {
 		marshalledTypeDef, err := proto.Marshal(td)

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -2,15 +2,16 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/cenkalti/backoff/v4"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/oklog/ulid/v2"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/telemetry"
@@ -30,7 +31,7 @@ const (
 )
 
 type Postgres struct {
-	pool                     *pgxpool.Pool
+	db                       *sql.DB
 	tracer                   trace.Tracer
 	logger                   logger.Logger
 	maxTuplesInWrite         int
@@ -88,16 +89,16 @@ func NewPostgresDatastore(uri string, opts ...PostgresOption) (*Postgres, error)
 		p.maxTypesInTypeDefinition = defaultMaxTypesInDefinition
 	}
 
-	pool, err := pgxpool.New(context.Background(), uri)
+	db, err := sql.Open("pgx", uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to Postgres: %w", err)
+		return nil, fmt.Errorf("failed to initialize Postgres connection: %w", err)
 	}
 
 	policy := backoff.NewExponentialBackOff()
 	policy.MaxElapsedTime = 1 * time.Minute
 	attempt := 1
 	err = backoff.Retry(func() error {
-		err = pool.Ping(context.Background())
+		err = db.PingContext(context.Background())
 		if err != nil {
 			p.logger.Info("waiting for Postgres", zap.Int("attempt", attempt))
 			attempt++
@@ -109,7 +110,7 @@ func NewPostgresDatastore(uri string, opts ...PostgresOption) (*Postgres, error)
 		return nil, fmt.Errorf("failed to initialize Postgres connection: %w", err)
 	}
 
-	p.pool = pool
+	p.db = db
 
 	return p, nil
 }
@@ -117,7 +118,7 @@ func NewPostgresDatastore(uri string, opts ...PostgresOption) (*Postgres, error)
 // Close closes any open connections and cleans up residual resources
 // used by this storage adapter instance.
 func (p *Postgres) Close(ctx context.Context) error {
-	p.pool.Close()
+	p.db.Close()
 
 	return nil
 }
@@ -126,8 +127,20 @@ func (p *Postgres) ListObjectsByType(ctx context.Context, store string, objectTy
 	ctx, span := p.tracer.Start(ctx, "postgres.ListObjectsByType")
 	defer span.End()
 
-	stmt := "SELECT DISTINCT object_type, object_id FROM tuple WHERE store = $1 AND object_type = $2"
-	rows, err := p.pool.Query(ctx, stmt, store, objectType)
+	stmt, args, err := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Select("object_type", "object_id").
+		Distinct().
+		From("tuple").
+		Where(squirrel.Eq{
+			"store":       store,
+			"object_type": objectType,
+		}).ToSql()
+	if err != nil {
+		return nil, handlePostgresError(err)
+	}
+
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +176,7 @@ func (p *Postgres) read(ctx context.Context, store string, tupleKey *openfgapb.T
 		return nil, err
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, args...)
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -180,59 +193,89 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 	}
 
 	now := time.Now().UTC()
-	tx, err := p.pool.Begin(ctx)
+	txn, err := p.db.BeginTx(ctx, nil)
 	if err != nil {
 		return handlePostgresError(err)
 	}
-	defer rollbackTx(ctx, tx, p.logger)
+	defer rollbackTx(ctx, txn, p.logger)
 
-	deleteBatch := &pgx.Batch{}
-	writeBatch := &pgx.Batch{}
-	changelogBatch := &pgx.Batch{}
+	changelogBuilder := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Insert("changelog").
+		Columns("store", "object_type", "object_id", "relation", "_user", "operation", "ulid", "inserted_at")
+
+	deletebuilder := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Delete("tuple")
 
 	for _, tk := range deletes {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
-		deleteBatch.Queue(`DELETE FROM tuple WHERE store = $1 AND object_type = $2 AND object_id = $3 AND relation = $4 AND _user = $5 AND user_type = $6`, store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()))
-		changelogBatch.Queue(`INSERT INTO changelog (store, object_type, object_id, relation, _user, operation, ulid, inserted_at) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`, store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_DELETE, id)
-	}
 
-	deleteResults := tx.SendBatch(ctx, deleteBatch)
-	for i := 0; i < deleteBatch.Len(); i++ {
-		tag, err := deleteResults.Exec()
+		stmt, args, err := deletebuilder.Where(squirrel.Eq{
+			"store":       store,
+			"object_type": objectType,
+			"object_id":   objectID,
+			"relation":    tk.GetRelation(),
+			"_user":       tk.GetUser(),
+			"user_type":   tupleUtils.GetUserTypeFromUser(tk.GetUser()),
+		}).ToSql()
 		if err != nil {
 			return handlePostgresError(err)
 		}
-		if tag.RowsAffected() != 1 {
-			return storage.InvalidWriteInputError(deletes[i], openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
+
+		res, err := txn.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return handlePostgresError(err, tk)
 		}
+
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			return handlePostgresError(err)
+		}
+
+		if rowsAffected != 1 {
+			return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
+		}
+
+		changelogBuilder = changelogBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_DELETE, id, "NOW()")
 	}
-	if err := deleteResults.Close(); err != nil {
-		return err
-	}
+
+	tupleInsertBuilder := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Insert("tuple").
+		Columns("store", "object_type", "object_id", "relation", "_user", "user_type", "ulid", "inserted_at")
 
 	for _, tk := range writes {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
-		writeBatch.Queue(`INSERT INTO tuple (store, object_type, object_id, relation, _user, user_type, ulid, inserted_at) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`, store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id)
-		changelogBatch.Queue(`INSERT INTO changelog (store, object_type, object_id, relation, _user, operation, ulid, inserted_at) VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())`, store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_WRITE, id)
+
+		stmt, args, err := tupleInsertBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id, "NOW()").ToSql()
+		if err != nil {
+			return handlePostgresError(err)
+		}
+
+		_, err = txn.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return handlePostgresError(err, tk)
+		}
+
+		changelogBuilder = changelogBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_WRITE, id, "NOW()")
 	}
 
-	writeResults := tx.SendBatch(ctx, writeBatch)
-	for i := 0; i < writeBatch.Len(); i++ {
-		if _, err := writeResults.Exec(); err != nil {
-			return handlePostgresError(err, writes[i])
+	if len(writes) > 0 || len(deletes) > 0 {
+		stmt, args, err := changelogBuilder.ToSql()
+		if err != nil {
+			return handlePostgresError(err)
+		}
+
+		_, err = txn.ExecContext(ctx, stmt, args...)
+		if err != nil {
+			return handlePostgresError(err)
 		}
 	}
-	if err := writeResults.Close(); err != nil {
-		return err
-	}
 
-	if err := tx.SendBatch(ctx, changelogBatch).Close(); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(ctx); err != nil {
+	if err := txn.Commit(); err != nil {
 		return handlePostgresError(err)
 	}
 
@@ -246,7 +289,7 @@ func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *op
 	objectType, objectID := tupleUtils.SplitObject(tupleKey.GetObject())
 	userType := tupleUtils.GetUserTypeFromUser(tupleKey.GetUser())
 
-	row := p.pool.QueryRow(ctx, `SELECT object_type, object_id, relation, _user FROM tuple WHERE store = $1 AND object_type = $2 AND object_id = $3 AND relation = $4 AND _user = $5 AND user_type = $6`,
+	row := p.db.QueryRowContext(ctx, `SELECT object_type, object_id, relation, _user FROM tuple WHERE store = $1 AND object_type = $2 AND object_id = $3 AND relation = $4 AND _user = $5 AND user_type = $6`,
 		store, objectType, objectID, tupleKey.GetRelation(), tupleKey.GetUser(), userType)
 
 	var record tupleRecord
@@ -266,7 +309,7 @@ func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, tupleKey
 		return nil, err
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, args...)
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -288,7 +331,7 @@ func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts 
 		targetUsersArg = append(targetUsersArg, targetUser)
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, store, opts.ObjectType, opts.Relation, targetUsersArg)
+	rows, err := p.db.QueryContext(ctx, stmt, store, opts.ObjectType, opts.Relation, targetUsersArg)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -317,7 +360,7 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 	defer span.End()
 
 	stmt := "SELECT schema_version, type, type_definition FROM authorization_model WHERE store = $1 AND authorization_model_id = $2"
-	rows, err := p.pool.Query(ctx, stmt, store, modelID)
+	rows, err := p.db.QueryContext(ctx, stmt, store, modelID)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -351,7 +394,7 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 	// Update the schema version lazily if it is not a valid typesystem.SchemaVersion.
 	if schemaVersion != typesystem.SchemaVersion1_0 && schemaVersion != typesystem.SchemaVersion1_1 {
 		schemaVersion = typesystem.SchemaVersion1_0
-		_, err = p.pool.Exec(ctx, "UPDATE authorization_model SET schema_version = $1 WHERE store = $2 AND authorization_model_id = $3", schemaVersion, store, modelID)
+		_, err = p.db.ExecContext(ctx, "UPDATE authorization_model SET schema_version = $1 WHERE store = $2 AND authorization_model_id = $3", schemaVersion, store, modelID)
 		if err != nil {
 			// Don't worry if we error, we'll update it lazily next time, but let's log:
 			p.logger.Warn("failed to lazily update schema version", zap.String("store", store), zap.String("authorization_model_id", modelID))
@@ -374,7 +417,7 @@ func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, op
 		return nil, nil, err
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, args...)
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, nil, handlePostgresError(err)
 	}
@@ -426,7 +469,7 @@ func (p *Postgres) FindLatestAuthorizationModelID(ctx context.Context, store str
 
 	var modelID string
 	stmt := "SELECT authorization_model_id FROM authorization_model WHERE store = $1 ORDER BY authorization_model_id DESC LIMIT 1"
-	err := p.pool.QueryRow(ctx, stmt, store).Scan(&modelID)
+	err := p.db.QueryRowContext(ctx, stmt, store).Scan(&modelID)
 	if err != nil {
 		return "", handlePostgresError(err)
 	}
@@ -443,7 +486,7 @@ func (p *Postgres) ReadTypeDefinition(
 
 	var marshalledTypeDef []byte
 	stmt := "SELECT type_definition FROM authorization_model WHERE store = $1 AND authorization_model_id = $2 AND type = $3"
-	err := p.pool.QueryRow(ctx, stmt, store, modelID, objectType).Scan(&marshalledTypeDef)
+	err := p.db.QueryRowContext(ctx, stmt, store, modelID, objectType).Scan(&marshalledTypeDef)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -471,21 +514,29 @@ func (p *Postgres) WriteAuthorizationModel(ctx context.Context, store string, mo
 		return storage.ExceededMaxTypeDefinitionsLimitError(p.maxTypesInTypeDefinition)
 	}
 
-	stmt := "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition) VALUES ($1, $2, $3, $4, $5)"
+	sqlbuilder := squirrel.
+		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
+		Insert("authorization_model").Columns("store", "authorization_model_id", "schema_version", "type", "type_definition")
 
-	inserts := &pgx.Batch{}
+	if len(typeDefinitions) < 1 {
+		return nil
+	}
+
 	for _, td := range typeDefinitions {
 		marshalledTypeDef, err := proto.Marshal(td)
 		if err != nil {
 			return err
 		}
 
-		inserts.Queue(stmt, store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef)
+		sqlbuilder = sqlbuilder.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef)
 	}
 
-	err := pgx.BeginFunc(ctx, p.pool, func(tx pgx.Tx) error {
-		return tx.SendBatch(ctx, inserts).Close()
-	})
+	stmt, args, err := sqlbuilder.ToSql()
+	if err != nil {
+		return handlePostgresError(err)
+	}
+
+	_, err = p.db.ExecContext(ctx, stmt, args...)
 	if err != nil {
 		return handlePostgresError(err)
 	}
@@ -500,7 +551,7 @@ func (p *Postgres) CreateStore(ctx context.Context, store *openfgapb.Store) (*op
 	var id, name string
 	var createdAt time.Time
 	stmt := "INSERT INTO store (id, name, created_at, updated_at) VALUES ($1, $2, NOW(), NOW()) RETURNING id, name, created_at"
-	err := p.pool.QueryRow(ctx, stmt, store.Id, store.Name).Scan(&id, &name, &createdAt)
+	err := p.db.QueryRowContext(ctx, stmt, store.Id, store.Name).Scan(&id, &name, &createdAt)
 	if err != nil {
 		return nil, handlePostgresError(err)
 	}
@@ -517,13 +568,13 @@ func (p *Postgres) GetStore(ctx context.Context, id string) (*openfgapb.Store, e
 	ctx, span := p.tracer.Start(ctx, "postgres.GetStore")
 	defer span.End()
 
-	row := p.pool.QueryRow(ctx, "SELECT id, name, created_at, updated_at FROM store WHERE id = $1 AND deleted_at IS NULL", id)
+	row := p.db.QueryRowContext(ctx, "SELECT id, name, created_at, updated_at FROM store WHERE id = $1 AND deleted_at IS NULL", id)
 
 	var storeID, name string
 	var createdAt, updatedAt time.Time
 	err := row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, storage.ErrNotFound
 		}
 		return nil, handlePostgresError(err)
@@ -546,7 +597,7 @@ func (p *Postgres) ListStores(ctx context.Context, opts storage.PaginationOption
 		return nil, nil, err
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, args...)
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, nil, handlePostgresError(err)
 	}
@@ -588,7 +639,7 @@ func (p *Postgres) DeleteStore(ctx context.Context, id string) error {
 	ctx, span := p.tracer.Start(ctx, "postgres.DeleteStore")
 	defer span.End()
 
-	_, err := p.pool.Exec(ctx, "UPDATE store SET deleted_at = NOW() WHERE id = $1", id)
+	_, err := p.db.ExecContext(ctx, "UPDATE store SET deleted_at = NOW() WHERE id = $1", id)
 	if err != nil {
 		return handlePostgresError(err)
 	}
@@ -606,7 +657,7 @@ func (p *Postgres) WriteAssertions(ctx context.Context, store, modelID string, a
 	}
 
 	stmt := "INSERT INTO assertion (store, authorization_model_id, assertions) VALUES ($1, $2, $3) ON CONFLICT (store, authorization_model_id) DO UPDATE SET assertions = $3"
-	_, err = p.pool.Exec(ctx, stmt, store, modelID, marshalledAssertions)
+	_, err = p.db.ExecContext(ctx, stmt, store, modelID, marshalledAssertions)
 	if err != nil {
 		return handlePostgresError(err)
 	}
@@ -619,9 +670,9 @@ func (p *Postgres) ReadAssertions(ctx context.Context, store, modelID string) ([
 	defer span.End()
 
 	var marshalledAssertions []byte
-	err := p.pool.QueryRow(ctx, `SELECT assertions FROM assertion WHERE store = $1 AND authorization_model_id = $2`, store, modelID).Scan(&marshalledAssertions)
+	err := p.db.QueryRowContext(ctx, `SELECT assertions FROM assertion WHERE store = $1 AND authorization_model_id = $2`, store, modelID).Scan(&marshalledAssertions)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if errors.Is(err, sql.ErrNoRows) {
 			return []*openfgapb.Assertion{}, nil
 		}
 		return nil, handlePostgresError(err)
@@ -650,7 +701,7 @@ func (p *Postgres) ReadChanges(
 		return nil, nil, err
 	}
 
-	rows, err := p.pool.Query(ctx, stmt, args...)
+	rows, err := p.db.QueryContext(ctx, stmt, args...)
 	if err != nil {
 		return nil, nil, handlePostgresError(err)
 	}
@@ -696,7 +747,7 @@ func (p *Postgres) IsReady(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 
-	if err := p.pool.Ping(ctx); err != nil {
+	if err := p.db.PingContext(ctx); err != nil {
 		return false, err
 	}
 

--- a/storage/postgres/postgres_test.go
+++ b/storage/postgres/postgres_test.go
@@ -37,7 +37,7 @@ func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
 	bytes, err := proto.Marshal(&openfgapb.TypeDefinition{Type: "document"})
 	require.NoError(t, err)
 
-	_, err = ds.pool.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition) VALUES ($1, $2, $3, $4, $5)", store, modelID, schemaVersion, "document", bytes)
+	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition) VALUES ($1, $2, $3, $4, $5)", store, modelID, schemaVersion, "document", bytes)
 	require.NoError(t, err)
 
 	model, err := ds.ReadAuthorizationModel(ctx, store, modelID)

--- a/storage/postgres/utils_test.go
+++ b/storage/postgres/utils_test.go
@@ -1,10 +1,10 @@
 package postgres
 
 import (
+	"database/sql"
 	"errors"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/openfga/openfga/storage"
 	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
@@ -26,8 +26,8 @@ func TestHandlePostgresError(t *testing.T) {
 		require.ErrorIs(t, err, storage.ErrCollision)
 	})
 
-	t.Run("pgx.ErrNoRows is converted to storage.ErrNotFound error", func(t *testing.T) {
-		err := handlePostgresError(pgx.ErrNoRows)
+	t.Run("sql.ErrNoRows is converted to storage.ErrNotFound error", func(t *testing.T) {
+		err := handlePostgresError(sql.ErrNoRows)
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -147,6 +147,14 @@ func NewCombinedIterator[T any](iter1, iter2 Iterator[T]) Iterator[T] {
 	return &combinedIterator[T]{iter1, iter2}
 }
 
+func NewStaticTupleIterator(tuples []*openfgapb.Tuple) TupleIterator {
+	iter := &staticIterator[*openfgapb.Tuple]{
+		items: tuples,
+	}
+
+	return iter
+}
+
 // NewStaticTupleKeyIterator returns a TupleKeyIterator that iterates over the provided slice.
 func NewStaticTupleKeyIterator(tupleKeys []*openfgapb.TupleKey) TupleKeyIterator {
 	iter := &staticIterator[*openfgapb.TupleKey]{
@@ -335,11 +343,8 @@ type AuthorizationModelBackend interface {
 
 type StoresBackend interface {
 	CreateStore(ctx context.Context, store *openfgapb.Store) (*openfgapb.Store, error)
-
 	DeleteStore(ctx context.Context, id string) error
-
 	GetStore(ctx context.Context, id string) (*openfgapb.Store, error)
-
 	ListStores(ctx context.Context, paginationOptions PaginationOptions) ([]*openfgapb.Store, []byte, error)
 }
 

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -176,20 +176,17 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		expectedError := storage.InvalidWriteInputError(tks[2], openfgapb.TupleOperation_TUPLE_OPERATION_WRITE)
 
 		// Write tks
-		if err := datastore.Write(ctx, store, nil, tks); err != nil {
-			t.Fatal(err)
-		}
+		err := datastore.Write(ctx, store, nil, tks)
+		require.NoError(t, err)
+
 		// Try to delete tks[0,1], and at the same time write tks[2]. It should fail with expectedError.
-		if err := datastore.Write(ctx, store, []*openfgapb.TupleKey{tks[0], tks[1]}, []*openfgapb.TupleKey{tks[2]}); err.Error() != expectedError.Error() {
-			t.Fatalf("got '%v', want '%v'", err, expectedError)
-		}
+		err = datastore.Write(ctx, store, []*openfgapb.TupleKey{tks[0], tks[1]}, []*openfgapb.TupleKey{tks[2]})
+		require.EqualError(t, err, expectedError.Error())
+
 		tuples, _, err := datastore.ReadByStore(ctx, store, storage.PaginationOptions{PageSize: 50})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tuples) != len(tks) {
-			t.Fatalf("got '%d', want '%d'", len(tuples), len(tks))
-		}
+		require.NoError(t, err)
+
+		require.Equal(t, len(tks), len(tuples))
 	})
 
 	t.Run("delete fails if the tuple does not exist", func(t *testing.T) {
@@ -197,9 +194,8 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		tk := &openfgapb.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
 		expectedError := storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
 
-		if err := datastore.Write(ctx, store, []*openfgapb.TupleKey{tk}, nil); err.Error() != expectedError.Error() {
-			t.Fatalf("got '%v', want '%v'", err, expectedError)
-		}
+		err := datastore.Write(ctx, store, []*openfgapb.TupleKey{tk}, nil)
+		require.EqualError(t, err, expectedError.Error())
 	})
 
 	t.Run("deleting a tuple which exists succeeds", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Refactor Postgres to use `database/sql`. This allows us to bypass this issue with https://github.com/jackc/pgx/issues/1354 and it also starts to lay the foundation for creating a shared/common package between SQL datastores (such as our Postgres and MySQL ones).

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
