### PR TITLE
chore: bump x/net package dependencies

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,6 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
 
       - id: go-cache-paths

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,6 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
           check-latest: true
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
           check-latest: true
       - name: golangci-lint
@@ -26,6 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
           check-latest: true
 
@@ -67,6 +69,7 @@ jobs:
 
         - uses: actions/setup-go@v3
           with:
+            go-version: '^1.19.6'
             go-version-file: './go.mod'
             check-latest: true
 
@@ -107,6 +110,7 @@ jobs:
 
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
           check-latest: true
 

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -20,6 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: "./go.mod"
           check-latest: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
           check-latest: true
 

--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
+          go-version: '^1.19.6'
           go-version-file: './go.mod'
       - uses: actions/cache@v3
         with:

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/crypto v0.6.0 // indirect
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771 // indirect
-	golang.org/x/net v0.6.0 // indirect
+	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/genproto v0.0.0-20230131230820-1c016267d619 // indirect

--- a/go.sum
+++ b/go.sum
@@ -561,8 +561,8 @@ golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.6.0 h1:L4ZwwTvKW9gr0ZMS1yrHD9GZhIuVjOBBnaKH+SPQK0Q=
-golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
+golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
+golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION

## Description
Update x/net package as identified by go vulnerability check

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
