### PR TITLE
fix: add missing typesystem context in ListObjects (concurrent check)

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -332,7 +332,7 @@ func (c *LocalChecker) ResolveCheck(
 
 	typesys, ok := typesystem.TypesystemFromContext(ctx)
 	if !ok {
-		return nil, fmt.Errorf("typesystem missing in context")
+		panic("typesystem missing in context")
 	}
 
 	object := req.GetTupleKey().GetObject()

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -90,6 +90,8 @@ func (q *ListObjectsQuery) handler(
 	}
 
 	handler := func() {
+		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+
 		err = q.performChecks(ctx, req, resultsChan)
 		if err != nil {
 			errChan <- err


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fixes ListObjects in the event that concurrent Checks are evaluated (for 1.0 models or models involving intersection or exclusion).

## References
Related to #524 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
