### PR TITLE
ci: fix goreleaser build

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -32,10 +32,6 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--build-arg"
-      - "OS=linux"
-      - "--build-arg"
-      - "ARCH=amd64"
 
     extra_files:
       - assets
@@ -52,10 +48,6 @@ dockers:
 
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--build-arg"
-      - "OS=linux"
-      - "--build-arg"
-      - "ARCH=arm64"
 
     extra_files:
       - assets

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,10 +38,6 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--build-arg"
-      - "OS=linux"
-      - "--build-arg"
-      - "ARCH=amd64"
 
     extra_files:
       - assets
@@ -63,10 +59,6 @@ dockers:
 
     build_flag_templates:
       - "--platform=linux/arm64"
-      - "--build-arg"
-      - "OS=linux"
-      - "--build-arg"
-      - "ARCH=arm64"
 
     extra_files:
       - assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 FROM golang:1.20-alpine AS builder
-ARG OS=linux
-ARG ARCH=amd64
 
 WORKDIR /app
 
 COPY . .
 RUN go build -o ./openfga ./cmd/openfga
-RUN wget -q -O grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.13/grpc_health_probe-${OS}-${ARCH}"
 
 FROM alpine as final
 EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY --from=builder /app/openfga /app/openfga
 COPY --from=builder /app/assets /app/assets
-COPY --from=builder /app/grpc_health_probe /bin/grpc_health_probe
 RUN chmod +x /bin/grpc_health_probe
 WORKDIR /app
 ENTRYPOINT ["./openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,13 +1,6 @@
-FROM alpine AS builder
-ARG OS=linux
-ARG ARCH=amd64
-RUN apk add --no-cache wget
-RUN wget -q -O /bin/grpc_health_probe "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.13/grpc_health_probe-${OS}-${ARCH}"
-
 FROM alpine
-
 COPY assets /assets
 COPY openfga /
-COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
 RUN chmod +x /bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Goreleaser doesn't play nicely with multi-stage builds 🤷 .. It wasn't meant to run multi-stage docker builds because it simply copies the built artifacts to the target container.

So I've changed the build process to fetch the `grpc-health-probe` from it's Github Container Registry source, which will fetch the appropriate container for the platform being built automatically. I've tested it out locally and it works great 👍 

## References
https://github.com/goreleaser/goreleaser/issues/609

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
