### PR TITLE
Updated error return to remove new line

### DIFF
--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -723,8 +723,6 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 					return nil
 				}
 			}
-			// ErrRes := ErrUserNotRelatedToType{computedUserset, userTypes}
-
 			return fmt.Errorf("%w: %s does not appear as a relation in any of the directly related user types %s", ErrRelationUndefined, computedUserset, userTypes)
 		} else {
 			// for 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -723,8 +723,9 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 					return nil
 				}
 			}
+			// ErrRes := ErrUserNotRelatedToType{computedUserset, userTypes}
 
-			return fmt.Errorf("%v %s does not appear as a relation in any of the directly related user types %v", ErrRelationUndefined, computedUserset, userTypes)
+			return fmt.Errorf("%w %s does not appear as a relation in any of the directly related user types %s", ErrRelationUndefined, computedUserset, userTypes)
 		} else {
 			// for 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model
 			for typeName := range t.relations {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -724,7 +724,7 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 				}
 			}
 
-			return errors.Join(ErrRelationUndefined, fmt.Errorf("%s does not appear as a relation in any of the directly related user types %v", computedUserset, userTypes))
+			return fmt.Errorf("%v %s does not appear as a relation in any of the directly related user types %v", ErrRelationUndefined, computedUserset, userTypes)
 		} else {
 			// for 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model
 			for typeName := range t.relations {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -725,7 +725,7 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 			}
 			// ErrRes := ErrUserNotRelatedToType{computedUserset, userTypes}
 
-			return fmt.Errorf("%w %s does not appear as a relation in any of the directly related user types %s", ErrRelationUndefined, computedUserset, userTypes)
+			return fmt.Errorf("%w: %s does not appear as a relation in any of the directly related user types %s", ErrRelationUndefined, computedUserset, userTypes)
 		} else {
 			// for 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model
 			for typeName := range t.relations {


### PR DESCRIPTION
PR resolves #814 by updating the returned error to remove the use of `errors.Join` which added the unwanted newline (`\n`).

## Description
Updated line 727 of `pkg/typesystem/typesystem.go` so that the the error prefix is included in the `fmt.Errorf` options, rather than using `errors.Join`

## References
Relates to Issue #814 
