### PR TITLE
fix: migration script #3 for mysql

### DIFF
--- a/assets/migrations/mysql/003_add_reverse_lookup_index.sql
+++ b/assets/migrations/mysql/003_add_reverse_lookup_index.sql
@@ -2,4 +2,4 @@
 CREATE INDEX idx_reverse_lookup_user on tuple (store, object_type, relation, _user);
 
 -- +goose Down
-DROP INDEX  idx_reverse_lookup_user;
+DROP INDEX  idx_reverse_lookup_user on tuple;


### PR DESCRIPTION
Current error:

```shell
[12/04/23 5:37:02] ~/GitHub/openfga (main) $ ./openfga migrate --datastore-engine mysql --datastore-uri 'root:secret@tcp(localhost:3306)/openfga?parseTime=true' --version 2

2023/04/12 17:37:20 ERROR 003_add_reverse_lookup_index.sql: failed to run SQL migration: failed to execute SQL query "DROP INDEX  idx_reverse_lookup_user;": Error 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
```

This PR fixes it.

Tested by:

`docker-compose up -d` with this Docker compose file

```yaml
services:
  mysql:
    image: mysql:latest
    container_name: mysql
    environment:
      - MYSQL_DATABASE=openfga
      - MYSQL_ROOT_PASSWORD=secret
    networks:
      - default
    ports:
      - "3306:3306"
    healthcheck:
      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
      interval: 5s
      timeout: 5s
      retries: 5
```

and then:

```shell
./openfga migrate --datastore-engine mysql --datastore-uri 'root:secret@tcp(localhost:3306)/openfga?parseTime=true' --version 4
./openfga migrate --datastore-engine mysql --datastore-uri 'root:secret@tcp(localhost:3306)/openfga?parseTime=true' --version 3
./openfga migrate --datastore-engine mysql --datastore-uri 'root:secret@tcp(localhost:3306)/openfga?parseTime=true' --version 2
./openfga migrate --datastore-engine mysql --datastore-uri 'root:secret@tcp(localhost:3306)/openfga?parseTime=true' --version 1
```