### PR TITLE
fix: continue Check evaluation search if typed-wildcard doesn't match

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -434,7 +434,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 						return &openfgapb.CheckResponse{Allowed: true}, nil
 					}
 
-					return &openfgapb.CheckResponse{Allowed: false}, nil
+					continue
 				}
 
 				if usersetRelation != "" {
@@ -449,7 +449,6 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 							},
 						}))
 				}
-
 			}
 
 			if len(handlers) == 0 {

--- a/tests/check/tests.yaml
+++ b/tests/check/tests.yaml
@@ -1810,6 +1810,35 @@ tests:
                 relation: writer
                 user: user:*
             expectation: true
+  - name: wildcard_and_userset_restriction
+    stages:
+      - model: |
+          type user
+          type user2
+          type group
+            relations
+              define member: [user2] as self
+          type document
+            relations
+              define viewer: [user:*, group#member] as self
+        tuples:
+          - object: document:public
+            relation: viewer
+            user: user:*
+          - object: document:public
+            relation: viewer
+            user: group:fga#member
+          - object: group:fga
+            relation: member
+            user: user2:bob
+        assertions:
+          - tuple:
+              object: document:public
+              relation: viewer
+              user: user2:bob
+            expectation: true
+
+
 
   - name: wildcard_obeys_the_types_in_stages
     stages:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fixes Check resolution when a typed-wildcard is encountered that doesn't match the type restrictions.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
