### PR TITLE
Adding validation for nonexistent storeID write

### DIFF
--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -39,7 +39,7 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgapb.ReadRequest) (*o
 	store := req.GetStoreId()
 	tk := req.GetTupleKey()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := q.datastore.GetStore(ctx, store); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -53,6 +53,10 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgapb.
 	defer span.End()
 
 	store := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if store == "" {
+		return serverErrors.NonExistentStoreID
+	}
 	modelID := req.GetAuthorizationModelId()
 	deletes := req.GetDeletes().GetTupleKeys()
 	writes := req.GetWrites().GetTupleKeys()

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -53,7 +53,7 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgapb.
 	defer span.End()
 	store := req.GetStoreId()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := c.datastore.GetStore(ctx, store); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/commands/write_assertions.go
+++ b/pkg/server/commands/write_assertions.go
@@ -36,7 +36,7 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgapb.Wri
 	assertions := req.GetAssertions()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is , can't write to invalid/empty store
 	if _, err := w.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/commands/write_assertions.go
+++ b/pkg/server/commands/write_assertions.go
@@ -35,6 +35,17 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgapb.Wri
 	modelID := req.GetAuthorizationModelId()
 	assertions := req.GetAssertions()
 
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := w.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	model, err := w.datastore.ReadAuthorizationModel(ctx, store, modelID)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -106,14 +106,14 @@ func TestValidateWriteRequest(t *testing.T) {
 	tests := []test{
 		{
 			name:          "nil_for_deletes_and_writes",
-			storeId:       "abcd123",
+			storeID:       "abcd123",
 			deletes:       nil,
 			writes:        nil,
 			expectedError: serverErrors.InvalidWriteInput,
 		},
 		{
 			name:    "write_failure_with_invalid_user",
-			storeId: "abcd123",
+			storeID: "abcd123",
 			deletes: []*openfgapb.TupleKey{},
 			writes:  []*openfgapb.TupleKey{badItem},
 			expectedError: serverErrors.ValidationError(
@@ -125,7 +125,7 @@ func TestValidateWriteRequest(t *testing.T) {
 		},
 		{
 			name:    "delete_failure_with_invalid_user",
-			storeId: "abcd123",
+			storeID: "abcd123",
 			deletes: []*openfgapb.TupleKey{badItem},
 			writes:  []*openfgapb.TupleKey{},
 			expectedError: serverErrors.ValidationError(
@@ -137,7 +137,7 @@ func TestValidateWriteRequest(t *testing.T) {
 		},
 		{
 			name:          "write_failure_with_nonexistent_store",
-			storeId:       "",
+			storeID:       "",
 			deletes:       []*openfgapb.TupleKey{},
 			writes:        []*openfgapb.TupleKey{},
 			expectedError: serverErrors.NonExistentStoreID,
@@ -161,7 +161,7 @@ func TestValidateWriteRequest(t *testing.T) {
 
 			ctx := context.Background()
 			req := &openfgapb.WriteRequest{
-				StoreId: test.storeId,
+				StoreId: test.storeID,
 				Writes:  &openfgapb.TupleKeys{TupleKeys: test.writes},
 				Deletes: &openfgapb.TupleKeys{TupleKeys: test.deletes},
 			}

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -91,7 +91,7 @@ func TestValidateNoDuplicatesAndCorrectSize(t *testing.T) {
 func TestValidateWriteRequest(t *testing.T) {
 	type test struct {
 		name          string
-		storeId       string
+		storeID       string
 		deletes       []*openfgapb.TupleKey
 		writes        []*openfgapb.TupleKey
 		expectedError error

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -140,7 +140,7 @@ func TestValidateWriteRequest(t *testing.T) {
 			storeID:       "",
 			deletes:       []*openfgapb.TupleKey{},
 			writes:        []*openfgapb.TupleKey{},
-			expectedError: serverErrors.NonExistentStoreID,
+			expectedError: serverErrors.StoreIDNotFound,
 		},
 	}
 

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -91,6 +91,7 @@ func TestValidateNoDuplicatesAndCorrectSize(t *testing.T) {
 func TestValidateWriteRequest(t *testing.T) {
 	type test struct {
 		name          string
+		storeId       string
 		deletes       []*openfgapb.TupleKey
 		writes        []*openfgapb.TupleKey
 		expectedError error
@@ -105,12 +106,14 @@ func TestValidateWriteRequest(t *testing.T) {
 	tests := []test{
 		{
 			name:          "nil_for_deletes_and_writes",
+			storeId:       "abcd123",
 			deletes:       nil,
 			writes:        nil,
 			expectedError: serverErrors.InvalidWriteInput,
 		},
 		{
 			name:    "write_failure_with_invalid_user",
+			storeId: "abcd123",
 			deletes: []*openfgapb.TupleKey{},
 			writes:  []*openfgapb.TupleKey{badItem},
 			expectedError: serverErrors.ValidationError(
@@ -122,6 +125,7 @@ func TestValidateWriteRequest(t *testing.T) {
 		},
 		{
 			name:    "delete_failure_with_invalid_user",
+			storeId: "abcd123",
 			deletes: []*openfgapb.TupleKey{badItem},
 			writes:  []*openfgapb.TupleKey{},
 			expectedError: serverErrors.ValidationError(
@@ -130,6 +134,13 @@ func TestValidateWriteRequest(t *testing.T) {
 					TupleKey: badItem,
 				},
 			),
+		},
+		{
+			name:          "write_failure_with_nonexistent_store",
+			storeId:       "",
+			deletes:       []*openfgapb.TupleKey{},
+			writes:        []*openfgapb.TupleKey{},
+			expectedError: serverErrors.NonExistentStoreID,
 		},
 	}
 
@@ -150,7 +161,7 @@ func TestValidateWriteRequest(t *testing.T) {
 
 			ctx := context.Background()
 			req := &openfgapb.WriteRequest{
-				StoreId: "abcd123",
+				StoreId: test.storeId,
 				Writes:  &openfgapb.TupleKeys{TupleKeys: test.writes},
 				Deletes: &openfgapb.TupleKeys{TupleKeys: test.deletes},
 			}

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -22,7 +22,7 @@ var (
 	InvalidExpandInput                     = status.Error(codes.Code(openfgapb.ErrorCode_invalid_expand_input), "Invalid input. Make sure you provide an object and a relation")
 	UnsupportedUserSet                     = status.Error(codes.Code(openfgapb.ErrorCode_unsupported_user_set), "Userset is not supported (right now)")
 	StoreIDNotFound                        = status.Error(codes.Code(openfgapb.NotFoundErrorCode_store_id_not_found), "Store ID not found")
-	NonExistentStoreID					   = status.Error(codes.Code(openfgapb.ErrorCode_invalid_write_input), "Invalid input. Make sure you provide existent store ID")
+	NonExistentStoreID                     = status.Error(codes.Code(openfgapb.ErrorCode_invalid_write_input), "Invalid input. Make sure you provide existent store ID")
 	MismatchObjectType                     = status.Error(codes.Code(openfgapb.ErrorCode_query_string_type_continuation_token_mismatch), "The type in the querystring and the continuation token don't match")
 	RequestCancelled                       = status.Error(codes.Code(openfgapb.InternalErrorCode_cancelled), "Request Cancelled")
 )

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -22,6 +22,7 @@ var (
 	InvalidExpandInput                     = status.Error(codes.Code(openfgapb.ErrorCode_invalid_expand_input), "Invalid input. Make sure you provide an object and a relation")
 	UnsupportedUserSet                     = status.Error(codes.Code(openfgapb.ErrorCode_unsupported_user_set), "Userset is not supported (right now)")
 	StoreIDNotFound                        = status.Error(codes.Code(openfgapb.NotFoundErrorCode_store_id_not_found), "Store ID not found")
+	NonExistentStoreID					   = status.Error(codes.Code(openfgapb.ErrorCode_invalid_write_input), "Invalid input. Make sure you provide existent store ID")
 	MismatchObjectType                     = status.Error(codes.Code(openfgapb.ErrorCode_query_string_type_continuation_token_mismatch), "The type in the querystring and the continuation token don't match")
 	RequestCancelled                       = status.Error(codes.Code(openfgapb.InternalErrorCode_cancelled), "Request Cancelled")
 )

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -22,7 +22,6 @@ var (
 	InvalidExpandInput                     = status.Error(codes.Code(openfgapb.ErrorCode_invalid_expand_input), "Invalid input. Make sure you provide an object and a relation")
 	UnsupportedUserSet                     = status.Error(codes.Code(openfgapb.ErrorCode_unsupported_user_set), "Userset is not supported (right now)")
 	StoreIDNotFound                        = status.Error(codes.Code(openfgapb.NotFoundErrorCode_store_id_not_found), "Store ID not found")
-	NonExistentStoreID                     = status.Error(codes.Code(openfgapb.ErrorCode_invalid_write_input), "Invalid input. Make sure you provide existent store ID")
 	MismatchObjectType                     = status.Error(codes.Code(openfgapb.ErrorCode_query_string_type_continuation_token_mismatch), "The type in the querystring and the continuation token don't match")
 	RequestCancelled                       = status.Error(codes.Code(openfgapb.InternalErrorCode_cancelled), "Request Cancelled")
 )

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,6 +84,16 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgapb.ListObjectsRequ
 	storeID := req.GetStoreId()
 	targetObjectType := req.GetType()
 
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	ctx, span := tracer.Start(ctx, "ListObjects", trace.WithAttributes(
 		attribute.String("object_type", targetObjectType),
 		attribute.String("relation", req.GetRelation()),
@@ -142,6 +152,16 @@ func (s *Server) StreamedListObjects(req *openfgapb.StreamedListObjectsRequest, 
 	defer span.End()
 
 	storeID := req.GetStoreId()
+
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return serverErrors.StoreIDNotFound
+			}
+			return serverErrors.HandleError("", err)
+		}
+	}
 
 	modelID, err := s.resolveAuthorizationModelID(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
@@ -232,6 +252,16 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	storeID := req.GetStoreId()
 
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	modelID, err := s.resolveAuthorizationModelID(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
 		return nil, err
@@ -268,7 +298,7 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 		checkConcurrencyLimit)
 
 	resp, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{
-		StoreID:              req.GetStoreId(),
+		StoreID:              storeID,
 		AuthorizationModelID: req.GetAuthorizationModelId(),
 		TupleKey:             req.GetTupleKey(),
 		ContextualTuples:     req.ContextualTuples.GetTupleKeys(),
@@ -303,6 +333,16 @@ func (s *Server) Expand(ctx context.Context, req *openfgapb.ExpandRequest) (*ope
 
 	storeID := req.GetStoreId()
 
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	modelID, err := s.resolveAuthorizationModelID(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
 		return nil, err
@@ -322,6 +362,17 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgapb.Read
 	))
 	defer span.End()
 
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	q := commands.NewReadAuthorizationModelQuery(s.datastore, s.logger)
 	return q.Execute(ctx, req)
 }
@@ -329,6 +380,17 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgapb.Read
 func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgapb.WriteAuthorizationModelRequest) (*openfgapb.WriteAuthorizationModelResponse, error) {
 	ctx, span := tracer.Start(ctx, "WriteAuthorizationModel")
 	defer span.End()
+
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
 
 	c := commands.NewWriteAuthorizationModelCommand(s.datastore, s.logger, s.config.AllowWriting1_0Models)
 	res, err := c.Execute(ctx, req)
@@ -345,6 +407,17 @@ func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgapb.Rea
 	ctx, span := tracer.Start(ctx, "ReadAuthorizationModels")
 	defer span.End()
 
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	c := commands.NewReadAuthorizationModelsQuery(s.datastore, s.logger, s.encoder)
 	return c.Execute(ctx, req)
 }
@@ -354,6 +427,15 @@ func (s *Server) WriteAssertions(ctx context.Context, req *openfgapb.WriteAssert
 	defer span.End()
 
 	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
 
 	modelID, err := s.resolveAuthorizationModelID(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
@@ -379,6 +461,17 @@ func (s *Server) ReadAssertions(ctx context.Context, req *openfgapb.ReadAssertio
 	ctx, span := tracer.Start(ctx, "ReadAssertions")
 	defer span.End()
 
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
+
 	modelID, err := s.resolveAuthorizationModelID(ctx, req.GetStoreId(), req.GetAuthorizationModelId())
 	if err != nil {
 		return nil, err
@@ -392,6 +485,17 @@ func (s *Server) ReadChanges(ctx context.Context, req *openfgapb.ReadChangesRequ
 		attribute.KeyValue{Key: "type", Value: attribute.StringValue(req.GetType())},
 	))
 	defer span.End()
+
+	storeID := req.GetStoreId()
+	// Check if store is empty, can't write to empty store
+	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return nil, serverErrors.StoreIDNotFound
+			}
+			return nil, serverErrors.HandleError("", err)
+		}
+	}
 
 	q := commands.NewReadChangesQuery(s.datastore, s.logger, s.encoder, s.config.ChangelogHorizonOffset)
 	return q.Execute(ctx, req)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -84,7 +84,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgapb.ListObjectsRequ
 	storeID := req.GetStoreId()
 	targetObjectType := req.GetType()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -153,7 +153,7 @@ func (s *Server) StreamedListObjects(req *openfgapb.StreamedListObjectsRequest, 
 
 	storeID := req.GetStoreId()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -252,7 +252,7 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	storeID := req.GetStoreId()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -333,7 +333,7 @@ func (s *Server) Expand(ctx context.Context, req *openfgapb.ExpandRequest) (*ope
 
 	storeID := req.GetStoreId()
 
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -363,7 +363,7 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgapb.Read
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -382,7 +382,7 @@ func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgapb.Wri
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -408,7 +408,7 @@ func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgapb.Rea
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -427,7 +427,7 @@ func (s *Server) WriteAssertions(ctx context.Context, req *openfgapb.WriteAssert
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -462,7 +462,7 @@ func (s *Server) ReadAssertions(ctx context.Context, req *openfgapb.ReadAssertio
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {
@@ -487,7 +487,7 @@ func (s *Server) ReadChanges(ctx context.Context, req *openfgapb.ReadChangesRequ
 	defer span.End()
 
 	storeID := req.GetStoreId()
-	// Check if store is empty, can't write to empty store
+	// Check if store is invalid/empty, can't write to invalid/empty store
 	if _, err := s.datastore.GetStore(ctx, storeID); err != nil {
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/test/expand.go
+++ b/pkg/server/test/expand.go
@@ -2164,6 +2164,25 @@ func TestExpandQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 				},
 			),
 		},
+		{
+			name: "invalid storeId",
+			model: &openfgapb.AuthorizationModel{
+				Id:            ulid.Make().String(),
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{Type: "repo"},
+				},
+			},
+			request: &openfgapb.ExpandRequest{
+				TupleKey: &openfgapb.TupleKey{
+					Object:   "repo:bar",
+					Relation: "baz",
+				},
+				StoreId: "",
+			},
+			allowSchema10: true,
+			expected:      serverErrors.StoreIDNotFound,
+		},
 	}
 
 	require := require.New(t)

--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -540,6 +540,29 @@ func ReadQueryErrorTest(t *testing.T, datastore storage.OpenFGADatastore) {
 				ContinuationToken: "foo",
 			},
 		},
+		{
+			_name: "ExecuteErrorsIfContinuationTokenIsBad",
+			model: &openfgapb.AuthorizationModel{
+				Id:            ulid.Make().String(),
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "repo",
+						Relations: map[string]*openfgapb.Userset{
+							"admin":  {},
+							"writer": {},
+						},
+					},
+				},
+			},
+			request: &openfgapb.ReadRequest{
+				TupleKey: &openfgapb.TupleKey{
+					Object: "repo:openfga/openfga",
+				},
+				ContinuationToken: "foo",
+				StoreId:           "",
+			},
+		},
 	}
 
 	require := require.New(t)

--- a/pkg/server/test/read_assertions.go
+++ b/pkg/server/test/read_assertions.go
@@ -29,6 +29,14 @@ func TestReadAssertionQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 				Assertions:           []*openfgapb.Assertion{},
 			},
 		},
+		{
+			_name:   "ReturnsAssertionModelNotFound",
+			request: &openfgapb.ReadAssertionsRequest{StoreId: "", AuthorizationModelId: "test"},
+			expectedResponse: &openfgapb.ReadAssertionsResponse{
+				AuthorizationModelId: "test",
+				Assertions:           []*openfgapb.Assertion{},
+			},
+		},
 	}
 
 	ctx := context.Background()

--- a/pkg/server/test/read_authzmodel.go
+++ b/pkg/server/test/read_authzmodel.go
@@ -103,6 +103,14 @@ func TestReadAuthorizationModelQueryErrors(t *testing.T, datastore storage.OpenF
 
 	var tests = []readAuthorizationModelQueryTest{
 		{
+			_name: "ReturnsStoreIDNotFoundIfStoreNotFound",
+			request: &openfgapb.ReadAuthorizationModelRequest{
+				StoreId: "",
+				Id:      "123",
+			},
+			expectedError: serverErrors.StoreIDNotFound,
+		},
+		{
 			_name: "ReturnsAuthorizationModelNotFoundIfAuthorizationModelNotInDatabase",
 			request: &openfgapb.ReadAuthorizationModelRequest{
 				StoreId: ulid.Make().String(),

--- a/pkg/server/test/read_changes.go
+++ b/pkg/server/test/read_changes.go
@@ -201,6 +201,23 @@ func TestReadChanges(t *testing.T, datastore storage.OpenFGADatastore) {
 		readChangesQuery := commands.NewReadChangesQuery(backend, logger.NewNoopLogger(), encoder, 2)
 		runTests(t, ctx, testCases, readChangesQuery)
 	})
+
+	t.Run("read_changes_with_invalid_storeId", func(t *testing.T) {
+		testCases := []testCase{
+			{
+				_name: "when_the_store_id_is_invalid",
+				request: &openfgapb.ReadChangesRequest{
+					StoreId: "",
+				},
+				expectedChanges:              nil,
+				expectEmptyContinuationToken: true,
+				expectedError:                serverErrors.StoreIDNotFound,
+			},
+		}
+
+		readChangesQuery := commands.NewReadChangesQuery(backend, logger.NewNoopLogger(), encoder, 2)
+		runTests(t, ctx, testCases, readChangesQuery)
+	})
 }
 
 func runTests(t *testing.T, ctx context.Context, testCasesInOrder []testCase, readChangesQuery *commands.ReadChangesQuery) {

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -52,6 +52,8 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	)
 
 	t.Run("TestListObjectsRespectsMaxResults", func(t *testing.T) { TestListObjectsRespectsMaxResults(t, ds) })
+
+	t.Run("TestReadAuthorizationModelsInvalidStoreID", func(t *testing.T) { TestReadAuthorizationModelsInvalidStoreID(t, ds) })
 }
 
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
A write request for nonexistent storeID shouldn't return 201, but should return an error

## Description
<!-- Provide a detailed description of the changes -->

Changes 
1. Added a check on storeID being non empty when validating WriteRequest 
2. Added a custom error for nonexistent storeID error, but resued error code `ErrorCode_invalid_write_input`
3. Added test  


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Addresses issue - https://github.com/openfga/openfga/issues/690 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
