### PR TITLE
chore: abbreviate `start-mysql` and `start-postgres`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ run: build ## Run the OpenFGA server with in-memory storage
 	./openfga run
 
 
-.PHONY: start-postgres-container
-start-postgres-container: ## Start a Postgres Docker container
+.PHONY: start-postgres
+start-postgres: ## Start a Postgres Docker container
 	docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14
 	@echo \> use \'postgres://postgres:password@localhost:5432/postgres\' to connect to postgres
 
@@ -43,8 +43,8 @@ migrate-postgres: build ## Run Postgres migrations
 run-postgres: build ## Run the OpenFGA server with Postgres storage
 	./openfga run --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres'
 
-.PHONY: start-mysql-container
-start-mysql-container: build ## Start a MySQL Docker container
+.PHONY: start-mysql
+start-mysql: build ## Start a MySQL Docker container
 	docker run -d --name mysql -p 3306:3306 -e MYSQL_ROOT_PASSWORD=secret -e MYSQL_DATABASE=openfga mysql:8
 	
 .PHONY: migrate-mysql


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This abbreviates the `make start-mysql` and `make start-postgres` commands. Typing our the `-container` suffix is a bit much for the fingers 😄 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
