### PR TITLE
fix: do not hard-code ports in test

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -293,8 +293,8 @@ func DefaultConfig() *Config {
 	}
 }
 
-// TCPRandomPort returns a random TCP Port along with a function that releases the port.
-// It is the responsibility of the caller to release the port. Otherwise, the port will be orphaned.
+// TCPRandomPort tries to find a random TCP Port. If it can't find one, it panics. Else, it returns the port and a function that releases the port.
+// It is the responsibility of the caller to call the release function.
 func TCPRandomPort() (int, func()) {
 	l, err := net.Listen("tcp", "")
 	if err != nil {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -316,8 +316,8 @@ func MustDefaultConfigWithRandomPorts() *Config {
 	defer l.Close()
 	grpcPort := l.Addr().(*net.TCPAddr).Port
 
-	config.GRPC.Addr = fmt.Sprintf("0.0.0.0:%d", grpcPort)
-	config.HTTP.Addr = fmt.Sprintf("0.0.0.0:%d", httpPort)
+	config.GRPC.Addr = fmt.Sprintf("localhost:%d", grpcPort)
+	config.HTTP.Addr = fmt.Sprintf("localhost:%d", httpPort)
 
 	return config
 }

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -315,10 +315,11 @@ func MustDefaultConfigWithRandomPorts() *Config {
 	config.Metrics.Enabled = false
 
 	httpPort, httpPortReleaser := TCPRandomPort()
-
-	grpcPort, grpcPortReleaser := TCPRandomPort()
 	defer func() {
 		httpPortReleaser()
+	}()
+	grpcPort, grpcPortReleaser := TCPRandomPort()
+	defer func() {
 		grpcPortReleaser()
 	}()
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -317,8 +317,10 @@ func MustDefaultConfigWithRandomPorts() *Config {
 	httpPort, httpPortReleaser := TCPRandomPort()
 
 	grpcPort, grpcPortReleaser := TCPRandomPort()
-	httpPortReleaser()
-	grpcPortReleaser()
+	defer func() {
+		httpPortReleaser()
+		grpcPortReleaser()
+	}()
 
 	config.GRPC.Addr = fmt.Sprintf("0.0.0.0:%d", grpcPort)
 	config.HTTP.Addr = fmt.Sprintf("0.0.0.0:%d", httpPort)

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -315,13 +315,9 @@ func MustDefaultConfigWithRandomPorts() *Config {
 	config.Metrics.Enabled = false
 
 	httpPort, httpPortReleaser := TCPRandomPort()
-	defer func() {
-		httpPortReleaser()
-	}()
+	defer httpPortReleaser()
 	grpcPort, grpcPortReleaser := TCPRandomPort()
-	defer func() {
-		grpcPortReleaser()
-	}()
+	defer grpcPortReleaser()
 
 	config.GRPC.Addr = fmt.Sprintf("0.0.0.0:%d", grpcPort)
 	config.HTTP.Addr = fmt.Sprintf("0.0.0.0:%d", httpPort)

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -575,7 +575,6 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 		Issuer:   localOIDCServerURL,
 	}
 
-	// release the oidc server port after obtaining cfg ports
 	oidcServerPortReleaser()
 
 	trustedIssuerServer, err := mocks.NewMockOidcServer(localOIDCServerURL)


### PR DESCRIPTION

## Description

Avoid hard coding ports in test

## References

Close https://github.com/openfga/openfga/issues/621


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
