### PR TITLE
fix: write assertion should not care about type restriction

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -11,18 +11,28 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-// ValidateTuple checks whether a tuple is welformed and valid according to the provided model.
-func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgapb.TupleKey) error {
+// ValidateUserObjectRelation checks whether a tuple is well formed
+func ValidateUserObjectRelation(typesys *typesystem.TypeSystem, tk *openfgapb.TupleKey) error {
 
 	if err := ValidateUser(typesys, tk.GetUser()); err != nil {
-		return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
+		return err
 	}
 
 	if err := ValidateObject(typesys, tk); err != nil {
-		return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
+		return err
 	}
 
 	if err := ValidateRelation(typesys, tk); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateTuple checks whether a tuple is well formed and valid according to the provided model.
+func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgapb.TupleKey) error {
+
+	if err := ValidateUserObjectRelation(typesys, tk); err != nil {
 		return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
 	}
 

--- a/server/commands/check.go
+++ b/server/commands/check.go
@@ -79,15 +79,7 @@ func (q *CheckQuery) Execute(ctx context.Context, req *openfgapb.CheckRequest) (
 		return nil, err
 	}
 
-	if err := validation.ValidateObject(typesys, tk); err != nil {
-		return nil, serverErrors.ValidationError(err)
-	}
-
-	if err := validation.ValidateRelation(typesys, tk); err != nil {
-		return nil, serverErrors.ValidationError(err)
-	}
-
-	if err := validation.ValidateUser(typesys, tk.GetUser()); err != nil {
+	if err := validation.ValidateUserObjectRelation(typesys, tk); err != nil {
 		return nil, serverErrors.ValidationError(err)
 	}
 

--- a/server/commands/write_assertions.go
+++ b/server/commands/write_assertions.go
@@ -44,7 +44,7 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgapb.Wri
 	typesys := typesystem.New(model)
 
 	for _, assertion := range assertions {
-		if err := validation.ValidateTuple(typesys, assertion.TupleKey); err != nil {
+		if err := validation.ValidateUserObjectRelation(typesys, assertion.TupleKey); err != nil {
 			return nil, serverErrors.ValidationError(err)
 		}
 	}


### PR DESCRIPTION

## Description
write_assertion should not care about type restriction as it is similar to check

## References
Close https://github.com/openfga/openfga/issues/411


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
