### PR TITLE
refactor: remove stacktrace from error logs

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -117,6 +117,7 @@ func NewLogger(logFormat, logLevel string) (*ZapLogger, error) {
 
 	cfg := zap.NewProductionConfig()
 	cfg.Level = zap.NewAtomicLevelAt(level)
+	cfg.DisableStacktrace = true
 
 	if logFormat == "text" {
 		cfg.Encoding = "console"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

The stacktrace is never useful, so remove it. E.g.:
```
github.com/openfga/openfga/pkg/logger.(*ZapLogger).Error
        /Users/craig/git/openfga/pkg/logger/logger.go:53
github.com/openfga/openfga/internal/middleware.NewLoggingInterceptor.func1
        /Users/craig/git/openfga/internal/middleware/logging.go:62
google.golang.org/grpc.getChainUnaryHandler.func1
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1163
github.com/openfga/openfga/internal/middleware.NewRequestIDInterceptor.func1
        /Users/craig/git/openfga/internal/middleware/requestid.go:48
google.golang.org/grpc.getChainUnaryHandler.func1
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1163
go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc.UnaryServerInterceptor.func1
        /Users/craig/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc@v0.38.0/interceptor.go:342
google.golang.org/grpc.getChainUnaryHandler.func1
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1163
github.com/grpc-ecosystem/go-grpc-middleware/validator.UnaryServerInterceptor.func1
        /Users/craig/go/pkg/mod/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0/validator/validator.go:47
google.golang.org/grpc.chainUnaryInterceptors.func1
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1154
go.buf.build/openfga/go/openfga/api/openfga/v1._OpenFGAService_WriteAuthorizationModel_Handler
        /Users/craig/go/pkg/mod/go.buf.build/openfga/go/openfga/api@v1.2.49/openfga/v1/openfga_service_grpc.pb.go:429
google.golang.org/grpc.(*Server).processUnaryRPC
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1336
google.golang.org/grpc.(*Server).handleStream
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:1704
google.golang.org/grpc.(*Server).serveStreams.func1.2
        /Users/craig/go/pkg/mod/google.golang.org/grpc@v1.52.3/server.go:965
```


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

Resolves #226.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
