### PR TITLE
chore: put OpenTelemetry metrics behind an experimental feature flag

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -37,7 +37,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "enum": ["list-objects-optimized"]
+                "enum": ["list-objects-optimized", "otel-metrics"]
             },
             "default": []
         },
@@ -148,24 +148,24 @@
                 }
             }
         },
-        "metrics": {
+        "otel": {
             "type": "object",
             "properties": {
-                "enabled": {
-                    "description": "Toggle OTel Collector export of metrics",
-                    "type": "boolean",
-                    "default": false
-                },
-                "endpoint": {
-                    "description": "Remote OTEL collector endpoint",
-                    "type": "string",
-                    "default": "0.0.0.0:4317"
-                },
-                "protocol": {
-                    "description": "Protocol used to send metrics to the collector",
-                    "type": "string",
-                    "enum": ["grpc", "http"],
-                    "default": "grpc"
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "description": "Remote OTEL collector endpoint",
+                            "type": "string",
+                            "default": "0.0.0.0:4317"
+                        },
+                        "protocol": {
+                            "description": "Protocol used to send metrics to the collector",
+                            "type": "string",
+                            "enum": ["grpc", "http"],
+                            "default": "grpc"
+                        }
+                    }
                 }
             }
         },

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -403,7 +403,7 @@ func RunServer(ctx context.Context, config *Config) error {
 		protocol := config.OpenTelemetry.Protocol
 		endpoint := config.OpenTelemetry.Endpoint
 
-		logger.Info(fmt.Sprintf("🕵 OpenTelemetry 'otlp' metrics export to '%s' through protocol '%s'", endpoint, protocol))
+		logger.Info(fmt.Sprintf("🕵 OpenTelemetry 'otlp' metrics exported to '%s' via protocol '%s'", endpoint, protocol))
 
 		meter, err = telemetry.NewOTLPMeter(ctx, logger, protocol, endpoint)
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,6 +47,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
+	"golang.org/x/exp/slices"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -164,11 +165,14 @@ type ProfilerConfig struct {
 	Addr    string
 }
 
-// MetricsConfig defines metrics configuration and exposure settings.
-type MetricsConfig struct {
-	Enabled  bool
+type OpenTelemetryMetricsConfig struct {
 	Endpoint string
 	Protocol string
+}
+
+// OpenTelemetryConfig defines configurations for OpenTelemetry telemetry settings.
+type OpenTelemetryConfig struct {
+	OpenTelemetryMetricsConfig `mapstructure:"metrics"`
 }
 
 type Config struct {
@@ -199,14 +203,14 @@ type Config struct {
 	// ResolveNodeLimit indicates how deeply nested an authorization model can be.
 	ResolveNodeLimit uint32
 
-	Datastore  DatastoreConfig
-	GRPC       GRPCConfig
-	HTTP       HTTPConfig
-	Authn      AuthnConfig
-	Log        LogConfig
-	Playground PlaygroundConfig
-	Profiler   ProfilerConfig
-	Metrics    MetricsConfig
+	Datastore     DatastoreConfig
+	GRPC          GRPCConfig
+	HTTP          HTTPConfig
+	Authn         AuthnConfig
+	Log           LogConfig
+	Playground    PlaygroundConfig
+	Profiler      ProfilerConfig
+	OpenTelemetry OpenTelemetryConfig `mapstructure:"otel"`
 }
 
 // DefaultConfig returns the OpenFGA server default configurations.
@@ -252,10 +256,11 @@ func DefaultConfig() *Config {
 			Enabled: false,
 			Addr:    ":3001",
 		},
-		Metrics: MetricsConfig{
-			Enabled:  false,
-			Protocol: "grpc",
-			Endpoint: "0.0.0.0:4317",
+		OpenTelemetry: OpenTelemetryConfig{
+			OpenTelemetryMetricsConfig: OpenTelemetryMetricsConfig{
+				Protocol: "grpc",
+				Endpoint: "0.0.0.0:4317",
+			},
 		},
 	}
 }
@@ -383,11 +388,24 @@ func RunServer(ctx context.Context, config *Config) error {
 	tracer := telemetry.NewNoopTracer()
 	tokenEncoder := encoder.NewBase64Encoder()
 
+	logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
+
+	var experimentals []server.ExperimentalFeatureFlag
+	for _, feature := range config.Experimentals {
+		experimentals = append(experimentals, server.ExperimentalFeatureFlag(feature))
+	}
+
 	var err error
 	meter := metric.NewNoopMeter()
-	if config.Metrics.Enabled {
-		logger.Info(fmt.Sprintf("🕵 OTLP metrics send through protocol '%s'", config.Metrics.Protocol))
-		meter, err = telemetry.NewOTLPMeter(ctx, logger, config.Metrics.Protocol, config.Metrics.Endpoint)
+
+	if slices.Contains(config.Experimentals, "otel-metrics") {
+
+		protocol := config.OpenTelemetry.Protocol
+		endpoint := config.OpenTelemetry.Endpoint
+
+		logger.Info(fmt.Sprintf("🕵 OpenTelemetry 'otlp' metrics export to '%s' through protocol '%s'", endpoint, protocol))
+
+		meter, err = telemetry.NewOTLPMeter(ctx, logger, protocol, endpoint)
 		if err != nil {
 			return fmt.Errorf("failed to initialize otlp metrics meter: %w", err)
 		}
@@ -493,13 +511,6 @@ func RunServer(ctx context.Context, config *Config) error {
 				}
 			}
 		}()
-	}
-
-	logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
-
-	var experimentals []server.ExperimentalFeatureFlag
-	for _, feature := range config.Experimentals {
-		experimentals = append(experimentals, server.ExperimentalFeatureFlag(feature))
 	}
 
 	svr := server.New(&server.Dependencies{
@@ -844,12 +855,9 @@ func bindRunFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint32("listObjects-max-results", defaultConfig.ListObjectsMaxResults, "the maximum results to return in ListObjects responses")
 	util.MustBindPFlag("listObjectsMaxResults", cmd.Flags().Lookup("listObjects-max-results"))
 
-	cmd.Flags().Bool("metrics-enabled", defaultConfig.Metrics.Enabled, "enable/disable OTel metrics export")
-	util.MustBindPFlag("metrics.enabled", cmd.Flags().Lookup("metrics-enabled"))
+	cmd.Flags().String("otel-telemetry-endpoint", defaultConfig.OpenTelemetry.Endpoint, "OpenTelemetry collector endpoint to use")
+	util.MustBindPFlag("otel.metrics.endpoint", cmd.Flags().Lookup("otel-telemetry-endpoint"))
 
-	cmd.Flags().String("metrics-endpoint", defaultConfig.Metrics.Endpoint, "OTel Collector endpoint to use")
-	util.MustBindPFlag("metrics.endpoint", cmd.Flags().Lookup("metrics-endpoint"))
-
-	cmd.Flags().String("metrics-protocol", defaultConfig.Metrics.Protocol, "the protocol to use to send OTLP metrics")
-	util.MustBindPFlag("metrics.protocol", cmd.Flags().Lookup("metrics-protocol"))
+	cmd.Flags().String("otel-telemetry-protocol", defaultConfig.OpenTelemetry.Protocol, "OpenTelemetry protocol to use to send OTLP metrics")
+	util.MustBindPFlag("otel.metrics.protocol", cmd.Flags().Lookup("otel-telemetry-protocol"))
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -851,15 +851,15 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), cfg.ListObjectsMaxResults)
 
-	val = res.Get("properties.metrics.properties.enabled.default")
+	val = res.Get("properties.experimentals.default")
 	require.True(t, val.Exists())
-	require.Equal(t, val.Bool(), cfg.Metrics.Enabled)
+	require.Equal(t, len(val.Array()), len(cfg.Experimentals))
 
-	val = res.Get("properties.metrics.properties.endpoint.default")
+	val = res.Get("properties.otel.properties.metrics.properties.endpoint.default")
 	require.True(t, val.Exists())
-	require.Equal(t, val.String(), cfg.Metrics.Endpoint)
+	require.Equal(t, val.String(), cfg.OpenTelemetry.Endpoint)
 
-	val = res.Get("properties.metrics.properties.protocol.default")
+	val = res.Get("properties.otel.properties.metrics.properties.protocol.default")
 	require.True(t, val.Exists())
-	require.Equal(t, val.String(), cfg.Metrics.Protocol)
+	require.Equal(t, val.String(), cfg.OpenTelemetry.Protocol)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This puts the OpenTelemetry metric integration behind an experimental feature flag `otel-metrics`. We will proceed forward with adding metrics as a first-class citizen of the server configurations once we've decided on a metric ecosystem that the community will benefit most from. We're still deciding between Prometheus for Metrics vs OpenTelemetry.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
