### PR TITLE
fix: filter reads by type restriction in direct relationship lookups

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -110,12 +110,13 @@ func runTests(t *testing.T, client pb.OpenFGAServiceClient, tests checkTests) {
 	ctx := context.Background()
 
 	for _, test := range tests.Tests {
+		resp, err := client.CreateStore(ctx, &pb.CreateStoreRequest{Name: test.Name})
+		require.NoError(t, err)
+
+		storeID := resp.GetId()
+
 		for _, stage := range test.Stages {
 			t.Run(test.Name, func(t *testing.T) {
-				resp, err := client.CreateStore(ctx, &pb.CreateStoreRequest{Name: test.Name})
-				require.NoError(t, err)
-
-				storeID := resp.GetId()
 
 				_, err = client.WriteAuthorizationModel(ctx, &pb.WriteAuthorizationModelRequest{
 					StoreId:         storeID,

--- a/tests/check/tests.yaml
+++ b/tests/check/tests.yaml
@@ -1439,3 +1439,35 @@ tests:
               relation: viewer
               user: user:*
             expectation: true
+
+  - name: prior_type_restrictions_ignored
+    stages:
+      - model: |
+          type user
+
+          type document
+            relations
+              define viewer: [user] as self
+        tuples:
+          - object: document:1
+            relation: viewer
+            user: user:jon
+        assertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            expectation: true
+      - model: |
+          type user
+          type employee
+
+          type document
+            relations
+              define viewer: [employee] as self
+        assertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            expectation: false


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fixes an issue with filtered reads on direct relationship look ups.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
