### PR TITLE
chore: add `timeout` flag to `migrate` command

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/openfga/openfga/assets"
@@ -19,6 +22,7 @@ const (
 	datastoreEngineFlag = "datastore-engine"
 	datastoreURIFlag    = "datastore-uri"
 	versionFlag         = "version"
+	timeoutFlag         = "timeout"
 )
 
 func NewMigrateCommand() *cobra.Command {
@@ -50,99 +54,82 @@ func runMigration(_ *cobra.Command, _ []string) error {
 	engine := viper.GetString(datastoreEngineFlag)
 	uri := viper.GetString(datastoreURIFlag)
 	version := viper.GetUint(versionFlag)
+	timeout := viper.GetDuration(timeoutFlag)
 
 	goose.SetLogger(goose.NopLogger())
 
+	var driver, dialect, migrationsPath string
 	switch engine {
 	case "memory":
 		return nil
 	case "mysql":
-		db, err := sql.Open("mysql", uri)
-		if err != nil {
-			log.Fatal("failed to parse the config from the connection uri", err)
-		}
-
-		defer func() {
-			if err := db.Close(); err != nil {
-				log.Fatal("failed to close the db", err)
-			}
-		}()
-
-		if err := goose.SetDialect("mysql"); err != nil {
-			log.Fatal("failed to initialize the migrate command", err)
-		}
-
-		goose.SetBaseFS(assets.EmbedMigrations)
-
-		if version > 0 {
-			currentVersion, err := goose.GetDBVersion(db)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			int64Version := int64(version)
-			if int64Version < currentVersion {
-				if err := goose.DownTo(db, assets.MySQLMigrationDir, int64Version); err != nil {
-					log.Fatal(err)
-				}
-			}
-
-			if err := goose.UpTo(db, assets.MySQLMigrationDir, int64Version); err != nil {
-				log.Fatal(err)
-			}
-		}
-
-		if err := goose.Up(db, assets.MySQLMigrationDir); err != nil {
-			log.Fatal(err)
-		}
-
-		return nil
+		driver = "mysql"
+		dialect = "mysql"
+		migrationsPath = assets.MySQLMigrationDir
 	case "postgres":
-		db, err := sql.Open("pgx", uri)
-		if err != nil {
-			log.Fatal("failed to parse the config from the connection uri", err)
-		}
-
-		defer func() {
-			if err := db.Close(); err != nil {
-				log.Fatal("failed to close the db", err)
-			}
-		}()
-
-		if err := goose.SetDialect("postgres"); err != nil {
-			log.Fatal("failed to initialize the migrate command", err)
-		}
-
-		goose.SetBaseFS(assets.EmbedMigrations)
-
-		if version > 0 {
-			currentVersion, err := goose.GetDBVersion(db)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			int64Version := int64(version)
-			if int64Version < currentVersion {
-				if err := goose.DownTo(db, assets.PostgresMigrationDir, int64Version); err != nil {
-					log.Fatal(err)
-				}
-			}
-
-			if err := goose.UpTo(db, assets.PostgresMigrationDir, int64Version); err != nil {
-				log.Fatal(err)
-			}
-
-			return nil
-		}
-
-		if err := goose.Up(db, assets.PostgresMigrationDir); err != nil {
-			log.Fatal(err)
-		}
-
-		return nil
+		driver = "pgx"
+		dialect = "postgres"
+		migrationsPath = assets.PostgresMigrationDir
 	default:
 		return fmt.Errorf("unknown datastore engine type: %s", engine)
 	}
+
+	db, err := sql.Open(driver, uri)
+	if err != nil {
+		log.Fatal("failed to parse the config from the connection uri", err)
+	}
+
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Fatal("failed to close the db", err)
+		}
+	}()
+
+	policy := backoff.NewExponentialBackOff()
+	policy.MaxElapsedTime = timeout
+	err = backoff.Retry(func() error {
+		err = db.PingContext(context.Background())
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, policy)
+	if err != nil {
+		log.Fatalf("failed to initialize database connection: %v", err)
+	}
+
+	if err := goose.SetDialect(dialect); err != nil {
+		log.Fatal("failed to initialize the migrate command", err)
+	}
+
+	goose.SetBaseFS(assets.EmbedMigrations)
+
+	if version > 0 {
+		currentVersion, err := goose.GetDBVersion(db)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		int64Version := int64(version)
+		if int64Version < currentVersion {
+			if err := goose.DownTo(db, migrationsPath, int64Version); err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		if err := goose.UpTo(db, migrationsPath, int64Version); err != nil {
+			log.Fatal(err)
+		}
+
+		return nil
+	}
+
+	if err := goose.Up(db, assets.PostgresMigrationDir); err != nil {
+		log.Fatal(err)
+	}
+
+	return nil
 }
 
 func bindMigrateFlags(cmd *cobra.Command) {
@@ -155,5 +142,8 @@ func bindMigrateFlags(cmd *cobra.Command) {
 	util.MustBindPFlag(datastoreURIFlag, flags.Lookup(datastoreURIFlag))
 
 	flags.Uint(versionFlag, 0, "`the version to migrate to. If omitted, the latest version of the schema will be used`")
-	util.MustBindPFlag("version", flags.Lookup(versionFlag))
+	util.MustBindPFlag(versionFlag, flags.Lookup(versionFlag))
+
+	flags.Duration(timeoutFlag, 1*time.Minute, "a timeout after which the migration process will terminate")
+	util.MustBindPFlag(timeoutFlag, flags.Lookup(timeoutFlag))
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds a `--timeout` flag (`OPENFGA_TIMEOUT` env variable) to the `openfga migrate` command so that we can wait up to the timeout period for the database to come online before attempting to apply migrations.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
