### PR TITLE
chore: add a span attr to indicate what ListObjects handler was used

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -119,8 +119,6 @@ func (q *ListObjectsQuery) handler(
 		// ConnectedObjects currently only supports models that do not include intersection and exclusion,
 		// and the model must include type info for ConnectedObjects to work.
 		if !containsIntersection && !containsExclusion && hasTypeInfo {
-			span.SetAttributes(attribute.Bool("list-objects-optimized", true))
-
 			userObj, userRel := tuple.SplitObjectRelation(req.GetUser())
 
 			userObjType, userObjID := tuple.SplitObject(userObj)
@@ -147,6 +145,8 @@ func (q *ListObjectsQuery) handler(
 			}
 
 			handler = func() {
+				span.SetAttributes(attribute.Bool("list-objects-optimized", true))
+
 				err = q.ConnectedObjects(ctx, &ConnectedObjectsRequest{
 					StoreID:          req.GetStoreId(),
 					ObjectType:       targetObjectType,

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	maximumConcurrentChecks = 100 // todo(jon-whit): make this configurable, but for now limit to 100 concurrent checks
+	listObjectsOptimizedKey = "list_objects_optimized"
 )
 
 type ListObjectsQuery struct {
@@ -93,7 +94,7 @@ func (q *ListObjectsQuery) handler(
 	}
 
 	handler := func() {
-		span.SetAttributes(attribute.Bool("list-objects-optimized", false))
+		span.SetAttributes(attribute.Bool(listObjectsOptimizedKey, false))
 
 		err = q.performChecks(ctx, req, resultsChan)
 		if err != nil {
@@ -145,7 +146,7 @@ func (q *ListObjectsQuery) handler(
 			}
 
 			handler = func() {
-				span.SetAttributes(attribute.Bool("list-objects-optimized", true))
+				span.SetAttributes(attribute.Bool(listObjectsOptimizedKey, true))
 
 				err = q.ConnectedObjects(ctx, &ConnectedObjectsRequest{
 					StoreID:          req.GetStoreId(),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR adds a span attribute to the `ListObjects` span that indicates what handler was used (optimized or non-optimized variant).

## References
This work is essentially superseded by https://github.com/openfga/openfga/pull/522, because at that point it will be obvious which path ListObjects took.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
