### PR TITLE
chore: split the server tests into individual tests

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -39,35 +39,32 @@ func init() {
 	}
 }
 
-func TestOpenFGAServer(t *testing.T) {
+func TestServerWithPostgresDatastore(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	t.Run("TestPostgresDatastore", func(t *testing.T) {
-		testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+	uri := testDatastore.GetConnectionURI()
+	ds, err := postgres.NewPostgresDatastore(uri)
+	require.NoError(t, err)
+	defer ds.Close()
 
-		uri := testDatastore.GetConnectionURI()
-		ds, err := postgres.NewPostgresDatastore(uri)
-		require.NoError(t, err)
-		defer ds.Close()
+	test.RunAllTests(t, ds)
+}
 
-		test.RunAllTests(t, ds)
-	})
+func TestServerWithMemoryDatastore(t *testing.T) {
+	ds := memory.New(telemetry.NewNoopTracer(), 10, 24)
+	defer ds.Close()
+	test.RunAllTests(t, ds)
+}
 
-	t.Run("TestMemoryDatastore", func(t *testing.T) {
-		ds := memory.New(telemetry.NewNoopTracer(), 10, 24)
-		defer ds.Close()
-		test.RunAllTests(t, ds)
-	})
+func TestServerWithMySQLDatastore(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	t.Run("TestMySQLDatastore", func(t *testing.T) {
-		testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+	uri := testDatastore.GetConnectionURI()
+	ds, err := mysql.NewMySQLDatastore(uri)
+	require.NoError(t, err)
+	defer ds.Close()
 
-		uri := testDatastore.GetConnectionURI()
-		ds, err := mysql.NewMySQLDatastore(uri)
-		require.NoError(t, err)
-		defer ds.Close()
-
-		test.RunAllTests(t, ds)
-	})
+	test.RunAllTests(t, ds)
 }
 
 func BenchmarkOpenFGAServer(b *testing.B) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This splits the individual `mysql`, `postgres`, and `memory` server tests into individual Go tests so that they can be run individually if you prefer. This is particularly helpful during development because then you can just run the `memory` tests for quick feedback.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
