### PR TITLE
chore: bump grpc healthprobe version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM cgr.dev/chainguard/static:latest
 EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
-COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
+COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.16 /ko-app/grpc-health-probe /bin/grpc_health_probe
 COPY --from=builder /app/openfga /openfga
 COPY --from=builder /app/assets /assets
 ENTRYPOINT ["/openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 FROM cgr.dev/chainguard/static:latest
 COPY assets /assets
 COPY openfga /
-COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.15 /ko-app/grpc-health-probe /bin/grpc_health_probe
+COPY --chmod=0755 --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.16 /ko-app/grpc-health-probe /bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION


<!-- Provide a brief summary of the changes -->

## Description
bump grpc healthprobe version

## References
https://github.com/grpc-ecosystem/grpc-health-probe/compare/v0.4.16...master
contains fix for https://github.com/advisories/GHSA-mh68-qf2j-8c5g

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
