### PR TITLE
fix: more appropriate error if the user type is incorrect

### DIFF
--- a/server/commands/write.go
+++ b/server/commands/write.go
@@ -160,7 +160,7 @@ func (c *WriteCommand) validateTypesForTuple(authModel *openfgapb.AuthorizationM
 	// at this point we know the auth model has type information
 	if userType != "" {
 		if _, ok := ts.GetTypeDefinition(userType); !ok {
-			return serverErrors.InvalidWriteInput
+			return serverErrors.WriteFailedDueToInvalidInput(nil)
 		}
 	}
 

--- a/server/test/write.go
+++ b/server/test/write.go
@@ -923,7 +923,7 @@ var writeCommandTests = []writeCommandTest{
 			},
 			},
 		},
-		err: serverErrors.InvalidWriteInput,
+		err: serverErrors.WriteFailedDueToInvalidInput(nil),
 	},
 	{
 		_name: "Write fails if user field contains a type that is not allowed by the authorization model (which only allows group:...)",


### PR DESCRIPTION
InvalidWriteInput: `Invalid input. Make sure you provide at least one write, or at least one delete`

WriteFailedDueToInvalidInput: `Write failed due to invalid input`