### PR TITLE
docs: add v1.0.1 release details to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+## [1.0.1] - 2023-04-18
+
+[Full changelog](https://github.com/openfga/openfga/compare/v1.0.0...v1.0.1)
+
+## Fixed
+* Correct permission and location for gRPC health probe in Docker image (#667)
+
 ## [1.0.0] - 2023-04-14
 
 [Full changelog](https://github.com/openfga/openfga/compare/v0.4.3...v1.0.0)
@@ -478,7 +485,8 @@ no tuple key instead.
 * Memory storage adapter implementation
 * Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/openfga/openfga/releases/tag/v1.0.1
 [1.0.0]: https://github.com/openfga/openfga/releases/tag/v1.0.0
 [0.4.3]: https://github.com/openfga/openfga/releases/tag/v0.4.3
 [0.4.2]: https://github.com/openfga/openfga/releases/tag/v0.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.0.0...v1.0.1)
 
 ## Fixed
-* Correct permission and location for gRPC health probe in Docker image (#667)
+* Correct permission and location for gRPC health probe in Docker image (#697)
 
 ## [1.0.0] - 2023-04-14
 


### PR DESCRIPTION
## Description
Adds the v1.0.1 release notes to the CHANGELOG.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
