### PR TITLE
chore: pin MySQL container image to v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A high-performance and flexible authorization/permission engine built for develo
 
 OpenFGA is designed to make it easy for developers to model their application permissions and add and integrate fine-grained authorization into their applications.
 
-It allows in-memory data storage for quick development, as well as pluggable database modules. It currently supports PostgreSQL and MySQL.
+It allows in-memory data storage for quick development, as well as pluggable database modules. It currently supports PostgreSQL 14 and MySQL 8.
 
 It offers an [HTTP API](https://openfga.dev/api/service) and a [gRPC API](https://buf.build/openfga/api/file/main:openfga/v1/openfga_service.proto). It has SDKs for [Node.js/JavaScript](https://www.npmjs.com/package/@openfga/sdk), [GoLang](https://github.com/openfga/go-sdk), [Python](https://github.com/openfga/python-sdk) and [.NET](https://www.nuget.org/packages/OpenFga.Sdk). Look in our [Community section](https://github.com/openfga/community#community-projects) for third-party SDKs and tools. 
 

--- a/assets/migrations/mysql/001_initialize_schema.sql
+++ b/assets/migrations/mysql/001_initialize_schema.sql
@@ -15,25 +15,25 @@ CREATE UNIQUE INDEX idx_tuple_ulid ON tuple (ulid);
 
 CREATE TABLE authorization_model (
     store CHAR(26) NOT NULL,
-	authorization_model_id CHAR(26) NOT NULL,
-	type VARCHAR(256) NOT NULL,
-	type_definition BLOB,
-	PRIMARY KEY (store, authorization_model_id, type)
+    authorization_model_id CHAR(26) NOT NULL,
+    type VARCHAR(256) NOT NULL,
+    type_definition BLOB,
+    PRIMARY KEY (store, authorization_model_id, type)
 );
 
 CREATE TABLE store (
-	id CHAR(26) PRIMARY KEY,
+    id CHAR(26) PRIMARY KEY,
     name VARCHAR(64) NOT NULL,
-	created_at TIMESTAMP NOT NULL,
-	updated_at TIMESTAMP,
-	deleted_at TIMESTAMP
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
 );
 
 CREATE TABLE assertion (
     store CHAR(26) NOT NULL,
-	authorization_model_id CHAR(26) NOT NULL,
-	assertions BLOB,
-	PRIMARY KEY (store, authorization_model_id)
+    authorization_model_id CHAR(26) NOT NULL,
+    assertions BLOB,
+    PRIMARY KEY (store, authorization_model_id)
 );
 
 CREATE TABLE changelog (
@@ -42,10 +42,10 @@ CREATE TABLE changelog (
     object_id VARCHAR(256) NOT NULL,
     relation VARCHAR(50) NOT NULL,
     _user VARCHAR(512) NOT NULL,
-	operation INTEGER NOT NULL,
-	ulid CHAR(26) NOT NULL,
-	inserted_at TIMESTAMP NOT NULL,
-	PRIMARY KEY (store, ulid, object_type)
+    operation INTEGER NOT NULL,
+    ulid CHAR(26) NOT NULL,
+    inserted_at TIMESTAMP NOT NULL,
+    PRIMARY KEY (store, ulid, object_type)
 );
 
 -- +goose Down

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	mySQLImage = "mysql:latest"
+	mySQLImage = "mysql:8"
 )
 
 type mySQLTestContainer struct {


### PR DESCRIPTION
- chore: pin MySQL container image to v8
- normalize tabs/spaces in migration script