### PR TITLE
fix: reverse expansion with indirect computed userset relationship

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -340,6 +340,42 @@ tests:
             expectation:
               - document:2
 
+  - name: simple_computeduserset_indirect_ref
+    stages:
+      - model: |
+          type user
+          type folder
+            relations
+              define parent: [folder] as self
+              define viewer: [user] as self or viewer from parent
+              define can_view as viewer
+        tuples:
+          - user: user:anne
+            relation: viewer
+            object: folder:a
+          - user: folder:a
+            relation: parent
+            object: folder:b
+        checkAssertions:
+          - tuple:
+              user: user:anne
+              relation: can_view
+              object: folder:a
+            expectation: true
+          - tuple:
+              user: user:anne
+              relation: can_view
+              object: folder:b
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:anne
+              type: folder
+              relation: can_view
+            expectation:
+              - folder:a
+              - folder:b
+
   - name: computed_userset_and_intersection
     stages:
       - model: |

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -171,7 +171,9 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 		var ingresses []*RelationshipIngress
 
 		// if source=document#writer
-		if target.GetType() == source.GetType() && t.ComputedUserset.GetRelation() == source.GetRelation() {
+		sourceRelMatchesRewritten := target.GetType() == source.GetType() && t.ComputedUserset.GetRelation() == source.GetRelation()
+
+		if sourceRelMatchesRewritten {
 			ingresses = append(ingresses, &RelationshipIngress{
 				Type:    ComputedUsersetIngress,
 				Ingress: typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
@@ -211,14 +213,15 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 			}
 
 			var directlyAssignable bool
-			matchesSourceRelation := typeRestriction.GetType() == source.GetType() && computedUserset == source.GetRelation()
-			if matchesSourceRelation {
+
+			sourceRelMatchesRewritten := typeRestriction.GetType() == source.GetType() && computedUserset == source.GetRelation()
+			if sourceRelMatchesRewritten {
 				directlyAssignable = g.typesystem.IsDirectlyAssignable(r)
 			}
 
 			// if the rewritten relation is directly assignable or matches the source, then it must
 			// be an ingress.
-			if directlyAssignable || matchesSourceRelation {
+			if directlyAssignable || sourceRelMatchesRewritten {
 				res = append(res, &RelationshipIngress{
 					Type:             TupleToUsersetIngress,
 					Ingress:          typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -868,11 +868,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			name: "unrelated_source_and_target_relationship_involving_ttu",
 			model: `
 			type user
-		
+
 			type folder
 				relations
 					define viewer: [user] as self
-		
+
 			type document
 				relations
 					define can_read as viewer from parent
@@ -882,6 +882,31 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			target:   typesystem.DirectRelationReference("document", "can_read"),
 			source:   typesystem.DirectRelationReference("document", ""),
 			expected: []*RelationshipIngress{},
+		},
+		{
+			name: "simple_computeduserset_indirect_ref",
+			model: `
+			type user
+
+			type document
+			  relations
+			    define parent: [document] as self
+			    define viewer: [user] as self or viewer from parent
+				define can_view as viewer
+			`,
+			target: typesystem.DirectRelationReference("document", "can_view"),
+			source: typesystem.DirectRelationReference("document", "viewer"),
+			expected: []*RelationshipIngress{
+				{
+					Type:    ComputedUsersetIngress,
+					Ingress: typesystem.DirectRelationReference("document", "can_view"),
+				},
+				{
+					Type:             TupleToUsersetIngress,
+					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Fixes the `RelationshipIngresses` computation of indirectly related relationships through computed usersets. This fixes a known bug with ListObjects that uses reverse expansion.

## References
Fixes #602 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
