### PR TITLE
chore: fix flaky `run` entrypoint tests

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -527,7 +527,11 @@ func RunServer(ctx context.Context, config *Config) error {
 
 	go func() {
 		if err := grpcServer.Serve(lis); err != nil {
-			logger.Fatal("failed to start grpc server", zap.Error(err))
+			if !errors.Is(err, grpc.ErrServerStopped) {
+				logger.Fatal("failed to start grpc server", zap.Error(err))
+			}
+
+			logger.Info("grpc server shut down..")
 		}
 	}()
 	logger.Info(fmt.Sprintf("grpc server listening on '%s'...", config.GRPC.Addr))


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fix flaky run tests due to the server stopping before it's had time to spin up.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
