### PR TITLE
chore: add a concurrency limited CheckResolver implementation

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -31,7 +31,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	checker := NewLocalChecker(ds, 100)
+	checker := NewCheckResolver(ds, 100)
 
 	typedefs := parser.MustParse(`
 	type user

--- a/internal/graph/limited_checker.go
+++ b/internal/graph/limited_checker.go
@@ -1,0 +1,60 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+)
+
+type LimitedLocalChecker struct {
+	resolver CheckResolver
+	limiter  chan struct{}
+}
+
+type LimitedLocalCheckerOpt func(l *LimitedLocalChecker)
+
+func WithCheckResolver(resolver CheckResolver) LimitedLocalCheckerOpt {
+	return func(l *LimitedLocalChecker) {
+		l.resolver = resolver
+	}
+}
+
+func WithConcurrencyLimit(limit uint32) LimitedLocalCheckerOpt {
+	return func(l *LimitedLocalChecker) {
+		l.limiter = make(chan struct{}, limit)
+	}
+}
+
+func MustNewLimitedLocalChecker(opts ...LimitedLocalCheckerOpt) *LimitedLocalChecker {
+	checker, err := NewLimitedLocalChecker(opts...)
+	if err != nil {
+		panic(err)
+	}
+
+	return checker
+}
+
+func NewLimitedLocalChecker(opts ...LimitedLocalCheckerOpt) (*LimitedLocalChecker, error) {
+
+	checker := &LimitedLocalChecker{
+		limiter: make(chan struct{}, 50),
+	}
+
+	for _, opt := range opts {
+		opt(checker)
+	}
+
+	if checker.resolver == nil {
+		return nil, fmt.Errorf("the provided CheckResolver cannot be nil")
+	}
+
+	return checker, nil
+}
+
+func (l *LimitedLocalChecker) ResolveCheck(ctx context.Context, req *ResolveCheckRequest) (*ResolveCheckResponse, error) {
+	l.limiter <- struct{}{}
+	defer func() {
+		<-l.limiter
+	}()
+
+	return l.resolver.ResolveCheck(ctx, req)
+}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -156,14 +156,9 @@ func (q *ListObjectsQuery) evaluate(
 			close(connectedObjectsResChan)
 		}()
 
-		localCheckResolver := graph.NewLocalChecker(
+		checkResolver := graph.NewCheckResolver(
 			storage.NewCombinedTupleReader(q.Datastore, req.GetContextualTuples().GetTupleKeys()),
 			q.CheckConcurrencyLimit,
-		)
-
-		checkResolver := graph.MustNewLimitedLocalChecker(
-			graph.WithCheckResolver(localCheckResolver),
-			graph.WithConcurrencyLimit(q.CheckConcurrencyLimit),
 		)
 
 		concurrencyLimiterCh := make(chan struct{}, maximumConcurrentChecks)

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -156,9 +156,14 @@ func (q *ListObjectsQuery) evaluate(
 			close(connectedObjectsResChan)
 		}()
 
-		checkResolver := graph.NewLocalChecker(
+		localCheckResolver := graph.NewLocalChecker(
 			storage.NewCombinedTupleReader(q.Datastore, req.GetContextualTuples().GetTupleKeys()),
 			q.CheckConcurrencyLimit,
+		)
+
+		checkResolver := graph.MustNewLimitedLocalChecker(
+			graph.WithCheckResolver(localCheckResolver),
+			graph.WithConcurrencyLimit(q.CheckConcurrencyLimit),
 		)
 
 		concurrencyLimiterCh := make(chan struct{}, maximumConcurrentChecks)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -226,14 +226,9 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 
-	localCheckResolver := graph.NewLocalChecker(
+	checkResolver := graph.NewCheckResolver(
 		storage.NewCombinedTupleReader(s.datastore, req.ContextualTuples.GetTupleKeys()),
 		checkConcurrencyLimit,
-	)
-
-	checkResolver := graph.MustNewLimitedLocalChecker(
-		graph.WithCheckResolver(localCheckResolver),
-		graph.WithConcurrencyLimit(checkConcurrencyLimit),
 	)
 
 	resp, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -226,9 +226,14 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 
-	checkResolver := graph.NewLocalChecker(
+	localCheckResolver := graph.NewLocalChecker(
 		storage.NewCombinedTupleReader(s.datastore, req.ContextualTuples.GetTupleKeys()),
 		checkConcurrencyLimit,
+	)
+
+	checkResolver := graph.MustNewLimitedLocalChecker(
+		graph.WithCheckResolver(localCheckResolver),
+		graph.WithConcurrencyLimit(checkConcurrencyLimit),
 	)
 
 	resp, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Implement a `CheckResolver` implementation that limits the total amount of concurrent evaluations that can be in flight at any given time.

Here's a sample screenshot if the concurrency limit is set to 1 (e.g. only 1 path of evaluation in flight at a time).
<img width="1819" alt="Screen Shot 2023-07-07 at 10 39 42 AM" src="https://github.com/openfga/openfga/assets/2899204/c85f2767-5582-4a3f-b170-daedd2a619bd">
As you can see, there are 3 paths of evaluation contained under the 'union' operator, but we evaluate them serially because the overall concurrency limit is set to 1.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
