### PR TITLE
fix: move RunAllTests into non _test.go

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -14,7 +14,6 @@ import (
 	pb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 )
 
 var tuples = []*pb.TupleKey{
@@ -50,64 +49,6 @@ func testRunAll(t *testing.T, engine string) {
 	defer conn.Close()
 
 	RunAllTests(t, pb.NewOpenFGAServiceClient(conn))
-}
-
-// RunAllTests will run all check tests
-func RunAllTests(t *testing.T, client CheckTestClientInterface) {
-	t.Run("RunAllTests", func(t *testing.T) {
-		t.Run("Check", func(t *testing.T) {
-			t.Parallel()
-			testCheck(t, client)
-		})
-		t.Run("BadAuthModelID", func(t *testing.T) {
-			t.Parallel()
-			testBadAuthModelID(t, client)
-		})
-	})
-}
-
-func testCheck(t *testing.T, client CheckTestClientInterface) {
-	t.Run("Schema1_1", func(t *testing.T) {
-		t.Parallel()
-		runSchema1_1CheckTests(t, client)
-	})
-	t.Run("Schema1_0", func(t *testing.T) {
-		t.Parallel()
-		runSchema1_0CheckTests(t, client)
-	})
-}
-
-func testBadAuthModelID(t *testing.T, client CheckTestClientInterface) {
-
-	ctx := context.Background()
-	resp, err := client.CreateStore(ctx, &pb.CreateStoreRequest{Name: "bad auth id"})
-	require.NoError(t, err)
-
-	storeID := resp.GetId()
-	model := `
-	type user
-
-	type doc
-	  relations
-	    define viewer: [user] as self
-	    define can_view as viewer
-	`
-	_, err = client.WriteAuthorizationModel(ctx, &pb.WriteAuthorizationModelRequest{
-		StoreId:         storeID,
-		SchemaVersion:   typesystem.SchemaVersion1_1,
-		TypeDefinitions: parser.MustParse(model),
-	})
-	require.NoError(t, err)
-	_, err = client.Check(ctx, &pb.CheckRequest{
-		StoreId:              storeID,
-		TupleKey:             tuple.NewTupleKey("doc:x", "viewer", "user:y"),
-		AuthorizationModelId: "01GS89AJC3R3PFQ9BNY5ZF6Q97",
-	})
-
-	require.Error(t, err)
-	e, ok := status.FromError(err)
-	require.True(t, ok)
-	require.Equal(t, int(pb.ErrorCode_authorization_model_not_found), int(e.Code()))
 }
 
 func BenchmarkCheckMemory(b *testing.B) {

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -41,21 +41,43 @@ type assertion struct {
 	ErrorCode        int `yaml:"errorCode"` // If ErrorCode is non-zero then we expect that the ListObjects call failed.
 }
 
-type ListObjectsClientInterface interface {
-	check.CheckTestClientInterface
+// ClientInterface defines interface for running ListObjects and StreamedListObjects tests
+type ClientInterface interface {
+	check.ClientInterface
 	ListObjects(ctx context.Context, in *pb.ListObjectsRequest, opts ...grpc.CallOption) (*pb.ListObjectsResponse, error)
 	StreamedListObjects(ctx context.Context, in *pb.StreamedListObjectsRequest, opts ...grpc.CallOption) (pb.OpenFGAService_StreamedListObjectsClient, error)
 }
 
-func runSchema1_1ListObjectsTests(t *testing.T, client ListObjectsClientInterface) {
+// RunAllTests will invoke all list objects tests
+func RunAllTests(t *testing.T, client ClientInterface) {
+	t.Run("RunAll", func(t *testing.T) {
+		t.Run("ListObjects", func(t *testing.T) {
+			t.Parallel()
+			testListObjects(t, client)
+		})
+	})
+}
+
+func testListObjects(t *testing.T, client ClientInterface) {
+	t.Run("Schema1_1", func(t *testing.T) {
+		t.Parallel()
+		runSchema1_1ListObjectsTests(t, client)
+	})
+	t.Run("Schema1_0", func(t *testing.T) {
+		t.Parallel()
+		runSchema1_0ListObjectsTests(t, client)
+	})
+}
+
+func runSchema1_1ListObjectsTests(t *testing.T, client ClientInterface) {
 	runTests(t, typesystem.SchemaVersion1_1, client)
 }
 
-func runSchema1_0ListObjectsTests(t *testing.T, client ListObjectsClientInterface) {
+func runSchema1_0ListObjectsTests(t *testing.T, client ClientInterface) {
 	runTests(t, typesystem.SchemaVersion1_0, client)
 }
 
-func runTests(t *testing.T, schemaVersion string, client ListObjectsClientInterface) {
+func runTests(t *testing.T, schemaVersion string, client ClientInterface) {
 	var b []byte
 	var err error
 	if schemaVersion == typesystem.SchemaVersion1_1 {

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -39,24 +39,3 @@ func testRunAll(t *testing.T, engine string) {
 	defer conn.Close()
 	RunAllTests(t, pb.NewOpenFGAServiceClient(conn))
 }
-
-// RunAllTests will invoke all list objects tests
-func RunAllTests(t *testing.T, client ListObjectsClientInterface) {
-	t.Run("RunAll", func(t *testing.T) {
-		t.Run("ListObjects", func(t *testing.T) {
-			t.Parallel()
-			testListObjects(t, client)
-		})
-	})
-}
-
-func testListObjects(t *testing.T, client ListObjectsClientInterface) {
-	t.Run("Schema1_1", func(t *testing.T) {
-		t.Parallel()
-		runSchema1_1ListObjectsTests(t, client)
-	})
-	t.Run("Schema1_0", func(t *testing.T) {
-		t.Parallel()
-		runSchema1_0ListObjectsTests(t, client)
-	})
-}

--- a/tests/writemodel/writemodel.go
+++ b/tests/writemodel/writemodel.go
@@ -344,9 +344,20 @@ var testCases = map[string]struct {
 	},
 }
 
+// ClientInterface defines interface for running WriteAuthorizationModel tests
 type ClientInterface interface {
 	CreateStore(ctx context.Context, in *pb.CreateStoreRequest, opts ...grpc.CallOption) (*pb.CreateStoreResponse, error)
 	WriteAuthorizationModel(ctx context.Context, in *pb.WriteAuthorizationModelRequest, opts ...grpc.CallOption) (*pb.WriteAuthorizationModelResponse, error)
+}
+
+// RunAllTests will run all write model tests
+func RunAllTests(t *testing.T, client ClientInterface) {
+	t.Run("RunAllTests", func(t *testing.T) {
+		t.Run("WriteTest", func(t *testing.T) {
+			t.Parallel()
+			runTests(t, client)
+		})
+	})
 }
 
 func runTests(t *testing.T, client ClientInterface) {

--- a/tests/writemodel/writemodel_test.go
+++ b/tests/writemodel/writemodel_test.go
@@ -28,12 +28,3 @@ func TestWriteAuthorizationModel(t *testing.T) {
 
 	RunAllTests(t, pb.NewOpenFGAServiceClient(conn))
 }
-
-func RunAllTests(t *testing.T, client ClientInterface) {
-	t.Run("RunAllTests", func(t *testing.T) {
-		t.Run("WriteTest", func(t *testing.T) {
-			t.Parallel()
-			runTests(t, client)
-		})
-	})
-}


### PR DESCRIPTION

## Description
Allows other packages to run RunAllTests in their unit tests

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
