### PR TITLE
feat: allow idempotent writes and deletes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ run-postgres: build ## Run the OpenFGA server with Postgres storage
 	./openfga run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres'
 
 .PHONY: start-mysql-container
-start-mysql-container: build ## Start a MySQL Docker container
+start-mysql-container: ## Start a MySQL Docker container
 	docker run -d --name mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_DATABASE=openfga mysql:8
 	
 .PHONY: migrate-mysql

--- a/server/commands/write.go
+++ b/server/commands/write.go
@@ -216,8 +216,6 @@ func (c *WriteCommand) validateNoDuplicatesAndCorrectSize(deletes []*openfgapb.T
 func handleError(err error) error {
 	if errors.Is(err, storage.ErrTransactionalWriteFailed) {
 		return serverErrors.WriteFailedDueToInvalidInput(nil)
-	} else if errors.Is(err, storage.ErrInvalidWriteInput) {
-		return serverErrors.WriteFailedDueToInvalidInput(err)
 	}
 
 	return serverErrors.HandleError("", err)

--- a/server/test/server.go
+++ b/server/test/server.go
@@ -59,7 +59,7 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 }
 
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
-	t.Run("TestWriteCommand", func(t *testing.T) { TestWriteCommand(t, ds) })
+	t.Run("TestWriteCommand", func(t *testing.T) { WriteCommandTest(t, ds) })
 	t.Run("TestWriteAuthorizationModel", func(t *testing.T) { WriteAuthorizationModelTest(t, ds) })
 	t.Run("TestWriteAssertions", func(t *testing.T) { TestWriteAssertions(t, ds) })
 	t.Run("TestCreateStore", func(t *testing.T) { TestCreateStore(t, ds) })

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -364,6 +364,28 @@ var writeCommandTests = []writeCommandTest{
 		err: serverErrors.DuplicateTupleInWrite(tk),
 	},
 	{
+		_name: "ExecuteDeleteTupleWhichDoesNotExistSucceeds",
+		// state
+		model: &openfgapb.AuthorizationModel{
+			Id:            ulid.Make().String(),
+			SchemaVersion: typesystem.SchemaVersion1_0,
+			TypeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "repository",
+					Relations: map[string]*openfgapb.Userset{
+						"administrator": {},
+					},
+				},
+			},
+		},
+		// input
+		request: &openfgapb.WriteRequest{
+			Deletes: &openfgapb.TupleKeys{TupleKeys: []*openfgapb.TupleKey{tk}},
+		},
+		// output
+		err: nil,
+	},
+	{
 		_name: "ExecuteWithWriteTupleWithInvalidAuthorizationModelReturnsError",
 		// state
 		model: &openfgapb.AuthorizationModel{

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -364,28 +364,6 @@ var writeCommandTests = []writeCommandTest{
 		err: serverErrors.DuplicateTupleInWrite(tk),
 	},
 	{
-		_name: "ExecuteDeleteTupleWhichDoesNotExistReturnsError",
-		// state
-		model: &openfgapb.AuthorizationModel{
-			Id:            ulid.Make().String(),
-			SchemaVersion: typesystem.SchemaVersion1_0,
-			TypeDefinitions: []*openfgapb.TypeDefinition{
-				{
-					Type: "repository",
-					Relations: map[string]*openfgapb.Userset{
-						"administrator": {},
-					},
-				},
-			},
-		},
-		// input
-		request: &openfgapb.WriteRequest{
-			Deletes: &openfgapb.TupleKeys{TupleKeys: []*openfgapb.TupleKey{tk}},
-		},
-		// output
-		err: serverErrors.WriteFailedDueToInvalidInput(storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)),
-	},
-	{
 		_name: "ExecuteWithWriteTupleWithInvalidAuthorizationModelReturnsError",
 		// state
 		model: &openfgapb.AuthorizationModel{
@@ -1434,7 +1412,7 @@ var writeCommandTests = []writeCommandTest{
 	},
 }
 
-func TestWriteCommand(t *testing.T, datastore storage.OpenFGADatastore) {
+func WriteCommandTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	require := require.New(t)
 	ctx := context.Background()
 	tracer := telemetry.NewNoopTracer()

--- a/storage/errors.go
+++ b/storage/errors.go
@@ -3,8 +3,6 @@ package storage
 import (
 	"errors"
 	"fmt"
-
-	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
 // since these errors are allocated at init time, it is better to leave them as normal errors instead of
@@ -12,7 +10,6 @@ import (
 var (
 	ErrCollision                = errors.New("item already exists")
 	ErrInvalidContinuationToken = errors.New("invalid continuation token")
-	ErrInvalidWriteInput        = errors.New("invalid write input")
 	ErrNotFound                 = errors.New("not found")
 	ErrTransactionalWriteFailed = errors.New("transactional write failed due to bad input")
 	ErrMismatchObjectType       = errors.New("mismatched types in request and continuation token")
@@ -22,15 +19,4 @@ var (
 
 func ExceededMaxTypeDefinitionsLimitError(limit int) error {
 	return fmt.Errorf("exceeded number of allowed type definitions: %d", limit)
-}
-
-func InvalidWriteInputError(tk *openfgapb.TupleKey, operation openfgapb.TupleOperation) error {
-	switch operation {
-	case openfgapb.TupleOperation_TUPLE_OPERATION_DELETE:
-		return fmt.Errorf("cannot delete a tuple which does not exist: user: '%s', relation: '%s', object: '%s': %w", tk.GetUser(), tk.GetRelation(), tk.GetObject(), ErrInvalidWriteInput)
-	case openfgapb.TupleOperation_TUPLE_OPERATION_WRITE:
-		return fmt.Errorf("cannot write a tuple which already exists: user: '%s', relation: '%s', object: '%s': %w", tk.GetUser(), tk.GetRelation(), tk.GetObject(), ErrInvalidWriteInput)
-	default:
-		return nil
-	}
 }

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -270,10 +270,6 @@ func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage
 
 	now := timestamppb.Now()
 
-	if err := validateTuples(s.tuples[store], deletes, writes); err != nil {
-		return err
-	}
-
 	var tuples []*openfgapb.Tuple
 
 Delete:
@@ -301,24 +297,6 @@ Write:
 	s.tuples[store] = tuples
 
 	return nil
-}
-
-func validateTuples(tuples []*openfgapb.Tuple, deletes, writes []*openfgapb.TupleKey) error {
-	for _, tk := range deletes {
-		if !find(tuples, tk) {
-			return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
-		}
-	}
-	return nil
-}
-
-func find(tuples []*openfgapb.Tuple, tupleKey *openfgapb.TupleKey) bool {
-	for _, tuple := range tuples {
-		if match(tuple.Key, tupleKey) {
-			return true
-		}
-	}
-	return false
 }
 
 // ReadUserTuple See storage.TupleBackend.ReadUserTuple

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -27,9 +27,9 @@ type staticIterator struct {
 
 func match(key *openfgapb.TupleKey, target *openfgapb.TupleKey) bool {
 	if key.Object != "" {
-		td, objectid := tupleUtils.SplitObject(key.Object)
-		if objectid == "" {
-			if td != tupleUtils.GetType(target.Object) {
+		objectType, objectID := tupleUtils.SplitObject(key.Object)
+		if objectID == "" {
+			if objectType != tupleUtils.GetType(target.Object) {
 				return false
 			}
 		} else {
@@ -275,6 +275,7 @@ func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage
 	}
 
 	var tuples []*openfgapb.Tuple
+
 Delete:
 	for _, t := range s.tuples[store] {
 		for _, k := range deletes {
@@ -296,7 +297,9 @@ Write:
 		tuples = append(tuples, &openfgapb.Tuple{Key: t, Timestamp: now})
 		s.changes[store] = append(s.changes[store], &openfgapb.TupleChange{TupleKey: t, Operation: openfgapb.TupleOperation_TUPLE_OPERATION_WRITE, Timestamp: now})
 	}
+
 	s.tuples[store] = tuples
+
 	return nil
 }
 
@@ -304,11 +307,6 @@ func validateTuples(tuples []*openfgapb.Tuple, deletes, writes []*openfgapb.Tupl
 	for _, tk := range deletes {
 		if !find(tuples, tk) {
 			return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
-		}
-	}
-	for _, tk := range writes {
-		if find(tuples, tk) {
-			return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_WRITE)
 		}
 	}
 	return nil

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -185,13 +185,13 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 		Insert("changelog").
 		Columns("store", "object_type", "object_id", "relation", "_user", "operation", "ulid", "inserted_at")
 
-	deletebuilder := squirrel.Delete("tuple")
+	deleteBuilder := squirrel.Delete("tuple")
 
 	for _, tk := range deletes {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
-		stmt, args, err := deletebuilder.Where(squirrel.Eq{
+		stmt, args, err := deleteBuilder.Where(squirrel.Eq{
 			"store":       store,
 			"object_type": objectType,
 			"object_id":   objectID,
@@ -228,7 +228,7 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 		}
 	}
 
-	tupleInsertBuilder := squirrel.
+	insertBuilder := squirrel.
 		Insert("tuple").
 		Columns("store", "object_type", "object_id", "relation", "_user", "user_type", "ulid", "inserted_at").
 		Suffix("on duplicate key update store=store")
@@ -237,7 +237,7 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
-		stmt, args, err := tupleInsertBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id, squirrel.Expr("NOW()")).ToSql()
+		stmt, args, err := insertBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id, squirrel.Expr("NOW()")).ToSql()
 		if err != nil {
 			return handleMySQLError(err)
 		}

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -218,6 +218,10 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 		}
 
 		stmt, args, err = changelogBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_DELETE, id, squirrel.Expr("NOW()")).ToSql()
+		if err != nil {
+			return handleMySQLError(err, tk)
+		}
+
 		_, err = tx.ExecContext(ctx, stmt, args...)
 		if err != nil {
 			return handleMySQLError(err)

--- a/storage/mysql/utils.go
+++ b/storage/mysql/utils.go
@@ -185,16 +185,12 @@ func rollbackTx(ctx context.Context, tx *sql.Tx, logger log.Logger) {
 	}
 }
 
-func handleMySQLError(err error, args ...interface{}) error {
+func handleMySQLError(err error) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
 	} else if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1062 {
-		if len(args) > 0 {
-			if tk, ok := args[0].(*openfgapb.TupleKey); ok {
-				return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_WRITE)
-			}
-		}
 		return storage.ErrCollision
 	}
+
 	return fmt.Errorf("mysql error: %w", err)
 }

--- a/storage/mysql/utils_test.go
+++ b/storage/mysql/utils_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/openfga/openfga/storage"
 	"github.com/stretchr/testify/require"
-	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
 func TestHandleMySQLError(t *testing.T) {
@@ -16,12 +15,8 @@ func TestHandleMySQLError(t *testing.T) {
 			Number:  1062,
 			Message: "Duplicate entry '' for key ''",
 		}
-		err := handleMySQLError(duplicateKeyError, &openfgapb.TupleKey{
-			Object:   "object",
-			Relation: "relation",
-			User:     "user",
-		})
-		require.ErrorIs(t, err, storage.ErrInvalidWriteInput)
+		err := handleMySQLError(duplicateKeyError)
+		require.ErrorIs(t, err, storage.ErrCollision)
 	})
 
 	t.Run("duplicate entry value error without tuple key returns collision", func(t *testing.T) {

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -204,7 +204,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 		Insert("changelog").
 		Columns("store", "object_type", "object_id", "relation", "_user", "operation", "ulid", "inserted_at")
 
-	deletebuilder := squirrel.
+	deleteBuilder := squirrel.
 		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
 		Delete("tuple")
 
@@ -212,7 +212,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
-		stmt, args, err := deletebuilder.Where(squirrel.Eq{
+		stmt, args, err := deleteBuilder.Where(squirrel.Eq{
 			"store":       store,
 			"object_type": objectType,
 			"object_id":   objectID,
@@ -249,7 +249,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 		}
 	}
 
-	tupleInsertBuilder := squirrel.
+	insertBuilder := squirrel.
 		StatementBuilder.PlaceholderFormat(squirrel.Dollar).
 		Insert("tuple").
 		Columns("store", "object_type", "object_id", "relation", "_user", "user_type", "ulid", "inserted_at").
@@ -259,7 +259,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
-		stmt, args, err := tupleInsertBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id, "NOW()").ToSql()
+		stmt, args, err := insertBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), tupleUtils.GetUserTypeFromUser(tk.GetUser()), id, "NOW()").ToSql()
 		if err != nil {
 			return handlePostgresError(err)
 		}

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -239,6 +239,10 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 		}
 
 		stmt, args, err = changelogBuilder.Values(store, objectType, objectID, tk.GetRelation(), tk.GetUser(), openfgapb.TupleOperation_TUPLE_OPERATION_DELETE, id, "NOW()").ToSql()
+		if err != nil {
+			return handlePostgresError(err, tk)
+		}
+
 		_, err = tx.ExecContext(ctx, stmt, args...)
 		if err != nil {
 			return handlePostgresError(err, tk)

--- a/storage/postgres/utils.go
+++ b/storage/postgres/utils.go
@@ -191,15 +191,10 @@ func rollbackTx(ctx context.Context, tx *sql.Tx, logger log.Logger) {
 	}
 }
 
-func handlePostgresError(err error, args ...interface{}) error {
+func handlePostgresError(err error) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
 	} else if strings.Contains(err.Error(), "duplicate key value") {
-		if len(args) > 0 {
-			if tk, ok := args[0].(*openfgapb.TupleKey); ok {
-				return storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_WRITE)
-			}
-		}
 		return storage.ErrCollision
 	}
 

--- a/storage/postgres/utils_test.go
+++ b/storage/postgres/utils_test.go
@@ -7,17 +7,12 @@ import (
 
 	"github.com/openfga/openfga/storage"
 	"github.com/stretchr/testify/require"
-	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
 func TestHandlePostgresError(t *testing.T) {
 	t.Run("duplicate key value error with tuple key wraps ErrInvalidWriteInput", func(t *testing.T) {
-		err := handlePostgresError(errors.New("duplicate key value"), &openfgapb.TupleKey{
-			Object:   "object",
-			Relation: "relation",
-			User:     "user",
-		})
-		require.ErrorIs(t, err, storage.ErrInvalidWriteInput)
+		err := handlePostgresError(errors.New("duplicate key value"))
+		require.ErrorIs(t, err, storage.ErrCollision)
 	})
 
 	t.Run("duplicate key value error without tuple key returns collision", func(t *testing.T) {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -255,7 +255,8 @@ type TupleBackend interface {
 
 	// Write updates data in the tuple backend, performing all delete operations in `deletes` before writing the values
 	// in `writes`, returning the time of the transaction, or an error. It is expected that there are at most
-	// MaxTuplesInWriteOperation deletes/writes.
+	// MaxTuplesInWriteOperation deletes/writes. Write is an idempotent operation: writing an existing tuple will be a
+	// no-op, and deleting a non-existing tuple is also a no-op.
 	Write(ctx context.Context, store string, d Deletes, w Writes) error
 
 	ReadUserTuple(

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -253,11 +253,9 @@ type TupleBackend interface {
 		opts PaginationOptions,
 	) ([]*openfgapb.Tuple, []byte, error)
 
-	// Write updates data in the tuple backend, performing all delete operations in
-	// `deletes` before adding new values in `writes`, returning the time of the transaction, or an error.
-	// It is expected that
-	// - there is at most 10 deletes/writes
-	// - no duplicate item in delete/write list
+	// Write updates data in the tuple backend, performing all delete operations in `deletes` before writing the values
+	// in `writes`, returning the time of the transaction, or an error. It is expected that there are at most
+	// MaxTuplesInWriteOperation deletes/writes.
 	Write(ctx context.Context, store string, d Deletes, w Writes) error
 
 	ReadUserTuple(

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -187,13 +187,11 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.Equal(t, 1, len(tuples))
 	})
 
-	t.Run("delete fails if the tuple does not exist", func(t *testing.T) {
-		store := testutils.CreateRandomString(10)
-		tk := &openfgapb.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
-		expectedError := storage.InvalidWriteInputError(tk, openfgapb.TupleOperation_TUPLE_OPERATION_DELETE)
+	t.Run("delete does not fail if the tuple does not exist", func(t *testing.T) {
+		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, store, []*openfgapb.TupleKey{tk}, nil)
-		require.EqualError(t, err, expectedError.Error())
+		err := datastore.Write(ctx, storeID, []*openfgapb.TupleKey{{Object: "doc:readme", Relation: "owner", User: "10"}}, nil)
+		require.NoError(t, err)
 	})
 
 	t.Run("deleting a tuple which exists succeeds", func(t *testing.T) {

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -132,7 +132,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 
-	t.Run("delete with a duplicate write succeeds", func(t *testing.T) {
+	t.Run("two deletes and a duplicate write succeeds", func(t *testing.T) {
 		storeID := ulid.Make().String()
 		tks := []*openfgapb.TupleKey{
 			{

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -228,6 +228,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 
 		// Check that the changelog only contains one tuple.
 		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: 10}, 0)
+		require.NoError(t, err)
 		require.Len(t, changes, 1)
 	})
 

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -198,7 +198,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, []*openfgapb.TupleKey{tk})
 		require.NoError(t, err)
 
-		// Second write of the same tuple should not fail, but won't update the changelog.
+		// Second write of the same tuple should not fail, and won't update the changelog.
 		err = datastore.Write(ctx, storeID, nil, []*openfgapb.TupleKey{tk})
 		require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Closes #258.

This PR makes changes to the Write API. Writes and deletes will become idempotent. This means:
- There will be no error if you try to insert the same tuple twice. The changelog will not contain the attempted second write.
- There will be no error if you try to delete a tuple which does not exist. The deletion attempt will not appear in the changelog.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
