### PR TITLE
chore: correct name for calling RelationshipIngresses

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -247,7 +247,7 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 	case *openfgapb.Userset_Union: // e.g. target = define viewer as self or writer
 		var res []*RelationshipIngress
 		for _, child := range t.Union.GetChild() {
-			// we recurse through each child targetRewrite
+			// we recurse through each child rewrite
 			childResults, err := g.findIngressesWithTargetRewrite(target, source, child, visited)
 			if err != nil {
 				return nil, err
@@ -258,6 +258,6 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 	case *openfgapb.Userset_Intersection, *openfgapb.Userset_Difference:
 		return nil, ErrNotImplemented
 	default:
-		panic("unexpected userset targetRewrite encountered")
+		panic("unexpected userset rewrite encountered")
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -126,18 +126,18 @@ func (g *ConnectedObjectGraph) findIngresses(target *openfgapb.RelationReference
 		return nil, err
 	}
 
-	return g.findIngressesWithRewrite(target, source, relation.GetRewrite(), visited)
+	return g.findIngressesWithTargetRewrite(target, source, relation.GetRewrite(), visited)
 }
 
-// findIngressesWithRewrite is what we use for recursive calls on the rewrites, particularly union where we don't
-// update the target and source, and only the rewrite.
-func (g *ConnectedObjectGraph) findIngressesWithRewrite(
+// findIngressesWithTargetRewrite is what we use for recursive calls on the targetRewrite, particularly union where we don't
+// update the target and source, and only the targetRewrite.
+func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 	target *openfgapb.RelationReference,
 	source *openfgapb.RelationReference,
-	rewrite *openfgapb.Userset,
+	targetRewrite *openfgapb.Userset,
 	visited map[string]struct{},
 ) ([]*RelationshipIngress, error) {
-	switch t := rewrite.GetUserset().(type) {
+	switch t := targetRewrite.GetUserset().(type) {
 	case *openfgapb.Userset_This: // e.g. define viewer:[user] as self
 		var res []*RelationshipIngress
 		directlyRelated, _ := g.typesystem.IsDirectlyRelated(target, source)
@@ -247,8 +247,8 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 	case *openfgapb.Userset_Union: // e.g. target = define viewer as self or writer
 		var res []*RelationshipIngress
 		for _, child := range t.Union.GetChild() {
-			// we recurse through each child rewrite
-			childResults, err := g.findIngressesWithRewrite(target, source, child, visited)
+			// we recurse through each child targetRewrite
+			childResults, err := g.findIngressesWithTargetRewrite(target, source, child, visited)
 			if err != nil {
 				return nil, err
 			}
@@ -258,6 +258,6 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 	case *openfgapb.Userset_Intersection, *openfgapb.Userset_Difference:
 		return nil, ErrNotImplemented
 	default:
-		panic("unexpected userset rewrite encountered")
+		panic("unexpected userset targetRewrite encountered")
 	}
 }


### PR DESCRIPTION

<!-- Provide a brief summary of the changes -->

## Description
Update variable name for caller for RelationshipIngresses to make reading clearer

## References
Close https://github.com/openfga/openfga/issues/612


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
