### PR TITLE
fix: error handling for check in auth model id not found

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -246,7 +246,7 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 	model, err := s.datastore.ReadAuthorizationModel(ctx, storeID, modelID)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
-			return nil, serverErrors.AuthorizationModelNotFound(req.GetAuthorizationModelId())
+			return nil, serverErrors.AuthorizationModelNotFound(modelID)
 		}
 		return nil, err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -245,6 +245,9 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	model, err := s.datastore.ReadAuthorizationModel(ctx, storeID, modelID)
 	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			return nil, serverErrors.AuthorizationModelNotFound(req.GetAuthorizationModelId())
+		}
 		return nil, err
 	}
 

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -152,13 +152,13 @@ func testBadAuthModelID(t *testing.T, engine string) {
 
 	storeID := resp.GetId()
 	model := `
-type user
+	type user
 
-type doc
-  relations
-    define viewer: [user] as self
-    define can_view as viewer
-`
+	type doc
+	  relations
+	    define viewer: [user] as self
+	    define can_view as viewer
+	`
 	_, err = client.WriteAuthorizationModel(ctx, &pb.WriteAuthorizationModelRequest{
 		StoreId:         storeID,
 		SchemaVersion:   typesystem.SchemaVersion1_1,

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -7,6 +7,7 @@ import (
 
 	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/openfga/openfga/cmd/run"
+	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/tests"
 	"github.com/stretchr/testify/require"
@@ -41,14 +42,19 @@ type assertion struct {
 
 func TestCheckMemory(t *testing.T) {
 	testCheck(t, "memory")
+	testBadAuthModelID(t, "memory")
 }
 
 func TestCheckPostgres(t *testing.T) {
 	testCheck(t, "postgres")
+	testBadAuthModelID(t, "postgres")
+
 }
 
 func TestCheckMySQL(t *testing.T) {
 	testCheck(t, "mysql")
+	testBadAuthModelID(t, "mysql")
+
 }
 
 func testCheck(t *testing.T, engine string) {
@@ -125,4 +131,65 @@ func runTests(t *testing.T, client pb.OpenFGAServiceClient, tests checkTests) {
 			}
 		})
 	}
+}
+
+func testBadAuthModelID(t *testing.T, engine string) {
+
+	cfg := run.MustDefaultConfigWithRandomPorts()
+	cfg.Log.Level = "none"
+	cfg.Datastore.Engine = engine
+
+	cancel := tests.StartServer(t, cfg)
+	defer cancel()
+
+	conn := tests.Connect(t, cfg.GRPC.Addr)
+	defer conn.Close()
+	client := pb.NewOpenFGAServiceClient(conn)
+
+	ctx := context.Background()
+	resp, err := client.CreateStore(ctx, &pb.CreateStoreRequest{Name: "bad auth id"})
+	require.NoError(t, err)
+
+	storeID := resp.GetId()
+	_, err = client.WriteAuthorizationModel(ctx, &pb.WriteAuthorizationModelRequest{
+		StoreId:       storeID,
+		SchemaVersion: typesystem.SchemaVersion1_1,
+		TypeDefinitions: []*pb.TypeDefinition{
+			{
+				Type:      "user",
+				Relations: map[string]*pb.Userset{},
+			},
+			{
+				Type: "doc",
+				Relations: map[string]*pb.Userset{
+					"viewer":   typesystem.This(),
+					"can_view": typesystem.ComputedUserset("viewer"),
+				},
+				Metadata: &pb.Metadata{
+					Relations: map[string]*pb.RelationMetadata{
+						"viewer": {
+							DirectlyRelatedUserTypes: []*pb.RelationReference{
+								{
+									Type: "user",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	_, err = client.Check(ctx, &pb.CheckRequest{
+		StoreId:              storeID,
+		TupleKey:             tuple.NewTupleKey("doc:x", "viewer", "user:y"),
+		AuthorizationModelId: "01GS89AJC3R3PFQ9BNY5ZF6Q97",
+	})
+
+	require.Error(t, err)
+	e, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, int(pb.ErrorCode_authorization_model_not_found), int(e.Code()))
+
+	cancel()
 }

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -151,12 +151,14 @@ func testBadAuthModelID(t *testing.T, engine string) {
 	require.NoError(t, err)
 
 	storeID := resp.GetId()
-	model := `type user
+	model := `
+type user
 
 type doc
   relations
     define viewer: [user] as self
-    define can_view as viewer`
+    define can_view as viewer
+`
 	_, err = client.WriteAuthorizationModel(ctx, &pb.WriteAuthorizationModelRequest{
 		StoreId:         storeID,
 		SchemaVersion:   typesystem.SchemaVersion1_1,


### PR DESCRIPTION


## Description
When auth model id is not found in check, it should return error auth model id not found instead of internal error.

## References
Close https://github.com/openfga/openfga/issues/540

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
