### PR TITLE
Add a command-line flag to customize service name in traces

### DIFF
--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -147,6 +147,10 @@ func bindRunFlags(command *cobra.Command) {
 	util.MustBindPFlag("trace.sampleRatio", flags.Lookup("trace-sample-ratio"))
 	util.MustBindEnv("trace.sampleRatio", "OPENFGA_TRACE_SAMPLE_RATIO")
 
+	flags.String("trace-service-name", defaultConfig.Trace.ServiceName, "the name of the service in traces.")
+	util.MustBindPFlag("trace.serviceName", flags.Lookup("trace-service-name"))
+	util.MustBindEnv("trace.serviceName", "OPENFGA_TRACE_SERVICE_NAME")
+
 	flags.Bool("metrics-enabled", defaultConfig.Metrics.Enabled, "enable/disable prometheus metrics on the '/metrics' endpoint")
 	util.MustBindPFlag("metrics.enabled", flags.Lookup("metrics-enabled"))
 	util.MustBindEnv("metrics.enabled", "OPENFGA_METRICS_ENABLED")

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -161,6 +161,7 @@ type TraceConfig struct {
 	Enabled     bool
 	OTLP        OTLPTraceConfig `mapstructure:"otlp"`
 	SampleRatio float64
+	ServiceName string
 }
 
 type OTLPTraceConfig struct {
@@ -274,6 +275,7 @@ func DefaultConfig() *Config {
 				Endpoint: "0.0.0.0:4317",
 			},
 			SampleRatio: 0.2,
+			ServiceName: "openfga",
 		},
 		Playground: PlaygroundConfig{
 			Enabled: true,
@@ -415,7 +417,7 @@ func RunServer(ctx context.Context, config *Config) error {
 	tp := sdktrace.NewTracerProvider()
 	if config.Trace.Enabled {
 		logger.Info(fmt.Sprintf("🕵 tracing enabled: sampling ratio is %v and sending traces to '%s'", config.Trace.SampleRatio, config.Trace.OTLP.Endpoint))
-		tp = telemetry.MustNewTracerProvider(config.Trace.OTLP.Endpoint, config.Trace.SampleRatio)
+		tp = telemetry.MustNewTracerProvider(config.Trace.OTLP.Endpoint, config.Trace.SampleRatio, config.Trace.ServiceName)
 	}
 
 	logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -17,9 +17,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-const serviceName = "openfga"
-
-func MustNewTracerProvider(endpoint string, ratio float64) *sdktrace.TracerProvider {
+func MustNewTracerProvider(endpoint string, ratio float64, serviceName string) *sdktrace.TracerProvider {
 	res, err := resource.Merge(
 		resource.Default(),
 		resource.NewSchemaless(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

This change allows you to give a specific name for the service in traces without doing changes on the trace aggregator side.
## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
