### PR TITLE
chore: add tracing to internal ConnectedObjects API

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -49,6 +49,19 @@ const (
 	ComputedUsersetIngress
 )
 
+func (r RelationshipIngressType) String() string {
+	switch r {
+	case DirectIngress:
+		return "direct"
+	case ComputedUsersetIngress:
+		return "computed_userset"
+	case TupleToUsersetIngress:
+		return "ttu"
+	default:
+		return "undefined"
+	}
+}
+
 // RelationshipIngress represents a possible ingress point between some source object reference
 // and a target user reference.
 type RelationshipIngress struct {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -10,6 +10,14 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
+func TestRelationshipIngressType_String(t *testing.T) {
+
+	require.Equal(t, "direct", DirectIngress.String())
+	require.Equal(t, "computed_userset", ComputedUsersetIngress.String())
+	require.Equal(t, "ttu", TupleToUsersetIngress.String())
+	require.Equal(t, "undefined", RelationshipIngressType(4).String())
+}
+
 func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 
 	tests := []struct {

--- a/pkg/server/commands/connected_objects.go
+++ b/pkg/server/commands/connected_objects.go
@@ -88,6 +88,8 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
+	ctx, span := tracer.Start(ctx, "streamedConnectedObjects")
+	defer span.End()
 
 	depth, ok := graph.ResolutionDepthFromContext(ctx)
 	if !ok {
@@ -189,6 +191,8 @@ func (c *ConnectedObjectsCommand) StreamedConnectedObjects(
 	req *ConnectedObjectsRequest,
 	resultChan chan<- string, // object string (e.g. document:1)
 ) error {
+	ctx, span := tracer.Start(ctx, "StreamedConnectedObjects")
+	defer span.End()
 
 	var foundCount *uint32
 	if c.Limit > 0 {
@@ -214,6 +218,8 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
+	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset")
+	defer span.End()
 
 	store := req.storeID
 
@@ -368,6 +374,8 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
+	ctx, span := tracer.Start(ctx, "reverseExpandDirect")
+	defer span.End()
 
 	store := req.storeID
 

--- a/pkg/server/commands/connected_objects.go
+++ b/pkg/server/commands/connected_objects.go
@@ -244,15 +244,14 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
-	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset")
-	span.SetAttributes(
+	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset", trace.WithAttributes(
 		attribute.String("source.object_type", req.sourceObjectRef.GetType()),
 		attribute.String("source.relation", req.sourceObjectRef.GetRelation()),
 		attribute.String("ingress.object_type", req.ingress.Ingress.GetType()),
 		attribute.String("ingress.relation", req.ingress.Ingress.GetRelation()),
 		attribute.String("ingress.type", req.ingress.Type.String()),
 		attribute.String("target.user", req.targetUserRef.String()),
-	)
+	))
 	defer span.End()
 
 	store := req.storeID
@@ -408,15 +407,14 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
-	ctx, span := tracer.Start(ctx, "reverseExpandDirect")
-	span.SetAttributes(
+	ctx, span := tracer.Start(ctx, "reverseExpandDirect", trace.WithAttributes(
 		attribute.String("source.object_type", req.sourceObjectRef.GetType()),
 		attribute.String("source.relation", req.sourceObjectRef.GetRelation()),
 		attribute.String("ingress.object_type", req.ingress.Ingress.GetType()),
 		attribute.String("ingress.relation", req.ingress.Ingress.GetRelation()),
 		attribute.String("ingress.type", req.ingress.Type.String()),
 		attribute.String("target.user", req.targetUserRef.String()),
-	)
+	))
 	defer span.End()
 
 	store := req.storeID

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -89,8 +89,10 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgapb.ListObjectsRequ
 	targetObjectType := req.GetType()
 
 	ctx, span := tracer.Start(ctx, "ListObjects", trace.WithAttributes(
-		attribute.KeyValue{Key: "store", Value: attribute.StringValue(req.GetStoreId())},
-		attribute.KeyValue{Key: "objectType", Value: attribute.StringValue(targetObjectType)},
+		attribute.String("store", storeID),
+		attribute.String("object_type", targetObjectType),
+		attribute.String("relation", req.GetRelation()),
+		attribute.String("user", req.GetUser()),
 	))
 	defer span.End()
 
@@ -140,8 +142,10 @@ func (s *Server) StreamedListObjects(req *openfgapb.StreamedListObjectsRequest, 
 	storeID := req.GetStoreId()
 	ctx := srv.Context()
 	ctx, span := tracer.Start(ctx, "StreamedListObjects", trace.WithAttributes(
-		attribute.KeyValue{Key: "store", Value: attribute.StringValue(req.GetStoreId())},
-		attribute.KeyValue{Key: "objectType", Value: attribute.StringValue(req.GetType())},
+		attribute.String("store", storeID),
+		attribute.String("object_type", req.GetType()),
+		attribute.String("relation", req.GetRelation()),
+		attribute.String("user", req.GetUser()),
 	))
 	defer span.End()
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This adds tracing to the internal `ConnectedObjects` API, which is a reverse graph expansion algorithm that is used in the optimized version of ListObjects (the one that works with models involving type restrictions).

Here's an example screenshot of the traces produced by the changes in this PR:
<img width="858" alt="Screen Shot 2023-02-09 at 4 13 09 PM" src="https://user-images.githubusercontent.com/2899204/217960060-4f6419f4-5d41-4b32-8420-2e02a506291a.png">

Each span is annotated with attributes that represent the relationship tuples that are expanded at each level in the reverse expansion graph evaluation.

## References
Related to https://github.com/openfga/openfga/pull/521

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
