### PR TITLE
fix: ConnectedObjects TTU expansion behavior

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -4334,3 +4334,39 @@ tests:
               relation: can_view
             expectation:
               - document:a
+
+  - name: evaluate_userset_in_computed_relation_of_ttu
+    stages:
+      - model: |
+          type user
+          type repo
+            relations
+              define owner: [organization] as self
+              define reader as repo_admin from owner
+          type organization
+            relations
+              define member: [user] as self
+              define repo_admin: [organization#member] as self
+        tuples:
+          - user: organization:openfga
+            relation: owner
+            object: repo:openfga/openfga
+          - user: organization:openfga#member
+            relation: repo_admin
+            object: organization:openfga
+          - user: user:erik
+            relation: member
+            object: organization:openfga
+        checkAssertions:
+          - tuple:
+              user: user:erik
+              relation: reader
+              object: repo:openfga/openfga
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:erik
+              type: repo
+              relation: reader
+            expectation:
+              - repo:openfga/openfga

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -232,6 +232,7 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 					TuplesetRelation: typesystem.DirectRelationReference(target.GetType(), tupleset),
 				})
 			} else {
+				matchesSourceType := typeRestriction.GetType() == source.GetType()
 				directlyAssignable := g.typesystem.IsDirectlyAssignable(r)
 
 				// if any of the inner type restrictions of the computed relation are related to the source, then there
@@ -247,11 +248,11 @@ func (g *ConnectedObjectGraph) findIngressesWithRewrite(
 				//   relations
 				//     define parent: [folder]
 				//     define viewer: viewer from parent
-				if directlyAssignable {
+				if directlyAssignable && matchesSourceType {
 					innerRelatedTypes, _ := g.typesystem.GetDirectlyRelatedUserTypes(typeRestriction.GetType(), computedUserset)
 					for _, innerRelatedTypeRestriction := range innerRelatedTypes {
 
-						if typeRestriction.GetType() == source.GetType() && innerRelatedTypeRestriction.GetType() == source.GetType() {
+						if innerRelatedTypeRestriction.GetType() == source.GetType() {
 							res = append(res, &RelationshipIngress{
 								Type:             TupleToUsersetIngress,
 								Ingress:          typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -927,6 +927,28 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "computed_target_of_ttu_related_to_same_type",
+			model: `
+			type folder
+			  relations
+				define viewer: [folder] as self
+
+			type document
+			  relations
+				define parent: [folder] as self
+				define viewer as viewer from parent
+			`,
+			target: typesystem.DirectRelationReference("document", "viewer"),
+			source: typesystem.DirectRelationReference("folder", "viewer"),
+			expected: []*RelationshipIngress{
+				{
+					Type:             TupleToUsersetIngress,
+					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -284,13 +284,9 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			model: `
 			type user
 
-			type group
-			  relations
-			    define member: [user] as self
-
 			type folder
 			  relations
-			    define viewer: [user, group#member] as self
+			    define viewer: [user] as self
 
 			type document
 			  relations
@@ -905,6 +901,29 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 					Type:             TupleToUsersetIngress,
 					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
+				},
+			},
+		},
+		{
+			name: "follow_computed_relation_of_ttu_to_computed_userset",
+			model: `
+			type user
+			type folder
+			  relations
+				define owner: [user] as self
+				define viewer: [user] as self or owner
+			type document
+			  relations
+				define can_read as viewer from parent
+				define parent: [document, folder] as self
+				define viewer: [user] as self
+			`,
+			target: typesystem.DirectRelationReference("document", "can_read"),
+			source: typesystem.DirectRelationReference("folder", "owner"),
+			expected: []*RelationshipIngress{
+				{
+					Type:    ComputedUsersetIngress,
+					Ingress: typesystem.DirectRelationReference("folder", "viewer"),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes some behavior with TTU ingresses not being computed properly, and this was leading to some behavior where `ListObjects` could fail to evaluate relationships consistently relative to `Check`.

## References
Fixes the ListObjects behavior for the example presented in #615.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
