### PR TITLE
feat(internal): make CombinedIterator accept more than two inputs

### DIFF
--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -102,38 +102,41 @@ func (u *uniqueObjectIterator) Stop() {
 }
 
 type combinedIterator[T any] struct {
-	iter1, iter2 Iterator[T]
+	iters []Iterator[T]
 }
 
 func (c *combinedIterator[T]) Next() (T, error) {
-	val, err := c.iter1.Next()
-	if err != nil {
-		if !errors.Is(err, ErrIteratorDone) {
-			return val, err
+	for i := 0; i < len(c.iters); i++ {
+		if c.iters[i] != nil {
+			val, err := c.iters[i].Next()
+			if err != nil {
+				if !errors.Is(err, ErrIteratorDone) {
+					return val, err
+				} else {
+					c.iters[i] = nil // end of this iterator
+				}
+			} else {
+				return val, nil
+			}
 		}
-	} else {
-		return val, nil
 	}
 
-	val, err = c.iter2.Next()
-	if err != nil {
-		if !errors.Is(err, ErrIteratorDone) {
-			return val, err
-		}
-	}
-
-	return val, err
+	var val T
+	return val, ErrIteratorDone
 }
 
 func (c *combinedIterator[T]) Stop() {
-	c.iter1.Stop()
-	c.iter2.Stop()
+	for i := 0; i < len(c.iters); i++ {
+		if c.iters[i] != nil {
+			c.iters[i].Stop()
+		}
+	}
 }
 
-// NewCombinedIterator takes two generic iterators of a given type T and combines them into a single iterator that yields
-// all of the values from both iterators. If the two iterators yield the same value then duplicates will be returned.
-func NewCombinedIterator[T any](iter1, iter2 Iterator[T]) Iterator[T] {
-	return &combinedIterator[T]{iter1, iter2}
+// NewCombinedIterator takes an array of generic iterators of a given type T and combines them into a single iterator that yields
+// all the values from all iterators. Duplicates can be returned.
+func NewCombinedIterator[T any](iters ...Iterator[T]) Iterator[T] {
+	return &combinedIterator[T]{iters}
 }
 
 // NewStaticTupleIterator returns a TupleIterator that iterates over the provided slice.

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -106,11 +106,11 @@ type combinedIterator[T any] struct {
 }
 
 func (c *combinedIterator[T]) Next() (T, error) {
-	for i := 0; i < len(c.iters); i++ {
-		if c.iters[i] == nil {
+	for i, iter := range c.iters {
+		if iter == nil {
 			continue
 		}
-		val, err := c.iters[i].Next()
+		val, err := iter.Next()
 		if err != nil {
 			if !errors.Is(err, ErrIteratorDone) {
 				return val, err
@@ -128,9 +128,9 @@ func (c *combinedIterator[T]) Next() (T, error) {
 }
 
 func (c *combinedIterator[T]) Stop() {
-	for i := 0; i < len(c.iters); i++ {
-		if c.iters[i] != nil {
-			c.iters[i].Stop()
+	for _, iter := range c.iters {
+		if iter != nil {
+			iter.Stop()
 		}
 	}
 }


### PR DESCRIPTION
I don't know why we didn't do this from the get-go :(

This PR also should bring a performance improvement because now, if the iterator is finished, we don't call `Next()`.