### PR TITLE
test: add tests for rollbacks of database scripts

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -61,7 +61,7 @@ func NewMigrateCommand() *cobra.Command {
 func runMigration(_ *cobra.Command, _ []string) error {
 	engine := viper.GetString(datastoreEngineFlag)
 	uri := viper.GetString(datastoreURIFlag)
-	version := viper.GetUint(versionFlag)
+	targetVersion := viper.GetUint(versionFlag)
 	timeout := viper.GetDuration(timeoutFlag)
 
 	goose.SetLogger(goose.NopLogger())
@@ -116,26 +116,33 @@ func runMigration(_ *cobra.Command, _ []string) error {
 
 	goose.SetBaseFS(assets.EmbedMigrations)
 
-	if version > 0 {
+	if targetVersion > 0 {
 		currentVersion, err := goose.GetDBVersion(db)
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Printf("current version %d, migrating to %d", currentVersion, targetVersion)
 
-		int64Version := int64(version)
-		if int64Version < currentVersion {
-			if err := goose.DownTo(db, migrationsPath, int64Version); err != nil {
+		targetInt64Version := int64(targetVersion)
+		if targetInt64Version < currentVersion {
+			if err := goose.DownTo(db, migrationsPath, targetInt64Version); err != nil {
 				log.Fatal(err)
 			}
+		} else if targetInt64Version > currentVersion {
+			if err := goose.UpTo(db, migrationsPath, targetInt64Version); err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			log.Println("nothing to do")
+			return nil
 		}
 
-		if err := goose.UpTo(db, migrationsPath, int64Version); err != nil {
-			log.Fatal(err)
-		}
+		log.Println("migration done")
 
 		return nil
 	}
 
+	// no target version specified, will apply all migrations available
 	if err := goose.Up(db, migrationsPath); err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -37,12 +37,13 @@ func TestMigrate(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 
-	version := testDatastore.GetDatabaseVersion()
+	// going from version 3 to 4 when migration #4 doesn't exist is a no-op
+	version := testDatastore.GetDatabaseVersion() + 1
 
 	migrateCommand := cmd.NewMigrateCommand()
 
-	for version > 0 {
-		t.Logf("downgrading to version %d", version)
+	for version >= 0 {
+		t.Logf("migrating to version %d", version)
 		migrateCommand.SetArgs([]string{"--datastore-engine", engine, "--datastore-uri", uri, "--version", strconv.Itoa(int(version))})
 		err = migrateCommand.Execute()
 		require.NoError(t, err)

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -38,7 +38,7 @@ func TestMigrate(t *testing.T) {
 	defer ds.Close()
 
 	// going from version 3 to 4 when migration #4 doesn't exist is a no-op
-	version := testDatastore.GetDatabaseVersion() + 1
+	version := testDatastore.GetDatabaseSchemaVersion() + 1
 
 	migrateCommand := cmd.NewMigrateCommand()
 

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -38,12 +38,13 @@ func TestMigrate(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 
-	version := testDatastore.GetDatabaseVersion()
+	// going from version 3 to 4 when migration #4 doesn't exist is a no-op
+	version := testDatastore.GetDatabaseVersion() + 1
 
 	migrateCommand := cmd.NewMigrateCommand()
 
-	for version > 0 {
-		t.Logf("downgrading to version %d", version)
+	for version >= 0 {
+		t.Logf("migrating to version %d", version)
 		migrateCommand.SetArgs([]string{"--datastore-engine", engine, "--datastore-uri", uri, "--version", strconv.Itoa(int(version))})
 		err = migrateCommand.Execute()
 		require.NoError(t, err)

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -39,7 +39,7 @@ func TestMigrate(t *testing.T) {
 	defer ds.Close()
 
 	// going from version 3 to 4 when migration #4 doesn't exist is a no-op
-	version := testDatastore.GetDatabaseVersion() + 1
+	version := testDatastore.GetDatabaseSchemaVersion() + 1
 
 	migrateCommand := cmd.NewMigrateCommand()
 

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -36,7 +36,7 @@ func NewMySQLTestContainer() *mySQLTestContainer {
 	return &mySQLTestContainer{}
 }
 
-func (m *mySQLTestContainer) GetDatabaseVersion() int64 {
+func (m *mySQLTestContainer) GetDatabaseSchemaVersion() int64 {
 	return m.version
 }
 

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -25,14 +25,19 @@ const (
 )
 
 type mySQLTestContainer struct {
-	addr  string
-	creds string
+	addr    string
+	creds   string
+	version int64
 }
 
 // NewMySQLTestContainer returns an implementation of the DatastoreTestContainer interface
 // for MySQL.
 func NewMySQLTestContainer() *mySQLTestContainer {
 	return &mySQLTestContainer{}
+}
+
+func (m *mySQLTestContainer) GetDatabaseVersion() int64 {
+	return m.version
 }
 
 // RunMySQLTestContainer runs a MySQL container, connects to it, and returns a
@@ -167,6 +172,10 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 
 	err = goose.Up(db, assets.MySQLMigrationDir)
 	require.NoError(t, err)
+	version, err := goose.GetDBVersion(db)
+	require.NoError(t, err)
+	mySQLTestContainer.version = version
+
 	err = db.Close()
 	require.NoError(t, err)
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -29,14 +29,19 @@ var (
 )
 
 type postgresTestContainer struct {
-	addr  string
-	creds string
+	addr    string
+	creds   string
+	version int64
 }
 
 // NewPostgresTestContainer returns an implementation of the DatastoreTestContainer interface
 // for Postgres.
 func NewPostgresTestContainer() *postgresTestContainer {
 	return &postgresTestContainer{}
+}
+
+func (p *postgresTestContainer) GetDatabaseVersion() int64 {
+	return p.version
 }
 
 // RunPostgresTestContainer runs a Postgres container, connects to it, and returns a
@@ -168,6 +173,11 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 
 	err = goose.Up(db, assets.PostgresMigrationDir)
 	require.NoError(t, err)
+
+	version, err := goose.GetDBVersion(db)
+	require.NoError(t, err)
+	pgTestContainer.version = version
+
 	err = db.Close()
 	require.NoError(t, err)
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -40,7 +40,7 @@ func NewPostgresTestContainer() *postgresTestContainer {
 	return &postgresTestContainer{}
 }
 
-func (p *postgresTestContainer) GetDatabaseVersion() int64 {
+func (p *postgresTestContainer) GetDatabaseSchemaVersion() int64 {
 	return p.version
 }
 

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -12,7 +12,7 @@ type DatastoreTestContainer interface {
 	GetConnectionURI() string
 
 	// GetDatabaseVersion returns the last migration applied (e.g. 3) when the container was created
-	GetDatabaseVersion() int64
+	GetDatabaseSchemaVersion() int64
 }
 
 type memoryTestContainer struct{}
@@ -21,7 +21,7 @@ func (m memoryTestContainer) GetConnectionURI() string {
 	return ""
 }
 
-func (m memoryTestContainer) GetDatabaseVersion() int64 {
+func (m memoryTestContainer) GetDatabaseSchemaVersion() int64 {
 	return 1
 }
 

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -10,6 +10,9 @@ type DatastoreTestContainer interface {
 	// GetConnectionURI returns a connection string to the datastore instance running inside
 	// the container.
 	GetConnectionURI() string
+
+	// GetDatabaseVersion returns the last migration applied (e.g. 3) when the container was created
+	GetDatabaseVersion() int64
 }
 
 type memoryTestContainer struct{}
@@ -18,9 +21,13 @@ func (m memoryTestContainer) GetConnectionURI() string {
 	return ""
 }
 
+func (m memoryTestContainer) GetDatabaseVersion() int64 {
+	return 1
+}
+
 // RunDatastoreTestContainer constructs and runs a specifc DatastoreTestContainer for the provided
-// datastore engine. The resources used by the test engine will be cleaned up after the test
-// has finished.
+// datastore engine. If applicable, it also runs all existing database migrations.
+// The resources used by the test engine will be cleaned up after the test has finished.
 func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContainer {
 	switch engine {
 	case "mysql":


### PR DESCRIPTION
This is to help detect problems like this: https://github.com/openfga/openfga/pull/691

Tested manually:

```shell
[17/04/23 7:48:07] ~/GitHub/openfga (test-migrations) $  make start-postgres 
docker run -d --name postgres -p 5432:5432 -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password postgres:14
c6c088272b07293dbc12f4611dedbfbc8307267ebda45fc36a5e4059a05fa3d6
> use 'postgres://postgres:password@localhost:5432/postgres' to connect to postgres
[17/04/23 7:48:11] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 4
2023/04/17 19:48:15 current version 0
2023/04/17 19:48:15 migrating to 4
2023/04/17 19:48:15 migration done
[17/04/23 7:48:15] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 4
2023/04/17 19:48:21 current version 3
2023/04/17 19:48:21 migrating to 4
2023/04/17 19:48:21 migration done
[17/04/23 7:48:21] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 3
2023/04/17 19:48:24 current version 3
2023/04/17 19:48:24 migrating to 3
2023/04/17 19:48:24 nothing to do
[17/04/23 7:48:24] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 2
2023/04/17 19:48:26 current version 3
2023/04/17 19:48:26 migrating to 2
2023/04/17 19:48:26 migration done
[17/04/23 7:48:26] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 1
2023/04/17 19:48:28 current version 2
2023/04/17 19:48:28 migrating to 1
2023/04/17 19:48:28 migration done
[17/04/23 7:48:28] ~/GitHub/openfga (test-migrations) $ ./openfga migrate --datastore-engine postgres --datastore-uri 'postgres://postgres:password@localhost:5432/postgres' --version 0
2023/04/17 19:48:29 current version 1
2023/04/17 19:48:29 running all migrations
2023/04/17 19:48:29 migration done
[17/04/23 7:48:29] ~/GitHub/openfga (test-migrations) $ 
```