### PR TITLE
feat: add three server settings to control resources used by Check API

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -12,6 +12,12 @@
             "default": 100,
             "x-env-variable": "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL"
         },
+        "maxConcurrentReads": {
+            "description": "The maximum allowed number of concurrent reads during queries.",
+            "type": "integer",
+            "default": 30,
+            "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS"
+        },
         "changelogHorizonOffset": {
             "description": "The offset (in minutes) from the current time. Changes that occur after this offset will not be included in the response of ReadChanges.",
             "type": "integer",
@@ -19,10 +25,16 @@
             "x-env-variable": "OPENFGA_CHANGELOG_HORIZON_OFFSET"
         },
         "resolveNodeLimit": {
-            "description": "Defines how deeply nested an authorization model can be.",
+            "description": "Defines how deeply nested an authorization model can be before a Check request errors out.",
             "type": "integer",
             "default": 25,
             "x-env-variable": "OPENFGA_RESOLVE_NODE_LIMIT"
+        },
+        "resolveNodeBreadthLimit": {
+            "description": "Defines how many nodes on a given level can be evaluated concurrently in a Check resolution tree.",
+            "type": "integer",
+            "default": 100,
+            "x-env-variable": "OPENFGA_RESOLVE_NODE_BREADTH_LIMIT"
         },
         "listObjectsDeadline": {
             "description": "The timeout deadline for serving ListObjects requests",

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -12,11 +12,17 @@
             "default": 100,
             "x-env-variable": "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL"
         },
-        "maxConcurrentReads": {
-            "description": "The maximum allowed number of concurrent reads during queries.",
+        "maxConcurrentReadsForCheck": {
+            "description": "The maximum allowed number of concurrent reads during Check queries.",
             "type": "integer",
             "default": 30,
-            "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS"
+            "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK"
+        },
+        "maxConcurrentReadsForListObjects": {
+            "description": "The maximum allowed number of concurrent reads during ListObjects queries.",
+            "type": "integer",
+            "default": 30,
+            "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS"
         },
         "changelogHorizonOffset": {
             "description": "The offset (in minutes) from the current time. Changes that occur after this offset will not be included in the response of ReadChanges.",
@@ -25,7 +31,7 @@
             "x-env-variable": "OPENFGA_CHANGELOG_HORIZON_OFFSET"
         },
         "resolveNodeLimit": {
-            "description": "Defines how deeply nested an authorization model can be before a Check request errors out.",
+            "description": "Defines how deeply nested an authorization model can be before a query errors out.",
             "type": "integer",
             "default": 25,
             "x-env-variable": "OPENFGA_RESOLVE_NODE_LIMIT"

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -13,13 +13,13 @@
             "x-env-variable": "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL"
         },
         "maxConcurrentReadsForCheck": {
-            "description": "The maximum allowed number of concurrent reads during Check queries.",
+            "description": "The maximum allowed number of concurrent reads in a single Check query.",
             "type": "integer",
             "default": 30,
             "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK"
         },
         "maxConcurrentReadsForListObjects": {
-            "description": "The maximum allowed number of concurrent reads during ListObjects queries.",
+            "description": "The maximum allowed number of concurrent reads in a single ListObjects query.",
             "type": "integer",
             "default": 30,
             "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS"
@@ -31,7 +31,7 @@
             "x-env-variable": "OPENFGA_CHANGELOG_HORIZON_OFFSET"
         },
         "resolveNodeLimit": {
-            "description": "Defines how deeply nested an authorization model can be before a query errors out.",
+            "description": "Maximum resolution depth to attempt before throwing an error (defines how deeply nested an authorization model can be before a query errors out).",
             "type": "integer",
             "default": 25,
             "x-env-variable": "OPENFGA_RESOLVE_NODE_LIMIT"

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -137,11 +137,17 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("maxTypesPerAuthorizationModel", flags.Lookup("max-types-per-authorization-model"))
 		util.MustBindEnv("maxTypesPerAuthorizationModel", "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL", "OPENFGA_MAXTYPESPERAUTHORIZATIONMODEL")
 
+		util.MustBindPFlag("maxConcurrentReads", flags.Lookup("max-concurrent-reads"))
+		util.MustBindEnv("maxConcurrentReads", "OPENFGA_MAX_CONCURRENT_READS", "OPENFGA_MAXCONCURRENTREADS")
+
 		util.MustBindPFlag("changelogHorizonOffset", flags.Lookup("changelog-horizon-offset"))
 		util.MustBindEnv("changelogHorizonOffset", "OPENFGA_CHANGELOG_HORIZON_OFFSET", "OPENFGA_CHANGELOGHORIZONOFFSET")
 
 		util.MustBindPFlag("resolveNodeLimit", flags.Lookup("resolve-node-limit"))
 		util.MustBindEnv("resolveNodeLimit", "OPENFGA_RESOLVE_NODE_LIMIT", "OPENFGA_RESOLVENODELIMIT")
+
+		util.MustBindPFlag("resolveNodeBreadthLimit", flags.Lookup("resolve-node-breadth-limit"))
+		util.MustBindEnv("resolveNodeBreadthLimit", "OPENFGA_RESOLVE_NODE_BREADTH_LIMIT", "OPENFGA_RESOLVENODEBREADTHLIMIT")
 
 		util.MustBindPFlag("listObjectsDeadline", flags.Lookup("listObjects-deadline"))
 		util.MustBindEnv("listObjectsDeadline", "OPENFGA_LIST_OBJECTS_DEADLINE", "OPENFGA_LISTOBJECTSDEADLINE")

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -137,8 +137,11 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("maxTypesPerAuthorizationModel", flags.Lookup("max-types-per-authorization-model"))
 		util.MustBindEnv("maxTypesPerAuthorizationModel", "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL", "OPENFGA_MAXTYPESPERAUTHORIZATIONMODEL")
 
-		util.MustBindPFlag("maxConcurrentReads", flags.Lookup("max-concurrent-reads"))
-		util.MustBindEnv("maxConcurrentReads", "OPENFGA_MAX_CONCURRENT_READS", "OPENFGA_MAXCONCURRENTREADS")
+		util.MustBindPFlag("maxConcurrentReadsForListObjects", flags.Lookup("max-concurrent-reads-for-list-objects"))
+		util.MustBindEnv("maxConcurrentReadsForListObjects", "OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS", "OPENFGA_MAXCONCURRENTREADSFORLISTOBJECTS")
+
+		util.MustBindPFlag("maxConcurrentReadsForCheck", flags.Lookup("max-concurrent-reads-for-check"))
+		util.MustBindEnv("maxConcurrentReadsForCheck", "OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK", "OPENFGA_MAXCONCURRENTREADSFORCHECK")
 
 		util.MustBindPFlag("changelogHorizonOffset", flags.Lookup("changelog-horizon-offset"))
 		util.MustBindEnv("changelogHorizonOffset", "OPENFGA_CHANGELOG_HORIZON_OFFSET", "OPENFGA_CHANGELOGHORIZONOFFSET")

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"math"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -712,8 +713,8 @@ func RunServer(ctx context.Context, config *Config) error {
 	}, &server.Config{
 		ResolveNodeLimit:                 config.ResolveNodeLimit,
 		ResolveNodeBreadthLimit:          config.ResolveNodeBreadthLimit,
-		MaxConcurrentReadsForCheck:       config.MaxConcurrentReadsForCheck,
-		MaxConcurrentReadsForListObjects: config.MaxConcurrentReadsForListObjects,
+		MaxConcurrentReadsForCheck:       uint32(math.Max(float64(config.MaxConcurrentReadsForCheck), float64(config.Datastore.MaxOpenConns))),
+		MaxConcurrentReadsForListObjects: uint32(math.Max(float64(config.MaxConcurrentReadsForListObjects), float64(config.Datastore.MaxOpenConns))),
 		ChangelogHorizonOffset:           config.ChangelogHorizonOffset,
 		ListObjectsDeadline:              config.ListObjectsDeadline,
 		ListObjectsMaxResults:            config.ListObjectsMaxResults,

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -165,13 +165,13 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Int("max-types-per-authorization-model", defaultConfig.MaxTypesPerAuthorizationModel, "the maximum allowed number of type definitions per authorization model")
 
-	flags.Uint32("max-concurrent-reads-for-list-objects", defaultConfig.MaxConcurrentReadsForListObjects, "the maximum allowed number of concurrent datastore reads during a ListObjects query. A high number means that you want ListObjects latency to be low, at the expense of other queries performance")
+	flags.Uint32("max-concurrent-reads-for-list-objects", defaultConfig.MaxConcurrentReadsForListObjects, "the maximum allowed number of concurrent datastore reads in a single ListObjects query. A high number means that you want ListObjects latency to be low, at the expense of other queries performance")
 
-	flags.Uint32("max-concurrent-reads-for-check", defaultConfig.MaxConcurrentReadsForCheck, "the maximum allowed number of concurrent datastore reads during a Check query. A high number means that you want Check latency to be low, at the expense of other queries performance")
+	flags.Uint32("max-concurrent-reads-for-check", defaultConfig.MaxConcurrentReadsForCheck, "the maximum allowed number of concurrent datastore reads in a single Check query. A high number means that you want Check latency to be low, at the expense of other queries performance")
 
 	flags.Int("changelog-horizon-offset", defaultConfig.ChangelogHorizonOffset, "the offset (in minutes) from the current time. Changes that occur after this offset will not be included in the response of ReadChanges")
 
-	flags.Uint32("resolve-node-limit", defaultConfig.ResolveNodeLimit, "defines how deeply nested an authorization model can be before a query errors out")
+	flags.Uint32("resolve-node-limit", defaultConfig.ResolveNodeLimit, "maximum resolution depth to attempt before throwing an error (defines how deeply nested an authorization model can be before a query errors out).")
 
 	flags.Uint32("resolve-node-breadth-limit", defaultConfig.ResolveNodeBreadthLimit, "defines how many nodes on a given level can be evaluated concurrently in a Check resolution tree")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"math"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -713,8 +712,8 @@ func RunServer(ctx context.Context, config *Config) error {
 	}, &server.Config{
 		ResolveNodeLimit:                 config.ResolveNodeLimit,
 		ResolveNodeBreadthLimit:          config.ResolveNodeBreadthLimit,
-		MaxConcurrentReadsForCheck:       uint32(math.Max(float64(config.MaxConcurrentReadsForCheck), float64(config.Datastore.MaxOpenConns))),
-		MaxConcurrentReadsForListObjects: uint32(math.Max(float64(config.MaxConcurrentReadsForListObjects), float64(config.Datastore.MaxOpenConns))),
+		MaxConcurrentReadsForCheck:       config.MaxConcurrentReadsForCheck,
+		MaxConcurrentReadsForListObjects: config.MaxConcurrentReadsForListObjects,
 		ChangelogHorizonOffset:           config.ChangelogHorizonOffset,
 		ListObjectsDeadline:              config.ListObjectsDeadline,
 		ListObjectsMaxResults:            config.ListObjectsMaxResults,

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -220,15 +220,6 @@ type authTest struct {
 }
 
 func TestVerifyConfig(t *testing.T) {
-	t.Run("MaxConcurrentReads_cannot_be_higher_than_DatastoreMaxOpenConns", func(t *testing.T) {
-		cfg := DefaultConfig()
-		cfg.MaxConcurrentReads = 100
-		cfg.Datastore.MaxOpenConns = 1
-
-		err := VerifyConfig(cfg)
-		require.EqualError(t, err, "config 'maxConcurrentReads' (100) cannot be higher than 'datastore.maxOpenConns' config (1)")
-	})
-
 	t.Run("UpstreamTimeout_cannot_be_less_than_ListObjectsDeadline", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.ListObjectsDeadline = 5 * time.Minute
@@ -907,9 +898,21 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), cfg.MaxTypesPerAuthorizationModel)
 
+	val = res.Get("properties.maxConcurrentReadsForListObjects.default")
+	require.True(t, val.Exists())
+	require.EqualValues(t, val.Int(), cfg.MaxConcurrentReadsForListObjects)
+
+	val = res.Get("properties.maxConcurrentReadsForCheck.default")
+	require.True(t, val.Exists())
+	require.EqualValues(t, val.Int(), cfg.MaxConcurrentReadsForCheck)
+
 	val = res.Get("properties.changelogHorizonOffset.default")
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), cfg.ChangelogHorizonOffset)
+
+	val = res.Get("properties.resolveNodeBreadthLimit.default")
+	require.True(t, val.Exists())
+	require.EqualValues(t, val.Int(), cfg.ResolveNodeBreadthLimit)
 
 	val = res.Get("properties.resolveNodeLimit.default")
 	require.True(t, val.Exists())

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -220,6 +220,15 @@ type authTest struct {
 }
 
 func TestVerifyConfig(t *testing.T) {
+	t.Run("MaxConcurrentReads_cannot_be_higher_than_DatastoreMaxOpenConns", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.MaxConcurrentReads = 100
+		cfg.Datastore.MaxOpenConns = 1
+
+		err := VerifyConfig(cfg)
+		require.EqualError(t, err, "config 'maxConcurrentReads' (100) cannot be higher than 'datastore.maxOpenConns' config (1)")
+	})
+
 	t.Run("UpstreamTimeout_cannot_be_less_than_ListObjectsDeadline", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.ListObjectsDeadline = 5 * time.Minute

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -92,8 +92,9 @@ type checkOutcome struct {
 // LocalChecker implements Check in a highly concurrent and localized manner. The
 // Check resolution is limited per branch of evaluation by the concurrencyLimit.
 type LocalChecker struct {
-	ds               storage.RelationshipTupleReader
-	concurrencyLimit uint32
+	ds                 storage.RelationshipTupleReader
+	concurrencyLimit   uint32
+	maxConcurrentReads uint32 //TODO not used yet
 }
 
 // NewLocalChecker constructs a LocalChecker that can be used to evaluate a Check
@@ -103,8 +104,9 @@ type LocalChecker struct {
 func NewLocalChecker(
 	ds storage.RelationshipTupleReader,
 	concurrencyLimit uint32,
+	maxConcurrentReads uint32,
 ) *LocalChecker {
-	checker := &LocalChecker{ds: ds, concurrencyLimit: concurrencyLimit}
+	checker := &LocalChecker{ds: ds, concurrencyLimit: concurrencyLimit, maxConcurrentReads: maxConcurrentReads}
 	return checker
 }
 

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -31,7 +31,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	checker := NewLocalChecker(ds, 100)
+	checker := NewLocalChecker(ds, 100, 100)
 
 	typedefs := parser.MustParse(`
 	type user
@@ -91,7 +91,7 @@ func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	checker := NewLocalChecker(ds, concurrencyLimit)
+	checker := NewLocalChecker(ds, concurrencyLimit, 100)
 
 	typedefs := parser.MustParse(`
 	type user

--- a/pkg/server/commands/connected_objects.go
+++ b/pkg/server/commands/connected_objects.go
@@ -91,9 +91,10 @@ type UserRef struct {
 }
 
 type ConnectedObjectsCommand struct {
-	Datastore        storage.RelationshipTupleReader
-	Typesystem       *typesystem.TypeSystem
-	ResolveNodeLimit uint32
+	Datastore               storage.RelationshipTupleReader
+	Typesystem              *typesystem.TypeSystem
+	ResolveNodeLimit        uint32
+	ResolveNodeBreadthLimit uint32
 
 	// Limit limits the results yielded by the ConnectedObjects API.
 	Limit uint32
@@ -176,7 +177,7 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	}
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(maximumConcurrentChecks)
+	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
 
 	for i, ingress := range ingresses {
 		span.SetAttributes(attribute.String(fmt.Sprintf("_ingress %d", i), ingress.String()))
@@ -308,7 +309,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(maximumConcurrentChecks)
+	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
 
 	for {
 		t, err := iter.Next()
@@ -457,7 +458,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(maximumConcurrentChecks)
+	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
 
 	for {
 		t, err := iter.Next()

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	streamedBufferSize      = 100
-	maximumConcurrentChecks = 100 // todo(jon-whit): make this configurable, but for now limit to 100 concurrent checks
+	streamedBufferSize = 100
 )
 
 var (
@@ -41,12 +40,13 @@ var (
 )
 
 type ListObjectsQuery struct {
-	Datastore             storage.RelationshipTupleReader
-	Logger                logger.Logger
-	ListObjectsDeadline   time.Duration
-	ListObjectsMaxResults uint32
-	ResolveNodeLimit      uint32
-	CheckConcurrencyLimit uint32
+	Datastore               storage.RelationshipTupleReader
+	Logger                  logger.Logger
+	ListObjectsDeadline     time.Duration
+	ListObjectsMaxResults   uint32
+	ResolveNodeLimit        uint32
+	ResolveNodeBreadthLimit uint32
+	MaxConcurrentReads      uint32
 }
 
 type ListObjectsResult struct {
@@ -138,10 +138,11 @@ func (q *ListObjectsQuery) evaluate(
 		var objectsFound = new(uint32)
 
 		connectedObjectsCmd := &ConnectedObjectsCommand{
-			Datastore:        q.Datastore,
-			Typesystem:       typesys,
-			ResolveNodeLimit: q.ResolveNodeLimit,
-			Limit:            maxResults,
+			Datastore:               q.Datastore,
+			Typesystem:              typesys,
+			ResolveNodeLimit:        q.ResolveNodeLimit,
+			Limit:                   maxResults,
+			ResolveNodeBreadthLimit: q.ResolveNodeBreadthLimit,
 		}
 
 		go func() {
@@ -159,14 +160,14 @@ func (q *ListObjectsQuery) evaluate(
 			close(connectedObjectsResChan)
 		}()
 
-		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.CheckConcurrencyLimit)
+		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.MaxConcurrentReads)
 
 		checkResolver := graph.NewLocalChecker(
 			storage.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),
-			q.CheckConcurrencyLimit,
+			q.ResolveNodeBreadthLimit,
 		)
 
-		concurrencyLimiterCh := make(chan struct{}, maximumConcurrentChecks)
+		concurrencyLimiterCh := make(chan struct{}, q.ResolveNodeBreadthLimit)
 
 		wg := sync.WaitGroup{}
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -141,8 +141,8 @@ func (q *ListObjectsQuery) evaluate(
 			Datastore:               q.Datastore,
 			Typesystem:              typesys,
 			ResolveNodeLimit:        q.ResolveNodeLimit,
-			Limit:                   maxResults,
 			ResolveNodeBreadthLimit: q.ResolveNodeBreadthLimit,
+			Limit:                   maxResults,
 		}
 
 		go func() {

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -165,6 +165,7 @@ func (q *ListObjectsQuery) evaluate(
 		checkResolver := graph.NewLocalChecker(
 			storage.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),
 			q.ResolveNodeBreadthLimit,
+			q.MaxConcurrentReads,
 		)
 
 		concurrencyLimiterCh := make(chan struct{}, q.ResolveNodeBreadthLimit)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -32,8 +32,6 @@ type ExperimentalFeatureFlag string
 const (
 	AuthorizationModelIDHeader = "openfga-authorization-model-id"
 	authorizationModelIDKey    = "authorization_model_id"
-
-	checkConcurrencyLimit = 100
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -60,11 +58,13 @@ type Dependencies struct {
 }
 
 type Config struct {
-	ResolveNodeLimit       uint32
-	ChangelogHorizonOffset int
-	ListObjectsDeadline    time.Duration
-	ListObjectsMaxResults  uint32
-	Experimentals          []ExperimentalFeatureFlag
+	ResolveNodeLimit        uint32
+	ResolveNodeBreadthLimit uint32
+	MaxConcurrentReads      uint32
+	ChangelogHorizonOffset  int
+	ListObjectsDeadline     time.Duration
+	ListObjectsMaxResults   uint32
+	Experimentals           []ExperimentalFeatureFlag
 }
 
 // New creates a new Server which uses the supplied backends
@@ -102,12 +102,13 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgapb.ListObjectsRequ
 	}
 
 	q := &commands.ListObjectsQuery{
-		Datastore:             storage.NewCombinedTupleReader(s.datastore, req.GetContextualTuples().GetTupleKeys()),
-		Logger:                s.logger,
-		ListObjectsDeadline:   s.config.ListObjectsDeadline,
-		ListObjectsMaxResults: s.config.ListObjectsMaxResults,
-		ResolveNodeLimit:      s.config.ResolveNodeLimit,
-		CheckConcurrencyLimit: checkConcurrencyLimit,
+		Datastore:               storage.NewCombinedTupleReader(s.datastore, req.GetContextualTuples().GetTupleKeys()),
+		Logger:                  s.logger,
+		ListObjectsDeadline:     s.config.ListObjectsDeadline,
+		ListObjectsMaxResults:   s.config.ListObjectsMaxResults,
+		ResolveNodeLimit:        s.config.ResolveNodeLimit,
+		ResolveNodeBreadthLimit: s.config.ResolveNodeBreadthLimit,
+		MaxConcurrentReads:      s.config.MaxConcurrentReads,
 	}
 
 	return q.Execute(
@@ -140,12 +141,12 @@ func (s *Server) StreamedListObjects(req *openfgapb.StreamedListObjectsRequest, 
 	}
 
 	q := &commands.ListObjectsQuery{
-		Datastore:             s.datastore,
-		Logger:                s.logger,
-		ListObjectsDeadline:   s.config.ListObjectsDeadline,
-		ListObjectsMaxResults: s.config.ListObjectsMaxResults,
-		ResolveNodeLimit:      s.config.ResolveNodeLimit,
-		CheckConcurrencyLimit: checkConcurrencyLimit,
+		Datastore:               s.datastore,
+		Logger:                  s.logger,
+		ListObjectsDeadline:     s.config.ListObjectsDeadline,
+		ListObjectsMaxResults:   s.config.ListObjectsMaxResults,
+		ResolveNodeLimit:        s.config.ResolveNodeLimit,
+		ResolveNodeBreadthLimit: s.config.ResolveNodeBreadthLimit,
 	}
 
 	req.AuthorizationModelId = typesys.GetAuthorizationModelID() // the resolved model id
@@ -228,7 +229,7 @@ func (s *Server) Check(ctx context.Context, req *openfgapb.CheckRequest) (*openf
 
 	checkResolver := graph.NewLocalChecker(
 		storage.NewCombinedTupleReader(s.datastore, req.ContextualTuples.GetTupleKeys()),
-		checkConcurrencyLimit,
+		s.config.ResolveNodeBreadthLimit,
 	)
 
 	resp, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -147,6 +147,7 @@ func (s *Server) StreamedListObjects(req *openfgapb.StreamedListObjectsRequest, 
 		ListObjectsMaxResults:   s.config.ListObjectsMaxResults,
 		ResolveNodeLimit:        s.config.ResolveNodeLimit,
 		ResolveNodeBreadthLimit: s.config.ResolveNodeBreadthLimit,
+		MaxConcurrentReads:      s.config.MaxConcurrentReads,
 	}
 
 	req.AuthorizationModelId = typesys.GetAuthorizationModelID() // the resolved model id

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -228,7 +228,9 @@ func TestOperationsWithInvalidModel(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit: test.DefaultResolveNodeLimit,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
 	})
 
 	_, err := s.Check(ctx, &openfgapb.CheckRequest{
@@ -335,7 +337,9 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit: test.DefaultResolveNodeLimit,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
 	})
 
 	start := time.Now()
@@ -477,9 +481,11 @@ func BenchmarkListObjectsNoRaceCondition(b *testing.B) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
 	})
 
 	b.ResetTimer()
@@ -537,9 +543,11 @@ func TestListObjects_Unoptimized_UnhappyPaths(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -599,9 +607,11 @@ func TestListObjects_Unoptimized_UnhappyPaths_Known_Error(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -680,9 +690,11 @@ func TestListObjects_UnhappyPaths(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -761,9 +773,11 @@ func TestListObjects_UnhappyPaths_Known_Error(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -824,10 +838,12 @@ func TestAuthorizationModelInvalidSchemaVersion(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:      test.DefaultResolveNodeLimit,
-		ListObjectsDeadline:   5 * time.Second,
-		ListObjectsMaxResults: 1000,
-		Experimentals:         []ExperimentalFeatureFlag{},
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:     5 * time.Second,
+		ListObjectsMaxResults:   1000,
+		Experimentals:           []ExperimentalFeatureFlag{},
 	})
 
 	t.Run("invalid_schema_error_in_check", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -175,7 +175,9 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit: test.DefaultResolveNodeLimit,
+		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
 	})
 
 	checkResponse, err := s.Check(ctx, &openfgapb.CheckRequest{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -175,9 +175,10 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
 	})
 
 	checkResponse, err := s.Check(ctx, &openfgapb.CheckRequest{
@@ -228,9 +229,10 @@ func TestOperationsWithInvalidModel(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
 	})
 
 	_, err := s.Check(ctx, &openfgapb.CheckRequest{
@@ -337,9 +339,10 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 		Logger:    logger.NewNoopLogger(),
 		Transport: gateway.NewNoopTransport(),
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
 	})
 
 	start := time.Now()
@@ -481,11 +484,12 @@ func BenchmarkListObjectsNoRaceCondition(b *testing.B) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
 	})
 
 	b.ResetTimer()
@@ -543,11 +547,12 @@ func TestListObjects_Unoptimized_UnhappyPaths(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -607,11 +612,12 @@ func TestListObjects_Unoptimized_UnhappyPaths_Known_Error(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -690,11 +696,12 @@ func TestListObjects_UnhappyPaths(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -773,11 +780,12 @@ func TestListObjects_UnhappyPaths_Known_Error(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
 	})
 
 	t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
@@ -838,12 +846,13 @@ func TestAuthorizationModelInvalidSchemaVersion(t *testing.T) {
 		Transport: transport,
 		Logger:    logger,
 	}, &Config{
-		ResolveNodeLimit:        test.DefaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: test.DefaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      test.DefaultMaxConcurrentReads,
-		ListObjectsDeadline:     5 * time.Second,
-		ListObjectsMaxResults:   1000,
-		Experimentals:           []ExperimentalFeatureFlag{},
+		ResolveNodeLimit:                 test.DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:          test.DefaultResolveNodeBreadthLimit,
+		MaxConcurrentReadsForListObjects: test.DefaultMaxConcurrentReads,
+		MaxConcurrentReadsForCheck:       test.DefaultMaxConcurrentReads,
+		ListObjectsDeadline:              5 * time.Second,
+		ListObjectsMaxResults:            1000,
+		Experimentals:                    []ExperimentalFeatureFlag{},
 	})
 
 	t.Run("invalid_schema_error_in_check", func(t *testing.T) {

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -1181,10 +1181,11 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			}
 
 			connectedObjectsCmd := commands.ConnectedObjectsCommand{
-				Datastore:        ds,
-				Typesystem:       typesystem.New(model),
-				ResolveNodeLimit: test.resolveNodeLimit,
-				Limit:            test.limit,
+				Datastore:               ds,
+				Typesystem:              typesystem.New(model),
+				ResolveNodeLimit:        test.resolveNodeLimit,
+				ResolveNodeBreadthLimit: DefaultResolveNodeBreadthLimit,
+				Limit:                   test.limit,
 			}
 
 			resultChan := make(chan *commands.ConnectedObjectsResult, 100)

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -201,12 +201,12 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 			ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 
 			listObjectsQuery := &commands.ListObjectsQuery{
-				Datastore:             datastore,
-				Logger:                logger.NewNoopLogger(),
-				ListObjectsDeadline:   listObjectsDeadline,
-				ListObjectsMaxResults: test.maxResults,
-				ResolveNodeLimit:      DefaultResolveNodeLimit,
-				CheckConcurrencyLimit: 100,
+				Datastore:               datastore,
+				Logger:                  logger.NewNoopLogger(),
+				ListObjectsDeadline:     listObjectsDeadline,
+				ListObjectsMaxResults:   test.maxResults,
+				ResolveNodeLimit:        DefaultResolveNodeLimit,
+				ResolveNodeBreadthLimit: DefaultResolveNodeBreadthLimit,
 			}
 
 			// assertions
@@ -312,12 +312,12 @@ func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatas
 	}
 
 	listObjectsQuery := commands.ListObjectsQuery{
-		Datastore:             ds,
-		Logger:                logger.NewNoopLogger(),
-		ListObjectsDeadline:   3 * time.Second,
-		ListObjectsMaxResults: 1000,
-		ResolveNodeLimit:      DefaultResolveNodeLimit,
-		CheckConcurrencyLimit: 100,
+		Datastore:               ds,
+		Logger:                  logger.NewNoopLogger(),
+		ListObjectsDeadline:     3 * time.Second,
+		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:        DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: DefaultResolveNodeBreadthLimit,
 	}
 
 	var r *openfgapb.ListObjectsResponse
@@ -381,12 +381,12 @@ func BenchmarkListObjectsWithConcurrentChecks(b *testing.B, ds storage.OpenFGADa
 	}
 
 	listObjectsQuery := commands.ListObjectsQuery{
-		Datastore:             ds,
-		Logger:                logger.NewNoopLogger(),
-		ListObjectsDeadline:   3 * time.Second,
-		ListObjectsMaxResults: 1000,
-		ResolveNodeLimit:      DefaultResolveNodeLimit,
-		CheckConcurrencyLimit: 100,
+		Datastore:               ds,
+		Logger:                  logger.NewNoopLogger(),
+		ListObjectsDeadline:     3 * time.Second,
+		ListObjectsMaxResults:   1000,
+		ResolveNodeLimit:        DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit: DefaultResolveNodeBreadthLimit,
 	}
 
 	var r *openfgapb.ListObjectsResponse

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -207,6 +207,7 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 				ListObjectsMaxResults:   test.maxResults,
 				ResolveNodeLimit:        DefaultResolveNodeLimit,
 				ResolveNodeBreadthLimit: DefaultResolveNodeBreadthLimit,
+				MaxConcurrentReads:      DefaultMaxConcurrentReads,
 			}
 
 			// assertions

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	DefaultResolveNodeLimit = 25
+	DefaultResolveNodeLimit        = 25
+	DefaultResolveNodeBreadthLimit = 100
 )
 
 func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -9,6 +9,7 @@ import (
 const (
 	DefaultResolveNodeLimit        = 25
 	DefaultResolveNodeBreadthLimit = 100
+	DefaultMaxConcurrentReads      = 30
 )
 
 func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {


### PR DESCRIPTION
## Description

(It'd be nice if this was merged first: https://github.com/openfga/openfga/pull/833)

Add two new server configuration settings:
- MAX_CONCURRENT_READS_FOR_CHECK controls, ultimately, database connections used
- MAX_CONCURRENT_READS_FOR_LIST_OBJECTS controls, ultimately, database connections used
- RESOLVE_NODE_BREADTH_LIMIT (not too happy with this name but i want it to mimic RESOLVE_NODE_LIMIT since they are kind of similar) controls, ultimately, goroutines spun up

## References
Follow-up PR of https://github.com/openfga/openfga/pull/860
