### PR TITLE
chore: add `grpc-health-probe` for Health checks

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,6 +38,10 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--build-arg"
+      - "OS=linux"
+      - "--build-arg"
+      - "ARCH=amd64"
 
     extra_files:
       - assets
@@ -59,6 +63,10 @@ dockers:
 
     build_flag_templates:
       - "--platform=linux/arm64"
+      - "--build-arg"
+      - "OS=linux"
+      - "--build-arg"
+      - "ARCH=arm64"
 
     extra_files:
       - assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
 FROM golang:1.20-alpine AS builder
+ARG OS
+ARG ARCH
 
 WORKDIR /app
 
 COPY . .
 RUN go build -o ./openfga ./cmd/openfga
+RUN wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.13/grpc_health_probe-${OS}-${ARCH}"
 
 FROM alpine as final
 EXPOSE 8081
@@ -11,5 +14,7 @@ EXPOSE 8080
 EXPOSE 3000
 COPY --from=builder /app/openfga /app/openfga
 COPY --from=builder /app/assets /app/assets
+COPY --from=builder /app/grpc_health_probe /bin/grpc_health_probe
+RUN chmod +x /bin/grpc_health_probe
 WORKDIR /app
 ENTRYPOINT ["./openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,8 @@
-FROM scratch
+FROM alpine
+ARG OS
+ARG ARCH
 COPY assets /assets
 COPY openfga /
+RUN wget -q -O /bin/grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.13/grpc_health_probe-${OS}-${ARCH}"
+RUN chmod +x /bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,11 @@ services:
     ports:
       - "8080:8080"
       - "3000:3000"
+    healthcheck:
+      test: ["CMD", "/bin/grpc_health_probe", "-addr=openfga:8081"]
+      interval: 5s
+      timeout: 30s
+      retries: 3
 
   otel-collector:
     image: otel/opentelemetry-collector:latest


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds the `grpc-health-probe` binary to the OpenFGA container during the Docker build process.

Since OpenFGA is a gRPC server with an HTTP proxy on top of it, it makes sense to expose the Health checks via the grpc-health-probe. This is the defacto standard way of doing Health checks for gRPC, and it aligns with the [gRPC Health Check Protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) as well.

https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/
https://github.com/grpc-ecosystem/grpc-health-probe/

## References
https://github.com/orgs/openfga/discussions/109

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
