### PR TITLE
fix: correct validation errors for typed wildcard behavior in 1.1 models

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -195,6 +195,10 @@ func ValidateObject(typesys *typesystem.TypeSystem, tk *openfgapb.TupleKey) erro
 		return fmt.Errorf("invalid 'object' field format")
 	}
 
+	if tuple.IsTypedWildcard(object) {
+		return fmt.Errorf("the 'object' field cannot reference a typed wildcard")
+	}
+
 	objectType := tuple.GetType(object)
 	_, ok := typesys.GetTypeDefinition(objectType)
 	if !ok {
@@ -251,6 +255,14 @@ func ValidateUser(typesys *typesystem.TypeSystem, user string) error {
 	if schemaVersion == typesystem.SchemaVersion1_1 {
 		if !tuple.IsValidObject(user) && !tuple.IsObjectRelation(user) {
 			return fmt.Errorf("the 'user' field must be an object (e.g. document:1) or an 'object#relation' or a typed wildcard (e.g. group:*)")
+		}
+
+		if tuple.IsObjectRelation(user) {
+			userObj, _ := tuple.SplitObjectRelation(user)
+
+			if tuple.IsTypedWildcard(userObj) {
+				return fmt.Errorf("the 'user' field cannot reference a typed wildcard in a userset value")
+			}
 		}
 	}
 


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The changes herein add extra tuple validations for 1.1 models. In particular, an `object` value cannot be formatted as a typed wildcard (e.g. `type:*`) AND `user` values involving usersets cannot reference a typed wildcard in their 'object' component. So tuples such as `document:*#viewer@user:jon` and `document:1#viewer@document:*#editor` are both invalid.

## References
Fixes #415 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
