### PR TITLE
perf: thin context wrapper over datastore

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -441,7 +441,7 @@ func RunServer(ctx context.Context, config *Config) error {
 	}
 	logger.Info(fmt.Sprintf("using '%v' storage engine", config.Datastore.Engine))
 
-	cachedOpenFGADatastore := caching.NewCachedOpenFGADatastore(datastore, config.Datastore.MaxCacheSize)
+	datastore = caching.NewCachedOpenFGADatastore(storage.NewContextWrapper(datastore), config.Datastore.MaxCacheSize)
 
 	var authenticator authn.Authenticator
 	switch config.Authn.Method {
@@ -514,7 +514,7 @@ func RunServer(ctx context.Context, config *Config) error {
 	}
 
 	svr := server.New(&server.Dependencies{
-		Datastore:    cachedOpenFGADatastore,
+		Datastore:    datastore,
 		Tracer:       tracer,
 		Logger:       logger,
 		Meter:        meter,
@@ -741,8 +741,6 @@ func RunServer(ctx context.Context, config *Config) error {
 	authenticator.Close()
 
 	datastore.Close()
-
-	cachedOpenFGADatastore.Close()
 
 	logger.Info("server exited. goodbye 👋")
 

--- a/pkg/storage/context.go
+++ b/pkg/storage/context.go
@@ -1,0 +1,73 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"go.opentelemetry.io/otel/trace"
+)
+
+var (
+	queryTimeout = 500 * time.Millisecond
+)
+
+// ContextTracerWrapper is a wrapper around a datastore that passes a new
+// context to the underlying datastore methods. It must be the first wrapper
+// around the datastore if traces are to work properly.
+type ContextTracerWrapper struct {
+	OpenFGADatastore
+}
+
+var _ OpenFGADatastore = (*ContextTracerWrapper)(nil)
+
+func NewContextWrapper(inner OpenFGADatastore) *ContextTracerWrapper {
+	return &ContextTracerWrapper{inner}
+}
+
+// queryContext returns a new context (not a child context) with a timeout and
+// the same span data as the supplied context.
+func queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	span := trace.SpanFromContext(ctx)
+	return trace.ContextWithSpan(context.Background(), span), func() {}
+	//return context.WithTimeout(trace.ContextWithSpan(context.Background(), span), queryTimeout)
+}
+
+func (c *ContextTracerWrapper) Close() {
+	c.OpenFGADatastore.Close()
+}
+
+func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (TupleIterator, error) {
+	queryCtx, cancel := queryContext(ctx)
+	defer cancel()
+
+	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey)
+}
+
+func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgapb.TupleKey, opts PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+	queryCtx, cancel := queryContext(ctx)
+	defer cancel()
+
+	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, opts)
+}
+
+func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
+	queryCtx, cancel := queryContext(ctx)
+	defer cancel()
+
+	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey)
+}
+
+func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (TupleIterator, error) {
+	queryCtx, cancel := queryContext(ctx)
+	defer cancel()
+
+	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, tupleKey)
+}
+
+func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts ReadStartingWithUserFilter) (TupleIterator, error) {
+	queryCtx, cancel := queryContext(ctx)
+	defer cancel()
+
+	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts)
+}

--- a/pkg/storage/context.go
+++ b/pkg/storage/context.go
@@ -2,14 +2,9 @@ package storage
 
 import (
 	"context"
-	"time"
 
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 	"go.opentelemetry.io/otel/trace"
-)
-
-var (
-	queryTimeout = 500 * time.Millisecond
 )
 
 // ContextTracerWrapper is a wrapper around a datastore that passes a new

--- a/pkg/storage/context.go
+++ b/pkg/storage/context.go
@@ -30,7 +30,6 @@ func NewContextWrapper(inner OpenFGADatastore) *ContextTracerWrapper {
 func queryContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	span := trace.SpanFromContext(ctx)
 	return trace.ContextWithSpan(context.Background(), span), func() {}
-	//return context.WithTimeout(trace.ContextWithSpan(context.Background(), span), queryTimeout)
 }
 
 func (c *ContextTracerWrapper) Close() {

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -87,12 +87,12 @@ type MemoryBackend struct {
 	assertions map[string][]*openfgapb.Assertion
 }
 
+var _ storage.OpenFGADatastore = (*MemoryBackend)(nil)
+
 type AuthorizationModelEntry struct {
 	model  *openfgapb.AuthorizationModel
 	latest bool
 }
-
-var _ storage.OpenFGADatastore = (*MemoryBackend)(nil)
 
 // New creates a new empty MemoryBackend.
 func New(tracer trace.Tracer, maxTuplesPerWrite int, maxTypesPerAuthorizationModel int) *MemoryBackend {
@@ -639,7 +639,7 @@ func (s *MemoryBackend) ReadAssertions(ctx context.Context, store, modelID strin
 	return assertions, nil
 }
 
-// MaxTuplesPerWriteOperation returns the maximum number of tuples allowed in one write operation
+// MaxTuplesPerWrite returns the maximum number of tuples allowed in one write operation
 func (s *MemoryBackend) MaxTuplesPerWrite() int {
 	return s.maxTuplesPerWrite
 }

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -34,6 +34,8 @@ type MySQL struct {
 	maxTypesPerModelField  int
 }
 
+var _ storage.OpenFGADatastore = (*MySQL)(nil)
+
 func New(uri string, cfg *common.Config) (*MySQL, error) {
 	db, err := sql.Open("mysql", uri)
 	if err != nil {

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -34,6 +34,8 @@ type Postgres struct {
 	maxTypesPerModelField  int
 }
 
+var _ storage.OpenFGADatastore = (*Postgres)(nil)
+
 func New(uri string, cfg *common.Config) (*Postgres, error) {
 	db, err := sql.Open("pgx", uri)
 	if err != nil {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

In a future PR I will add a timeout context to the datastore calls, but this requires removing the ctx from the datastore iterators.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

#380

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
