### PR TITLE
refactor: constructor of in-memory storage

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -440,7 +440,7 @@ func RunServer(ctx context.Context, config *Config) error {
 	var err error
 	switch config.Datastore.Engine {
 	case "memory":
-		opts := []memory.MemoryStorageOption{
+		opts := []memory.StorageOption{
 			memory.WithMaxTypesPerAuthorizationModel(config.MaxTypesPerAuthorizationModel),
 			memory.WithMaxTuplesPerWrite(config.MaxTuplesPerWrite),
 		}

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -440,7 +440,11 @@ func RunServer(ctx context.Context, config *Config) error {
 	var err error
 	switch config.Datastore.Engine {
 	case "memory":
-		datastore = memory.New(config.MaxTuplesPerWrite, config.MaxTypesPerAuthorizationModel)
+		opts := []memory.MemoryStorageOption{
+			memory.WithMaxTypesPerAuthorizationModel(config.MaxTypesPerAuthorizationModel),
+			memory.WithMaxTuplesPerWrite(config.MaxTuplesPerWrite),
+		}
+		datastore = memory.New(opts...)
 	case "mysql":
 		datastore, err = mysql.New(config.Datastore.URI, dsCfg)
 		if err != nil {

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestResolveCheckDeterministic(t *testing.T) {
 
-	ds := memory.New(10, 24)
+	ds := memory.New()
 
 	storeID := ulid.Make().String()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -110,7 +110,7 @@ func BenchmarkOpenFGAServer(b *testing.B) {
 	})
 
 	b.Run("BenchmarkMemoryDatastore", func(b *testing.B) {
-		ds := memory.New(10, 24)
+		ds := memory.New()
 		defer ds.Close()
 		test.RunAllBenchmarks(b, ds)
 	})
@@ -704,7 +704,7 @@ func MustBootstrapDatastore(t testing.TB, engine string) storage.OpenFGADatastor
 
 	switch engine {
 	case "memory":
-		ds = memory.New(10, 24)
+		ds = memory.New()
 	case "postgres":
 		ds, err = postgres.New(uri, sqlcommon.NewConfig())
 	case "mysql":

--- a/pkg/storage/caching/caching_test.go
+++ b/pkg/storage/caching/caching_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCache(t *testing.T) {
 	ctx := context.Background()
-	memoryBackend := memory.New(10000, 10000)
+	memoryBackend := memory.New()
 	cachingBackend := NewCachedOpenFGADatastore(memoryBackend, 5)
 	defer cachingBackend.Close()
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -63,6 +63,13 @@ func (s *staticIterator) Next() (*openfgapb.Tuple, error) {
 
 func (s *staticIterator) Stop() {}
 
+type MemoryStorageOption func(ds *MemoryBackend)
+
+const (
+	defaultMaxTuplesPerWrite             = 100
+	defaultMaxTypesPerAuthorizationModel = 100
+)
+
 // A MemoryBackend provides an ephemeral memory-backed implementation of TupleBackend and AuthorizationModelBackend.
 // MemoryBackend instances may be safely shared by multiple go-routines.
 type MemoryBackend struct {
@@ -97,16 +104,30 @@ type AuthorizationModelEntry struct {
 }
 
 // New creates a new empty MemoryBackend.
-func New(maxTuplesPerWrite int, maxTypesPerAuthorizationModel int) *MemoryBackend {
-	return &MemoryBackend{
-		maxTuplesPerWrite:             maxTuplesPerWrite,
-		maxTypesPerAuthorizationModel: maxTypesPerAuthorizationModel,
+func New(opts ...MemoryStorageOption) storage.OpenFGADatastore {
+	ds := &MemoryBackend{
+		maxTuplesPerWrite:             defaultMaxTuplesPerWrite,
+		maxTypesPerAuthorizationModel: defaultMaxTypesPerAuthorizationModel,
 		tuples:                        make(map[string][]*openfgapb.Tuple, 0),
 		changes:                       make(map[string][]*openfgapb.TupleChange, 0),
 		authorizationModels:           make(map[string]map[string]*AuthorizationModelEntry),
 		stores:                        make(map[string]*openfgapb.Store, 0),
 		assertions:                    make(map[string][]*openfgapb.Assertion, 0),
 	}
+
+	for _, opt := range opts {
+		opt(ds)
+	}
+
+	return ds
+}
+
+func WithMaxTuplesPerWrite(n int) MemoryStorageOption {
+	return func(ds *MemoryBackend) { ds.maxTuplesPerWrite = n }
+}
+
+func WithMaxTypesPerAuthorizationModel(n int) MemoryStorageOption {
+	return func(ds *MemoryBackend) { ds.maxTypesPerAuthorizationModel = n }
 }
 
 // Close closes any open connections and cleans up residual resources

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -63,7 +63,7 @@ func (s *staticIterator) Next() (*openfgapb.Tuple, error) {
 
 func (s *staticIterator) Stop() {}
 
-type MemoryStorageOption func(ds *MemoryBackend)
+type StorageOption func(ds *MemoryBackend)
 
 const (
 	defaultMaxTuplesPerWrite             = 100
@@ -104,7 +104,7 @@ type AuthorizationModelEntry struct {
 }
 
 // New creates a new empty MemoryBackend.
-func New(opts ...MemoryStorageOption) storage.OpenFGADatastore {
+func New(opts ...StorageOption) storage.OpenFGADatastore {
 	ds := &MemoryBackend{
 		maxTuplesPerWrite:             defaultMaxTuplesPerWrite,
 		maxTypesPerAuthorizationModel: defaultMaxTypesPerAuthorizationModel,
@@ -122,11 +122,11 @@ func New(opts ...MemoryStorageOption) storage.OpenFGADatastore {
 	return ds
 }
 
-func WithMaxTuplesPerWrite(n int) MemoryStorageOption {
+func WithMaxTuplesPerWrite(n int) StorageOption {
 	return func(ds *MemoryBackend) { ds.maxTuplesPerWrite = n }
 }
 
-func WithMaxTypesPerAuthorizationModel(n int) MemoryStorageOption {
+func WithMaxTypesPerAuthorizationModel(n int) StorageOption {
 	return func(ds *MemoryBackend) { ds.maxTypesPerAuthorizationModel = n }
 }
 

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -9,14 +9,8 @@ import (
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
 )
 
-var memoryStorage *MemoryBackend
-
-func init() {
-	memoryStorage = New(10000, 10000)
-}
-
 func TestMemdbStorage(t *testing.T) {
-	ds := New(10, 24)
+	ds := New()
 	test.RunAllTests(t, ds)
 }
 


### PR DESCRIPTION
## Description
- refactor: constructor of in-memory storage to use the `options` pattern: https://golang.cafe/blog/golang-functional-options-pattern.html