### PR TITLE
chore: every PR runs the PR workflow no matter what branch they target

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,8 +1,6 @@
 name: Pull Request
 on:
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
I need this so that I can run the tests on https://github.com/openfga/openfga/pull/706 and https://github.com/openfga/openfga/pull/707, which target a branch that is not `main`