### PR TITLE
fix: in ListObjects API, Check calls have now a bounded number of concurrent database reads

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -39,11 +39,11 @@ import (
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/health"
 	"github.com/openfga/openfga/pkg/storage"
-	"github.com/openfga/openfga/pkg/storage/caching"
 	"github.com/openfga/openfga/pkg/storage/memory"
 	"github.com/openfga/openfga/pkg/storage/mysql"
 	"github.com/openfga/openfga/pkg/storage/postgres"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
@@ -555,7 +555,7 @@ func RunServer(ctx context.Context, config *Config) error {
 	default:
 		return fmt.Errorf("storage engine '%s' is unsupported", config.Datastore.Engine)
 	}
-	datastore = caching.NewCachedOpenFGADatastore(storage.NewContextWrapper(datastore), config.Datastore.MaxCacheSize)
+	datastore = storagewrappers.NewCachedOpenFGADatastore(storage.NewContextWrapper(datastore), config.Datastore.MaxCacheSize)
 
 	logger.Info(fmt.Sprintf("using '%v' storage engine", config.Datastore.Engine))
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -97,7 +97,9 @@ type LocalChecker struct {
 }
 
 // NewLocalChecker constructs a LocalChecker that can be used to evaluate a Check
-// request locally and with a high degree of concurrency.
+// request locally. Thinking of a Check request as a tree of tuple evaluations, the concurrencyLimit parameter controls,
+// on a given level of the tree, the maximum number of nodes that can be evaluated concurrently (the breadth).
+// There is also a limit on the depth that will be evaluated before returning an error.
 func NewLocalChecker(
 	ds storage.RelationshipTupleReader,
 	concurrencyLimit uint32,

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -160,7 +160,6 @@ func (q *ListObjectsQuery) evaluate(
 		}()
 
 		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.CheckConcurrencyLimit)
-		defer limitedTupleReader.Close()
 
 		checkResolver := graph.NewLocalChecker(
 			storage.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -31,12 +31,12 @@ const (
 var (
 	furtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "list_objects_further_eval_required_count",
-		Help: "Number of ListObjects calls that need to issue a Check call to determine a final result",
+		Help: "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
 	})
 
 	noFurtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "list_objects_no_further_eval_required_count",
-		Help: "Number of ListObjects calls that don't need to issue a Check call to determine a final result",
+		Help: "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
 	})
 )
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/prometheus/client_golang/prometheus"
@@ -156,8 +157,10 @@ func (q *ListObjectsQuery) evaluate(
 			close(connectedObjectsResChan)
 		}()
 
+		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.CheckConcurrencyLimit)
+
 		checkResolver := graph.NewLocalChecker(
-			storage.NewCombinedTupleReader(q.Datastore, req.GetContextualTuples().GetTupleKeys()),
+			storage.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),
 			q.CheckConcurrencyLimit,
 		)
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -160,6 +160,7 @@ func (q *ListObjectsQuery) evaluate(
 		}()
 
 		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.CheckConcurrencyLimit)
+		defer limitedTupleReader.Close()
 
 		checkResolver := graph.NewLocalChecker(
 			storage.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -31,10 +31,12 @@ const (
 var (
 	furtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "list_objects_further_eval_required_count",
+		Help: "Number of ListObjects calls that need to issue a Check call to determine a final result",
 	})
 
 	noFurtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "list_objects_no_further_eval_required_count",
+		Help: "Number of ListObjects calls that don't need to issue a Check call to determine a final result",
 	})
 )
 
@@ -54,7 +56,7 @@ type ListObjectsResult struct {
 
 // listObjectsRequest captures the RPC request definition interface for the ListObjects API.
 // The unary and streaming RPC definitions implement this interface, and so it can be used
-// interchangably for a canonical representation between the two.
+// interchangeably for a canonical representation between the two.
 type listObjectsRequest interface {
 	GetStoreId() string
 	GetAuthorizationModelId() string

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -8,12 +8,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
-
-var tracer = otel.Tracer("pkg/storage/boundedconcurrency")
 
 var _ storage.RelationshipTupleReader = (*boundedConcurrencyTupleReader)(nil)
 

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -69,10 +69,6 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(ctx context.Context, s
 	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
 }
 
-func (b *boundedConcurrencyTupleReader) Close() {
-	close(b.limiter)
-}
-
 func (b *boundedConcurrencyTupleReader) waitForLimiter(ctx context.Context) {
 	start := time.Now()
 

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -1,0 +1,85 @@
+package storagewrappers
+
+import (
+	"context"
+	"time"
+
+	"github.com/openfga/openfga/pkg/storage"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+var tracer = otel.Tracer("pkg/storage/boundedconcurrency")
+
+var _ storage.RelationshipTupleReader = (*boundedConcurrencyTupleReader)(nil)
+
+type boundedConcurrencyTupleReader struct {
+	storage.RelationshipTupleReader
+	limiter chan struct{}
+}
+
+// NewBoundedConcurrencyTupleReader returns a wrapper over a datastore that makes sure that there are, at most,
+// N concurrent calls to Read, ReadUserTuple and ReadUsersetTuples.
+// Consumers can then rest assured that one client will not hoard all the database connections available for one Check call.
+func NewBoundedConcurrencyTupleReader(wrapped storage.RelationshipTupleReader, N uint32) *boundedConcurrencyTupleReader {
+	return &boundedConcurrencyTupleReader{
+		RelationshipTupleReader: wrapped,
+		limiter:                 make(chan struct{}, N),
+	}
+}
+
+func (b *boundedConcurrencyTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (*openfgapb.Tuple, error) {
+	ctx, span := tracer.Start(ctx, "ReadUserTuple_boundedConcurrency")
+	start := time.Now()
+
+	b.limiter <- struct{}{}
+
+	end := time.Now()
+	span.SetAttributes(attribute.Int64("time_waiting", end.Sub(start).Milliseconds()))
+
+	defer func() {
+		<-b.limiter
+		span.End()
+	}()
+
+	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey)
+}
+
+func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgapb.TupleKey) (storage.TupleIterator, error) {
+	ctx, span := tracer.Start(ctx, "Read_boundedConcurrency")
+	start := time.Now()
+
+	b.limiter <- struct{}{}
+
+	end := time.Now()
+	span.SetAttributes(attribute.Int64("time_waiting", end.Sub(start).Milliseconds()))
+
+	defer func() {
+		<-b.limiter
+		span.End()
+	}()
+
+	return b.RelationshipTupleReader.Read(ctx, store, tupleKey)
+}
+
+func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+	ctx, span := tracer.Start(ctx, "ReadUsersetTuples_boundedConcurrency")
+	start := time.Now()
+
+	b.limiter <- struct{}{}
+
+	end := time.Now()
+	span.SetAttributes(attribute.Int64("time_waiting", end.Sub(start).Milliseconds()))
+
+	defer func() {
+		<-b.limiter
+		span.End()
+	}()
+
+	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
+}
+
+func (b *boundedConcurrencyTupleReader) Close() {
+	close(b.limiter)
+}

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -17,10 +17,13 @@ const timeWaitingSpanAttribute = "time_waiting"
 var _ storage.RelationshipTupleReader = (*boundedConcurrencyTupleReader)(nil)
 
 var (
-	timeWaitingHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
-		Name:    "datastore_bounded_read_delay_ms",
-		Help:    "Time spent waiting for Read, ReadUserTuple and ReadUsersetTuples calls to the datastore",
-		Buckets: []float64{10, 25, 50, 100, 1000, 5000}, // milliseconds. Upper bound is config.UpstreamTimeout
+	boundedReadDelayMsHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:                            "datastore_bounded_read_delay_ms",
+		Help:                            "Time spent waiting for Read, ReadUserTuple and ReadUsersetTuples calls to the datastore",
+		Buckets:                         []float64{1, 3, 5, 10, 25, 50, 100, 1000, 5000}, // milliseconds. Upper bound is config.UpstreamTimeout
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
 	})
 )
 
@@ -76,7 +79,7 @@ func (b *boundedConcurrencyTupleReader) waitForLimiter(ctx context.Context) {
 
 	end := time.Now()
 	timeWaiting := end.Sub(start).Milliseconds()
-	timeWaitingHistogram.Observe(float64(timeWaiting))
+	boundedReadDelayMsHistogram.Observe(float64(timeWaiting))
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(attribute.Int64(timeWaitingSpanAttribute, timeWaiting))
 }

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -1,0 +1,65 @@
+package storagewrappers
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/memory"
+	"github.com/openfga/openfga/pkg/storage/mocks"
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/stretchr/testify/require"
+	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+)
+
+func TestBoundedConcurrencyWrapper(t *testing.T) {
+	store := ulid.Make().String()
+	t.Logf("create a slow backend that takes 1 second per read call")
+	slowBackend := mocks.NewMockSlowDataStorage(memory.New(), time.Second)
+
+	t.Logf("write a tuple")
+	err := slowBackend.Write(context.Background(), store, []*openfgapb.TupleKey{}, []*openfgapb.TupleKey{
+		tuple.NewTupleKey("obj:1", "viewer", "user:anne"),
+	})
+	require.NoError(t, err)
+
+	t.Logf("create a limited tuple reader that allows 1 concurrent read a time")
+	limitedTupleReader := NewBoundedConcurrencyTupleReader(slowBackend, 1)
+	defer limitedTupleReader.Close()
+
+	t.Logf("Read the tuple from 3 goroutines: Each should be run serially")
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	start := time.Now()
+
+	go func() {
+		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"))
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	go func() {
+		_, err := limitedTupleReader.ReadUsersetTuples(context.Background(), store, storage.ReadUsersetTuplesFilter{
+			Object:   "obj:1",
+			Relation: "viewer",
+		})
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	go func() {
+		_, err := limitedTupleReader.Read(context.Background(), store, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	end := time.Now()
+
+	require.True(t, end.Sub(start) >= 3*time.Second, "Expected all reads to take at least 3 seconds")
+}

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -26,7 +26,6 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 
 	// create a limited tuple reader that allows 1 concurrent read a time
 	limitedTupleReader := NewBoundedConcurrencyTupleReader(slowBackend, 1)
-	defer limitedTupleReader.Close()
 
 	// do reads from 3 goroutines - each should be run serially
 	var wg sync.WaitGroup

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -17,20 +17,18 @@ import (
 
 func TestBoundedConcurrencyWrapper(t *testing.T) {
 	store := ulid.Make().String()
-	t.Logf("create a slow backend that takes 1 second per read call")
 	slowBackend := mocks.NewMockSlowDataStorage(memory.New(), time.Second)
 
-	t.Logf("write a tuple")
 	err := slowBackend.Write(context.Background(), store, []*openfgapb.TupleKey{}, []*openfgapb.TupleKey{
 		tuple.NewTupleKey("obj:1", "viewer", "user:anne"),
 	})
 	require.NoError(t, err)
 
-	t.Logf("create a limited tuple reader that allows 1 concurrent read a time")
+	// create a limited tuple reader that allows 1 concurrent read a time
 	limitedTupleReader := NewBoundedConcurrencyTupleReader(slowBackend, 1)
 	defer limitedTupleReader.Close()
 
-	t.Logf("Read the tuple from 3 goroutines: Each should be run serially")
+	// do reads from 3 goroutines - each should be run serially
 	var wg sync.WaitGroup
 	wg.Add(3)
 

--- a/pkg/storage/storagewrappers/caching.go
+++ b/pkg/storage/storagewrappers/caching.go
@@ -1,5 +1,5 @@
-// Package caching contains wrappers that cache storage data
-package caching
+// Package storagewrappers contains decorators for storage data
+package storagewrappers
 
 import (
 	"context"

--- a/pkg/storage/storagewrappers/caching_test.go
+++ b/pkg/storage/storagewrappers/caching_test.go
@@ -1,4 +1,4 @@
-package caching
+package storagewrappers
 
 import (
 	"context"


### PR DESCRIPTION
## Description

This PR implements a wrapper for the [`RelationshipTupleReader` interface](https://github.com/openfga/openfga/blob/main/pkg/storage/storage.go#L47) that has a channel limiter so that only so many database queries can be in flight per request.

It also measures how much time is spent waiting. For example: for a complex ListObjects call:

<img width="1090" alt="image" src="https://github.com/openfga/openfga/assets/5374887/8bab5137-24f7-474f-8a68-93e3e8c6ac82">

<img width="1919" alt="image" src="https://github.com/openfga/openfga/assets/5374887/f6bc1eff-2ff8-442d-a868-dbc8c186fde2">


In this PR we use it only for ListObjects API calls, so that one complex ListObjects call won't hog all database connections.

In the future we can introduce this idea in Check API, too.

## References
This is a follow-up of https://github.com/openfga/openfga/pull/855

## Testing

Ran a load test for 10 minutes on both this PR and main: `ab -r -t 600 -c 100 -p body.txt -T application/json http://localhost:8080/stores/01H4SEESD718G51KWP3GHBKNE7/list-objects`

<img width="646" alt="image" src="https://github.com/openfga/openfga/assets/5374887/705407f0-5d48-4e9c-945c-51c9eff4aba7">
