### PR TITLE
fix: resolve race condition with sync map access in optimized ListObj…

### DIFF
--- a/pkg/server/commands/connected_objects.go
+++ b/pkg/server/commands/connected_objects.go
@@ -310,7 +310,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		foundObject := tk.GetObject()
 		foundObjectType, foundObjectID := tuple.SplitObject(foundObject)
 
-		if _, ok := foundObjectsMap.Load(foundObject); ok {
+		if _, ok := foundObjectsMap.LoadOrStore(foundObject, struct{}{}); ok {
 			// todo(jon-whit): we could optimize this by avoiding reading this
 			// from the database in the first place
 
@@ -324,7 +324,6 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 			}
 
 			resultChan <- foundObject
-			foundObjectsMap.Store(foundObject, struct{}{})
 		}
 
 		var targetUserRef isUserRef


### PR DESCRIPTION
…ects

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes a race on synchronized map access in the optimized ListObjects implementation which was leading to duplicates being returned in the response.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
