### PR TITLE
style: naming of connected objects query

### DIFF
--- a/pkg/server/commands/connectedobjects/connected_objects.go
+++ b/pkg/server/commands/connectedobjects/connected_objects.go
@@ -21,7 +21,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var tracer = otel.Tracer("openfga/pkg/server/commands/connectedobjects")
+var tracer = otel.Tracer("openfga/pkg/server/commands/connected_objects")
 
 const (
 	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)

--- a/pkg/server/commands/connectedobjects/connected_objects.go
+++ b/pkg/server/commands/connectedobjects/connected_objects.go
@@ -165,7 +165,7 @@ func (c *ConnectedObjectsQuery) execute(
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
-	ctx, span := tracer.Start(ctx, "execute", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "connectedObjects.execute", trace.WithAttributes(
 		attribute.String("object_type", req.ObjectType),
 		attribute.String("relation", req.Relation),
 		attribute.String("user", req.User.String()),
@@ -276,7 +276,7 @@ func (c *ConnectedObjectsQuery) Execute(
 	req *ConnectedObjectsRequest,
 	resultChan chan<- *ConnectedObjectsResult, // object string (e.g. document:1)
 ) error {
-	ctx, span := tracer.Start(ctx, "Execute", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "connectedObjects.Execute", trace.WithAttributes(
 		attribute.String("object_type", req.ObjectType),
 		attribute.String("relation", req.Relation),
 		attribute.String("user", req.User.String()),

--- a/pkg/server/commands/connectedobjects/connected_objects.go
+++ b/pkg/server/commands/connectedobjects/connected_objects.go
@@ -1,4 +1,5 @@
-package commands
+// Package connectedobjects contains the code that handles the ConnectedObjects API
+package connectedobjects
 
 import (
 	"context"
@@ -14,20 +15,30 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	openfgapb "go.buf.build/openfga/go/openfga/api/openfga/v1"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+)
+
+var tracer = otel.Tracer("openfga/pkg/server/commands/connectedobjects")
+
+const (
+	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
+	defaultResolveNodeLimit        = 25
+	defaultResolveNodeBreadthLimit = 100
+	defaultMaxResults              = 1000
 )
 
 type ConnectedObjectsRequest struct {
 	StoreID          string
 	ObjectType       string
 	Relation         string
-	User             isUserRef
+	User             IsUserRef
 	ContextualTuples []*openfgapb.TupleKey
 }
 
-type isUserRef interface {
+type IsUserRef interface {
 	isUserRef()
 	GetObjectType() string
 	String() string
@@ -37,7 +48,7 @@ type UserRefObject struct {
 	Object *openfgapb.Object
 }
 
-var _ isUserRef = (*UserRefObject)(nil)
+var _ IsUserRef = (*UserRefObject)(nil)
 
 func (u *UserRefObject) isUserRef() {}
 
@@ -53,7 +64,7 @@ type UserRefTypedWildcard struct {
 	Type string
 }
 
-var _ isUserRef = (*UserRefTypedWildcard)(nil)
+var _ IsUserRef = (*UserRefTypedWildcard)(nil)
 
 func (*UserRefTypedWildcard) isUserRef() {}
 
@@ -88,46 +99,44 @@ type UserRef struct {
 	//  *UserRef_Object
 	//  *UserRef_TypedWildcard
 	//  *UserRef_ObjectRelation
-	Ref isUserRef
+	Ref IsUserRef
 }
 
-type ConnectedObjectsCommand struct {
-	Datastore               storage.RelationshipTupleReader
-	Typesystem              *typesystem.TypeSystem
-	ResolveNodeLimit        uint32
-	ResolveNodeBreadthLimit uint32
-
-	// Limit limits the results yielded by the ConnectedObjects API.
-	Limit uint32
+type ConnectedObjectsQuery struct {
+	datastore               storage.RelationshipTupleReader
+	typesystem              *typesystem.TypeSystem
+	resolveNodeLimit        uint32
+	resolveNodeBreadthLimit uint32
+	maxResults              uint32
 }
 
-type ConnectedObjectsQueryOption func(d *ConnectedObjectsCommand)
+type ConnectedObjectsQueryOption func(d *ConnectedObjectsQuery)
 
-func WithCOResolveNodeLimit(limit uint32) ConnectedObjectsQueryOption {
-	return func(d *ConnectedObjectsCommand) {
-		d.ResolveNodeLimit = limit
+func WithResolveNodeLimit(limit uint32) ConnectedObjectsQueryOption {
+	return func(d *ConnectedObjectsQuery) {
+		d.resolveNodeLimit = limit
 	}
 }
 
-func WithCOResolveNodeBreadthLimit(limit uint32) ConnectedObjectsQueryOption {
-	return func(d *ConnectedObjectsCommand) {
-		d.ResolveNodeBreadthLimit = limit
+func WithResolveNodeBreadthLimit(limit uint32) ConnectedObjectsQueryOption {
+	return func(d *ConnectedObjectsQuery) {
+		d.resolveNodeBreadthLimit = limit
 	}
 }
 
-func WithMaxResults(limit uint32) ConnectedObjectsQueryOption {
-	return func(d *ConnectedObjectsCommand) {
-		d.Limit = limit
+func WithMaxResults(maxResults uint32) ConnectedObjectsQueryOption {
+	return func(d *ConnectedObjectsQuery) {
+		d.maxResults = maxResults
 	}
 }
 
-func NewConnectedObjectsQuery(ds storage.RelationshipTupleReader, ts *typesystem.TypeSystem, opts ...ConnectedObjectsQueryOption) *ConnectedObjectsCommand {
-	query := &ConnectedObjectsCommand{
-		Datastore:               ds,
-		Typesystem:              ts,
-		ResolveNodeLimit:        defaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
-		Limit:                   defaultListObjectsMaxResults,
+func NewConnectedObjectsQuery(ds storage.RelationshipTupleReader, ts *typesystem.TypeSystem, opts ...ConnectedObjectsQueryOption) *ConnectedObjectsQuery {
+	query := &ConnectedObjectsQuery{
+		datastore:               ds,
+		typesystem:              ts,
+		resolveNodeLimit:        defaultResolveNodeLimit,
+		resolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
+		maxResults:              defaultMaxResults,
 	}
 
 	for _, opt := range opts {
@@ -149,14 +158,14 @@ type ConnectedObjectsResult struct {
 	ResultStatus ConditionalResultStatus
 }
 
-func (c *ConnectedObjectsCommand) streamedConnectedObjects(
+func (c *ConnectedObjectsQuery) execute(
 	ctx context.Context,
 	req *ConnectedObjectsRequest,
 	resultChan chan<- *ConnectedObjectsResult,
 	foundObjectsMap *sync.Map,
 	foundCount *uint32,
 ) error {
-	ctx, span := tracer.Start(ctx, "streamedConnectedObjects", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "execute", trace.WithAttributes(
 		attribute.String("object_type", req.ObjectType),
 		attribute.String("relation", req.Relation),
 		attribute.String("user", req.User.String()),
@@ -167,7 +176,7 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	if !ok {
 		ctx = graph.ContextWithResolutionDepth(ctx, 0)
 	} else {
-		if depth >= c.ResolveNodeLimit {
+		if depth >= c.resolveNodeLimit {
 			return serverErrors.AuthorizationModelResolutionTooComplex
 		}
 
@@ -202,7 +211,7 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	targetObjRef := typesystem.DirectRelationReference(req.ObjectType, req.Relation)
 
 	// build the graph of possible edges between object types in the graph based on the authz model's type info
-	g := graph.BuildConnectedObjectGraph(c.Typesystem)
+	g := graph.BuildConnectedObjectGraph(c.typesystem)
 
 	// find the possible incoming edges (ingresses) between the target user reference and the source (object, relation) reference
 	span.SetAttributes(
@@ -214,7 +223,7 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	}
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
+	subg.SetLimit(int(c.resolveNodeBreadthLimit))
 
 	for i, ingress := range ingresses {
 		span.SetAttributes(attribute.String(fmt.Sprintf("_ingress %d", i), ingress.String()))
@@ -234,7 +243,7 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 			case graph.ComputedUsersetIngress:
 
 				// lookup the rewritten target relation on the computed_userset ingress
-				return c.streamedConnectedObjects(ctx, &ConnectedObjectsRequest{
+				return c.execute(ctx, &ConnectedObjectsRequest{
 					StoreID:    storeID,
 					ObjectType: req.ObjectType,
 					Relation:   req.Relation,
@@ -258,16 +267,16 @@ func (c *ConnectedObjectsCommand) streamedConnectedObjects(
 	return subg.Wait()
 }
 
-// StreamedConnectedObjects yields all the objects of the provided objectType that
+// Execute yields all the objects of the provided objectType that
 // the given user has a specific relation with. The results will be limited by the request
-// limit. If a 0 limit is provided then all objects of the provided objectType will be
+// maxResults. If a 0 maxResults is provided then all objects of the provided objectType will be
 // returned.
-func (c *ConnectedObjectsCommand) StreamedConnectedObjects(
+func (c *ConnectedObjectsQuery) Execute(
 	ctx context.Context,
 	req *ConnectedObjectsRequest,
 	resultChan chan<- *ConnectedObjectsResult, // object string (e.g. document:1)
 ) error {
-	ctx, span := tracer.Start(ctx, "StreamedConnectedObjects", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "Execute", trace.WithAttributes(
 		attribute.String("object_type", req.ObjectType),
 		attribute.String("relation", req.Relation),
 		attribute.String("user", req.User.String()),
@@ -275,23 +284,23 @@ func (c *ConnectedObjectsCommand) StreamedConnectedObjects(
 	defer span.End()
 
 	var foundCount *uint32
-	if c.Limit > 0 {
+	if c.maxResults > 0 {
 		foundCount = new(uint32)
 	}
 
 	var foundObjects sync.Map
-	return c.streamedConnectedObjects(ctx, req, resultChan, &foundObjects, foundCount)
+	return c.execute(ctx, req, resultChan, &foundObjects, foundCount)
 }
 
 type reverseExpandRequest struct {
 	storeID          string
 	ingress          *graph.RelationshipIngress
 	targetObjectRef  *openfgapb.RelationReference
-	sourceUserRef    isUserRef
+	sourceUserRef    IsUserRef
 	contextualTuples []*openfgapb.TupleKey
 }
 
-func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
+func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 	ctx context.Context,
 	req *reverseExpandRequest,
 	resultChan chan<- *ConnectedObjectsResult,
@@ -333,7 +342,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		})
 	}
 
-	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.Datastore, req.contextualTuples)
+	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
 		ObjectType: req.ingress.Ingress.GetType(),
@@ -346,7 +355,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
+	subg.SetLimit(int(c.resolveNodeBreadthLimit))
 
 	for {
 		t, err := iter.Next()
@@ -372,7 +381,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		}
 
 		if foundObjectType == targetObjectType {
-			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.maxResults {
 				break
 			}
 
@@ -387,7 +396,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 			}
 		}
 
-		var sourceUserRef isUserRef
+		var sourceUserRef IsUserRef
 		sourceUserRef = &UserRefObject{
 			Object: &openfgapb.Object{
 				Type: foundObjectType,
@@ -409,7 +418,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 		}
 
 		subg.Go(func() error {
-			return c.streamedConnectedObjects(subgctx, &ConnectedObjectsRequest{
+			return c.execute(subgctx, &ConnectedObjectsRequest{
 				StoreID:          store,
 				ObjectType:       targetObjectType,
 				Relation:         targetObjectRel,
@@ -422,7 +431,7 @@ func (c *ConnectedObjectsCommand) reverseExpandTupleToUserset(
 	return subg.Wait()
 }
 
-func (c *ConnectedObjectsCommand) reverseExpandDirect(
+func (c *ConnectedObjectsQuery) reverseExpandDirect(
 	ctx context.Context,
 	req *reverseExpandRequest,
 	resultChan chan<- *ConnectedObjectsResult,
@@ -450,7 +459,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 
 	targetUserObjectType := req.sourceUserRef.GetObjectType()
 
-	publiclyAssignable, err := c.Typesystem.IsPubliclyAssignable(ingress, targetUserObjectType)
+	publiclyAssignable, err := c.typesystem.IsPubliclyAssignable(ingress, targetUserObjectType)
 	if err != nil {
 		return err
 	}
@@ -482,7 +491,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 		userFilter = append(userFilter, val.ObjectRelation)
 	}
 
-	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.Datastore, req.contextualTuples)
+	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
 		ObjectType: ingress.GetType(),
@@ -495,7 +504,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 	defer iter.Stop()
 
 	subg, subgctx := errgroup.WithContext(ctx)
-	subg.SetLimit(int(c.ResolveNodeBreadthLimit))
+	subg.SetLimit(int(c.resolveNodeBreadthLimit))
 
 	for {
 		t, err := iter.Next()
@@ -521,7 +530,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 		}
 
 		if foundObjectType == targetObjectType {
-			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.Limit {
+			if foundCount != nil && atomic.AddUint32(foundCount, 1) > c.maxResults {
 				break
 			}
 
@@ -544,7 +553,7 @@ func (c *ConnectedObjectsCommand) reverseExpandDirect(
 		}
 
 		subg.Go(func() error {
-			return c.streamedConnectedObjects(subgctx, &ConnectedObjectsRequest{
+			return c.execute(subgctx, &ConnectedObjectsRequest{
 				StoreID:          store,
 				ObjectType:       targetObjectType,
 				Relation:         targetObjectRel,

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/server/commands/connectedobjects"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -47,62 +48,62 @@ var (
 )
 
 type ListObjectsQuery struct {
-	Datastore               storage.RelationshipTupleReader
-	Logger                  logger.Logger
-	ListObjectsDeadline     time.Duration
-	ListObjectsMaxResults   uint32
-	ResolveNodeLimit        uint32
-	ResolveNodeBreadthLimit uint32
-	MaxConcurrentReads      uint32
+	datastore               storage.RelationshipTupleReader
+	logger                  logger.Logger
+	listObjectsDeadline     time.Duration
+	listObjectsMaxResults   uint32
+	resolveNodeLimit        uint32
+	resolveNodeBreadthLimit uint32
+	maxConcurrentReads      uint32
 }
 
 type ListObjectsQueryOption func(d *ListObjectsQuery)
 
 func WithMaxConcurrentReads(max uint32) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.MaxConcurrentReads = max
+		d.maxConcurrentReads = max
 	}
 }
 
 func WithListObjectsDeadline(deadline time.Duration) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.ListObjectsDeadline = deadline
+		d.listObjectsDeadline = deadline
 	}
 }
 
 func WithListObjectsMaxResults(max uint32) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.ListObjectsMaxResults = max
+		d.listObjectsMaxResults = max
 	}
 }
 
 func WithResolveNodeLimit(limit uint32) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.ResolveNodeLimit = limit
+		d.resolveNodeLimit = limit
 	}
 }
 
 func WithResolveNodeBreadthLimit(limit uint32) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.ResolveNodeBreadthLimit = limit
+		d.resolveNodeBreadthLimit = limit
 	}
 }
 
 func WithLogger(l logger.Logger) ListObjectsQueryOption {
 	return func(d *ListObjectsQuery) {
-		d.Logger = l
+		d.logger = l
 	}
 }
 
 func NewListObjectsQuery(ds storage.RelationshipTupleReader, opts ...ListObjectsQueryOption) *ListObjectsQuery {
 	query := &ListObjectsQuery{
-		Datastore:               ds,
-		Logger:                  logger.NewNoopLogger(),
-		ListObjectsDeadline:     defaultListObjectsDeadline,
-		ListObjectsMaxResults:   defaultListObjectsMaxResults,
-		ResolveNodeLimit:        defaultResolveNodeLimit,
-		ResolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
-		MaxConcurrentReads:      defaultMaxConcurrentReads,
+		datastore:               ds,
+		logger:                  logger.NewNoopLogger(),
+		listObjectsDeadline:     defaultListObjectsDeadline,
+		listObjectsMaxResults:   defaultListObjectsMaxResults,
+		resolveNodeLimit:        defaultResolveNodeLimit,
+		resolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
+		maxConcurrentReads:      defaultMaxConcurrentReads,
 	}
 
 	for _, opt := range opts {
@@ -175,8 +176,8 @@ func (q *ListObjectsQuery) evaluate(
 		userObj, userRel := tuple.SplitObjectRelation(req.GetUser())
 		userObjType, userObjID := tuple.SplitObject(userObj)
 
-		var sourceUserRef isUserRef
-		sourceUserRef = &UserRefObject{
+		var sourceUserRef connectedobjects.IsUserRef
+		sourceUserRef = &connectedobjects.UserRefObject{
 			Object: &openfgapb.Object{
 				Type: userObjType,
 				Id:   userObjID,
@@ -184,12 +185,12 @@ func (q *ListObjectsQuery) evaluate(
 		}
 
 		if tuple.IsTypedWildcard(userObj) {
-			sourceUserRef = &UserRefTypedWildcard{Type: tuple.GetType(userObj)}
+			sourceUserRef = &connectedobjects.UserRefTypedWildcard{Type: tuple.GetType(userObj)}
 
 		}
 
 		if userRel != "" {
-			sourceUserRef = &UserRefObjectRelation{
+			sourceUserRef = &connectedobjects.UserRefObjectRelation{
 				ObjectRelation: &openfgapb.ObjectRelation{
 					Object:   userObj,
 					Relation: userRel,
@@ -197,17 +198,17 @@ func (q *ListObjectsQuery) evaluate(
 			}
 		}
 
-		connectedObjectsResChan := make(chan *ConnectedObjectsResult, 1)
+		connectedObjectsResChan := make(chan *connectedobjects.ConnectedObjectsResult, 1)
 		var objectsFound = new(uint32)
 
-		connectedObjectsCmd := NewConnectedObjectsQuery(q.Datastore, typesys,
-			WithCOResolveNodeLimit(q.ResolveNodeLimit),
-			WithCOResolveNodeBreadthLimit(q.ResolveNodeBreadthLimit),
-			WithMaxResults(maxResults),
+		connectedObjectsQuery := connectedobjects.NewConnectedObjectsQuery(q.datastore, typesys,
+			connectedobjects.WithResolveNodeLimit(q.resolveNodeLimit),
+			connectedobjects.WithResolveNodeBreadthLimit(q.resolveNodeBreadthLimit),
+			connectedobjects.WithMaxResults(maxResults),
 		)
 
 		go func() {
-			err = connectedObjectsCmd.StreamedConnectedObjects(ctx, &ConnectedObjectsRequest{
+			err = connectedObjectsQuery.Execute(ctx, &connectedobjects.ConnectedObjectsRequest{
 				StoreID:          req.GetStoreId(),
 				ObjectType:       targetObjectType,
 				Relation:         targetRelation,
@@ -221,21 +222,21 @@ func (q *ListObjectsQuery) evaluate(
 			close(connectedObjectsResChan)
 		}()
 
-		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.Datastore, q.MaxConcurrentReads)
+		limitedTupleReader := storagewrappers.NewBoundedConcurrencyTupleReader(q.datastore, q.maxConcurrentReads)
 
 		checkResolver := graph.NewLocalChecker(
 			storagewrappers.NewCombinedTupleReader(limitedTupleReader, req.GetContextualTuples().GetTupleKeys()),
-			graph.WithResolveNodeBreadthLimit(q.ResolveNodeBreadthLimit),
-			graph.WithMaxConcurrentReads(q.MaxConcurrentReads),
+			graph.WithResolveNodeBreadthLimit(q.resolveNodeBreadthLimit),
+			graph.WithMaxConcurrentReads(q.maxConcurrentReads),
 		)
 
-		concurrencyLimiterCh := make(chan struct{}, q.ResolveNodeBreadthLimit)
+		concurrencyLimiterCh := make(chan struct{}, q.resolveNodeBreadthLimit)
 
 		wg := sync.WaitGroup{}
 
 		for res := range connectedObjectsResChan {
 
-			if res.ResultStatus == NoFurtherEvalStatus {
+			if res.ResultStatus == connectedobjects.NoFurtherEvalStatus {
 				noFurtherEvalRequiredCounter.Inc()
 
 				if atomic.AddUint32(objectsFound, 1) <= maxResults {
@@ -248,7 +249,7 @@ func (q *ListObjectsQuery) evaluate(
 			furtherEvalRequiredCounter.Inc()
 
 			wg.Add(1)
-			go func(res *ConnectedObjectsResult) {
+			go func(res *connectedobjects.ConnectedObjectsResult) {
 				defer func() {
 					<-concurrencyLimiterCh
 					wg.Done()
@@ -262,7 +263,7 @@ func (q *ListObjectsQuery) evaluate(
 					TupleKey:             tuple.NewTupleKey(res.Object, req.GetRelation(), req.GetUser()),
 					ContextualTuples:     req.GetContextualTuples().GetTupleKeys(),
 					ResolutionMetadata: &graph.ResolutionMetadata{
-						Depth: q.ResolveNodeLimit,
+						Depth: q.resolveNodeLimit,
 					},
 				})
 				if err != nil {
@@ -286,23 +287,23 @@ func (q *ListObjectsQuery) evaluate(
 	return nil
 }
 
-// Execute the ListObjectsQuery, returning a list of object IDs up to a maximum of q.ListObjectsMaxResults
-// or until q.ListObjectsDeadline is hit, whichever happens first.
+// Execute the ListObjectsQuery, returning a list of object IDs up to a maximum of q.listObjectsMaxResults
+// or until q.listObjectsDeadline is hit, whichever happens first.
 func (q *ListObjectsQuery) Execute(
 	ctx context.Context,
 	req *openfgapb.ListObjectsRequest,
 ) (*openfgapb.ListObjectsResponse, error) {
 
 	resultsChan := make(chan ListObjectsResult, 1)
-	maxResults := q.ListObjectsMaxResults
+	maxResults := q.listObjectsMaxResults
 	if maxResults > 0 {
 		resultsChan = make(chan ListObjectsResult, maxResults)
 	}
 
 	timeoutCtx := ctx
-	if q.ListObjectsDeadline != 0 {
+	if q.listObjectsDeadline != 0 {
 		var cancel context.CancelFunc
-		timeoutCtx, cancel = context.WithTimeout(ctx, q.ListObjectsDeadline)
+		timeoutCtx, cancel = context.WithTimeout(ctx, q.listObjectsDeadline)
 		defer cancel()
 	}
 
@@ -317,9 +318,9 @@ func (q *ListObjectsQuery) Execute(
 		select {
 
 		case <-timeoutCtx.Done():
-			q.Logger.WarnWithContext(
+			q.logger.WarnWithContext(
 				ctx, "list objects timeout with list object configuration timeout",
-				zap.String("timeout duration", q.ListObjectsDeadline.String()),
+				zap.String("timeout duration", q.listObjectsDeadline.String()),
 			)
 			return &openfgapb.ListObjectsResponse{
 				Objects: objects,
@@ -344,8 +345,8 @@ func (q *ListObjectsQuery) Execute(
 }
 
 // ExecuteStreamed executes the ListObjectsQuery, returning a stream of object IDs.
-// It ignores the value of q.ListObjectsMaxResults and returns all available results
-// until q.ListObjectsDeadline is hit
+// It ignores the value of q.listObjectsMaxResults and returns all available results
+// until q.listObjectsDeadline is hit
 func (q *ListObjectsQuery) ExecuteStreamed(
 	ctx context.Context,
 	req *openfgapb.StreamedListObjectsRequest,
@@ -357,9 +358,9 @@ func (q *ListObjectsQuery) ExecuteStreamed(
 	resultsChan := make(chan ListObjectsResult, streamedBufferSize)
 
 	timeoutCtx := ctx
-	if q.ListObjectsDeadline != 0 {
+	if q.listObjectsDeadline != 0 {
 		var cancel context.CancelFunc
-		timeoutCtx, cancel = context.WithTimeout(ctx, q.ListObjectsDeadline)
+		timeoutCtx, cancel = context.WithTimeout(ctx, q.listObjectsDeadline)
 		defer cancel()
 	}
 
@@ -372,9 +373,9 @@ func (q *ListObjectsQuery) ExecuteStreamed(
 		select {
 
 		case <-timeoutCtx.Done():
-			q.Logger.WarnWithContext(
+			q.logger.WarnWithContext(
 				ctx, "list objects timeout with list object configuration timeout",
-				zap.String("timeout duration", q.ListObjectsDeadline.String()),
+				zap.String("timeout duration", q.listObjectsDeadline.String()),
 			)
 			return nil
 

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -8,7 +8,7 @@ import (
 
 	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/oklog/ulid/v2"
-	"github.com/openfga/openfga/pkg/server/commands"
+	"github.com/openfga/openfga/pkg/server/commands/connectedobjects"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -23,19 +23,19 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 		name             string
 		model            string
 		tuples           []*openfgapb.TupleKey
-		request          *commands.ConnectedObjectsRequest
+		request          *connectedobjects.ConnectedObjectsRequest
 		resolveNodeLimit uint32
 		limit            uint32
-		expectedResult   []*commands.ConnectedObjectsResult
+		expectedResult   []*connectedobjects.ConnectedObjectsResult
 		expectedError    error
 	}{
 		{
 			name: "basic_intersection",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -56,24 +56,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:2", "viewer", "user:jon"),
 				tuple.NewTupleKey("document:3", "allowed", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.RequiresFurtherEvalStatus,
+					ResultStatus: connectedobjects.RequiresFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.RequiresFurtherEvalStatus,
+					ResultStatus: connectedobjects.RequiresFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "indirect_intersection",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -100,20 +100,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:X", "writer", "user:jon"),
 				tuple.NewTupleKey("folder:X", "editor", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.RequiresFurtherEvalStatus,
+					ResultStatus: connectedobjects.RequiresFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "restrict_results_based_on_limit",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "folder",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -134,24 +134,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:folder2", "viewer", "user:jon"),
 				tuple.NewTupleKey("folder:folder3", "viewer", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "folder:folder1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "folder:folder2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "resolve_direct_relationships_with_tuples_and_contextual_tuples",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -172,24 +172,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			tuples: []*openfgapb.TupleKey{
 				tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:doc1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:doc3",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "direct_relations_involving_relationships_with_users_and_usersets",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "jon",
 				}},
@@ -211,24 +211,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:doc3", "viewer", "group:openfga#member"),
 				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:doc1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:doc3",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "success_with_direct_relationships_and_computed_usersets",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "jon",
 				}},
@@ -251,24 +251,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:doc3", "owner", "group:openfga#member"),
 				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:doc1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:doc3",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "success_with_many_tuples",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -309,24 +309,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("group:eng", "member", "group:openfga#member"),
 				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:doc1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:doc2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "resolve_objects_involved_in_recursive_hierarchy",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "folder",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -346,28 +346,28 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
 				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "folder:folder1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "folder:folder2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "folder:folder3",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "resolution_depth_exceeded_failure",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "folder",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -392,11 +392,11 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 		},
 		{
 			name: "objects_connected_to_a_userset",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "group",
 				Relation:   "member",
-				User: &commands.UserRefObjectRelation{
+				User: &connectedobjects.UserRefObjectRelation{
 					ObjectRelation: &openfgapb.ObjectRelation{
 						Object:   "group:iam",
 						Relation: "member",
@@ -415,24 +415,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("group:eng", "member", "group:iam#member"),
 				tuple.NewTupleKey("group:iam", "member", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "group:opensource",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "group:eng",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_1",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -452,20 +452,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:1", "viewer", "document:1#editor"),
 				tuple.NewTupleKey("document:1", "owner", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_2",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -488,20 +488,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 				tuple.NewTupleKey("group:eng", "manager", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_3",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "trial",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "fede",
@@ -526,20 +526,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("trial:1", "editor", "team:devs#member"),
 				tuple.NewTupleKey("team:devs", "admin", "user:fede"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "trial:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "objects_connected_indirectly_through_a_ttu",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "view",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "organization",
 						Id:   "2",
@@ -561,20 +561,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:1", "parent", "organization:1"),
 				tuple.NewTupleKey("organization:1", "viewer", "organization:2"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "directly_related_typed_wildcard",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User:       &commands.UserRefTypedWildcard{Type: "user"},
+				User:       &connectedobjects.UserRefTypedWildcard{Type: "user"},
 			},
 			model: `
 			type user
@@ -588,24 +588,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:2", "viewer", "user:*"),
 				tuple.NewTupleKey("document:3", "viewer", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "indirectly_related_typed_wildcard",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User:       &commands.UserRefTypedWildcard{Type: "user"},
+				User:       &connectedobjects.UserRefTypedWildcard{Type: "user"},
 			},
 			model: `
 			type user
@@ -621,20 +621,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
 				tuple.NewTupleKey("group:eng", "member", "user:*"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "relationship_through_multiple_indirections",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -658,20 +658,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("group:eng", "member", "team:tigers#member"),
 				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "typed_wildcard_relationship_through_multiple_indirections",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -695,20 +695,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("group:eng", "member", "team:tigers#member"),
 				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "simple_typed_wildcard_and_direct_relation",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{Type: "user", Id: "jon"},
 				},
 			},
@@ -722,24 +722,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:1", "viewer", "user:*"),
 				tuple.NewTupleKey("document:2", "viewer", "user:jon"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "simple_typed_wildcard_and_indirect_relation",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "jon",
@@ -761,24 +761,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "connected_objects_with_public_user_access_1",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "*",
@@ -801,20 +801,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
 				tuple.NewTupleKey("document:3", "viewer", "group:other#member"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "connected_objects_with_public_user_access_2",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "resource",
 				Relation:   "reader",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{
 						Type: "user",
 						Id:   "bev",
@@ -834,20 +834,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			tuples: []*openfgapb.TupleKey{
 				tuple.NewTupleKey("resource:x", "writer", "user:*"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "resource:x",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_1",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{
+				User: &connectedobjects.UserRefObject{
 					Object: &openfgapb.Object{Type: "user", Id: "jon"},
 				},
 				ContextualTuples: []*openfgapb.TupleKey{
@@ -861,24 +861,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			  relations
 			    define viewer: [user, user:*] as self
 			`,
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_2",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User:       &commands.UserRefTypedWildcard{Type: "user"},
+				User:       &connectedobjects.UserRefTypedWildcard{Type: "user"},
 				ContextualTuples: []*openfgapb.TupleKey{
 					tuple.NewTupleKey("document:1", "viewer", "employee:*"),
 					tuple.NewTupleKey("document:2", "viewer", "user:*"),
@@ -891,20 +891,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			  relations
 			    define viewer: [user:*] as self
 			`,
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_3",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObjectRelation{
+				User: &connectedobjects.UserRefObjectRelation{
 					ObjectRelation: &openfgapb.ObjectRelation{
 						Object:   "group:eng",
 						Relation: "member",
@@ -925,20 +925,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			  relations
 			    define viewer: [group#member] as self
 			`,
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "non-assignable_ttu_relationship",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "jon",
 				}},
@@ -961,24 +961,24 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:1", "viewer", "user:jon"),
 				tuple.NewTupleKey("folder:2", "viewer", "user:*"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 				{
 					Object:       "document:2",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "non-assignable_ttu_relationship_without_wildcard_connectivity",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "jon",
 				}},
@@ -1002,20 +1002,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:1", "viewer", "user:jon"),
 				tuple.NewTupleKey("folder:2", "viewer", "user:*"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_1",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "document",
 				Relation:   "viewer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "jon",
 				}},
@@ -1040,20 +1040,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:1", "viewer", "group:eng#member"),
 				tuple.NewTupleKey("group:eng", "member", "user:*"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "document:1",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_2",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "resource",
 				Relation:   "writer",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "anne",
 				}},
@@ -1079,20 +1079,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("org:eng", "dept", "group:fga"),
 				tuple.NewTupleKey("group:fga", "member", "user:anne"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "resource:eng_handbook",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_3",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "resource",
 				Relation:   "reader",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "anne",
 				}},
@@ -1119,20 +1119,20 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("org:eng", "dept", "group:fga"),
 				tuple.NewTupleKey("group:fga", "member", "user:anne"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "resource:eng_handbook",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
 		{
 			name: "cyclical_tupleset_relation_terminates",
-			request: &commands.ConnectedObjectsRequest{
+			request: &connectedobjects.ConnectedObjectsRequest{
 				StoreID:    ulid.Make().String(),
 				ObjectType: "node",
 				Relation:   "editor",
-				User: &commands.UserRefObject{Object: &openfgapb.Object{
+				User: &connectedobjects.UserRefObject{Object: &openfgapb.Object{
 					Type: "user",
 					Id:   "wonder",
 				}},
@@ -1148,10 +1148,10 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			tuples: []*openfgapb.TupleKey{
 				tuple.NewTupleKey("node:abc", "editor", "user:wonder"),
 			},
-			expectedResult: []*commands.ConnectedObjectsResult{
+			expectedResult: []*connectedobjects.ConnectedObjectsResult{
 				{
 					Object:       "node:abc",
-					ResultStatus: commands.NoFurtherEvalStatus,
+					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
 		},
@@ -1176,22 +1176,22 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			err = ds.Write(ctx, store, nil, test.tuples)
 			require.NoError(err)
 
-			var opts []commands.ConnectedObjectsQueryOption
+			var opts []connectedobjects.ConnectedObjectsQueryOption
 
 			if test.resolveNodeLimit != 0 {
-				opts = append(opts, commands.WithCOResolveNodeLimit(test.resolveNodeLimit))
+				opts = append(opts, connectedobjects.WithResolveNodeLimit(test.resolveNodeLimit))
 			}
 
 			if test.limit != 0 {
-				opts = append(opts, commands.WithMaxResults(test.limit))
+				opts = append(opts, connectedobjects.WithMaxResults(test.limit))
 			}
 
-			connectedObjectsCmd := commands.NewConnectedObjectsQuery(ds, typesystem.New(model), opts...)
+			connectedObjectsCmd := connectedobjects.NewConnectedObjectsQuery(ds, typesystem.New(model), opts...)
 
-			resultChan := make(chan *commands.ConnectedObjectsResult, 100)
+			resultChan := make(chan *connectedobjects.ConnectedObjectsResult, 100)
 			done := make(chan struct{})
 
-			var results []*commands.ConnectedObjectsResult
+			var results []*connectedobjects.ConnectedObjectsResult
 			go func() {
 				for result := range resultChan {
 					results = append(results, result)
@@ -1204,7 +1204,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			defer cancel()
 
 			go func() {
-				err = connectedObjectsCmd.StreamedConnectedObjects(timeoutCtx, test.request, resultChan)
+				err = connectedObjectsCmd.Execute(timeoutCtx, test.request, resultChan)
 				require.ErrorIs(err, test.expectedError)
 				close(resultChan)
 			}()

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -47,6 +47,7 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	)
 
 	t.Run("TestListObjectsRespectsMaxResults", func(t *testing.T) { TestListObjectsRespectsMaxResults(t, ds) })
+	t.Run("TestConnectedObjects", func(t *testing.T) { ConnectedObjectsTest(t, ds) })
 }
 
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
@@ -55,7 +56,6 @@ func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestWriteAssertions", func(t *testing.T) { TestWriteAssertions(t, ds) })
 	t.Run("TestCreateStore", func(t *testing.T) { TestCreateStore(t, ds) })
 	t.Run("TestDeleteStore", func(t *testing.T) { TestDeleteStore(t, ds) })
-	t.Run("TestConnectedObjects", func(t *testing.T) { ConnectedObjectsTest(t, ds) })
 }
 
 func RunAllBenchmarks(b *testing.B, ds storage.OpenFGADatastore) {


### PR DESCRIPTION
## Description
Follow-up of https://github.com/openfga/openfga/pull/872.

- `ConnectedObjectsCommand` -> `ConnectedObjectsQuery`  (command modifies data, query doesn't)
- `ConnectedObjectsQuery.StreamedConnectedObjects()` -> `ConnectedObjectsQuery.Execute()`  (same pattern as other queries/commands)
- `ListObjectsQuery`'s and `ConnectedObjectsQuery`'s struct fields are now private (same pattern as other queries/commands)
- `ConnectedObjectsQuery.Limit` -> `ConnectedObjectsQuery.MaxResults` (same as ListObjectsQuery)

No functional changes
