### PR TITLE
fix: skip computed relations on tuplesets if they are undefined

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -520,6 +520,12 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 				User:     tk.GetUser(),
 			}
 
+			if _, err := typesys.GetRelation(tuple.GetType(userObj), computedRelation); err != nil {
+				if errors.Is(err, typesystem.ErrRelationUndefined) {
+					continue // skip computed relations on tupleset relationships if they are undefined
+				}
+			}
+
 			handlers = append(handlers, c.dispatch(
 				ctx,
 				&ResolveCheckRequest{

--- a/tests/oldcheck/check_test.go
+++ b/tests/oldcheck/check_test.go
@@ -26,9 +26,10 @@ type checkTest struct {
 }
 
 type assertion struct {
-	Tuple       *pb.TupleKey
-	Expectation bool
-	Trace       string
+	Tuple            *pb.TupleKey
+	ContextualTuples []*pb.TupleKey `yaml:"contextualTuples"`
+	Expectation      bool
+	Trace            string
 }
 
 func TestCheckMemory(t *testing.T) {
@@ -96,7 +97,10 @@ func runTest(t *testing.T, client pb.OpenFGAServiceClient, tests checkTests) {
 				resp, err := client.Check(ctx, &pb.CheckRequest{
 					StoreId:  storeID,
 					TupleKey: assertion.Tuple,
-					Trace:    false,
+					ContextualTuples: &pb.ContextualTupleKeys{
+						TupleKeys: assertion.ContextualTuples,
+					},
+					Trace: false,
 				})
 				require.NoError(t, err)
 				require.Equal(t, assertion.Expectation, resp.Allowed, assertion)

--- a/tests/oldcheck/tests.yaml
+++ b/tests/oldcheck/tests.yaml
@@ -1344,3 +1344,31 @@ tests:
           relation: viewer
           user: user:aardvark
         expectation: false
+
+  - name: skip_undefined_computed_relations_on_tuplesets
+    model: |
+      type rule
+        relations
+          define assigned as self
+          define has_assigned as u1 from assigned or u2 from assigned
+      type parent1
+        relations
+          define role as self
+          define u1 as role
+      type parent2
+        relations
+          define role as self
+          define u2 as role
+    assertions:
+      - tuple:
+          object: rule:X
+          relation: has_assigned
+          user: user:1
+        contextualTuples:
+          - object: parent2:a
+            relation: role
+            user: user:1
+          - object: rule:X
+            relation: assigned
+            user: parent2:a
+        expectation: true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Skip computed relations on tupleset relationships if they are undefined for that model.

## References
Fixes #531 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
