### PR TITLE
chore: wireup model schema_version usage metrics

### DIFF
--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -11,6 +11,7 @@ import (
 	mockstorage "github.com/openfga/openfga/pkg/storage/mocks"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
@@ -41,7 +42,7 @@ func TestValidateNoDuplicatesAndCorrectSize(t *testing.T) {
 		}
 	}
 
-	cmd := NewWriteCommand(mockDatastore, logger)
+	cmd := NewWriteCommand(mockDatastore, logger, nil)
 
 	tests := []test{
 		{
@@ -142,11 +143,7 @@ func TestValidateWriteRequest(t *testing.T) {
 			maxTuplesInWriteOp := 10
 			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 			mockDatastore.EXPECT().MaxTuplesPerWrite().AnyTimes().Return(maxTuplesInWriteOp)
-			cmd := NewWriteCommand(mockDatastore, logger)
-
-			if len(test.writes) > 0 {
-				mockDatastore.EXPECT().ReadAuthorizationModel(gomock.Any(), gomock.Any(), gomock.Any()).Return(&openfgapb.AuthorizationModel{}, nil)
-			}
+			cmd := NewWriteCommand(mockDatastore, logger, typesystem.New(&openfgapb.AuthorizationModel{}))
 
 			ctx := context.Background()
 			req := &openfgapb.WriteRequest{

--- a/pkg/server/test/expand.go
+++ b/pkg/server/test/expand.go
@@ -1983,7 +1983,7 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 			test.request.AuthorizationModelId = test.model.Id
 
 			// act
-			query := commands.NewExpandQuery(datastore, logger)
+			query := commands.NewExpandQuery(datastore, logger, typesystem.New(test.model))
 			got, err := query.Execute(ctx, test.request)
 			require.NoError(err)
 
@@ -2176,7 +2176,7 @@ func TestExpandQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 			test.request.AuthorizationModelId = test.model.Id
 
 			// act
-			query := commands.NewExpandQuery(datastore, logger)
+			query := commands.NewExpandQuery(datastore, logger, typesystem.New(test.model))
 			resp, err := query.Execute(ctx, test.request)
 
 			// assert

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -168,9 +168,9 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 				ListObjectsMaxResults: test.maxResults,
 				ResolveNodeLimit:      defaultResolveNodeLimit,
 				CheckResolver:         checker,
+				Typesystem:            typesystem.New(model),
 			}
-			typesys := typesystem.New(model)
-			ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+
 			ctx = storage.ContextWithContextualTuples(ctx, test.contextualTuples.GetTupleKeys())
 
 			// assertions
@@ -276,9 +276,11 @@ func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatas
 		require.NoError(b, err)
 	}
 
+	typesys := typesystem.New(model)
+
 	connectedObjCmd := commands.ConnectedObjectsCommand{
 		Datastore:        ds,
-		Typesystem:       typesystem.New(model),
+		Typesystem:       typesys,
 		ResolveNodeLimit: defaultResolveNodeLimit,
 	}
 
@@ -287,11 +289,10 @@ func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatas
 		Logger:           logger.NewNoopLogger(),
 		ResolveNodeLimit: defaultResolveNodeLimit,
 		ConnectedObjects: connectedObjCmd.StreamedConnectedObjects,
+		Typesystem:       typesys,
 	}
 
 	var r *openfgapb.ListObjectsResponse
-
-	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -348,11 +349,10 @@ func BenchmarkListObjectsWithConcurrentChecks(b *testing.B, ds storage.OpenFGADa
 		Logger:           logger.NewNoopLogger(),
 		ResolveNodeLimit: defaultResolveNodeLimit,
 		CheckResolver:    graph.NewLocalChecker(storage.NewContextualTupleDatastore(ds), checkConcurrencyLimit),
+		Typesystem:       typesystem.New(model),
 	}
 
 	var r *openfgapb.ListObjectsResponse
-
-	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/server/test/write.go
+++ b/pkg/server/test/write.go
@@ -1561,7 +1561,7 @@ func TestWriteCommand(t *testing.T, datastore storage.OpenFGADatastore) {
 				require.NoError(err)
 			}
 
-			cmd := commands.NewWriteCommand(datastore, logger)
+			cmd := commands.NewWriteCommand(datastore, logger, typesystem.New(test.model))
 			test.request.StoreId = store
 			test.request.AuthorizationModelId = test.model.Id
 			resp, gotErr := cmd.Execute(ctx, test.request)

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -1,0 +1,99 @@
+package typesystem
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	modelSchemaVersionCounter = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "model_schema_version_counter",
+			Help: "A counter counting the different authorization model schema versions that have been resolved",
+		},
+		[]string{"schema_version"},
+	)
+)
+
+// TypesystemResolverFunc is a function that implementations can implement to provide lookup and
+// resolution of a Typesystem.
+type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (*TypeSystem, error)
+
+// MemoizedTypesystemResolverFunc memoizes the provided TypesystemResolverFunc. It returns
+// the value from the first invocation of the underlying resolver function.
+//
+// The memoized resolver function is safe for concurrent use.
+func MemoizedTypesystemResolverFunc(fn TypesystemResolverFunc) TypesystemResolverFunc {
+	var cache sync.Map
+
+	return func(ctx context.Context, storeID, modelID string) (*TypeSystem, error) {
+		tracer.Start(ctx, "MemoizedTypesystemResolverFunc")
+
+		// if modelID is empty always fetch the latest model and construct the typesystem from it
+		if modelID == "" {
+			return fn(ctx, storeID, modelID)
+		}
+
+		key := fmt.Sprintf("%s/%s", storeID, modelID)
+
+		if val, found := cache.Load(key); found {
+			return val.(*TypeSystem), nil
+		}
+
+		typesys, err := fn(ctx, storeID, modelID)
+		if err != nil {
+			return nil, err
+		}
+
+		cache.Store(key, typesys)
+		return typesys, nil
+	}
+}
+
+// NewTypesystemResolver returns a TypesystemResolverFunc that either fetches the provided authorization
+// model (if provided) or looks up the latest authorizaiton model, and then it constructs a TypeSystem from
+// the resolved model.
+func NewTypesystemResolver(reader storage.AuthorizationModelReadBackend) TypesystemResolverFunc {
+	return func(ctx context.Context, storeID, modelID string) (*TypeSystem, error) {
+		ctx, span := tracer.Start(ctx, "ResolveTypesystem")
+		defer span.End()
+
+		var err error
+
+		if modelID != "" {
+			if _, err := ulid.Parse(modelID); err != nil {
+				return nil, ErrModelNotFound
+			}
+		}
+
+		if modelID == "" {
+			if modelID, err = reader.FindLatestAuthorizationModelID(ctx, storeID); err != nil {
+				if errors.Is(err, storage.ErrNotFound) {
+					return nil, ErrNoModelsDefined
+				}
+
+				return nil, fmt.Errorf("failed to FindLatestAuthorizationModelID: %w", err)
+			}
+		}
+
+		model, err := reader.ReadAuthorizationModel(ctx, storeID, modelID)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, ErrModelNotFound
+			}
+
+			return nil, fmt.Errorf("failed to ReadAuthorizationModel: %w", err)
+		}
+
+		modelSchemaVersionCounter.WithLabelValues(model.GetSchemaVersion()).Add(1)
+
+		return New(model), nil
+	}
+}

--- a/pkg/typesystem/resolver_test.go
+++ b/pkg/typesystem/resolver_test.go
@@ -1,0 +1,94 @@
+package typesystem
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	parser "github.com/craigpastro/openfga-dsl-parser/v2"
+	"github.com/golang/mock/gomock"
+	"github.com/oklog/ulid/v2"
+	mockstorage "github.com/openfga/openfga/pkg/storage/mocks"
+	"github.com/stretchr/testify/require"
+	openfgav1 "go.buf.build/openfga/go/openfga/api/openfga/v1"
+)
+
+func TestMemoizedTypesystemResolverFunc(t *testing.T) {
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	modelID := ulid.Make().String()
+
+	typedefs := parser.MustParse(`
+	type user
+	type document
+	  relations
+	    define viewer: [user] as self
+	`)
+
+	mockDatastore.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		Return(&openfgav1.AuthorizationModel{
+			SchemaVersion:   SchemaVersion1_1,
+			TypeDefinitions: typedefs,
+		}, nil)
+
+	resolver := MemoizedTypesystemResolverFunc(
+		NewTypesystemResolver(mockDatastore),
+	)
+
+	typesys, err := resolver(context.Background(), storeID, modelID)
+	require.NoError(t, err)
+	require.NotNil(t, typesys)
+
+	relation, err := typesys.GetRelation("document", "viewer")
+	require.NoError(t, err)
+	require.NotNil(t, relation)
+}
+
+func TestTypesystemResolver_FindLatestAuthorizationModelIDError(t *testing.T) {
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+
+	dbErr := fmt.Errorf("db error")
+	mockDatastore.EXPECT().
+		FindLatestAuthorizationModelID(gomock.Any(), storeID).
+		Return("", dbErr)
+
+	resolver := NewTypesystemResolver(mockDatastore)
+
+	typesys, err := resolver(context.Background(), storeID, "")
+	require.ErrorIs(t, err, dbErr)
+	require.Nil(t, typesys)
+}
+
+func TestTypesystemResolver_ReadAuthorizationModelError(t *testing.T) {
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	modelID := ulid.Make().String()
+
+	dbErr := fmt.Errorf("db error")
+	mockDatastore.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		Return(nil, dbErr)
+
+	resolver := NewTypesystemResolver(mockDatastore)
+
+	typesys, err := resolver(context.Background(), storeID, modelID)
+	require.ErrorIs(t, err, dbErr)
+	require.Nil(t, typesys)
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -8,7 +8,10 @@ import (
 
 	"github.com/openfga/openfga/pkg/tuple"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"go.opentelemetry.io/otel"
 )
+
+var tracer = otel.Tracer("pkg/typesystem")
 
 type ctxKey string
 
@@ -20,7 +23,16 @@ const (
 )
 
 var (
-	ErrDuplicateTypes        = errors.New("an authorization model cannot contain duplicate types")
+	ErrDuplicateTypes = errors.New("an authorization model cannot contain duplicate types")
+
+	// ErrModelNotFound represents an error that is encountered when trying to resolve a specific
+	// authorization model (of a specific identifier) and it is not present in the OpenFGA store.
+	ErrModelNotFound = errors.New("authorization model not found")
+
+	// ErrNoModelsDefined represents an error that is encountered when trying to resolve the latest
+	// authorization model and none are defined in the OpenFGA store.
+	ErrNoModelsDefined = errors.New("no authorization models defined")
+
 	ErrInvalidSchemaVersion  = errors.New("invalid schema version")
 	ErrInvalidModel          = errors.New("invalid authorization model encountered")
 	ErrRelationUndefined     = errors.New("undefined relation")


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Introduce a new metric `model_schema_version_counter` which tracks a count of the various `schema_version` values that we encounter when resolving an authorization model, and wire it up by making use of the `TypesystemResolverFunc` at the top-level in the server.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
