### PR TITLE
Revert "fix: validate models with non-zero entrypoints properly (#802)"

### DIFF
--- a/pkg/server/test/write_authzmodel.go
+++ b/pkg/server/test/write_authzmodel.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/oklog/ulid/v2"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands"
@@ -135,77 +134,6 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 					},
 				},
 			},
-		},
-		{
-			name: "self_referencing_type_restriction_with_entrypoint",
-			request: &openfgapb.WriteAuthorizationModelRequest{
-				StoreId: storeID,
-				TypeDefinitions: parser.MustParse(`
-				type user
-
-				type document
-				  relations
-				    define editor: [user] as self
-				    define viewer: [document#viewer] as self or editor
-				`),
-				SchemaVersion: typesystem.SchemaVersion1_1,
-			},
-		},
-		{
-			name: "self_referencing_type_restriction_without_entrypoint_1",
-			request: &openfgapb.WriteAuthorizationModelRequest{
-				StoreId: storeID,
-				TypeDefinitions: parser.MustParse(`
-				type user
-				type document
-				  relations
-				    define viewer: [document#viewer] as self
-				`),
-				SchemaVersion: typesystem.SchemaVersion1_1,
-			},
-			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{
-				ObjectType: "document",
-				Relation:   "viewer",
-				Cause:      typesystem.ErrCycle,
-			}),
-		},
-		{
-			name: "self_referencing_type_restriction_without_entrypoint_2",
-			request: &openfgapb.WriteAuthorizationModelRequest{
-				StoreId: storeID,
-				TypeDefinitions: parser.MustParse(`
-				type user
-				type document
-				  relations
-				    define editor: [user] as self
-				    define viewer: [document#viewer] as self and editor
-				`),
-				SchemaVersion: typesystem.SchemaVersion1_1,
-			},
-			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{
-				ObjectType: "document",
-				Relation:   "viewer",
-				Cause:      typesystem.ErrCycle,
-			}),
-		},
-		{
-			name: "self_referencing_type_restriction_without_entrypoint_3",
-			request: &openfgapb.WriteAuthorizationModelRequest{
-				StoreId: storeID,
-				TypeDefinitions: parser.MustParse(`
-				type user
-				type document
-				  relations
-				    define restricted: [user] as self
-				    define viewer: [document#viewer] as self but not restricted
-				`),
-				SchemaVersion: typesystem.SchemaVersion1_1,
-			},
-			err: serverErrors.InvalidAuthorizationModelInput(&typesystem.InvalidRelationError{
-				ObjectType: "document",
-				Relation:   "viewer",
-				Cause:      typesystem.ErrCycle,
-			}),
 		},
 	}
 

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -781,12 +781,8 @@ func (t *TypeSystem) validateRelationTypeRestrictions() error {
 			if assignable && len(relatedTypes) == 1 {
 				relatedObjectType := relatedTypes[0].GetType()
 				relatedRelation := relatedTypes[0].GetRelation()
-
 				if objectType == relatedObjectType && name == relatedRelation {
-					switch relation.GetRewrite().Userset.(type) {
-					case *openfgapb.Userset_This, *openfgapb.Userset_Intersection, *openfgapb.Userset_Difference:
-						return &InvalidRelationError{ObjectType: objectType, Relation: name, Cause: ErrCycle}
-					}
+					return &InvalidRelationError{ObjectType: objectType, Relation: name, Cause: ErrCycle}
 				}
 			}
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -491,60 +491,87 @@ func TestSuccessfulRelationTypeRestrictionsValidations(t *testing.T) {
 			name: "succeeds_on_a_valid_typeSystem_with_an_objectType_type",
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-
-				type document
-				  relations
-				    define reader: [user] as self
-				`),
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"reader": {Userset: &openfgapb.Userset_This{}},
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"reader": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{
+											Type: "user",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "succeeds_on_a_valid_typeSystem_with_a_type_and_type#relation_type",
 			model: &openfgapb.AuthorizationModel{
 				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-
-				type group
-				  relations
-				    define admin: [user] as self
-				    define member: [user] as self
-
-				type document
-				  relations
-				    define reader: [user, group#member] as self
-				    define writer: [user, group#admin] as self
-				`),
-			},
-		},
-		{
-			name: "self_referencing_type_restriction_with_nonzero_entrypoint_1",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-
-				type document
-				  relations
-				    define viewer: [document#viewer] as self or editor
-				    define editor: [user] as self
-				`),
-			},
-		},
-		{
-			name: "self_referencing_type_restriction_with_nonzero_entrypoint_2",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-
-				type document
-				  relations
-				    define viewer: [document#viewer] as self or editor
-				    define editor: [document] as self
-				`),
+				TypeDefinitions: []*openfgapb.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgapb.Userset{
+							"admin":  {Userset: &openfgapb.Userset_This{}},
+							"member": {Userset: &openfgapb.Userset_This{}},
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"admin": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{
+											Type: "user",
+										},
+									},
+								},
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										{
+											Type: "user",
+										},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgapb.Userset{
+							"reader": {Userset: &openfgapb.Userset_This{}},
+							"writer": {Userset: &openfgapb.Userset_This{}},
+						},
+						Metadata: &openfgapb.Metadata{
+							Relations: map[string]*openfgapb.RelationMetadata{
+								"reader": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										DirectRelationReference("user", ""),
+										DirectRelationReference("group", "member"),
+									},
+								},
+								"writer": {
+									DirectlyRelatedUserTypes: []*openfgapb.RelationReference{
+										DirectRelationReference("user", ""),
+										DirectRelationReference("group", "admin"),
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1020,59 +1047,6 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 				},
 			},
 			err: InvalidRelationTypeError("document", "parent", "folder", ""),
-		},
-		{
-			name: "self_referencing_type_restriction_with_zero_entrypoints_1",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type document
-				  relations
-				    define viewer: [document#viewer] as self
-				`),
-			},
-			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
-		},
-		{
-			name: "self_referencing_type_restriction_with_zero_entrypoints_2",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type document
-				  relations
-				    define viewer: [document#viewer] as self or editor
-				    define editor: [document#editor] as self
-				`),
-			},
-			err: &InvalidRelationError{ObjectType: "document", Relation: "editor", Cause: ErrCycle},
-		},
-		{
-			name: "self_referencing_type_restriction_with_zero_entrypoints_3",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-				type document
-				  relations
-				    define viewer: [document#viewer] as self and editor
-				    define editor: [user] as self
-				`),
-			},
-			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
-		},
-		{
-			name: "self_referencing_type_restriction_with_zero_entrypoints_4",
-			model: &openfgapb.AuthorizationModel{
-				SchemaVersion: SchemaVersion1_1,
-				TypeDefinitions: parser.MustParse(`
-				type user
-				type document
-				  relations
-				    define restricted: [user] as self
-				    define viewer: [document#viewer] as self but not restricted
-				`),
-			},
-			err: &InvalidRelationError{ObjectType: "document", Relation: "viewer", Cause: ErrCycle},
 		},
 	}
 


### PR DESCRIPTION
This reverts commit d3b5eec530dd068057378a34b7f9c12f45fa9078.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Reverts commit starting with sha `d3b5eec5`

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
