### PR TITLE
chore: refactor iterators

### DIFF
--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -245,7 +245,7 @@ func (query *CheckQuery) resolveDirectUserSet(
 	}
 
 	for {
-		usersetTuple, err := iter.Next()
+		usersetTuple, err := iter.Next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break
@@ -528,7 +528,7 @@ func (query *CheckQuery) resolveTupleToUserset(
 	c := make(chan *chanResolveResult)
 
 	for {
-		tuple, err := iter.Next()
+		tuple, err := iter.Next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break

--- a/server/commands/check_utils.go
+++ b/server/commands/check_utils.go
@@ -359,7 +359,7 @@ func (rc *resolutionContext) readUsersetTuples(ctx context.Context, backend stor
 	iter2 := storage.NewTupleKeyIteratorFromTupleIterator(usersetTuples)
 
 	return storage.NewFilteredTupleKeyIterator(
-		storage.NewCombinedIterator(iter1, iter2, ctx),
+		storage.NewCombinedIterator(iter1, iter2),
 		validation.FilterInvalidTuples(rc.model),
 	), nil
 }
@@ -375,7 +375,7 @@ func (rc *resolutionContext) read(ctx context.Context, backend storage.TupleBack
 	iter2 := storage.NewTupleKeyIteratorFromTupleIterator(tuples)
 
 	return storage.NewFilteredTupleKeyIterator(
-		storage.NewCombinedIterator(iter1, iter2, ctx),
+		storage.NewCombinedIterator(iter1, iter2),
 		validation.FilterInvalidTuples(rc.model),
 	), nil
 }

--- a/server/commands/check_utils.go
+++ b/server/commands/check_utils.go
@@ -359,7 +359,7 @@ func (rc *resolutionContext) readUsersetTuples(ctx context.Context, backend stor
 	iter2 := storage.NewTupleKeyIteratorFromTupleIterator(usersetTuples)
 
 	return storage.NewFilteredTupleKeyIterator(
-		storage.NewCombinedIterator(iter1, iter2),
+		storage.NewCombinedIterator(iter1, iter2, ctx),
 		validation.FilterInvalidTuples(rc.model),
 	), nil
 }
@@ -375,7 +375,7 @@ func (rc *resolutionContext) read(ctx context.Context, backend storage.TupleBack
 	iter2 := storage.NewTupleKeyIteratorFromTupleIterator(tuples)
 
 	return storage.NewFilteredTupleKeyIterator(
-		storage.NewCombinedIterator(iter1, iter2),
+		storage.NewCombinedIterator(iter1, iter2, ctx),
 		validation.FilterInvalidTuples(rc.model),
 	), nil
 }

--- a/server/commands/connected_objects.go
+++ b/server/commands/connected_objects.go
@@ -175,14 +175,14 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		return err
 	}
 
-	iter := storage.NewCombinedIterator(iter1, iter2, ctx)
+	iter := storage.NewCombinedIterator(iter1, iter2)
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(maximumConcurrentChecks)
 
 	for {
-		t, err := iter.Next()
+		t, err := iter.Next(ctx)
 		if err != nil {
 			if errors.Is(err, storage.ErrIteratorDone) {
 				break
@@ -289,14 +289,14 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 		return err
 	}
 
-	iter := storage.NewCombinedIterator(iter1, iter2, ctx)
+	iter := storage.NewCombinedIterator(iter1, iter2)
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(maximumConcurrentChecks)
 
 	for {
-		t, err := iter.Next()
+		t, err := iter.Next(ctx)
 		if err != nil {
 			if errors.Is(err, storage.ErrIteratorDone) {
 				break

--- a/server/commands/connected_objects.go
+++ b/server/commands/connected_objects.go
@@ -68,36 +68,32 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 		return err
 	}
 
+	subg, subgctx := errgroup.WithContext(ctx)
+	subg.SetLimit(maximumConcurrentChecks)
+
 	for _, ingress := range ingresses {
-		select {
-		case <-ctx.Done():
-			// if the request times out, or it's cancelled manually, we short circuit so that we avoid unnecessary database lookups
-			return nil
-		default:
+		innerLoopIngress := ingress
+		subg.Go(func() error {
 			r := &reverseExpandRequest{
 				storeID:          storeID,
-				ingress:          ingress,
+				ingress:          innerLoopIngress,
 				sourceObjectRef:  sourceObjRef,
 				targetUserRef:    req.User,
 				contextualTuples: req.ContextualTuples,
 			}
 
-			var err error
-			switch ingress.Type {
+			switch innerLoopIngress.Type {
 			case graph.DirectIngress:
-				err = c.reverseExpandDirect(ctx, r, resultChan, foundObjectsMap, foundCount)
+				return c.reverseExpandDirect(subgctx, r, resultChan, foundObjectsMap, foundCount)
 			case graph.TupleToUsersetIngress:
-				err = c.reverseExpandTupleToUserset(ctx, r, resultChan, foundObjectsMap, foundCount)
+				return c.reverseExpandTupleToUserset(subgctx, r, resultChan, foundObjectsMap, foundCount)
 			default:
-				err = fmt.Errorf("unsupported ingress type")
+				return fmt.Errorf("unsupported ingress type")
 			}
-			if err != nil {
-				return err
-			}
-		}
+		})
 	}
 
-	return nil
+	return subg.Wait()
 }
 
 // StreamedConnectedObjects yields all of the objects of the provided objectType that
@@ -179,73 +175,66 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		return err
 	}
 
-	iter := storage.NewCombinedIterator(iter1, iter2)
+	iter := storage.NewCombinedIterator(iter1, iter2, ctx)
 	defer iter.Stop()
 
-	g := errgroup.Group{}
-	g.SetLimit(100) // set some concurrency limit
+	subg, subgctx := errgroup.WithContext(ctx)
+	subg.SetLimit(maximumConcurrentChecks)
 
-ForLoop:
 	for {
-		select {
-		case <-ctx.Done():
-			// if the request times out, or it's cancelled manually, we short circuit so that we avoid unnecessary database lookups
-			break ForLoop
-		default:
-			t, err := iter.Next()
-			if err != nil {
-				if errors.Is(err, storage.ErrIteratorDone) {
-					break ForLoop
-				}
-
-				return err
+		t, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, storage.ErrIteratorDone) {
+				break
 			}
 
-			tk := t.GetKey()
-
-			foundObject := tk.GetObject()
-			foundObjectType, _ := tuple.SplitObject(foundObject)
-
-			userObj, _ := tuple.SplitObjectRelation(tk.GetUser())
-
-			if userObj == tuple.Wildcard {
-
-				return serverErrors.InvalidTuple(
-					fmt.Sprintf("unexpected wildcard evaluated on relation '%s#%s'", foundObjectType, tuplesetRelation),
-					tuple.NewTupleKey(foundObject, tuplesetRelation, tuple.Wildcard),
-				)
-			}
-
-			if _, ok := foundObjectsMap.Load(foundObject); ok {
-				// todo(jon-whit): we could optimize this by avoiding reading this
-				// from the database in the first place
-
-				// if we've already evaluated/found the object, then continue
-				continue
-			}
-
-			if foundObjectType == sourceObjectType {
-				if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
-					break ForLoop
-				}
-
-				resultChan <- foundObject
-				foundObjectsMap.Store(foundObject, struct{}{})
-			}
-
-			g.Go(func() error {
-				return c.streamedConnectedObjects(ctx, &ConnectedObjectsRequest{
-					StoreID:          store,
-					ObjectType:       sourceObjectType,
-					Relation:         sourceObjectRel,
-					User:             &openfgapb.ObjectRelation{Object: foundObject, Relation: req.targetUserRef.Relation},
-					ContextualTuples: req.contextualTuples,
-				}, resultChan, foundObjectsMap, foundCount)
-			})
+			return err
 		}
+
+		tk := t.GetKey()
+
+		foundObject := tk.GetObject()
+		foundObjectType, _ := tuple.SplitObject(foundObject)
+
+		userObj, _ := tuple.SplitObjectRelation(tk.GetUser())
+
+		if userObj == tuple.Wildcard {
+
+			return serverErrors.InvalidTuple(
+				fmt.Sprintf("unexpected wildcard evaluated on relation '%s#%s'", foundObjectType, tuplesetRelation),
+				tuple.NewTupleKey(foundObject, tuplesetRelation, tuple.Wildcard),
+			)
+		}
+
+		if _, ok := foundObjectsMap.Load(foundObject); ok {
+			// todo(jon-whit): we could optimize this by avoiding reading this
+			// from the database in the first place
+
+			// if we've already evaluated/found the object, then continue
+			continue
+		}
+
+		if foundObjectType == sourceObjectType {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+				break
+			}
+
+			resultChan <- foundObject
+			foundObjectsMap.Store(foundObject, struct{}{})
+		}
+
+		subg.Go(func() error {
+			return c.streamedConnectedObjects(subgctx, &ConnectedObjectsRequest{
+				StoreID:          store,
+				ObjectType:       sourceObjectType,
+				Relation:         sourceObjectRel,
+				User:             &openfgapb.ObjectRelation{Object: foundObject, Relation: req.targetUserRef.Relation},
+				ContextualTuples: req.contextualTuples,
+			}, resultChan, foundObjectsMap, foundCount)
+		})
 	}
 
-	return g.Wait()
+	return subg.Wait()
 }
 
 func (c *ConnectedObjectsCommand) reverseExpandDirect(
@@ -300,66 +289,59 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 		return err
 	}
 
-	iter := storage.NewCombinedIterator(iter1, iter2)
+	iter := storage.NewCombinedIterator(iter1, iter2, ctx)
 	defer iter.Stop()
 
-	g := errgroup.Group{}
-	g.SetLimit(100) // set some concurrency limit
+	subg, subgctx := errgroup.WithContext(ctx)
+	subg.SetLimit(maximumConcurrentChecks)
 
-ForLoop:
 	for {
-		select {
-		case <-ctx.Done():
-			// if the request times out, or it's cancelled manually, we short circuit so that we avoid unnecessary database lookups
-			break ForLoop
-		default:
-			t, err := iter.Next()
-			if err != nil {
-				if errors.Is(err, storage.ErrIteratorDone) {
-					break ForLoop
-				}
-
-				return err
+		t, err := iter.Next()
+		if err != nil {
+			if errors.Is(err, storage.ErrIteratorDone) {
+				break
 			}
 
-			tk := t.GetKey()
-
-			foundObject := tk.GetObject()
-			foundObjectType, _ := tuple.SplitObject(foundObject)
-
-			if _, ok := foundObjectsMap.Load(foundObject); ok {
-				// todo(jon-whit): we could optimize this by avoiding reading this
-				// from the database in the first place
-
-				// if we've already evaluated/found the object, then continue
-				continue
-			}
-
-			if foundObjectType == sourceObjectType {
-				if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
-					break ForLoop
-				}
-
-				resultChan <- foundObject
-				foundObjectsMap.Store(foundObject, struct{}{})
-			}
-
-			user := &openfgapb.ObjectRelation{Object: foundObject}
-			if tk.GetRelation() != "" {
-				user.Relation = tk.GetRelation()
-			}
-
-			g.Go(func() error {
-				return c.streamedConnectedObjects(ctx, &ConnectedObjectsRequest{
-					StoreID:          store,
-					ObjectType:       sourceObjectType,
-					Relation:         sourceObjectRel,
-					User:             user,
-					ContextualTuples: req.contextualTuples,
-				}, resultChan, foundObjectsMap, foundCount)
-			})
+			return err
 		}
+
+		tk := t.GetKey()
+
+		foundObject := tk.GetObject()
+		foundObjectType, _ := tuple.SplitObject(foundObject)
+
+		if _, ok := foundObjectsMap.Load(foundObject); ok {
+			// todo(jon-whit): we could optimize this by avoiding reading this
+			// from the database in the first place
+
+			// if we've already evaluated/found the object, then continue
+			continue
+		}
+
+		if foundObjectType == sourceObjectType {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+				break
+			}
+
+			resultChan <- foundObject
+			foundObjectsMap.Store(foundObject, struct{}{})
+		}
+
+		user := &openfgapb.ObjectRelation{Object: foundObject}
+		if tk.GetRelation() != "" {
+			user.Relation = tk.GetRelation()
+		}
+
+		subg.Go(func() error {
+			return c.streamedConnectedObjects(subgctx, &ConnectedObjectsRequest{
+				StoreID:          store,
+				ObjectType:       sourceObjectType,
+				Relation:         sourceObjectRel,
+				User:             user,
+				ContextualTuples: req.contextualTuples,
+			}, resultChan, foundObjectsMap, foundCount)
+		})
 	}
 
-	return g.Wait()
+	return subg.Wait()
 }

--- a/server/commands/expand.go
+++ b/server/commands/expand.go
@@ -135,7 +135,7 @@ func (query *ExpandQuery) resolveThis(ctx context.Context, store string, tk *ope
 
 	distinctUsers := make(map[string]bool)
 	for {
-		tk, err := filteredIter.Next()
+		tk, err := filteredIter.Next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break
@@ -248,7 +248,7 @@ func (query *ExpandQuery) resolveTupleToUserset(
 	var computed []*openfgapb.UsersetTree_Computed
 	seen := make(map[string]bool)
 	for {
-		tk, err := filteredIter.Next()
+		tk, err := filteredIter.Next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break

--- a/server/commands/list_objects.go
+++ b/server/commands/list_objects.go
@@ -247,7 +247,7 @@ func (q *ListObjectsQuery) performChecks(ctx context.Context, req listObjectsReq
 	}
 
 	// pass contextual tuples iterator (iter1) first to exploit uniqueness optimization
-	iter := storage.NewUniqueObjectIterator(iter1, iter2, ctx)
+	iter := storage.NewUniqueObjectIterator(iter1, iter2)
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
@@ -255,7 +255,7 @@ func (q *ListObjectsQuery) performChecks(ctx context.Context, req listObjectsReq
 
 	// iterate over all object IDs in the store and check if the user has relation with each
 	for {
-		object, err := iter.Next()
+		object, err := iter.Next(ctx)
 		if err != nil {
 			if !errors.Is(err, storage.ErrIteratorDone) {
 				return err

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -45,12 +45,17 @@ func match(key *openfgapb.TupleKey, target *openfgapb.TupleKey) bool {
 }
 
 func (s *staticIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
-	if len(s.tuples) == 0 {
+	select {
+	case <-ctx.Done():
 		return nil, storage.ErrIteratorDone
+	default:
+		if len(s.tuples) == 0 {
+			return nil, storage.ErrIteratorDone
+		}
+		next, rest := s.tuples[0], s.tuples[1:]
+		s.tuples = rest
+		return next, nil
 	}
-	next, rest := s.tuples[0], s.tuples[1:]
-	s.tuples = rest
-	return next, nil
 }
 
 func (s *staticIterator) Stop() {}

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -44,7 +44,7 @@ func match(key *openfgapb.TupleKey, target *openfgapb.TupleKey) bool {
 	return true
 }
 
-func (s *staticIterator) Next() (*openfgapb.Tuple, error) {
+func (s *staticIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
 	if len(s.tuples) == 0 {
 		return nil, storage.ErrIteratorDone
 	}

--- a/storage/mocks/mock_storage.go
+++ b/storage/mocks/mock_storage.go
@@ -38,18 +38,18 @@ func (m *MockIterator[T]) EXPECT() *MockIteratorMockRecorder[T] {
 }
 
 // Next mocks base method.
-func (m *MockIterator[T]) Next() (T, error) {
+func (m *MockIterator[T]) Next(ctx context.Context) (T, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Next")
+	ret := m.ctrl.Call(m, "Next", ctx)
 	ret0, _ := ret[0].(T)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Next indicates an expected call of Next.
-func (mr *MockIteratorMockRecorder[T]) Next() *gomock.Call {
+func (mr *MockIteratorMockRecorder[T]) Next(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockIterator[T])(nil).Next))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockIterator[T])(nil).Next), ctx)
 }
 
 // Stop mocks base method.

--- a/storage/mysql/iterators.go
+++ b/storage/mysql/iterators.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 
@@ -68,7 +69,7 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 	return res, contToken, nil
 }
 
-func (t *tupleIterator) Next() (*openfgapb.Tuple, error) {
+func (t *tupleIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
 	record, err := t.next()
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ type objectIterator struct {
 
 var _ storage.ObjectIterator = (*objectIterator)(nil)
 
-func (o *objectIterator) Next() (*openfgapb.Object, error) {
+func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 	if !o.rows.Next() {
 		o.Stop()
 		return nil, storage.ErrIteratorDone

--- a/storage/mysql/iterators.go
+++ b/storage/mysql/iterators.go
@@ -22,8 +22,8 @@ var _ storage.TupleIterator = (*tupleIterator)(nil)
 func NewMysqlTupleIterator(rows *sql.Rows) *tupleIterator {
 	return &tupleIterator{
 		rows:     rows,
-		resultCh: make(chan *tupleRecord),
-		errCh:    make(chan error),
+		resultCh: make(chan *tupleRecord, 1),
+		errCh:    make(chan error, 1),
 	}
 }
 
@@ -31,7 +31,7 @@ func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
 	go func() {
 		if !t.rows.Next() {
 			t.Stop()
-			t.errCh <- storage.ErrIteratorDone
+			close(t.resultCh)
 			return
 		}
 
@@ -120,8 +120,8 @@ type objectIterator struct {
 func NewMysqlObjectIterator(rows *sql.Rows) *objectIterator {
 	return &objectIterator{
 		rows:     rows,
-		resultCh: make(chan *openfgapb.Object),
-		errCh:    make(chan error),
+		resultCh: make(chan *openfgapb.Object, 1),
+		errCh:    make(chan error, 1),
 	}
 }
 
@@ -131,7 +131,7 @@ func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 	go func() {
 		if !o.rows.Next() {
 			o.Stop()
-			o.errCh <- storage.ErrIteratorDone
+			close(o.resultCh)
 			return
 		}
 

--- a/storage/mysql/iterators.go
+++ b/storage/mysql/iterators.go
@@ -11,37 +11,66 @@ import (
 )
 
 type tupleIterator struct {
-	rows *sql.Rows
+	rows     *sql.Rows
+	resultCh chan *tupleRecord
+	errCh    chan error
 }
 
 var _ storage.TupleIterator = (*tupleIterator)(nil)
 
-func (t *tupleIterator) next() (*tupleRecord, error) {
-	if !t.rows.Next() {
-		t.Stop()
+// NewMysqlTupleIterator returns a tuple iterator for MySQL
+func NewMysqlTupleIterator(rows *sql.Rows) *tupleIterator {
+	return &tupleIterator{
+		rows:     rows,
+		resultCh: make(chan *tupleRecord),
+		errCh:    make(chan error),
+	}
+}
+
+func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
+	go func() {
+		if !t.rows.Next() {
+			t.Stop()
+			t.errCh <- storage.ErrIteratorDone
+			return
+		}
+
+		var record tupleRecord
+		if err := t.rows.Scan(&record.store, &record.objectType, &record.objectID, &record.relation, &record.user, &record.ulid, &record.insertedAt); err != nil {
+			t.errCh <- err
+			return
+		}
+
+		if err := t.rows.Err(); err != nil {
+			t.errCh <- err
+			return
+		}
+
+		t.resultCh <- &record
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, storage.ErrIteratorDone
+	case err := <-t.errCh:
+		return nil, handleMySQLError(err)
+	case result, ok := <-t.resultCh:
+		if ok {
+			return result, nil
+		}
+
 		return nil, storage.ErrIteratorDone
 	}
-
-	var record tupleRecord
-	if err := t.rows.Scan(&record.store, &record.objectType, &record.objectID, &record.relation, &record.user, &record.ulid, &record.insertedAt); err != nil {
-		return nil, handleMySQLError(err)
-	}
-
-	if t.rows.Err() != nil {
-		return nil, handleMySQLError(t.rows.Err())
-	}
-
-	return &record, nil
 }
 
 // toArray converts the tupleIterator to an []*openfgapb.Tuple and a possibly empty continuation token. If the
 // continuation token exists it is the ulid of the last element of the returned array.
-func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+func (t *tupleIterator) toArray(ctx context.Context, opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
 	defer t.Stop()
 
 	var res []*openfgapb.Tuple
 	for i := 0; i < opts.PageSize; i++ {
-		tupleRecord, err := t.next()
+		tupleRecord, err := t.next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				return res, nil, nil
@@ -53,7 +82,7 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 
 	// Check if we are at the end of the iterator. If we are then we do not need to return a continuation token.
 	// This is why we have LIMIT+1 in the query.
-	tupleRecord, err := t.next()
+	tupleRecord, err := t.next(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
 			return res, nil, nil
@@ -70,16 +99,11 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 }
 
 func (t *tupleIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
-	select {
-	case <-ctx.Done():
-		return nil, storage.ErrIteratorDone
-	default:
-		record, err := t.next()
-		if err != nil {
-			return nil, err
-		}
-		return record.asTuple(), nil
+	record, err := t.next(ctx)
+	if err != nil {
+		return nil, err
 	}
+	return record.asTuple(), nil
 }
 
 func (t *tupleIterator) Stop() {
@@ -87,34 +111,58 @@ func (t *tupleIterator) Stop() {
 }
 
 type objectIterator struct {
-	rows *sql.Rows
+	rows     *sql.Rows
+	resultCh chan *openfgapb.Object
+	errCh    chan error
+}
+
+// NewMysqlObjectIterator returns a tuple iterator for Postgres
+func NewMysqlObjectIterator(rows *sql.Rows) *objectIterator {
+	return &objectIterator{
+		rows:     rows,
+		resultCh: make(chan *openfgapb.Object),
+		errCh:    make(chan error),
+	}
 }
 
 var _ storage.ObjectIterator = (*objectIterator)(nil)
 
 func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
-	select {
-	case <-ctx.Done():
-		return nil, storage.ErrIteratorDone
-	default:
+	go func() {
 		if !o.rows.Next() {
 			o.Stop()
-			return nil, storage.ErrIteratorDone
+			o.errCh <- storage.ErrIteratorDone
+			return
 		}
 
 		var objectID, objectType string
 		if err := o.rows.Scan(&objectType, &objectID); err != nil {
-			return nil, handleMySQLError(err)
+			o.errCh <- err
+			return
 		}
 
-		if o.rows.Err() != nil {
-			return nil, handleMySQLError(o.rows.Err())
+		if err := o.rows.Err(); err != nil {
+			o.errCh <- err
+			return
 		}
 
-		return &openfgapb.Object{
+		o.resultCh <- &openfgapb.Object{
 			Type: objectType,
 			Id:   objectID,
-		}, nil
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, storage.ErrIteratorDone
+	case err := <-o.errCh:
+		return nil, handleMySQLError(err)
+	case result, ok := <-o.resultCh:
+		if ok {
+			return result, nil
+		}
+
+		return nil, storage.ErrIteratorDone
 	}
 }
 

--- a/storage/mysql/iterators.go
+++ b/storage/mysql/iterators.go
@@ -70,11 +70,16 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 }
 
 func (t *tupleIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
-	record, err := t.next()
-	if err != nil {
-		return nil, err
+	select {
+	case <-ctx.Done():
+		return nil, storage.ErrIteratorDone
+	default:
+		record, err := t.next()
+		if err != nil {
+			return nil, err
+		}
+		return record.asTuple(), nil
 	}
-	return record.asTuple(), nil
 }
 
 func (t *tupleIterator) Stop() {
@@ -88,24 +93,29 @@ type objectIterator struct {
 var _ storage.ObjectIterator = (*objectIterator)(nil)
 
 func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
-	if !o.rows.Next() {
-		o.Stop()
+	select {
+	case <-ctx.Done():
 		return nil, storage.ErrIteratorDone
-	}
+	default:
+		if !o.rows.Next() {
+			o.Stop()
+			return nil, storage.ErrIteratorDone
+		}
 
-	var objectID, objectType string
-	if err := o.rows.Scan(&objectType, &objectID); err != nil {
-		return nil, handleMySQLError(err)
-	}
+		var objectID, objectType string
+		if err := o.rows.Scan(&objectType, &objectID); err != nil {
+			return nil, handleMySQLError(err)
+		}
 
-	if o.rows.Err() != nil {
-		return nil, handleMySQLError(o.rows.Err())
-	}
+		if o.rows.Err() != nil {
+			return nil, handleMySQLError(o.rows.Err())
+		}
 
-	return &openfgapb.Object{
-		Type: objectType,
-		Id:   objectID,
-	}, nil
+		return &openfgapb.Object{
+			Type: objectType,
+			Id:   objectID,
+		}, nil
+	}
 }
 
 func (o *objectIterator) Stop() {

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -126,7 +126,7 @@ func (m *MySQL) ListObjectsByType(ctx context.Context, store string, objectType 
 		return nil, err
 	}
 
-	return &objectIterator{rows: rows}, nil
+	return NewMysqlObjectIterator(rows), nil
 }
 
 func (m *MySQL) Read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (storage.TupleIterator, error) {
@@ -145,7 +145,7 @@ func (m *MySQL) ReadPage(ctx context.Context, store string, tupleKey *openfgapb.
 		return nil, nil, err
 	}
 
-	return iter.toArray(opts)
+	return iter.toArray(ctx, opts)
 }
 
 func (m *MySQL) read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey, opts storage.PaginationOptions) (*tupleIterator, error) {
@@ -162,7 +162,7 @@ func (m *MySQL) read(ctx context.Context, store string, tupleKey *openfgapb.Tupl
 		return nil, handleMySQLError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewMysqlTupleIterator(rows), nil
 }
 
 func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
@@ -265,7 +265,7 @@ func (m *MySQL) ReadUsersetTuples(ctx context.Context, store string, tupleKey *o
 		return nil, handleMySQLError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewMysqlTupleIterator(rows), nil
 }
 
 func (m *MySQL) ReadByStore(ctx context.Context, store string, opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
@@ -276,7 +276,7 @@ func (m *MySQL) ReadByStore(ctx context.Context, store string, opts storage.Pagi
 	if err != nil {
 		return nil, nil, err
 	}
-	return iter.toArray(opts)
+	return iter.toArray(ctx, opts)
 }
 
 func (m *MySQL) MaxTuplesInWriteOperation() int {
@@ -721,7 +721,7 @@ func (m *MySQL) ReadStartingWithUser(ctx context.Context, store string, opts sto
 		return nil, handleMySQLError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewMysqlTupleIterator(rows), nil
 }
 
 // IsReady reports whether this MySQL datastore instance is ready

--- a/storage/mysql/mysql.go
+++ b/storage/mysql/mysql.go
@@ -144,6 +144,7 @@ func (m *MySQL) ReadPage(ctx context.Context, store string, tupleKey *openfgapb.
 	if err != nil {
 		return nil, nil, err
 	}
+	defer iter.Stop()
 
 	return iter.toArray(ctx, opts)
 }
@@ -276,6 +277,7 @@ func (m *MySQL) ReadByStore(ctx context.Context, store string, opts storage.Pagi
 	if err != nil {
 		return nil, nil, err
 	}
+	defer iter.Stop()
 	return iter.toArray(ctx, opts)
 }
 

--- a/storage/mysql/utils.go
+++ b/storage/mysql/utils.go
@@ -188,6 +188,8 @@ func rollbackTx(ctx context.Context, tx *sql.Tx, logger log.Logger) {
 func handleMySQLError(err error, args ...interface{}) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
+	} else if errors.Is(err, storage.ErrIteratorDone) {
+		return storage.ErrIteratorDone
 	} else if me, ok := err.(*mysql.MySQLError); ok && me.Number == 1062 {
 		if len(args) > 0 {
 			if tk, ok := args[0].(*openfgapb.TupleKey); ok {

--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -22,8 +22,8 @@ var _ storage.TupleIterator = (*tupleIterator)(nil)
 func NewPostgresTupleIterator(rows *sql.Rows) *tupleIterator {
 	return &tupleIterator{
 		rows:     rows,
-		resultCh: make(chan *tupleRecord),
-		errCh:    make(chan error),
+		resultCh: make(chan *tupleRecord, 1),
+		errCh:    make(chan error, 1),
 	}
 }
 
@@ -31,7 +31,7 @@ func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
 	go func() {
 		if !t.rows.Next() {
 			t.Stop()
-			t.errCh <- storage.ErrIteratorDone
+			close(t.resultCh)
 			return
 		}
 
@@ -120,8 +120,8 @@ type objectIterator struct {
 func NewPostgresObjectIterator(rows *sql.Rows) *objectIterator {
 	return &objectIterator{
 		rows:     rows,
-		resultCh: make(chan *openfgapb.Object),
-		errCh:    make(chan error),
+		resultCh: make(chan *openfgapb.Object, 1),
+		errCh:    make(chan error, 1),
 	}
 }
 
@@ -131,7 +131,7 @@ func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 	go func() {
 		if !o.rows.Next() {
 			o.Stop()
-			o.errCh <- storage.ErrIteratorDone
+			close(o.resultCh)
 			return
 		}
 

--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -1,6 +1,7 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -68,7 +69,7 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 	return res, contToken, nil
 }
 
-func (t *tupleIterator) Next() (*openfgapb.Tuple, error) {
+func (t *tupleIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
 	record, err := t.next()
 	if err != nil {
 		return nil, err
@@ -86,7 +87,7 @@ type objectIterator struct {
 
 var _ storage.ObjectIterator = (*objectIterator)(nil)
 
-func (o *objectIterator) Next() (*openfgapb.Object, error) {
+func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 	if !o.rows.Next() {
 		o.Stop()
 		return nil, storage.ErrIteratorDone

--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -11,37 +11,66 @@ import (
 )
 
 type tupleIterator struct {
-	rows *sql.Rows
+	rows     *sql.Rows
+	resultCh chan *tupleRecord
+	errCh    chan error
 }
 
 var _ storage.TupleIterator = (*tupleIterator)(nil)
 
-func (t *tupleIterator) next() (*tupleRecord, error) {
-	if !t.rows.Next() {
-		t.Stop()
+// NewPostgresTupleIterator returns a tuple iterator for Postgres
+func NewPostgresTupleIterator(rows *sql.Rows) *tupleIterator {
+	return &tupleIterator{
+		rows:     rows,
+		resultCh: make(chan *tupleRecord),
+		errCh:    make(chan error),
+	}
+}
+
+func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
+	go func() {
+		if !t.rows.Next() {
+			t.Stop()
+			t.errCh <- storage.ErrIteratorDone
+			return
+		}
+
+		var record tupleRecord
+		if err := t.rows.Scan(&record.store, &record.objectType, &record.objectID, &record.relation, &record.user, &record.ulid, &record.insertedAt); err != nil {
+			t.errCh <- err
+			return
+		}
+
+		if err := t.rows.Err(); err != nil {
+			t.errCh <- err
+			return
+		}
+
+		t.resultCh <- &record
+	}()
+
+	select {
+	case <-ctx.Done():
+		return nil, storage.ErrIteratorDone
+	case err := <-t.errCh:
+		return nil, handlePostgresError(err)
+	case result, ok := <-t.resultCh:
+		if ok {
+			return result, nil
+		}
+
 		return nil, storage.ErrIteratorDone
 	}
-
-	var record tupleRecord
-	if err := t.rows.Scan(&record.store, &record.objectType, &record.objectID, &record.relation, &record.user, &record.ulid, &record.insertedAt); err != nil {
-		return nil, handlePostgresError(err)
-	}
-
-	if t.rows.Err() != nil {
-		return nil, handlePostgresError(t.rows.Err())
-	}
-
-	return &record, nil
 }
 
 // toArray converts the tupleIterator to an []*openfgapb.Tuple and a possibly empty continuation token. If the
 // continuation token exists it is the ulid of the last element of the returned array.
-func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+func (t *tupleIterator) toArray(ctx context.Context, opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
 	defer t.Stop()
 
 	var res []*openfgapb.Tuple
 	for i := 0; i < opts.PageSize; i++ {
-		tupleRecord, err := t.next()
+		tupleRecord, err := t.next(ctx)
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				return res, nil, nil
@@ -53,7 +82,7 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 
 	// Check if we are at the end of the iterator. If we are then we do not need to return a continuation token.
 	// This is why we have LIMIT+1 in the query.
-	tupleRecord, err := t.next()
+	tupleRecord, err := t.next(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
 			return res, nil, nil
@@ -70,16 +99,11 @@ func (t *tupleIterator) toArray(opts storage.PaginationOptions) ([]*openfgapb.Tu
 }
 
 func (t *tupleIterator) Next(ctx context.Context) (*openfgapb.Tuple, error) {
-	select {
-	case <-ctx.Done():
-		return nil, storage.ErrIteratorDone
-	default:
-		record, err := t.next()
-		if err != nil {
-			return nil, err
-		}
-		return record.asTuple(), nil
+	record, err := t.next(ctx)
+	if err != nil {
+		return nil, err
 	}
+	return record.asTuple(), nil
 }
 
 func (t *tupleIterator) Stop() {
@@ -87,34 +111,57 @@ func (t *tupleIterator) Stop() {
 }
 
 type objectIterator struct {
-	rows *sql.Rows
+	rows     *sql.Rows
+	resultCh chan *openfgapb.Object
+	errCh    chan error
+}
+
+// NewPostgresObjectIterator returns a tuple iterator for Postgres
+func NewPostgresObjectIterator(rows *sql.Rows) *objectIterator {
+	return &objectIterator{
+		rows:     rows,
+		resultCh: make(chan *openfgapb.Object),
+		errCh:    make(chan error),
+	}
 }
 
 var _ storage.ObjectIterator = (*objectIterator)(nil)
 
 func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
-	select {
-	case <-ctx.Done():
-		return nil, storage.ErrIteratorDone
-	default:
+	go func() {
 		if !o.rows.Next() {
 			o.Stop()
-			return nil, storage.ErrIteratorDone
+			o.errCh <- storage.ErrIteratorDone
+			return
 		}
 
 		var objectID, objectType string
 		if err := o.rows.Scan(&objectType, &objectID); err != nil {
-			return nil, handlePostgresError(err)
+			o.errCh <- err
+			return
 		}
 
-		if o.rows.Err() != nil {
-			return nil, handlePostgresError(o.rows.Err())
+		if err := o.rows.Err(); err != nil {
+			o.errCh <- err
+			return
 		}
 
-		return &openfgapb.Object{
+		o.resultCh <- &openfgapb.Object{
 			Type: objectType,
 			Id:   objectID,
-		}, nil
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil, storage.ErrIteratorDone
+	case err := <-o.errCh:
+		return nil, handlePostgresError(err)
+	case result, ok := <-o.resultCh:
+		if ok {
+			return result, nil
+		}
+
+		return nil, storage.ErrIteratorDone
 	}
 }
 

--- a/storage/postgres/iterators.go
+++ b/storage/postgres/iterators.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-
 	"github.com/openfga/openfga/storage"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
@@ -30,18 +29,15 @@ func NewPostgresTupleIterator(rows *sql.Rows) *tupleIterator {
 func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
 	go func() {
 		if !t.rows.Next() {
-			t.Stop()
-			close(t.resultCh)
+			if err := t.rows.Err(); err != nil {
+				t.errCh <- err
+				return
+			}
+			t.errCh <- storage.ErrIteratorDone
 			return
 		}
-
 		var record tupleRecord
 		if err := t.rows.Scan(&record.store, &record.objectType, &record.objectID, &record.relation, &record.user, &record.ulid, &record.insertedAt); err != nil {
-			t.errCh <- err
-			return
-		}
-
-		if err := t.rows.Err(); err != nil {
 			t.errCh <- err
 			return
 		}
@@ -54,20 +50,14 @@ func (t *tupleIterator) next(ctx context.Context) (*tupleRecord, error) {
 		return nil, storage.ErrIteratorDone
 	case err := <-t.errCh:
 		return nil, handlePostgresError(err)
-	case result, ok := <-t.resultCh:
-		if ok {
-			return result, nil
-		}
-
-		return nil, storage.ErrIteratorDone
+	case result := <-t.resultCh:
+		return result, nil
 	}
 }
 
 // toArray converts the tupleIterator to an []*openfgapb.Tuple and a possibly empty continuation token. If the
 // continuation token exists it is the ulid of the last element of the returned array.
 func (t *tupleIterator) toArray(ctx context.Context, opts storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
-	defer t.Stop()
-
 	var res []*openfgapb.Tuple
 	for i := 0; i < opts.PageSize; i++ {
 		tupleRecord, err := t.next(ctx)
@@ -130,8 +120,11 @@ var _ storage.ObjectIterator = (*objectIterator)(nil)
 func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 	go func() {
 		if !o.rows.Next() {
-			o.Stop()
-			close(o.resultCh)
+			if err := o.rows.Err(); err != nil {
+				o.errCh <- err
+				return
+			}
+			o.errCh <- storage.ErrIteratorDone
 			return
 		}
 
@@ -156,12 +149,8 @@ func (o *objectIterator) Next(ctx context.Context) (*openfgapb.Object, error) {
 		return nil, storage.ErrIteratorDone
 	case err := <-o.errCh:
 		return nil, handlePostgresError(err)
-	case result, ok := <-o.resultCh:
-		if ok {
-			return result, nil
-		}
-
-		return nil, storage.ErrIteratorDone
+	case result := <-o.resultCh:
+		return result, nil
 	}
 }
 

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -145,7 +145,7 @@ func (p *Postgres) ListObjectsByType(ctx context.Context, store string, objectTy
 		return nil, err
 	}
 
-	return &objectIterator{rows: rows}, nil
+	return NewPostgresObjectIterator(rows), nil
 }
 
 func (p *Postgres) Read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (storage.TupleIterator, error) {
@@ -164,7 +164,7 @@ func (p *Postgres) ReadPage(ctx context.Context, store string, tupleKey *openfga
 		return nil, nil, err
 	}
 
-	return iter.toArray(opts)
+	return iter.toArray(ctx, opts)
 }
 
 func (p *Postgres) read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey, opts storage.PaginationOptions) (*tupleIterator, error) {
@@ -181,7 +181,7 @@ func (p *Postgres) read(ctx context.Context, store string, tupleKey *openfgapb.T
 		return nil, handlePostgresError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewPostgresTupleIterator(rows), nil
 }
 
 func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
@@ -314,7 +314,7 @@ func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, tupleKey
 		return nil, handlePostgresError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewPostgresTupleIterator(rows), nil
 }
 
 func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
@@ -336,7 +336,7 @@ func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts 
 		return nil, handlePostgresError(err)
 	}
 
-	return &tupleIterator{rows: rows}, nil
+	return NewPostgresTupleIterator(rows), nil
 }
 
 func (p *Postgres) MaxTuplesInWriteOperation() int {

--- a/storage/postgres/postgres.go
+++ b/storage/postgres/postgres.go
@@ -163,6 +163,7 @@ func (p *Postgres) ReadPage(ctx context.Context, store string, tupleKey *openfga
 	if err != nil {
 		return nil, nil, err
 	}
+	defer iter.Stop()
 
 	return iter.toArray(ctx, opts)
 }

--- a/storage/postgres/utils.go
+++ b/storage/postgres/utils.go
@@ -194,6 +194,8 @@ func rollbackTx(ctx context.Context, tx *sql.Tx, logger log.Logger) {
 func handlePostgresError(err error, args ...interface{}) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
+	} else if errors.Is(err, storage.ErrIteratorDone) {
+		return storage.ErrIteratorDone
 	} else if strings.Contains(err.Error(), "duplicate key value") {
 		if len(args) > 0 {
 			if tk, ok := args[0].(*openfgapb.TupleKey); ok {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -79,7 +80,7 @@ func TestCombinedIterator(t *testing.T) {
 
 	iter1 := NewStaticTupleKeyIterator([]*openfgapb.TupleKey{expected[0]})
 	iter2 := NewStaticTupleKeyIterator([]*openfgapb.TupleKey{expected[1]})
-	iter := NewCombinedIterator(iter1, iter2)
+	iter := NewCombinedIterator(iter1, iter2, context.Background())
 
 	var actual []*openfgapb.TupleKey
 	for {
@@ -124,7 +125,7 @@ func TestUniqueObjectIterator(t *testing.T) {
 		{Type: "document", Id: "4"},
 	})
 
-	iter := NewUniqueObjectIterator(iter1, iter2)
+	iter := NewUniqueObjectIterator(iter1, iter2, context.Background())
 	defer iter.Stop()
 
 	var actual []string
@@ -169,7 +170,7 @@ func ExampleNewUniqueObjectIterator() {
 	// constrained than the other iterator (iter2). In practice iter2 will
 	// be coming from a database that should guarantee uniqueness over the
 	// objects yielded.
-	iter := NewUniqueObjectIterator(iter1, iter2)
+	iter := NewUniqueObjectIterator(iter1, iter2, context.Background())
 	defer iter.Stop()
 
 	var objects []string

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -57,7 +57,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 
 	var actual []*openfgapb.TupleKey
 	for {
-		tk, err := iter.Next()
+		tk, err := iter.Next(context.Background())
 		if err != nil {
 			if errors.Is(err, ErrIteratorDone) {
 				break
@@ -80,11 +80,11 @@ func TestCombinedIterator(t *testing.T) {
 
 	iter1 := NewStaticTupleKeyIterator([]*openfgapb.TupleKey{expected[0]})
 	iter2 := NewStaticTupleKeyIterator([]*openfgapb.TupleKey{expected[1]})
-	iter := NewCombinedIterator(iter1, iter2, context.Background())
+	iter := NewCombinedIterator(iter1, iter2)
 
 	var actual []*openfgapb.TupleKey
 	for {
-		tk, err := iter.Next()
+		tk, err := iter.Next(context.Background())
 		if err != nil {
 			if errors.Is(err, ErrIteratorDone) {
 				break
@@ -125,12 +125,12 @@ func TestUniqueObjectIterator(t *testing.T) {
 		{Type: "document", Id: "4"},
 	})
 
-	iter := NewUniqueObjectIterator(iter1, iter2, context.Background())
+	iter := NewUniqueObjectIterator(iter1, iter2)
 	defer iter.Stop()
 
 	var actual []string
 	for {
-		obj, err := iter.Next()
+		obj, err := iter.Next(context.Background())
 		if err != nil {
 			if errors.Is(err, ErrIteratorDone) {
 				break
@@ -170,12 +170,12 @@ func ExampleNewUniqueObjectIterator() {
 	// constrained than the other iterator (iter2). In practice iter2 will
 	// be coming from a database that should guarantee uniqueness over the
 	// objects yielded.
-	iter := NewUniqueObjectIterator(iter1, iter2, context.Background())
+	iter := NewUniqueObjectIterator(iter1, iter2)
 	defer iter.Stop()
 
 	var objects []string
 	for {
-		obj, err := iter.Next()
+		obj, err := iter.Next(context.Background())
 		if err != nil {
 			if err == ErrIteratorDone {
 				break
@@ -209,7 +209,7 @@ func ExampleNewFilteredTupleKeyIterator() {
 
 	var filtered []string
 	for {
-		tuple, err := iter.Next()
+		tuple, err := iter.Next(context.Background())
 		if err != nil {
 			if err == ErrIteratorDone {
 				break

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -282,7 +282,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 
 		var gotTupleKeys []*openfgapb.TupleKey
 		for {
-			tk, err := iter.Next()
+			tk, err := iter.Next(ctx)
 			if err != nil {
 				if errors.Is(err, storage.ErrIteratorDone) {
 					break
@@ -295,7 +295,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		}
 
 		// Then the iterator should run out
-		_, err = gotTuples.Next()
+		_, err = gotTuples.Next(ctx)
 		require.ErrorIs(t, err, storage.ErrIteratorDone)
 
 		require.Len(t, gotTupleKeys, 3)
@@ -312,7 +312,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer gotTuples.Stop()
 
-		_, err = gotTuples.Next()
+		_, err = gotTuples.Next(context.Background())
 		require.ErrorIs(t, err, storage.ErrIteratorDone)
 	})
 }
@@ -411,7 +411,7 @@ func ListObjectsByTypeTest(t *testing.T, ds storage.OpenFGADatastore) {
 
 	var actual []string
 	for {
-		obj, err := iter.Next()
+		obj, err := iter.Next(context.Background())
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break
@@ -547,7 +547,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 func getObjects(tupleIterator storage.TupleIterator, require *require.Assertions) []string {
 	var objects []string
 	for {
-		tp, err := tupleIterator.Next()
+		tp, err := tupleIterator.Next(context.Background())
 		if err != nil {
 			if err == storage.ErrIteratorDone {
 				break

--- a/storage/test/tuples.go
+++ b/storage/test/tuples.go
@@ -416,6 +416,7 @@ func ListObjectsByTypeTest(t *testing.T, ds storage.OpenFGADatastore) {
 			if err == storage.ErrIteratorDone {
 				break
 			}
+			require.NoError(t, err)
 		}
 
 		actual = append(actual, tuple.ObjectKey(obj))


### PR DESCRIPTION
Suggestion: click this:

<img width="245" alt="image" src="https://user-images.githubusercontent.com/5374887/206080201-35599579-e1e8-4ffc-94af-e58d8176d093.png">

---

This is a follow-up of https://github.com/openfga/openfga/pull/368.

The `Next()` function of the iterators was modified to take in a `context` that, when cancelled or deadlined, will make the iterator's `Next()` function return `ErrIteratorDone`. 

Load tests were run against ListObjects to ensure there is no goroutine leaks.