### PR TITLE
fix: regression in #757

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -212,15 +212,15 @@ func (q *ListObjectsQuery) Execute(
 				Objects: objects,
 			}, nil
 
-		case objectID, ok := <-resultsChan:
-			if !ok { //channel was closed and no new values are available
+		case objectID, channelOpen := <-resultsChan:
+			if !channelOpen {
 				return &openfgapb.ListObjectsResponse{
 					Objects: objects,
 				}, nil
 			}
 			objects = append(objects, objectID)
-		case genericError, ok := <-errChan:
-			if ok { //a value is available
+		case genericError, valueAvailable := <-errChan:
+			if valueAvailable {
 				return nil, serverErrors.NewInternalError("", genericError)
 			}
 		}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -94,9 +94,9 @@ func (q *ListObjectsQuery) evaluate(
 		if err != nil {
 			errChan <- err
 			close(errChan)
+		} else {
+			close(resultsChan)
 		}
-
-		close(resultsChan)
 	}
 
 	hasTypeInfo, err := typesys.HasTypeInfo(targetObjectType, targetRelation)
@@ -159,9 +159,9 @@ func (q *ListObjectsQuery) evaluate(
 			if err != nil {
 				errChan <- err
 				close(errChan)
+			} else {
+				close(resultsChan)
 			}
-
-			close(resultsChan)
 		}
 	}
 
@@ -213,14 +213,14 @@ func (q *ListObjectsQuery) Execute(
 			}, nil
 
 		case objectID, ok := <-resultsChan:
-			if !ok {
+			if !ok { //channel was closed and no new values are available
 				return &openfgapb.ListObjectsResponse{
 					Objects: objects,
 				}, nil
 			}
 			objects = append(objects, objectID)
 		case genericError, ok := <-errChan:
-			if ok {
+			if ok { //a value is available
 				return nil, serverErrors.NewInternalError("", genericError)
 			}
 		}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -94,9 +94,9 @@ func (q *ListObjectsQuery) evaluate(
 		if err != nil {
 			errChan <- err
 			close(errChan)
-		} else {
-			close(resultsChan)
+			return
 		}
+		close(resultsChan)
 	}
 
 	hasTypeInfo, err := typesys.HasTypeInfo(targetObjectType, targetRelation)
@@ -159,9 +159,9 @@ func (q *ListObjectsQuery) evaluate(
 			if err != nil {
 				errChan <- err
 				close(errChan)
-			} else {
-				close(resultsChan)
+				return
 			}
+			close(resultsChan)
 		}
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -348,7 +348,7 @@ func (m *mockStreamServer) Send(*openfgapb.StreamedListObjectsResponse) error {
 }
 
 // This runs TestListObjects_Unoptimized_UnhappyPaths many times over to ensure no race conditions (see https://github.com/openfga/openfga/pull/762)
-func BenchmarkListObjects(b *testing.B) {
+func BenchmarkListObjectsNoRaceCondition(b *testing.B) {
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
 	transport := gateway.NewNoopTransport()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -347,6 +347,68 @@ func (m *mockStreamServer) Send(*openfgapb.StreamedListObjectsResponse) error {
 	return nil
 }
 
+// This runs TestListObjects_Unoptimized_UnhappyPaths many times over to ensure no race conditions (see https://github.com/openfga/openfga/pull/762)
+func BenchmarkListObjects(b *testing.B) {
+	ctx := context.Background()
+	logger := logger.NewNoopLogger()
+	transport := gateway.NewNoopTransport()
+	store := ulid.Make().String()
+	modelID := ulid.Make().String()
+
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+
+	data, err := os.ReadFile("testdata/github.json")
+	require.NoError(b, err)
+
+	var gitHubTypeDefinitions openfgapb.WriteAuthorizationModelRequest
+	err = protojson.Unmarshal(data, &gitHubTypeDefinitions)
+	require.NoError(b, err)
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	mockDatastore.EXPECT().ReadAuthorizationModel(gomock.Any(), store, modelID).AnyTimes().Return(&openfgapb.AuthorizationModel{
+		SchemaVersion:   typesystem.SchemaVersion1_0,
+		TypeDefinitions: gitHubTypeDefinitions.GetTypeDefinitions(),
+	}, nil)
+	mockDatastore.EXPECT().ListObjectsByType(gomock.Any(), store, "repo").AnyTimes().Return(nil, errors.New("error reading from storage"))
+
+	s := New(&Dependencies{
+		Datastore: mockDatastore,
+		Transport: transport,
+		Logger:    logger,
+	}, &Config{
+		ResolveNodeLimit:         25,
+		ListObjectsDeadline:      5 * time.Second,
+		ListObjectsMaxResults:    1000,
+		AllowEvaluating1_0Models: true,
+	})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := s.ListObjects(ctx, &openfgapb.ListObjectsRequest{
+			StoreId:              store,
+			AuthorizationModelId: modelID,
+			Type:                 "repo",
+			Relation:             "owner",
+			User:                 "bob",
+		})
+
+		require.ErrorIs(b, err, serverErrors.NewInternalError("", errors.New("error reading from storage")))
+
+		err = s.StreamedListObjects(&openfgapb.StreamedListObjectsRequest{
+			StoreId:              store,
+			AuthorizationModelId: modelID,
+			Type:                 "repo",
+			Relation:             "owner",
+			User:                 "bob",
+		}, NewMockStreamServer())
+
+		require.ErrorIs(b, err, serverErrors.NewInternalError("", errors.New("error reading from storage")))
+	}
+}
+
+// This test ensures that when the data storage fails, ListObjects v0 throws an error
 func TestListObjects_Unoptimized_UnhappyPaths(t *testing.T) {
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
@@ -409,6 +471,7 @@ func TestListObjects_Unoptimized_UnhappyPaths(t *testing.T) {
 	})
 }
 
+// This test ensures that when the data storage fails, ListObjects v1 throws an error
 func TestListObjects_UnhappyPaths(t *testing.T) {
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()


### PR DESCRIPTION
This fixes a regression introduced in https://github.com/openfga/openfga/pull/757. The failure is seen here https://github.com/openfga/openfga/actions/runs/4994450765/jobs/8945024934#step:5:38. Note that this failure happens once in a while, not all the time :)

The following benchmarks (not included in the PR) are minimum reproducible examples of the overall behavior before that PR, after that PR, and with this PR fixing it.

```go
// passes
func BenchmarkBeforePR757(b *testing.B) {
	for i := 0; i < b.N; i++ {
		errChan := make(chan error) //unbuffered
		resultsChan := make(chan error, 1000)
		go func() {
			errChan <- fmt.Errorf("error!")
			close(resultsChan)
		}()

		for {
			select {
			case _, ok := <-resultsChan:
				if !ok {
					panic("not expected")
				}
			case _, ok := <-errChan:
				if ok {
					return
				}
			}
		}
	}
}

// panics after some time
func BenchmarkAfterPR757(b *testing.B) {
	for i := 0; i < b.N; i++ {
		errChan := make(chan error, 1) //buffered, this is new
		resultsChan := make(chan error, 1000)
		go func() {
			errChan <- fmt.Errorf("error!")
			close(errChan) // this is new!
			close(resultsChan) 
		}()

		for {
			select {
                         // If multiple cases are ready, Go picks one randomly
			case _, ok := <-resultsChan:
				if !ok {
					panic("not expected")
				}
			case _, ok := <-errChan:
				if ok {
					return
				}
			}
		}
	}
}

// passes
func BenchmarkAfterPR762(b *testing.B) {
	for i := 0; i < b.N; i++ {
		errChan := make(chan error, 1)
		resultsChan := make(chan error, 1000)
		go func() {
			errChan <- fmt.Errorf("error!")
			close(errChan)
		}()

		for {
			select {
			case _, ok := <-resultsChan:
				if !ok {
					panic("not expected")
				}
			case _, ok := <-errChan:
				if ok {
					return
				}
			}
		}
	}
}
```

💡 As a follow-up, instead of having `errChan` and `resultsChan`, we may consider having just one channel that can store both errors and results.