### PR TITLE
refactor: pass the logger to run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -320,17 +320,18 @@ func run(_ *cobra.Command, _ []string) {
 		panic(err)
 	}
 
-	if err := RunServer(context.Background(), config); err != nil {
+	if err := VerifyConfig(config); err != nil {
+		panic(err)
+	}
+
+	logger := buildLogger(config.Log.Format)
+
+	if err := RunServer(context.Background(), config, logger); err != nil {
 		panic(err)
 	}
 }
 
-func RunServer(ctx context.Context, config *Config) error {
-	if err := VerifyConfig(config); err != nil {
-		return err
-	}
-
-	logger := buildLogger(config.Log.Format)
+func RunServer(ctx context.Context, config *Config, logger logger.Logger) error {
 	tracer := telemetry.NewNoopTracer()
 	meter := telemetry.NewNoopMeter()
 	tokenEncoder := encoder.NewBase64Encoder()

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/server/authn/mocks"
 	serverErrors "github.com/openfga/openfga/server/errors"
 	"github.com/stretchr/testify/require"
@@ -274,7 +275,7 @@ func TestBuildServiceWithPresharedKeyAuthenticationFailsIfZeroKeys(t *testing.T)
 	cfg.Authn.Method = "preshared"
 	cfg.Authn.AuthnPresharedKeyConfig = &AuthnPresharedKeyConfig{}
 
-	err := RunServer(context.Background(), cfg)
+	err := RunServer(context.Background(), cfg, logger.NewNoopLogger())
 	require.EqualError(t, err, "failed to initialize authenticator: invalid auth configuration, please specify at least one key")
 }
 
@@ -284,7 +285,7 @@ func TestBuildServiceWithNoAuth(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -313,7 +314,7 @@ func TestBuildServiceWithPresharedKeyAuthentication(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -437,7 +438,7 @@ func TestHTTPServerWithCORS(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -540,7 +541,7 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -600,7 +601,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -624,7 +625,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -659,7 +660,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -684,7 +685,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -705,7 +706,7 @@ func TestHTTPServerDisabled(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -722,7 +723,7 @@ func TestHTTPServerEnabled(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -122,7 +122,7 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	require.NoError(t, err)
 
 	backoffPolicy := backoff.NewExponentialBackOff()
-	backoffPolicy.MaxElapsedTime = 30 * time.Second
+	backoffPolicy.MaxElapsedTime = time.Minute
 	err = backoff.Retry(
 		func() error {
 			return db.Ping()

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -123,7 +123,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 	require.NoError(t, err)
 
 	backoffPolicy := backoff.NewExponentialBackOff()
-	backoffPolicy.MaxElapsedTime = 30 * time.Second
+	backoffPolicy.MaxElapsedTime = time.Minute
 	err = backoff.Retry(
 		func() error {
 			return db.Ping()

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/openfga/openfga/cmd"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
@@ -71,7 +72,7 @@ func testCheck(t *testing.T, engine string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		if err := cmd.RunServer(ctx, cfg); err != nil {
+		if err := cmd.RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()

--- a/tests/oldcheck/check_test.go
+++ b/tests/oldcheck/check_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	parser "github.com/craigpastro/openfga-dsl-parser"
 	"github.com/openfga/openfga/cmd"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
@@ -67,7 +68,7 @@ func testCheck(t *testing.T, engine string) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		if err := cmd.RunServer(ctx, cfg); err != nil {
+		if err := cmd.RunServer(ctx, cfg, logger.NewNoopLogger()); err != nil {
 			log.Fatal(err)
 		}
 	}()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

What do you think of this? I think either this, or the option to turn off the logger in the config would be nice.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
