### PR TITLE
fix: update README for build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Alternatively you can build OpenFGA by cloning the project from this Github repo
 2. Then use the build command:
 
    ```bash
-   make build
+   go build -o ./openfga ./cmd/openfga
    ```
 
 3. Run the server with:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can install from source using Go modules:
 2. Then use the install command:
 
    ```bash
-   make build
+   go install github.com/openfga/openfga/cmd/openfga
    ```
 
 3. Run the server with:
@@ -101,7 +101,7 @@ Alternatively you can build OpenFGA by cloning the project from this Github repo
 2. Then use the build command:
 
    ```bash
-   go build cmd/openfga/openfga.go
+   make build
    ```
 
 3. Run the server with:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can install from source using Go modules:
 2. Then use the install command:
 
    ```bash
-   go install github.com/openfga/openfga/cmd/openfga
+   make build
    ```
 
 3. Run the server with:


### PR DESCRIPTION
## Description
Update README build instruction as there is no `cmd/openfga/openfga.go` file.  Instead, user should invoke `make build`.

## References
Close https://github.com/openfga/openfga/issues/352

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
