### PR TITLE
chore: move some tuples to ContextualTuples to avoid dynamo limits

### DIFF
--- a/server/test/connected_objects.go
+++ b/server/test/connected_objects.go
@@ -334,6 +334,10 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				ObjectType: "document",
 				Relation:   "viewer",
 				User:       &openfgapb.ObjectRelation{Object: "user:jon"},
+				ContextualTuples: []*openfgapb.TupleKey{
+					tuple.NewTupleKey("folder:folder5", "parent", "folder:folder4"),
+					tuple.NewTupleKey("folder:folder6", "viewer", "user:bob"),
+				},
 			},
 			model: &openfgapb.AuthorizationModel{
 				Id:            ulid.Make().String(),
@@ -406,8 +410,6 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
 				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
 				tuple.NewTupleKey("folder:folder4", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("folder:folder5", "parent", "folder:folder4"),
-				tuple.NewTupleKey("folder:folder6", "viewer", "user:bob"),
 
 				tuple.NewTupleKey("document:doc1", "parent", "folder:folder3"),
 				tuple.NewTupleKey("document:doc2", "parent", "folder:folder5"),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This moves some of the test tuples for one of the ConnectedObjects test cases to be split between ContextualTuples and storage tuples.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
