### PR TITLE
test: Check concurrency set to 1 causes no deadlock

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -72,3 +72,50 @@ func TestResolveCheckDeterministic(t *testing.T) {
 	require.ErrorIs(t, err, ErrResolutionDepthExceeded)
 	require.Nil(t, resp)
 }
+
+func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
+	const concurrencyLimit = 1
+	ds := memory.New()
+	defer ds.Close()
+
+	storeID := ulid.Make().String()
+
+	err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "group:1#member"),
+		tuple.NewTupleKey("document:1", "viewer", "group:2#member"),
+		tuple.NewTupleKey("group:1", "member", "group:1a#member"),
+		tuple.NewTupleKey("group:1", "member", "group:1b#member"),
+		tuple.NewTupleKey("group:2", "member", "group:2a#member"),
+		tuple.NewTupleKey("group:2", "member", "group:2b#member"),
+		tuple.NewTupleKey("group:2b", "member", "user:jon"),
+	})
+	require.NoError(t, err)
+
+	checker := NewLocalChecker(ds, concurrencyLimit)
+
+	typedefs := parser.MustParse(`
+	type user
+	type group
+	  relations
+		define member: [user, group#member] as self
+	type document
+	  relations
+		define viewer: [group#member] as self
+	`)
+
+	ctx := typesystem.ContextWithTypesystem(context.Background(), typesystem.New(
+		&openfgav1.AuthorizationModel{
+			Id:              ulid.Make().String(),
+			TypeDefinitions: typedefs,
+			SchemaVersion:   typesystem.SchemaVersion1_1,
+		},
+	))
+
+	resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
+		StoreID:            storeID,
+		TupleKey:           tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+		ResolutionMetadata: &ResolutionMetadata{Depth: 25},
+	})
+	require.NoError(t, err)
+	require.True(t, resp.Allowed)
+}


### PR DESCRIPTION
Adding the test mentioned here https://github.com/openfga/openfga/pull/855#issuecomment-1629551787. 

This test passes on `main`, but on that (closed) PR fails with:

```GOROOT=/usr/local/opt/go/libexec #gosetup
GOPATH=/Users/mparnisari/go #gosetup
/usr/local/opt/go/libexec/bin/go test -c -o /Users/mparnisari/Library/Caches/JetBrains/GoLand2023.1/tmp/GoLand/___TestCheckWithOneConcurrentGoroutineCausesNoDeadlock_in_github_com_openfga_openfga_internal_graph.test github.com/openfga/openfga/internal/graph #gosetup
/usr/local/opt/go/libexec/bin/go tool test2json -t /Users/mparnisari/Library/Caches/JetBrains/GoLand2023.1/tmp/GoLand/___TestCheckWithOneConcurrentGoroutineCausesNoDeadlock_in_github_com_openfga_openfga_internal_graph.test -test.v -test.paniconexit0 -test.run ^\QTestCheckWithOneConcurrentGoroutineCausesNoDeadlock\E$
=== RUN   TestCheckWithOneConcurrentGoroutineCausesNoDeadlock
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000682680, {0x182ce6e?, 0x2a1ef416bc96c?}, 0x1854cf8)
	/usr/local/opt/go/libexec/src/testing/testing.go:1630 +0x405
testing.runTests.func1(0x1e34500?)
	/usr/local/opt/go/libexec/src/testing/testing.go:2036 +0x45
testing.tRunner(0xc000682680, 0xc00035fc88)
	/usr/local/opt/go/libexec/src/testing/testing.go:1576 +0x10b
testing.runTests(0xc0000ab720?, {0x1e1d340, 0x7, 0x7}, {0xc00001f378?, 0x100c00035fd10?, 0x0?})
	/usr/local/opt/go/libexec/src/testing/testing.go:2034 +0x489
testing.(*M).Run(0xc0000ab720)
	/usr/local/opt/go/libexec/src/testing/testing.go:1906 +0x63a
main.main()
	_testmain.go:59 +0x1aa

goroutine 7 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc0002c9380?}, 0x2c9380?, {0xc00012f078, 0x1, 0x1})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).ResolveCheck(0xc0000a9200, {0x190bd50?, 0xc0002c9350?}, 0xc000361360)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:380 +0x425
github.com/openfga/openfga/internal/graph.TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(0x0?)
	/Users/mparnisari/GitHub/openfga/internal/graph/check_test.go:114 +0x76f
testing.tRunner(0xc000682820, 0x1854cf8)
	/usr/local/opt/go/libexec/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	/usr/local/opt/go/libexec/src/testing/testing.go:1629 +0x3ea

goroutine 10 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc0002c9950?}, 0x25aef0?, {0xc00012f080, 0x1, 0x1})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).checkDirect.func1({0x190bca8, 0xc000361720})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:532 +0x7f8
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a

goroutine 9 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc0002c98c0)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 13 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc000692000?}, 0x19034a0?, {0xc0003c6060, 0x2, 0x2})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).checkDirect.func1.2({0x190bca8, 0xc000361860})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:527 +0xd05
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a

goroutine 12 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc000131da0)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 49 [select]:
github.com/openfga/openfga/internal/graph.resolver.func2()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:175 +0x118
created by github.com/openfga/openfga/internal/graph.resolver
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:170 +0x1ca

goroutine 50 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc00068e030)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 51 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc0006922a0?}, 0x6922a0?, {0xc000012018, 0x1, 0x1})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).ResolveCheck(0xc0000a9200, {0x190bca8?, 0xc0006901e0?}, 0xc000690140)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:380 +0x425
github.com/openfga/openfga/internal/graph.(*LimitedLocalChecker).ResolveCheck(0xc0000102b8, {0x190bca8, 0xc0006901e0}, 0x0?)
	/Users/mparnisari/GitHub/openfga/internal/graph/limited_checker.go:59 +0xb2
github.com/openfga/openfga/internal/graph.(*LocalChecker).dispatch.func1({0x190bca8?, 0xc0006901e0?})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:342 +0x3c
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a

goroutine 54 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc000692420?}, 0x258ef0?, {0xc0003c60f0, 0x2, 0x2})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).checkDirect.func1({0x190bca8, 0xc000690410})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:532 +0x7f8
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a

goroutine 53 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc000692360)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 59 [select]:
github.com/openfga/openfga/internal/graph.union({0x190bd50?, 0xc000692630?}, 0x19034a0?, {0xc0003c61d0, 0x2, 0x2})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:210 +0x1ee
github.com/openfga/openfga/internal/graph.(*LocalChecker).checkDirect.func1.2({0x190bca8, 0xc000690550})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:527 +0xd05
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a

goroutine 58 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc000694660)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 60 [select]:
github.com/openfga/openfga/internal/graph.resolver.func2()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:175 +0x118
created by github.com/openfga/openfga/internal/graph.resolver
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:170 +0x1ca

goroutine 61 [select]:
github.com/openfga/openfga/internal/graph.resolver.func1(0xc00068e240)
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:161 +0x1c7
created by github.com/openfga/openfga/internal/graph.resolver.func2
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:178 +0x6e

goroutine 62 [chan send]:
github.com/openfga/openfga/internal/graph.(*LimitedLocalChecker).ResolveCheck(0xc0000102b8, {0x190bca8, 0xc0006909b0}, 0x0?)
	/Users/mparnisari/GitHub/openfga/internal/graph/limited_checker.go:54 +0x65
github.com/openfga/openfga/internal/graph.(*LocalChecker).dispatch.func1({0x190bca8?, 0xc0006909b0?})
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:342 +0x3c
github.com/openfga/openfga/internal/graph.resolver.func1.1()
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:156 +0x37
created by github.com/openfga/openfga/internal/graph.resolver.func1
	/Users/mparnisari/GitHub/openfga/internal/graph/check.go:155 +0x14a


Process finished with the exit code 1
```