### PR TITLE
fix: down script of postgres/003_add_reverse_lookup_index.sql

### DIFF
--- a/assets/migrations/postgres/003_add_reverse_lookup_index.sql
+++ b/assets/migrations/postgres/003_add_reverse_lookup_index.sql
@@ -2,4 +2,4 @@
 CREATE INDEX idx_reverse_lookup_user on tuple (store, object_type, relation, _user);
 
 -- +goose Down
-DROP INDEX  idx_reverse_lookup_user;
+DROP INDEX IF EXISTS idx_reverse_lookup_user ;


### PR DESCRIPTION
If in a future PR we decide to drop the Postgres index `idx_reverse_lookup_user` and then you try to rollback to version 2, migration script #3 will fail because it is not idempotent.

TODO: find if there is an equivalent for MySQL.