### PR TITLE
fix: add missing profiler-addr flag

### DIFF
--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -123,6 +123,10 @@ func bindRunFlags(command *cobra.Command) {
 	util.MustBindPFlag("profiler.enabled", flags.Lookup("profiler-enabled"))
 	util.MustBindEnv("profiler.enabled", "OPENFGA_PROFILER_ENABLED")
 
+	flags.String("profiler-addr", defaultConfig.Profiler.Addr, "the host:port address to serve the pprof profiler server on")
+	util.MustBindPFlag("profiler.addr", flags.Lookup("profiler-addr"))
+	util.MustBindEnv("profiler.addr", "OPENFGA_PROFILER_ADDRESS")
+
 	flags.String("log-format", defaultConfig.Log.Format, "the log format to output logs in")
 	util.MustBindPFlag("log.format", flags.Lookup("log-format"))
 	util.MustBindEnv("log.format", "OPENFGA_LOG_FORMAT")


### PR DESCRIPTION
Fixes

```shell
[3/03/23 1:38:05] ~/GitHub/openfga (main) $ docker run -p 8080:8080 -p 8081:8081 openfga/openfga run --profiler-addr=":3001" --profiler-enabled
Error: unknown flag: --profiler-addr
```

http://openfga.dev/docs/getting-started/setup-openfga#profiler-pprof