### PR TITLE
fix: validate models with non-zero entrypoints properly

### DIFF
--- a/pkg/server/test/write_authzmodel.go
+++ b/pkg/server/test/write_authzmodel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/oklog/ulid/v2"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands"
@@ -133,6 +134,21 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 						},
 					},
 				},
+			},
+		},
+		{
+			name: "self_referencing_type_restriction_with_entrypoint",
+			request: &openfgapb.WriteAuthorizationModelRequest{
+				StoreId: storeID,
+				TypeDefinitions: parser.MustParse(`
+				type user
+
+				type document
+				  relations
+				    define editor: [user] as self
+				    define viewer: [document#viewer] as self or editor
+				`),
+				SchemaVersion: typesystem.SchemaVersion1_1,
 			},
 		},
 	}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -781,7 +781,9 @@ func (t *TypeSystem) validateRelationTypeRestrictions() error {
 			if assignable && len(relatedTypes) == 1 {
 				relatedObjectType := relatedTypes[0].GetType()
 				relatedRelation := relatedTypes[0].GetRelation()
-				if objectType == relatedObjectType && name == relatedRelation {
+
+				if objectType == relatedObjectType && name == relatedRelation &&
+					reflect.TypeOf(relation.GetRewrite().Userset) == reflect.TypeOf(&openfgapb.Userset_This{}) {
 					return &InvalidRelationError{ObjectType: objectType, Relation: name, Cause: ErrCycle}
 				}
 			}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -782,9 +782,11 @@ func (t *TypeSystem) validateRelationTypeRestrictions() error {
 				relatedObjectType := relatedTypes[0].GetType()
 				relatedRelation := relatedTypes[0].GetRelation()
 
-				if objectType == relatedObjectType && name == relatedRelation &&
-					reflect.TypeOf(relation.GetRewrite().Userset) == reflect.TypeOf(&openfgapb.Userset_This{}) {
-					return &InvalidRelationError{ObjectType: objectType, Relation: name, Cause: ErrCycle}
+				if objectType == relatedObjectType && name == relatedRelation {
+					switch relation.GetRewrite().Userset.(type) {
+					case *openfgapb.Userset_This, *openfgapb.Userset_Intersection, *openfgapb.Userset_Difference:
+						return &InvalidRelationError{ObjectType: objectType, Relation: name, Cause: ErrCycle}
+					}
 				}
 			}
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -1046,6 +1046,32 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 			},
 			err: &InvalidRelationError{ObjectType: "document", Relation: "editor", Cause: ErrCycle},
 		},
+		{
+			name: "self_referencing_type_restriction_with_zero_entrypoints_3",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type document
+				  relations
+				    define viewer: [document#viewer] as self and editor
+				    define editor: [document#editor] as self
+				`),
+			},
+			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
+		},
+		{
+			name: "self_referencing_type_restriction_with_zero_entrypoints_4",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type document
+				  relations
+				    define viewer: [document#viewer] as self and editor
+				    define editor: [document#editor] as self
+				`),
+			},
+			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -491,87 +491,60 @@ func TestSuccessfulRelationTypeRestrictionsValidations(t *testing.T) {
 			name: "succeeds_on_a_valid_typeSystem_with_an_objectType_type",
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "user",
-					},
-					{
-						Type: "document",
-						Relations: map[string]*openfgapb.Userset{
-							"reader": {Userset: &openfgapb.Userset_This{}},
-						},
-						Metadata: &openfgapb.Metadata{
-							Relations: map[string]*openfgapb.RelationMetadata{
-								"reader": {
-									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
-										{
-											Type: "user",
-										},
-									},
-								},
-							},
-						},
-					},
-				},
+				TypeDefinitions: parser.MustParse(`
+				type user
+
+				type document
+				  relations
+				    define reader: [user] as self
+				`),
 			},
 		},
 		{
 			name: "succeeds_on_a_valid_typeSystem_with_a_type_and_type#relation_type",
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: []*openfgapb.TypeDefinition{
-					{
-						Type: "user",
-					},
-					{
-						Type: "group",
-						Relations: map[string]*openfgapb.Userset{
-							"admin":  {Userset: &openfgapb.Userset_This{}},
-							"member": {Userset: &openfgapb.Userset_This{}},
-						},
-						Metadata: &openfgapb.Metadata{
-							Relations: map[string]*openfgapb.RelationMetadata{
-								"admin": {
-									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
-										{
-											Type: "user",
-										},
-									},
-								},
-								"member": {
-									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
-										{
-											Type: "user",
-										},
-									},
-								},
-							},
-						},
-					},
-					{
-						Type: "document",
-						Relations: map[string]*openfgapb.Userset{
-							"reader": {Userset: &openfgapb.Userset_This{}},
-							"writer": {Userset: &openfgapb.Userset_This{}},
-						},
-						Metadata: &openfgapb.Metadata{
-							Relations: map[string]*openfgapb.RelationMetadata{
-								"reader": {
-									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
-										DirectRelationReference("user", ""),
-										DirectRelationReference("group", "member"),
-									},
-								},
-								"writer": {
-									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
-										DirectRelationReference("user", ""),
-										DirectRelationReference("group", "admin"),
-									},
-								},
-							},
-						},
-					},
-				},
+				TypeDefinitions: parser.MustParse(`
+				type user
+
+				type group
+				  relations
+				    define admin: [user] as self
+				    define member: [user] as self
+
+				type document
+				  relations
+				    define reader: [user, group#member] as self
+				    define writer: [user, group#admin] as self
+				`),
+			},
+		},
+		{
+			name: "self_referencing_type_restriction_with_nonzero_entrypoint_1",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type user
+
+				type document
+				  relations
+				    define viewer: [document#viewer] as self or editor
+				    define editor: [user] as self
+				`),
+			},
+		},
+		{
+			name: "self_referencing_type_restriction_with_nonzero_entrypoint_2",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type user
+
+				type document
+				  relations
+				    define viewer: [document#viewer] as self or editor
+				    define editor: [document] as self
+				`),
 			},
 		},
 	}
@@ -1047,6 +1020,31 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 				},
 			},
 			err: InvalidRelationTypeError("document", "parent", "folder", ""),
+		},
+		{
+			name: "self_referencing_type_restriction_with_zero_entrypoints_1",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type document
+				  relations
+				    define viewer: [document#viewer] as self
+				`),
+			},
+			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
+		},
+		{
+			name: "self_referencing_type_restriction_with_zero_entrypoints_2",
+			model: &openfgapb.AuthorizationModel{
+				SchemaVersion: SchemaVersion1_1,
+				TypeDefinitions: parser.MustParse(`
+				type document
+				  relations
+				    define viewer: [document#viewer] as self or editor
+				    define editor: [document#editor] as self
+				`),
+			},
+			err: &InvalidRelationError{ObjectType: "document", Relation: "editor", Cause: ErrCycle},
 		},
 	}
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -1051,10 +1051,11 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
 				TypeDefinitions: parser.MustParse(`
+				type user
 				type document
 				  relations
 				    define viewer: [document#viewer] as self and editor
-				    define editor: [document#editor] as self
+				    define editor: [user] as self
 				`),
 			},
 			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
@@ -1064,10 +1065,11 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
 				TypeDefinitions: parser.MustParse(`
+				type user
 				type document
 				  relations
-				    define viewer: [document#viewer] as self and editor
-				    define editor: [document#editor] as self
+				    define restricted: [user] as self
+				    define viewer: [document#viewer] as self but not restricted
 				`),
 			},
 			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes a bug with model validation that wasn't allowing models with non-zero entrypoints to be written to OpenFGA.

## References
Fixes the issue reported in #801.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
