### PR TITLE
refactor: getTypeDefinitionRelationUsersets to only get the rewrite

### DIFF
--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -107,7 +107,7 @@ func (query *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckReques
 	}, nil
 }
 
-// getTypeRelationRewrite validates a tuple and returns the userset corresponding to the "object" and "relation"
+// getTypeRelationRewrite returns the rewrite corresponding to the "object" and "relation"
 func getTypeRelationRewrite(tk *openfgapb.TupleKey, typesys *typesystem.TypeSystem) (*openfgapb.Userset, error) {
 	objectType := tupleUtils.GetType(tk.GetObject())
 

--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -77,17 +77,17 @@ func (query *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckReques
 
 	rc := newResolutionContext(req.GetStoreId(), model, tk, contextualTuples, resolutionTracer, utils.NewResolutionMetadata(), &circuitBreaker{breakerState: false})
 
-	userset, err := getTypeDefinitionRelationUsersets(rc.tk, typesys)
+	err = validation.ValidateTuple(typesys, tk)
+	if err != nil {
+		return nil, serverErrors.HandleTupleValidateError(err)
+	}
+
+	rewrite, err := getTypeRelationRewrite(rc.tk, typesys)
 	if err != nil {
 		return nil, err
 	}
-	if userset == nil {
-		// the tuple in the Check request is invalid according to the model being used, so throw an error
-		actualErr := validation.ValidateTuple(typesys, rc.tk)
-		return nil, serverErrors.HandleTupleValidateError(actualErr)
-	}
 
-	if err := query.resolveNode(ctx, rc, userset, typesys); err != nil {
+	if err := query.resolveNode(ctx, rc, rewrite, typesys); err != nil {
 		return nil, err
 	}
 
@@ -107,38 +107,13 @@ func (query *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckReques
 	}, nil
 }
 
-// getTypeDefinitionRelationUsersets validates a tuple and returns the userset corresponding to the "object" and "relation"
-func getTypeDefinitionRelationUsersets(tk *openfgapb.TupleKey, typesys *typesystem.TypeSystem) (*openfgapb.Userset, error) {
-
+// getTypeRelationRewrite validates a tuple and returns the userset corresponding to the "object" and "relation"
+func getTypeRelationRewrite(tk *openfgapb.TupleKey, typesys *typesystem.TypeSystem) (*openfgapb.Userset, error) {
 	objectType := tupleUtils.GetType(tk.GetObject())
 
 	relation, err := typesys.GetRelation(objectType, tk.GetRelation())
 	if err != nil {
-		if errors.Is(err, typesystem.ErrObjectTypeUndefined) {
-			return nil, serverErrors.HandleTupleValidateError(
-				&tupleUtils.TypeNotFoundError{
-					TypeName: objectType,
-				},
-			)
-		}
-
-		if errors.Is(err, typesystem.ErrRelationUndefined) {
-			return nil, serverErrors.HandleTupleValidateError(
-				&tupleUtils.RelationNotFoundError{
-					TypeName: objectType,
-					Relation: tk.GetRelation(),
-					TupleKey: tk,
-				},
-			)
-		}
-
 		return nil, err
-	}
-
-	err = validation.ValidateTuple(typesys, tk)
-	if err != nil {
-		// the tuple in the request context is invalid according to the model being used, so ignore it and swallow the error
-		return nil, nil
 	}
 
 	return relation.GetRewrite(), nil
@@ -220,11 +195,13 @@ func (query *CheckQuery) resolveComputed(
 	computedTK := &openfgapb.TupleKey{Object: rc.tk.GetObject(), Relation: nodes.ComputedUserset.GetRelation(), User: rc.tk.GetUser()}
 	tracer := rc.tracer.AppendComputed().AppendString(tupleUtils.ToObjectRelationString(computedTK.GetObject(), computedTK.GetRelation()))
 	nestedRC := rc.fork(computedTK, tracer, false)
-	userset, err := getTypeDefinitionRelationUsersets(nestedRC.tk, typesys)
+
+	rewrite, err := getTypeRelationRewrite(nestedRC.tk, typesys)
 	if err != nil {
 		return err
 	}
-	return query.resolveNode(ctx, nestedRC, userset, typesys)
+
+	return query.resolveNode(ctx, nestedRC, rewrite, typesys)
 }
 
 // resolveDirectUserSet attempts to find individual user concurrently by resolving the usersets. If the user is found
@@ -307,9 +284,9 @@ func (query *CheckQuery) resolveDirectUserSet(
 		go func(c chan<- *chanResolveResult) {
 			defer wg.Done()
 
-			userset, err := getTypeDefinitionRelationUsersets(nestedRC.tk, typesys)
+			rewrite, err := getTypeRelationRewrite(nestedRC.tk, typesys)
 			if err == nil {
-				err = query.resolveNode(ctx, nestedRC, userset, typesys)
+				err = query.resolveNode(ctx, nestedRC, rewrite, typesys)
 			}
 
 			select {
@@ -572,9 +549,9 @@ func (query *CheckQuery) resolveTupleToUserset(
 		go func(c chan<- *chanResolveResult) {
 			defer wg.Done()
 
-			userset, err := getTypeDefinitionRelationUsersets(nestedRC.tk, typesys) // folder:budgets#reader
+			rewrite, err := getTypeRelationRewrite(nestedRC.tk, typesys) // folder:budgets#reader
 			if err == nil {
-				err = query.resolveNode(ctx, nestedRC, userset, typesys)
+				err = query.resolveNode(ctx, nestedRC, rewrite, typesys)
 			}
 
 			select {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
