### PR TITLE
fix: avoid re-eval of visited rewrites during rewrite tree recursion

### DIFF
--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -861,6 +861,30 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			},
 			expectedObjects: []string{"resource:eng_handbook"},
 		},
+		{
+			name: "cyclical_tupleset_relation_terminates",
+			request: &commands.ConnectedObjectsRequest{
+				StoreID:    ulid.Make().String(),
+				ObjectType: "node",
+				Relation:   "editor",
+				User: &commands.UserRefObject{Object: &openfgapb.Object{
+					Type: "user",
+					Id:   "wonder",
+				}},
+			},
+			model: `
+			type user
+
+			type node
+			  relations
+			    define parent: [node] as self
+			    define editor: [user] as self or editor from parent
+			`,
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("node:abc", "editor", "user:wonder"),
+			},
+			expectedObjects: []string{"node:abc"},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -297,6 +297,13 @@ func (t *TypeSystem) RelationInvolvesIntersection(objectType, relation string) (
 
 func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, visited map[string]struct{}) (bool, error) {
 
+	key := fmt.Sprintf("%s#%s", objectType, relation)
+	if _, ok := visited[key]; ok {
+		return false, nil
+	}
+
+	visited[key] = struct{}{}
+
 	rel, err := t.GetRelation(objectType, relation)
 	if err != nil {
 		return false, err
@@ -397,7 +404,6 @@ func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, v
 			if _, ok := visited[key]; ok {
 				continue
 			}
-			visited[key] = struct{}{}
 
 			containsIntersection, err := t.relationInvolvesIntersection(
 				typeRestriction.GetType(),
@@ -427,6 +433,14 @@ func (t *TypeSystem) RelationInvolvesExclusion(objectType, relation string) (boo
 }
 
 func (t *TypeSystem) relationInvolvesExclusion(objectType, relation string, visited map[string]struct{}) (bool, error) {
+
+	key := fmt.Sprintf("%s#%s", objectType, relation)
+	if _, ok := visited[key]; ok {
+		return false, nil
+	}
+
+	visited[key] = struct{}{}
+
 	rel, err := t.GetRelation(objectType, relation)
 	if err != nil {
 		return false, err
@@ -526,7 +540,6 @@ func (t *TypeSystem) relationInvolvesExclusion(objectType, relation string, visi
 			if _, ok := visited[key]; ok {
 				continue
 			}
-			visited[key] = struct{}{}
 
 			containsExclusion, err := t.relationInvolvesExclusion(
 				typeRestriction.GetType(),

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -1200,6 +1200,19 @@ func TestRelationInvolvesIntersection(t *testing.T) {
 			rr:       DirectRelationReference("example", "editor"),
 			expected: false,
 		},
+		{
+			name: "cyclical_evaluation_of_tupleset",
+			model: `
+			type user
+
+			type node
+			  relations
+			    define parent: [node] as self
+			    define editor: [user] as self or editor from parent
+			`,
+			rr:       DirectRelationReference("node", "editor"),
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {
@@ -1344,6 +1357,19 @@ func TestRelationInvolvesExclusion(t *testing.T) {
 			    define viewer: [example#editor] as self
 			`,
 			rr:       DirectRelationReference("example", "editor"),
+			expected: false,
+		},
+		{
+			name: "cyclical_evaluation_of_tupleset",
+			model: `
+			type user
+
+			type node
+			  relations
+			    define parent: [node] as self
+			    define editor: [user] as self or editor from parent
+			`,
+			rr:       DirectRelationReference("node", "editor"),
 			expected: false,
 		},
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This code ensures that we don't revisit prior relationship rewrites during rewrite tree evaluation when checking if Intersection or Exclusion rewrite operators are involved.

This code positively impacts ListObjects because we use `RelationInvolvesIntersection` and `RelationInvolvesExclusion` to determine if we should use the optimized ListObjects (`ConnectedObjects` implementation) or the unoptimized version (concurrent `Check` evaluation). 

These two methods (RelationInvolvesIntersection RelationInvolvesExclusion) were encountering stackoverflow scenarios because this safeguard wasn't in place for this specific (and unique) case.

## References
Fixes #505 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
