### PR TITLE
Feature[credentials]: Support explicit datastore username & password configuration points

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -113,6 +113,16 @@
                     ],
                     "x-env-variable": "OPENFGA_DATASTORE_URI"
                 },
+                "username": {
+                    "description": "The username for the connection to the datastore. If provided it will overwrite any username provided in the connection string.",
+                    "type": "string",
+                    "x-env-variable": "OPENFGA_DATASTORE_USERNAME"
+                },
+                "password": {
+                    "description": "The password for the connection to the datastore. If provided it will overwrite any password provided in the connection string.",
+                    "type": "string",
+                    "x-env-variable": "OPENFGA_DATASTORE_PASSWORD"
+                },
                 "maxCacheSize": {
                     "description": "The maximum number of cache keys that the storage cache can store before evicting old keys.",
                     "type": "integer",

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -119,7 +119,7 @@
                     "x-env-variable": "OPENFGA_DATASTORE_USERNAME"
                 },
                 "password": {
-                    "description": "The connection password to use to connect to the datastore (overwrites any password provided in the connection uri).",
+                    "description": "The connection password to connect to the datastore (overwrites any password provided in the connection uri).",
                     "type": "string",
                     "x-env-variable": "OPENFGA_DATASTORE_PASSWORD"
                 },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -114,7 +114,7 @@
                     "x-env-variable": "OPENFGA_DATASTORE_URI"
                 },
                 "username": {
-                    "description": "The connection username to use to connect to the datastore (overwrites any username provided in the connection uri).",
+                    "description": "The connection username to connect to the datastore (overwrites any username provided in the connection uri).",
                     "type": "string",
                     "x-env-variable": "OPENFGA_DATASTORE_USERNAME"
                 },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -114,12 +114,12 @@
                     "x-env-variable": "OPENFGA_DATASTORE_URI"
                 },
                 "username": {
-                    "description": "The username for the connection to the datastore. If provided it will overwrite any username provided in the connection string.",
+                    "description": "The connection username to use to connect to the datastore (overwrites any username provided in the connection uri).",
                     "type": "string",
                     "x-env-variable": "OPENFGA_DATASTORE_USERNAME"
                 },
                 "password": {
-                    "description": "The password for the connection to the datastore. If provided it will overwrite any password provided in the connection string.",
+                    "description": "The connection password to use to connect to the datastore (overwrites any password provided in the connection uri).",
                     "type": "string",
                     "x-env-variable": "OPENFGA_DATASTORE_PASSWORD"
                 },

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -91,6 +91,14 @@ func bindRunFlags(command *cobra.Command) {
 	util.MustBindPFlag("datastore.uri", flags.Lookup("datastore-uri"))
 	util.MustBindEnv("datastore.uri", "OPENFGA_DATASTORE_URI")
 
+	flags.String("datastore-username", "", "the connection username to use to connect to the datastore (overwrites any username provided in the connection uri)")
+	util.MustBindPFlag("datastore.username", flags.Lookup("datastore-username"))
+	util.MustBindEnv("datastore.username", "OPENFGA_DATASTORE_USERNAME")
+
+	flags.String("datastore-password", "", "the connection password to use to connect to the datastore (overwrites any password provided in the connection uri)")
+	util.MustBindPFlag("datastore.password", flags.Lookup("datastore-password"))
+	util.MustBindEnv("datastore.password", "OPENFGA_DATASTORE_PASSWORD")
+
 	flags.Int("datastore-max-cache-size", defaultConfig.Datastore.MaxCacheSize, "the maximum number of cache keys that the storage cache can store before evicting old keys")
 	util.MustBindPFlag("datastore.maxCacheSize", flags.Lookup("datastore-max-cache-size"))
 	util.MustBindEnv("datastore.maxCacheSize", "OPENFGA_DATASTORE_MAX_CACHE_SIZE", "OPENFGA_DATASTORE_MAXCACHESIZE")

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -202,5 +202,4 @@ func bindRunFlags(command *cobra.Command) {
 	flags.Bool("allow-evaluating-1.0-models", defaultConfig.AllowEvaluating1_0Models, "allow evaluating of models with 1.0 schema")
 	util.MustBindPFlag("allowEvaluating1_0Models", flags.Lookup("allow-evaluating-1.0-models"))
 	util.MustBindEnv("allowEvaluating1_0Models", "OPENFGA_ALLOW_EVALUATING_1_0_MODELS")
-
 }

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -401,7 +401,7 @@ func VerifyConfig(cfg *Config) error {
 	return nil
 }
 
-func run(cmd *cobra.Command, _ []string) {
+func run(_ *cobra.Command, _ []string) {
 	config, err := ReadConfig()
 	if err != nil {
 		panic(err)

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -78,8 +78,10 @@ func NewRunCommand() *cobra.Command {
 type DatastoreConfig struct {
 
 	// Engine is the datastore engine to use (e.g. 'memory', 'postgres', 'mysql')
-	Engine string
-	URI    string
+	Engine   string
+	URI      string
+	Username string
+	Password string
 
 	// MaxCacheSize is the maximum number of cache keys that the storage cache can store before evicting
 	// old keys. The storage cache is used to cache query results for various static resources
@@ -431,6 +433,8 @@ func RunServer(ctx context.Context, config *Config) error {
 	}
 
 	dsCfg := sqlcommon.NewConfig(
+		sqlcommon.WithUsername(config.Datastore.Username),
+		sqlcommon.WithPassword(config.Datastore.Password),
 		sqlcommon.WithLogger(logger),
 		sqlcommon.WithMaxTuplesPerWrite(config.MaxTuplesPerWrite),
 		sqlcommon.WithMaxTypesPerAuthorizationModel(config.MaxTypesPerAuthorizationModel),

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -401,7 +401,7 @@ func VerifyConfig(cfg *Config) error {
 	return nil
 }
 
-func run(_ *cobra.Command, _ []string) {
+func run(cmd *cobra.Command, _ []string) {
 	config, err := ReadConfig()
 	if err != nil {
 		panic(err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -45,8 +45,25 @@ func init() {
 func TestServerWithPostgresDatastore(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := postgres.New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	test.RunAllTests(t, ds)
+}
+
+func TestServerWithPostgresDatastoreAndExplicitCredentials(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(false)
+	ds, err := postgres.New(
+		uri,
+		sqlcommon.NewConfig(
+			sqlcommon.WithUsername(testDatastore.GetUsername()),
+			sqlcommon.WithPassword(testDatastore.GetPassword()),
+		),
+	)
 	require.NoError(t, err)
 	defer ds.Close()
 
@@ -62,8 +79,25 @@ func TestServerWithMemoryDatastore(t *testing.T) {
 func TestServerWithMySQLDatastore(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := mysql.New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	test.RunAllTests(t, ds)
+}
+
+func TestServerWithMySQLDatastoreAndExplicitCredentials(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(false)
+	ds, err := mysql.New(
+		uri,
+		sqlcommon.NewConfig(
+			sqlcommon.WithUsername(testDatastore.GetUsername()),
+			sqlcommon.WithPassword(testDatastore.GetPassword()),
+		),
+	)
 	require.NoError(t, err)
 	defer ds.Close()
 
@@ -75,7 +109,7 @@ func BenchmarkOpenFGAServer(b *testing.B) {
 	b.Run("BenchmarkPostgresDatastore", func(b *testing.B) {
 		testDatastore := storagefixtures.RunDatastoreTestContainer(b, "postgres")
 
-		uri := testDatastore.GetConnectionURI()
+		uri := testDatastore.GetConnectionURI(true)
 		ds, err := postgres.New(uri, sqlcommon.NewConfig())
 		require.NoError(b, err)
 		defer ds.Close()
@@ -91,7 +125,7 @@ func BenchmarkOpenFGAServer(b *testing.B) {
 	b.Run("BenchmarkMySQLDatastore", func(b *testing.B) {
 		testDatastore := storagefixtures.RunDatastoreTestContainer(b, "mysql")
 
-		uri := testDatastore.GetConnectionURI()
+		uri := testDatastore.GetConnectionURI(true)
 		ds, err := mysql.New(uri, sqlcommon.NewConfig())
 		require.NoError(b, err)
 		defer ds.Close()

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -12,7 +12,6 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/cenkalti/backoff/v4"
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -20,7 +20,7 @@ import (
 func TestMySQLDatastore(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -32,7 +32,7 @@ func TestMigrate(t *testing.T) {
 	// starts the container and runs migration up to the latest migration version available
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, engine)
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -55,7 +55,7 @@ func TestMigrate(t *testing.T) {
 func TestReadEnsureNoOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -103,7 +103,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 func TestReadPageEnsureOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -37,6 +38,38 @@ type Postgres struct {
 var _ storage.OpenFGADatastore = (*Postgres)(nil)
 
 func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
+
+	// Is username or password explicitly provided?
+	if cfg.Username != "" || cfg.Password != "" {
+		parsed, err := url.Parse(uri)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse postgres connection uri: %w", err)
+		}
+
+		// Username always set to some value
+		username := ""
+		if cfg.Username != "" {
+			username = cfg.Username
+		} else if parsed.User != nil {
+			username = parsed.User.Username()
+		}
+
+		// Only set password if one was provided in either source
+		if cfg.Password != "" {
+			parsed.User = url.UserPassword(username, cfg.Password)
+		} else if parsed.User != nil {
+			if password, ok := parsed.User.Password(); ok {
+				parsed.User = url.UserPassword(username, password)
+			} else {
+				parsed.User = url.User(username)
+			}
+		} else {
+			parsed.User = url.User(username)
+		}
+
+		uri = parsed.String()
+	}
+
 	db, err := sql.Open("pgx", uri)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize postgres connection: %w", err)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -39,14 +39,12 @@ var _ storage.OpenFGADatastore = (*Postgres)(nil)
 
 func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 
-	// Is username or password explicitly provided?
 	if cfg.Username != "" || cfg.Password != "" {
 		parsed, err := url.Parse(uri)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse postgres connection uri: %w", err)
 		}
 
-		// Username always set to some value
 		username := ""
 		if cfg.Username != "" {
 			username = cfg.Username
@@ -54,7 +52,6 @@ func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 			username = parsed.User.Username()
 		}
 
-		// Only set password if one was provided in either source
 		if cfg.Password != "" {
 			parsed.User = url.UserPassword(username, cfg.Password)
 		} else if parsed.User != nil {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -21,7 +21,7 @@ import (
 func TestPostgresDatastore(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -33,7 +33,7 @@ func TestMigrate(t *testing.T) {
 	// starts the container and runs migration up to the latest migration version available
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, engine)
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -55,7 +55,7 @@ func TestMigrate(t *testing.T) {
 func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
 func TestReadEnsureNoOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
@@ -129,7 +129,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 func TestReadPageEnsureOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	uri := testDatastore.GetConnectionURI()
+	uri := testDatastore.GetConnectionURI(true)
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -20,6 +20,8 @@ import (
 )
 
 type Config struct {
+	Username               string
+	Password               string
 	Logger                 logger.Logger
 	MaxTuplesPerWriteField int
 	MaxTypesPerModelField  int
@@ -31,6 +33,18 @@ type Config struct {
 }
 
 type DatastoreOption func(*Config)
+
+func WithUsername(username string) DatastoreOption {
+	return func(config *Config) {
+		config.Username = username
+	}
+}
+
+func WithPassword(password string) DatastoreOption {
+	return func(config *Config) {
+		config.Password = password
+	}
+}
 
 func WithLogger(l logger.Logger) DatastoreOption {
 	return func(cfg *Config) {

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -25,9 +25,10 @@ const (
 )
 
 type mySQLTestContainer struct {
-	addr    string
-	creds   string
-	version int64
+	addr     string
+	version  int64
+	username string
+	password string
 }
 
 // NewMySQLTestContainer returns an implementation of the DatastoreTestContainer interface
@@ -141,11 +142,12 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	})
 
 	mySQLTestContainer := &mySQLTestContainer{
-		addr:  fmt.Sprintf("localhost:%s", p[0].HostPort),
-		creds: "root:secret",
+		addr:     fmt.Sprintf("localhost:%s", p[0].HostPort),
+		username: "root",
+		password: "secret",
 	}
 
-	uri := fmt.Sprintf("%s@tcp(%s)/defaultdb?parseTime=true", mySQLTestContainer.creds, mySQLTestContainer.addr)
+	uri := fmt.Sprintf("%s:%s@tcp(%s)/defaultdb?parseTime=true", mySQLTestContainer.username, mySQLTestContainer.password, mySQLTestContainer.addr)
 
 	err = mysql.SetLogger(goose.NopLogger())
 	require.NoError(t, err)
@@ -183,11 +185,24 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 }
 
 // GetConnectionURI returns the mysql connection uri for the running mysql test container.
-func (m *mySQLTestContainer) GetConnectionURI() string {
+func (m *mySQLTestContainer) GetConnectionURI(includeCredentials bool) string {
+	creds := ""
+	if includeCredentials {
+		creds = fmt.Sprintf("%s:%s@", m.username, m.password)
+	}
+
 	return fmt.Sprintf(
-		"%s@tcp(%s)/%s?parseTime=true",
-		m.creds,
+		"%stcp(%s)/%s?parseTime=true",
+		creds,
 		m.addr,
 		"defaultdb",
 	)
+}
+
+func (m *mySQLTestContainer) GetUsername() string {
+	return m.username
+}
+
+func (m *mySQLTestContainer) GetPassword() string {
+	return m.password
 }

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -9,15 +9,26 @@ type DatastoreTestContainer interface {
 
 	// GetConnectionURI returns a connection string to the datastore instance running inside
 	// the container.
-	GetConnectionURI() string
+	GetConnectionURI(includeCredentials bool) string
 
 	// GetDatabaseVersion returns the last migration applied (e.g. 3) when the container was created
 	GetDatabaseSchemaVersion() int64
+
+	GetUsername() string
+	GetPassword() string
 }
 
 type memoryTestContainer struct{}
 
-func (m memoryTestContainer) GetConnectionURI() string {
+func (m memoryTestContainer) GetConnectionURI(includeCredentials bool) string {
+	return ""
+}
+
+func (m memoryTestContainer) GetUsername() string {
+	return ""
+}
+
+func (m memoryTestContainer) GetPassword() string {
 	return ""
 }
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -22,7 +22,7 @@ type TestClientBootstrapper interface {
 
 func StartServer(t testing.TB, cfg *run.Config) context.CancelFunc {
 	container := storage.RunDatastoreTestContainer(t, cfg.Datastore.Engine)
-	cfg.Datastore.URI = container.GetConnectionURI()
+	cfg.Datastore.URI = container.GetConnectionURI(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
This adds explicit support for separately providing a username and/or password to the datastore as separate explicit configuration values.

All the expected sources are supported: config.yaml, flags and environment variables. Both postgrsql & mysql are implemented.


## Description

When using secret managers like Vault or even Kubernetes secrets only allowing the specifying a full connection URI only becomes problematic.Usually _only_ the credentials are stored in these services and they may need to be rotated in an automated fashion.

Allowing the username and/or password to be provided separately eases integration of OpenFGA with these credential managements systems. For example, passing the base URI to a Helm chart value and then providing the username and password via K8s secrets mapped as environment variables.

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
