### PR TITLE
feat: add version in CLI

### DIFF
--- a/cmd/openfga/main.go
+++ b/cmd/openfga/main.go
@@ -16,6 +16,9 @@ func main() {
 	migrateCmd := cmd.NewMigrateCommand()
 	rootCmd.AddCommand(migrateCmd)
 
+	versionCmd := cmd.NewVersionCommand()
+	rootCmd.AddCommand(versionCmd)
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/openfga/openfga/internal/build"
+	"github.com/spf13/cobra"
+)
+
+// NewVersionCommand returns the command to get openfga version
+func NewVersionCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Return the OpenFGA version",
+		Long:  "Return the OpenFGA version.",
+		RunE:  version,
+		Args:  cobra.NoArgs,
+	}
+
+	return cmd
+}
+
+// print out the built version
+func version(_ *cobra.Command, _ []string) error {
+	log.Println("OpenFGA Version", build.Version)
+	return nil
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,6 +22,6 @@ func NewVersionCommand() *cobra.Command {
 
 // print out the built version
 func version(_ *cobra.Command, _ []string) error {
-	log.Printf("OpenFGA Version %s Date %s commit id %s ", build.Version, build.Date, build.Commit)
+	log.Printf("OpenFGA version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
 	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -22,6 +22,6 @@ func NewVersionCommand() *cobra.Command {
 
 // print out the built version
 func version(_ *cobra.Command, _ []string) error {
-	log.Println("OpenFGA Version", build.Version)
+	log.Printf("OpenFGA Version %s Date %s commit id %s ", build.Version, build.Date, build.Commit)
 	return nil
 }


### PR DESCRIPTION

## Description
Allow printing out of version in CLI

```shell
adriantam@C02F5002MD6P openfga % ./openfga
A high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.

OpenFGA is designed to make it easy for developers to model their application permissions, and to add and integrate fine-grained authorization into their applications.
Complete documentation is available at https://openfga.dev.

Usage:
  openfga [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  migrate     Run database schema migrations needed for the OpenFGA server
  run         Run the OpenFGA server
  version     Return the OpenFGA version

Flags:
  -h, --help   help for openfga

Use "openfga [command] --help" for more information about a command.
adriantam@C02F5002MD6P openfga % ./openfga  version
2023/03/10 15:02:35 OpenFGA Version dev
```

## References
N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
