### PR TITLE
ci: update nightly release workflow

### DIFF
--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -35,11 +35,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --skip-publish --rm-dist --config .goreleaser-nightly.yaml
+          args: release --clean --config .goreleaser-nightly.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to Docker Hub
-        uses: actions-hub/docker@master
-        with:
-          args: push openfga/openfga:nightly

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -40,17 +40,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to Docker Hub
-        uses: docker/build-push-action@v2
+        uses: actions-hub/docker@master
         with:
-          context: .
-          file: ./Dockerfile.goreleaser
-          push: true
-          tags: openfga/openfga:nightly
-
-      - name: Update Docker Hub Description
-        uses: peter-evans/dockerhub-description@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: openfga/openfga
-          short-description: ${{ github.event.repository.description }}
+          args: push openfga/openfga:nightly

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist --config .goreleaser.yaml
+          args: release --clean --config .goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -20,6 +20,10 @@ builds:
       - "-X github.com/openfga/openfga/internal/build.Commit={{.Commit}}"
       - "-X github.com/openfga/openfga/internal/build.Date={{.Date}}"
 
+# Do not make github release
+release:
+  disable: true
+
 dockers:
   - goos: linux
     goarch: amd64
@@ -57,11 +61,6 @@ docker_manifests:
     image_templates:
       - openfga/openfga:nightly-amd64
       - openfga/openfga:nightly-arm64
-
-release:
-  github:
-    owner: openfga
-    name: openfga
 
 archives:
   - replacements:


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Update the nightly release build workflow by removing the extra build step. Since `goreleaser` already builds the image and makes it available for the Docker daemon context, we just have to publish the built manifest by calling `docker push openfga/openfga:latest`.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
