### PR TITLE
fix: race condition in memory store list object

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -119,7 +119,7 @@ func (s *MemoryBackend) ListObjectsByType(ctx context.Context, store string, obj
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	for _, t := range s.tuples[store] {
 		if objectType == "" || !strings.HasPrefix(t.Key.Object, objectType+":") {
 			continue

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -116,6 +116,8 @@ func (s *MemoryBackend) ListObjectsByType(ctx context.Context, store string, obj
 
 	uniqueObjects := make(map[string]bool, 0)
 	matches := make([]*openfgapb.Object, 0)
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	for _, t := range s.tuples[store] {
 		if objectType == "" || !strings.HasPrefix(t.Key.Object, objectType+":") {
 			continue

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -116,8 +116,10 @@ func (s *MemoryBackend) ListObjectsByType(ctx context.Context, store string, obj
 
 	uniqueObjects := make(map[string]bool, 0)
 	matches := make([]*openfgapb.Object, 0)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	
 	for _, t := range s.tuples[store] {
 		if objectType == "" || !strings.HasPrefix(t.Key.Object, objectType+":") {
 			continue


### PR DESCRIPTION
## Description
Race condition detected when running test in parallel. Root cause is ListObjectsByType's access to s.tuples is not guarded by mutex.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
