### PR TITLE
fix: inject typesystem into context in benchmarks

### DIFF
--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -539,6 +539,8 @@ func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatas
 
 	var r *openfgapb.ListObjectsResponse
 
+	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		r, _ = listObjectsQuery.Execute(ctx, &openfgapb.ListObjectsRequest{
@@ -597,6 +599,8 @@ func BenchmarkListObjectsWithConcurrentChecks(b *testing.B, ds storage.OpenFGADa
 	}
 
 	var r *openfgapb.ListObjectsResponse
+
+	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes the ListObjects benchmarks by injecting the needed `typesystem` into the context before calling `Execute`.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
