### PR TITLE
fix: list objects to respect configurable ListObjectsDeadline

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -197,9 +197,8 @@ func (q *ListObjectsQuery) Execute(
 
 		case <-timeoutCtx.Done():
 			q.Logger.WarnWithContext(
-				ctx, fmt.Sprintf("list objects timeout with relation '%s'", req.Relation),
-				zap.String("store_id", req.GetStoreId()),
-				zap.String("object_type", req.Type),
+				ctx, "list objects timeout with list object configuration timeout",
+				zap.String("timeout duration", q.ListObjectsDeadline.String()),
 			)
 			return &openfgapb.ListObjectsResponse{
 				Objects: objects,
@@ -250,9 +249,8 @@ func (q *ListObjectsQuery) ExecuteStreamed(
 
 		case <-timeoutCtx.Done():
 			q.Logger.WarnWithContext(
-				ctx, fmt.Sprintf("streamed list objects timeout with relation '%s'", req.Relation),
-				zap.String("store_id", req.GetStoreId()),
-				zap.String("object_type", req.Type),
+				ctx, "list objects timeout with list object configuration timeout",
+				zap.String("timeout duration", q.ListObjectsDeadline.String()),
 			)
 			return nil
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -194,6 +194,17 @@ func (q *ListObjectsQuery) Execute(
 
 	for {
 		select {
+
+		case <-timeoutCtx.Done():
+			q.Logger.WarnWithContext(
+				ctx, fmt.Sprintf("list objects timeout with relation '%s'", req.Relation),
+				zap.String("store_id", req.GetStoreId()),
+				zap.String("object_type", req.Type),
+			)
+			return &openfgapb.ListObjectsResponse{
+				Objects: objects,
+			}, nil
+
 		case objectID, ok := <-resultsChan:
 			if !ok {
 				return &openfgapb.ListObjectsResponse{
@@ -236,6 +247,15 @@ func (q *ListObjectsQuery) ExecuteStreamed(
 
 	for {
 		select {
+
+		case <-timeoutCtx.Done():
+			q.Logger.WarnWithContext(
+				ctx, fmt.Sprintf("streamed list objects timeout with relation '%s'", req.Relation),
+				zap.String("store_id", req.GetStoreId()),
+				zap.String("object_type", req.Type),
+			)
+			return nil
+
 		case object, ok := <-resultsChan:
 			if !ok {
 				// Channel closed! No more results.

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -29,6 +29,119 @@ func (x *mockStreamServer) Send(m *openfgapb.StreamedListObjectsResponse) error 
 	return nil
 }
 
+// mockSlowDataStorage is a proxy to the actual ds except the Reads are slow time by the sleepTime
+// This allows simulating list objection condition that times out
+type mockSlowDataStorage struct {
+	sleepTime time.Duration
+	ds        storage.OpenFGADatastore
+}
+
+func NewMockSlowDataStorage(ds storage.OpenFGADatastore, sleepTime time.Duration) storage.OpenFGADatastore {
+	return &mockSlowDataStorage{
+		sleepTime: sleepTime,
+		ds:        ds,
+	}
+}
+
+func (m *mockSlowDataStorage) Close() {}
+
+func (m *mockSlowDataStorage) ListObjectsByType(ctx context.Context, store string, objectType string) (storage.ObjectIterator, error) {
+	return m.ds.ListObjectsByType(ctx, store, objectType)
+}
+
+func (m *mockSlowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.Read(ctx, store, key)
+}
+
+func (m *mockSlowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadPage(ctx, store, key, paginationOptions)
+}
+
+func (m *mockSlowDataStorage) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgapb.TupleChange, []byte, error) {
+	return m.ds.ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset)
+}
+
+func (m *mockSlowDataStorage) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
+	return m.ds.Write(ctx, store, deletes, writes)
+}
+
+func (m *mockSlowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadUserTuple(ctx, store, key)
+}
+
+func (m *mockSlowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadUsersetTuples(ctx, store, filter)
+}
+
+func (m *mockSlowDataStorage) ReadStartingWithUser(
+	ctx context.Context,
+	store string,
+	filter storage.ReadStartingWithUserFilter,
+) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadStartingWithUser(ctx, store, filter)
+}
+
+func (m *mockSlowDataStorage) ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgapb.AuthorizationModel, error) {
+	return m.ds.ReadAuthorizationModel(ctx, store, id)
+}
+
+func (m *mockSlowDataStorage) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgapb.AuthorizationModel, []byte, error) {
+	return m.ds.ReadAuthorizationModels(ctx, store, options)
+}
+
+func (m *mockSlowDataStorage) FindLatestAuthorizationModelID(ctx context.Context, store string) (string, error) {
+	return m.ds.FindLatestAuthorizationModelID(ctx, store)
+}
+
+func (m *mockSlowDataStorage) ReadTypeDefinition(ctx context.Context, store, id, objectType string) (*openfgapb.TypeDefinition, error) {
+	return m.ds.ReadTypeDefinition(ctx, store, id, objectType)
+}
+
+func (m *mockSlowDataStorage) WriteAuthorizationModel(ctx context.Context, store string, model *openfgapb.AuthorizationModel) error {
+	return m.ds.WriteAuthorizationModel(ctx, store, model)
+}
+
+func (m *mockSlowDataStorage) CreateStore(ctx context.Context, newStore *openfgapb.Store) (*openfgapb.Store, error) {
+	return m.ds.CreateStore(ctx, newStore)
+}
+
+func (m *mockSlowDataStorage) DeleteStore(ctx context.Context, id string) error {
+	return m.ds.DeleteStore(ctx, id)
+}
+
+func (m *mockSlowDataStorage) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgapb.Assertion) error {
+	return m.ds.WriteAssertions(ctx, store, modelID, assertions)
+}
+
+func (m *mockSlowDataStorage) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgapb.Assertion, error) {
+	return m.ds.ReadAssertions(ctx, store, modelID)
+}
+
+func (m *mockSlowDataStorage) MaxTuplesPerWrite() int {
+	return m.ds.MaxTuplesPerWrite()
+}
+
+func (m *mockSlowDataStorage) MaxTypesPerAuthorizationModel() int {
+	return m.ds.MaxTypesPerAuthorizationModel()
+}
+
+func (m *mockSlowDataStorage) GetStore(ctx context.Context, storeID string) (*openfgapb.Store, error) {
+	return m.ds.GetStore(ctx, storeID)
+}
+
+func (m *mockSlowDataStorage) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgapb.Store, []byte, error) {
+	return m.ds.ListStores(ctx, paginationOptions)
+}
+
+func (m *mockSlowDataStorage) IsReady(ctx context.Context) (bool, error) {
+	return m.ds.IsReady(ctx)
+}
+
 type listObjectsTestCase struct {
 	name                   string
 	schema                 string
@@ -41,6 +154,8 @@ type listObjectsTestCase struct {
 	allResults             []string //all the results. the server may return less
 	maxResults             uint32
 	minimumResultsExpected uint32
+	listObjectsDeadline    time.Duration // 1 minute if not set
+	dsSlowTime             time.Duration // if set, purposely use a slow storage to slow down read and simulate timeout
 }
 
 func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore) {
@@ -158,6 +273,33 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 			minimumResultsExpected: 1,
 			allResults:             []string{"team:1"},
 		},
+		{
+			// should not return any useful data as it times out
+			// however, there should not be any error
+			name:   "connected objects timeout",
+			schema: typesystem.SchemaVersion1_1,
+			model: `
+			type user
+			type repo
+			  relations
+				define admin: [user] as self
+			`,
+			tuples: []*openfgapb.TupleKey{
+				tuple.NewTupleKey("repo:1", "admin", "user:alice"),
+				tuple.NewTupleKey("repo:2", "admin", "user:alice"),
+			},
+			user:       "user:alice",
+			objectType: "repo",
+			relation:   "admin",
+			contextualTuples: &openfgapb.ContextualTupleKeys{
+				TupleKeys: []*openfgapb.TupleKey{tuple.NewTupleKey("repo:3", "admin", "user:alice")},
+			},
+			maxResults:             2,
+			minimumResultsExpected: 0,
+			allResults:             []string{},
+			listObjectsDeadline:    1 * time.Second,
+			dsSlowTime:             2 * time.Second, // We are mocking the ds to slow down the read call and simulate timeout
+		},
 	}
 
 	for _, test := range testCases {
@@ -181,10 +323,21 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 			require.NoError(t, err)
 
 			// act: run ListObjects
+
+			listObjectsDeadline := time.Minute
+			if test.listObjectsDeadline > 0 {
+				listObjectsDeadline = test.listObjectsDeadline
+			}
+
+			datastore := ds
+			if test.dsSlowTime > 0 {
+				datastore = NewMockSlowDataStorage(ds, test.dsSlowTime)
+			}
+
 			listObjectsQuery := &commands.ListObjectsQuery{
-				Datastore:             ds,
+				Datastore:             datastore,
 				Logger:                logger.NewNoopLogger(),
-				ListObjectsDeadline:   time.Minute,
+				ListObjectsDeadline:   listObjectsDeadline,
 				ListObjectsMaxResults: test.maxResults,
 				ResolveNodeLimit:      defaultResolveNodeLimit,
 			}

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/mocks"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
@@ -27,119 +28,6 @@ type mockStreamServer struct {
 func (x *mockStreamServer) Send(m *openfgapb.StreamedListObjectsResponse) error {
 	x.channel <- m.Object
 	return nil
-}
-
-// mockSlowDataStorage is a proxy to the actual ds except the Reads are slow time by the sleepTime
-// This allows simulating list objection condition that times out
-type mockSlowDataStorage struct {
-	sleepTime time.Duration
-	ds        storage.OpenFGADatastore
-}
-
-func NewMockSlowDataStorage(ds storage.OpenFGADatastore, sleepTime time.Duration) storage.OpenFGADatastore {
-	return &mockSlowDataStorage{
-		sleepTime: sleepTime,
-		ds:        ds,
-	}
-}
-
-func (m *mockSlowDataStorage) Close() {}
-
-func (m *mockSlowDataStorage) ListObjectsByType(ctx context.Context, store string, objectType string) (storage.ObjectIterator, error) {
-	return m.ds.ListObjectsByType(ctx, store, objectType)
-}
-
-func (m *mockSlowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
-	return m.ds.Read(ctx, store, key)
-}
-
-func (m *mockSlowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
-	time.Sleep(m.sleepTime)
-	return m.ds.ReadPage(ctx, store, key, paginationOptions)
-}
-
-func (m *mockSlowDataStorage) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgapb.TupleChange, []byte, error) {
-	return m.ds.ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset)
-}
-
-func (m *mockSlowDataStorage) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
-	return m.ds.Write(ctx, store, deletes, writes)
-}
-
-func (m *mockSlowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
-	time.Sleep(m.sleepTime)
-	return m.ds.ReadUserTuple(ctx, store, key)
-}
-
-func (m *mockSlowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
-	return m.ds.ReadUsersetTuples(ctx, store, filter)
-}
-
-func (m *mockSlowDataStorage) ReadStartingWithUser(
-	ctx context.Context,
-	store string,
-	filter storage.ReadStartingWithUserFilter,
-) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
-	return m.ds.ReadStartingWithUser(ctx, store, filter)
-}
-
-func (m *mockSlowDataStorage) ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgapb.AuthorizationModel, error) {
-	return m.ds.ReadAuthorizationModel(ctx, store, id)
-}
-
-func (m *mockSlowDataStorage) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgapb.AuthorizationModel, []byte, error) {
-	return m.ds.ReadAuthorizationModels(ctx, store, options)
-}
-
-func (m *mockSlowDataStorage) FindLatestAuthorizationModelID(ctx context.Context, store string) (string, error) {
-	return m.ds.FindLatestAuthorizationModelID(ctx, store)
-}
-
-func (m *mockSlowDataStorage) ReadTypeDefinition(ctx context.Context, store, id, objectType string) (*openfgapb.TypeDefinition, error) {
-	return m.ds.ReadTypeDefinition(ctx, store, id, objectType)
-}
-
-func (m *mockSlowDataStorage) WriteAuthorizationModel(ctx context.Context, store string, model *openfgapb.AuthorizationModel) error {
-	return m.ds.WriteAuthorizationModel(ctx, store, model)
-}
-
-func (m *mockSlowDataStorage) CreateStore(ctx context.Context, newStore *openfgapb.Store) (*openfgapb.Store, error) {
-	return m.ds.CreateStore(ctx, newStore)
-}
-
-func (m *mockSlowDataStorage) DeleteStore(ctx context.Context, id string) error {
-	return m.ds.DeleteStore(ctx, id)
-}
-
-func (m *mockSlowDataStorage) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgapb.Assertion) error {
-	return m.ds.WriteAssertions(ctx, store, modelID, assertions)
-}
-
-func (m *mockSlowDataStorage) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgapb.Assertion, error) {
-	return m.ds.ReadAssertions(ctx, store, modelID)
-}
-
-func (m *mockSlowDataStorage) MaxTuplesPerWrite() int {
-	return m.ds.MaxTuplesPerWrite()
-}
-
-func (m *mockSlowDataStorage) MaxTypesPerAuthorizationModel() int {
-	return m.ds.MaxTypesPerAuthorizationModel()
-}
-
-func (m *mockSlowDataStorage) GetStore(ctx context.Context, storeID string) (*openfgapb.Store, error) {
-	return m.ds.GetStore(ctx, storeID)
-}
-
-func (m *mockSlowDataStorage) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgapb.Store, []byte, error) {
-	return m.ds.ListStores(ctx, paginationOptions)
-}
-
-func (m *mockSlowDataStorage) IsReady(ctx context.Context) (bool, error) {
-	return m.ds.IsReady(ctx)
 }
 
 type listObjectsTestCase struct {
@@ -276,7 +164,7 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 		{
 			// should not return any useful data as it times out
 			// however, there should not be any error
-			name:   "connected objects timeout",
+			name:   "list_objects_timeout",
 			schema: typesystem.SchemaVersion1_1,
 			model: `
 			type user
@@ -331,7 +219,7 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 
 			datastore := ds
 			if test.dsSlowTime > 0 {
-				datastore = NewMockSlowDataStorage(ds, test.dsSlowTime)
+				datastore = mocks.NewMockSlowDataStorage(ds, test.dsSlowTime)
 			}
 
 			listObjectsQuery := &commands.ListObjectsQuery{

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -162,8 +162,6 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 			allResults:             []string{"team:1"},
 		},
 		{
-			// should not return any useful data as it times out
-			// however, there should not be any error
 			name:   "respects_max_results_when_deadline_timeout_and_returns_no_error_and_no_results",
 			schema: typesystem.SchemaVersion1_1,
 			model: `

--- a/pkg/storage/mocks/slow_storage.go
+++ b/pkg/storage/mocks/slow_storage.go
@@ -1,0 +1,124 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/openfga/openfga/pkg/storage"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+)
+
+// SlowDataStorage is a proxy to the actual ds except the Reads are slow time by the sleepTime
+// This allows simulating list objection condition that times out
+type SlowDataStorage struct {
+	sleepTime time.Duration
+	ds        storage.OpenFGADatastore
+}
+
+// NewMockSlowDataStorage returns SlowDataStorage which is a proxy to the actual ds except the Reads are slow time by the sleepTime
+// This allows simulating list objection condition that times out
+func NewMockSlowDataStorage(ds storage.OpenFGADatastore, sleepTime time.Duration) storage.OpenFGADatastore {
+	return &SlowDataStorage{
+		sleepTime: sleepTime,
+		ds:        ds,
+	}
+}
+
+func (m *SlowDataStorage) Close() {}
+
+func (m *SlowDataStorage) ListObjectsByType(ctx context.Context, store string, objectType string) (storage.ObjectIterator, error) {
+	return m.ds.ListObjectsByType(ctx, store, objectType)
+}
+
+func (m *SlowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.Read(ctx, store, key)
+}
+
+func (m *SlowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadPage(ctx, store, key, paginationOptions)
+}
+
+func (m *SlowDataStorage) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgapb.TupleChange, []byte, error) {
+	return m.ds.ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset)
+}
+
+func (m *SlowDataStorage) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
+	return m.ds.Write(ctx, store, deletes, writes)
+}
+
+func (m *SlowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadUserTuple(ctx, store, key)
+}
+
+func (m *SlowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadUsersetTuples(ctx, store, filter)
+}
+
+func (m *SlowDataStorage) ReadStartingWithUser(
+	ctx context.Context,
+	store string,
+	filter storage.ReadStartingWithUserFilter,
+) (storage.TupleIterator, error) {
+	time.Sleep(m.sleepTime)
+	return m.ds.ReadStartingWithUser(ctx, store, filter)
+}
+
+func (m *SlowDataStorage) ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgapb.AuthorizationModel, error) {
+	return m.ds.ReadAuthorizationModel(ctx, store, id)
+}
+
+func (m *SlowDataStorage) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgapb.AuthorizationModel, []byte, error) {
+	return m.ds.ReadAuthorizationModels(ctx, store, options)
+}
+
+func (m *SlowDataStorage) FindLatestAuthorizationModelID(ctx context.Context, store string) (string, error) {
+	return m.ds.FindLatestAuthorizationModelID(ctx, store)
+}
+
+func (m *SlowDataStorage) ReadTypeDefinition(ctx context.Context, store, id, objectType string) (*openfgapb.TypeDefinition, error) {
+	return m.ds.ReadTypeDefinition(ctx, store, id, objectType)
+}
+
+func (m *SlowDataStorage) WriteAuthorizationModel(ctx context.Context, store string, model *openfgapb.AuthorizationModel) error {
+	return m.ds.WriteAuthorizationModel(ctx, store, model)
+}
+
+func (m *SlowDataStorage) CreateStore(ctx context.Context, newStore *openfgapb.Store) (*openfgapb.Store, error) {
+	return m.ds.CreateStore(ctx, newStore)
+}
+
+func (m *SlowDataStorage) DeleteStore(ctx context.Context, id string) error {
+	return m.ds.DeleteStore(ctx, id)
+}
+
+func (m *SlowDataStorage) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgapb.Assertion) error {
+	return m.ds.WriteAssertions(ctx, store, modelID, assertions)
+}
+
+func (m *SlowDataStorage) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgapb.Assertion, error) {
+	return m.ds.ReadAssertions(ctx, store, modelID)
+}
+
+func (m *SlowDataStorage) MaxTuplesPerWrite() int {
+	return m.ds.MaxTuplesPerWrite()
+}
+
+func (m *SlowDataStorage) MaxTypesPerAuthorizationModel() int {
+	return m.ds.MaxTypesPerAuthorizationModel()
+}
+
+func (m *SlowDataStorage) GetStore(ctx context.Context, storeID string) (*openfgapb.Store, error) {
+	return m.ds.GetStore(ctx, storeID)
+}
+
+func (m *SlowDataStorage) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgapb.Store, []byte, error) {
+	return m.ds.ListStores(ctx, paginationOptions)
+}
+
+func (m *SlowDataStorage) IsReady(ctx context.Context) (bool, error) {
+	return m.ds.IsReady(ctx)
+}

--- a/pkg/storage/mocks/slow_storage.go
+++ b/pkg/storage/mocks/slow_storage.go
@@ -8,56 +8,57 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-// SlowDataStorage is a proxy to the actual ds except the Reads are slow time by the readTuplesDelay
+// slowDataStorage is a proxy to the actual ds except the Reads are slow time by the readTuplesDelay
 // This allows simulating list objection condition that times out
-type SlowDataStorage struct {
+type slowDataStorage struct {
 	readTuplesDelay time.Duration
 	ds              storage.OpenFGADatastore
 }
 
 // NewMockSlowDataStorage returns a wrapper of a datastore that adds artificial delays into the reads of tuples
 func NewMockSlowDataStorage(ds storage.OpenFGADatastore, readTuplesDelay time.Duration) storage.OpenFGADatastore {
-	return &SlowDataStorage{
+	return &slowDataStorage{
 		readTuplesDelay: readTuplesDelay,
 		ds:              ds,
 	}
 }
 
-func (m *SlowDataStorage) Close() {}
+func (m *slowDataStorage) Close() {}
 
-func (m *SlowDataStorage) ListObjectsByType(ctx context.Context, store string, objectType string) (storage.ObjectIterator, error) {
+func (m *slowDataStorage) ListObjectsByType(ctx context.Context, store string, objectType string) (storage.ObjectIterator, error) {
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.ListObjectsByType(ctx, store, objectType)
 }
 
-func (m *SlowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
+func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
 	return m.ds.Read(ctx, store, key)
 }
 
-func (m *SlowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
+func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
 	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadPage(ctx, store, key, paginationOptions)
 }
 
-func (m *SlowDataStorage) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgapb.TupleChange, []byte, error) {
+func (m *slowDataStorage) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgapb.TupleChange, []byte, error) {
 	return m.ds.ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset)
 }
 
-func (m *SlowDataStorage) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
+func (m *slowDataStorage) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
 	return m.ds.Write(ctx, store, deletes, writes)
 }
 
-func (m *SlowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
+func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
 	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadUserTuple(ctx, store, key)
 }
 
-func (m *SlowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadUsersetTuples(ctx, store, filter)
 }
 
-func (m *SlowDataStorage) ReadStartingWithUser(
+func (m *slowDataStorage) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
@@ -66,58 +67,54 @@ func (m *SlowDataStorage) ReadStartingWithUser(
 	return m.ds.ReadStartingWithUser(ctx, store, filter)
 }
 
-func (m *SlowDataStorage) ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgapb.AuthorizationModel, error) {
+func (m *slowDataStorage) ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgapb.AuthorizationModel, error) {
 	return m.ds.ReadAuthorizationModel(ctx, store, id)
 }
 
-func (m *SlowDataStorage) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgapb.AuthorizationModel, []byte, error) {
+func (m *slowDataStorage) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgapb.AuthorizationModel, []byte, error) {
 	return m.ds.ReadAuthorizationModels(ctx, store, options)
 }
 
-func (m *SlowDataStorage) FindLatestAuthorizationModelID(ctx context.Context, store string) (string, error) {
+func (m *slowDataStorage) FindLatestAuthorizationModelID(ctx context.Context, store string) (string, error) {
 	return m.ds.FindLatestAuthorizationModelID(ctx, store)
 }
 
-func (m *SlowDataStorage) ReadTypeDefinition(ctx context.Context, store, id, objectType string) (*openfgapb.TypeDefinition, error) {
-	return m.ds.ReadTypeDefinition(ctx, store, id, objectType)
-}
-
-func (m *SlowDataStorage) WriteAuthorizationModel(ctx context.Context, store string, model *openfgapb.AuthorizationModel) error {
+func (m *slowDataStorage) WriteAuthorizationModel(ctx context.Context, store string, model *openfgapb.AuthorizationModel) error {
 	return m.ds.WriteAuthorizationModel(ctx, store, model)
 }
 
-func (m *SlowDataStorage) CreateStore(ctx context.Context, newStore *openfgapb.Store) (*openfgapb.Store, error) {
+func (m *slowDataStorage) CreateStore(ctx context.Context, newStore *openfgapb.Store) (*openfgapb.Store, error) {
 	return m.ds.CreateStore(ctx, newStore)
 }
 
-func (m *SlowDataStorage) DeleteStore(ctx context.Context, id string) error {
+func (m *slowDataStorage) DeleteStore(ctx context.Context, id string) error {
 	return m.ds.DeleteStore(ctx, id)
 }
 
-func (m *SlowDataStorage) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgapb.Assertion) error {
+func (m *slowDataStorage) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgapb.Assertion) error {
 	return m.ds.WriteAssertions(ctx, store, modelID, assertions)
 }
 
-func (m *SlowDataStorage) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgapb.Assertion, error) {
+func (m *slowDataStorage) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgapb.Assertion, error) {
 	return m.ds.ReadAssertions(ctx, store, modelID)
 }
 
-func (m *SlowDataStorage) MaxTuplesPerWrite() int {
+func (m *slowDataStorage) MaxTuplesPerWrite() int {
 	return m.ds.MaxTuplesPerWrite()
 }
 
-func (m *SlowDataStorage) MaxTypesPerAuthorizationModel() int {
+func (m *slowDataStorage) MaxTypesPerAuthorizationModel() int {
 	return m.ds.MaxTypesPerAuthorizationModel()
 }
 
-func (m *SlowDataStorage) GetStore(ctx context.Context, storeID string) (*openfgapb.Store, error) {
+func (m *slowDataStorage) GetStore(ctx context.Context, storeID string) (*openfgapb.Store, error) {
 	return m.ds.GetStore(ctx, storeID)
 }
 
-func (m *SlowDataStorage) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgapb.Store, []byte, error) {
+func (m *slowDataStorage) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgapb.Store, []byte, error) {
 	return m.ds.ListStores(ctx, paginationOptions)
 }
 
-func (m *SlowDataStorage) IsReady(ctx context.Context) (bool, error) {
+func (m *slowDataStorage) IsReady(ctx context.Context) (bool, error) {
 	return m.ds.IsReady(ctx)
 }

--- a/pkg/storage/mocks/slow_storage.go
+++ b/pkg/storage/mocks/slow_storage.go
@@ -8,19 +8,18 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-// SlowDataStorage is a proxy to the actual ds except the Reads are slow time by the sleepTime
+// SlowDataStorage is a proxy to the actual ds except the Reads are slow time by the readTuplesDelay
 // This allows simulating list objection condition that times out
 type SlowDataStorage struct {
-	sleepTime time.Duration
-	ds        storage.OpenFGADatastore
+	readTuplesDelay time.Duration
+	ds              storage.OpenFGADatastore
 }
 
-// NewMockSlowDataStorage returns SlowDataStorage which is a proxy to the actual ds except the Reads are slow time by the sleepTime
-// This allows simulating list objection condition that times out
-func NewMockSlowDataStorage(ds storage.OpenFGADatastore, sleepTime time.Duration) storage.OpenFGADatastore {
+// NewMockSlowDataStorage returns a wrapper of a datastore that adds artificial delays into the reads of tuples
+func NewMockSlowDataStorage(ds storage.OpenFGADatastore, readTuplesDelay time.Duration) storage.OpenFGADatastore {
 	return &SlowDataStorage{
-		sleepTime: sleepTime,
-		ds:        ds,
+		readTuplesDelay: readTuplesDelay,
+		ds:              ds,
 	}
 }
 
@@ -31,12 +30,12 @@ func (m *SlowDataStorage) ListObjectsByType(ctx context.Context, store string, o
 }
 
 func (m *SlowDataStorage) Read(ctx context.Context, store string, key *openfgapb.TupleKey) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.Read(ctx, store, key)
 }
 
 func (m *SlowDataStorage) ReadPage(ctx context.Context, store string, key *openfgapb.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgapb.Tuple, []byte, error) {
-	time.Sleep(m.sleepTime)
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadPage(ctx, store, key, paginationOptions)
 }
 
@@ -49,12 +48,12 @@ func (m *SlowDataStorage) Write(ctx context.Context, store string, deletes stora
 }
 
 func (m *SlowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
-	time.Sleep(m.sleepTime)
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadUserTuple(ctx, store, key)
 }
 
 func (m *SlowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadUsersetTuples(ctx, store, filter)
 }
 
@@ -63,7 +62,7 @@ func (m *SlowDataStorage) ReadStartingWithUser(
 	store string,
 	filter storage.ReadStartingWithUserFilter,
 ) (storage.TupleIterator, error) {
-	time.Sleep(m.sleepTime)
+	time.Sleep(m.readTuplesDelay)
 	return m.ds.ReadStartingWithUser(ctx, store, filter)
 }
 


### PR DESCRIPTION
## Description
List objects should return results when ListObjectsDeadline is hit rather than waiting for results to be completed. Otherwise, 500 internal error will be returned if the request takes a long time (i.e., maybe due to many items to be looked up).

## References
- Close https://github.com/openfga/openfga/issues/703

## Tests
- Added unit test
- Manual test by adding a 10 seconds timeout in the [reverseExpandObject](https://github.com/openfga/openfga/blob/f33657319d7885600a19c112509868a6ee1c5b3e/pkg/server/commands/connected_objects.go#L452).  Observe than 500 Internal Error is returned before the change.  200 OK with empty list is returned after the change.

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
