### PR TITLE
chore: update version of ghcr.io/grpc-ecosystem/grpc-health-probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM cgr.dev/chainguard/static@sha256:d1f247050de27feffaedfd47e71c15795a9887d30c
 EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.16 /ko-app/grpc-health-probe /user/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.18 /ko-app/grpc-health-probe /user/local/bin/grpc_health_probe
 COPY --from=builder /app/openfga /openfga
 COPY --from=builder /app/assets /assets
 ENTRYPOINT ["/openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
 FROM cgr.dev/chainguard/static@sha256:d1f247050de27feffaedfd47e71c15795a9887d30c76e6d64de9f079765c37a3
 COPY assets /assets
 COPY openfga /
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.16 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.18 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
## Description
Update version of the binary `grpc-health-probe` that is bundled in our Docker image.

## References
- https://github.com/openfga/openfga/security/advisories/GHSA-r4mc-x5qf-96fj
- https://github.com/grpc-ecosystem/grpc-health-probe/pkgs/container/grpc-health-probe

