### PR TITLE
build: use chainguard images in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.20-alpine AS builder
+FROM cgr.dev/chainguard/go:1.20 AS builder
 
 WORKDIR /app
 
 COPY . .
-RUN go build -o ./openfga ./cmd/openfga
+RUN CGO_ENABLED=0 go build -o openfga ./cmd/openfga
 
-FROM alpine as final
+FROM cgr.dev/chainguard/static:latest
+
 EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
 COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
-COPY --from=builder /app/openfga /app/openfga
-COPY --from=builder /app/assets /app/assets
-WORKDIR /app
-ENTRYPOINT ["./openfga"]
+COPY --from=builder /app/openfga /openfga
+COPY --from=builder /app/assets /assets
+ENTRYPOINT ["/openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
-FROM alpine
+FROM cgr.dev/chainguard/static:latest
 COPY assets /assets
 COPY openfga /
 COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

👋 Build using the chainguard go image (which uses glibc rather than musl) and then run the resulting executable in the distroless chainguard image. This should be more secure than a generic alpine image.

I remember a long time ago wondering why it wouldn't work in a distroless image because we had no dependency on CGO, but you must explicitly have `CGO_ENABLED=0` in the build step for it to work. 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
