### PR TITLE
fix: update order of middleware

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -476,14 +476,14 @@ func RunServer(ctx context.Context, config *Config) error {
 	}
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
-		grpc_validator.UnaryServerInterceptor(),
 		requestid.NewUnaryInterceptor(),
+		grpc_validator.UnaryServerInterceptor(),
 		grpc_ctxtags.UnaryServerInterceptor(),
 	}
 
 	streamingInterceptors := []grpc.StreamServerInterceptor{
-		grpc_validator.StreamServerInterceptor(),
 		requestid.NewStreamingInterceptor(),
+		grpc_validator.StreamServerInterceptor(),
 		grpc_ctxtags.StreamServerInterceptor(),
 	}
 


### PR DESCRIPTION


## Description
Change so that we get request id first.  This allows us usage of request id in validation layer.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
