### PR TITLE
fix: database calls for ListObjects v0 use a new context object to avoid db connection churning

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -54,7 +54,7 @@ type RelationshipTupleReader interface {
 
 	// ReadPage is similar to Read, but with PaginationOptions. Instead of returning a TupleIterator, ReadPage
 	// returns a page of tuples and a possibly non-empty continuation token.
-	// There is NO guarantee on the order returned on the list.
+	// The tuples returned are ordered by ULID.
 	ReadPage(
 		ctx context.Context,
 		store string,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -54,6 +54,7 @@ type RelationshipTupleReader interface {
 
 	// ReadPage is similar to Read, but with PaginationOptions. Instead of returning a TupleIterator, ReadPage
 	// returns a page of tuples and a possibly non-empty continuation token.
+	// There is NO guarantee on the order returned on the list.
 	ReadPage(
 		ctx context.Context,
 		store string,
@@ -76,6 +77,7 @@ type RelationshipTupleReader interface {
 	//	object=document:1, relation=viewer, allowedTypesForUser=[group#member]
 	// this method would return the tuple (document:doc1, viewer, group:eng#member)
 	// If allowedTypesForUser is empty, both tuples would be returned.
+	// There is NO guarantee on the order returned on the iterator.
 	ReadUsersetTuples(
 		ctx context.Context,
 		store string,
@@ -92,6 +94,7 @@ type RelationshipTupleReader interface {
 	//
 	// ReverseReadTuples for ['user:jon', 'group:eng#member'] filtered by 'document#viewer' would
 	// return ['document:doc1#viewer@user:jon', 'document:doc2#viewer@group:eng#member'].
+	// There is NO guarantee on the order returned on the iterator.
 	ReadStartingWithUser(
 		ctx context.Context,
 		store string,
@@ -101,6 +104,7 @@ type RelationshipTupleReader interface {
 	// ListObjectsByType returns all the objects of a specific type.
 	// You can assume that the type has already been validated.
 	// The result can't have duplicate elements.
+	// There is NO guarantee on the order returned on the iterator.
 	ListObjectsByType(
 		ctx context.Context,
 		store string,

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -555,7 +555,6 @@ func TuplePaginationOptionsTest(t *testing.T, datastore storage.OpenFGADatastore
 }
 
 func ListObjectsByTypeTest(t *testing.T, ds storage.OpenFGADatastore) {
-	expected := []string{"document:doc1", "document:doc2"}
 	storeID := ulid.Make().String()
 
 	err := ds.Write(context.Background(), storeID, nil, []*openfgapb.TupleKey{
@@ -581,7 +580,7 @@ func ListObjectsByTypeTest(t *testing.T, ds storage.OpenFGADatastore) {
 		actual = append(actual, tuple.ObjectKey(obj))
 	}
 
-	require.Equal(t, expected, actual)
+	require.ElementsMatch(t, []string{"document:doc1", "document:doc2"}, actual)
 }
 
 func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) {


### PR DESCRIPTION
Fixes: 

- database calls for ListObjects v0 use a new context object to avoid database connection churning
- flaky test