### PR TITLE
fix: in write API, if auth model ID not found, throw 400 instead of 500 error

### DIFF
--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -65,6 +65,9 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgapb.
 
 		authModel, err := c.datastore.ReadAuthorizationModel(ctx, store, modelID)
 		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return serverErrors.AuthorizationModelNotFound(modelID)
+			}
 			return err
 		}
 

--- a/pkg/server/test/write.go
+++ b/pkg/server/test/write.go
@@ -638,25 +638,34 @@ var writeCommandTests = []writeCommandTest{
 		// state
 		model: &openfgapb.AuthorizationModel{
 			Id:            ulid.Make().String(),
-			SchemaVersion: typesystem.SchemaVersion1_0,
+			SchemaVersion: typesystem.SchemaVersion1_1,
 			TypeDefinitions: []*openfgapb.TypeDefinition{
+				{
+					Type: "user",
+				},
 				{
 					Type: "repo",
 					Relations: map[string]*openfgapb.Userset{
 						"admin":  {Userset: &openfgapb.Userset_This{}},
 						"writer": {Userset: &openfgapb.Userset_This{}},
 					},
-				},
-				{
-					Type: "org",
-					Relations: map[string]*openfgapb.Userset{
-						"owner": {Userset: &openfgapb.Userset_This{}},
-					},
-				},
-				{
-					Type: "team",
-					Relations: map[string]*openfgapb.Userset{
-						"member": {Userset: &openfgapb.Userset_This{}},
+					Metadata: &openfgapb.Metadata{
+						Relations: map[string]*openfgapb.RelationMetadata{
+							"admin": {
+								DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+									{
+										Type: "user",
+									},
+								},
+							},
+							"writer": {
+								DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+									{
+										Type: "user",
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -665,13 +674,11 @@ var writeCommandTests = []writeCommandTest{
 		request: &openfgapb.WriteRequest{
 			AuthorizationModelId: "01GZFXJ2XPAF8FBHDKJ83XAJQP",
 			Writes: &openfgapb.TupleKeys{TupleKeys: []*openfgapb.TupleKey{
-				tuple.NewTupleKey("org:openfga", "owner", "github|jose@openfga"),
-				tuple.NewTupleKey("repo:openfga/openfga", "admin", "github|jose@openfga"),
-				tuple.NewTupleKey("repo:openfga/openfga", "writer", "team:openfga/iam#member"),
-				tuple.NewTupleKey("team:openfga/iam", "member", "iaco@openfga"),
+				tuple.NewTupleKey("repo:openfga/openfga", "admin", "user:github|jose@openfga"),
+				tuple.NewTupleKey("repo:openfga/openfga", "writer", "user:github|jon@openfga"),
 			}},
 		},
-		allowSchema10: true,
+		allowSchema10: false,
 		err:           serverErrors.AuthorizationModelNotFound("01GZFXJ2XPAF8FBHDKJ83XAJQP"),
 	},
 	{


### PR DESCRIPTION

## Description
Should respond with proper error message when auth model id is not found for write.

## References
Close https://github.com/openfga/openfga/issues/724

## Testing

1. Create store
2. Write auth model
3. Write tuples but specify auth model id that is a valid ulid but no such auth model id
4. Ensure 400 Bad Request is returned (not 500)

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
