### PR TITLE
ci: use native `--chmod` arg in `COPY` command

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -85,11 +85,15 @@ jobs:
             restore-keys: |
               ${{ runner.os }}-go
 
+        - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v2
+
         # build the openfga/openfga image for the functional tests
         - uses: docker/build-push-action@v3
           with:
             file: Dockerfile
             push: false # don't publish the built container for functional tests
+            load: true
             tags: "openfga/openfga:functionaltest"
 
         - name: Functional Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ FROM alpine as final
 EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
+COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY --from=builder /app/openfga /app/openfga
 COPY --from=builder /app/assets /app/assets
-RUN chmod +x /bin/grpc_health_probe
 WORKDIR /app
 ENTRYPOINT ["./openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,5 @@
 FROM alpine
 COPY assets /assets
 COPY openfga /
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
-RUN chmod +x /bin/grpc_health_probe
+COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Change usages of `RUN chmod +x ...` to the natively supported `COPY --chmod=0755 ..` instead. My theory is this will eliminate the cross-platform build issue that we're seeing with our releases.

https://github.com/openfga/openfga/actions/runs/4196374586/jobs/7277261746

`RUN chmod +x` - we're getting an "exec format" error I believe because it's attempting to use a cached layer of the `alpine` image for the `linux/amd64` platform target when it's running the `linux/arm64` build. Using the native `--chmod` I hope allows the docker buildkit to figure it out better 🤷 ...

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
