### PR TITLE
feat: count db reads in check

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -56,7 +56,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 		},
 	))
 
-	resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
+	resp, _, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 		StoreID:            storeID,
 		TupleKey:           tuple.NewTupleKey("document:1", "viewer", "user:jon"),
 		ResolutionMetadata: &ResolutionMetadata{Depth: 2},
@@ -64,7 +64,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.Allowed)
 
-	resp, err = checker.ResolveCheck(ctx, &ResolveCheckRequest{
+	resp, _, err = checker.ResolveCheck(ctx, &ResolveCheckRequest{
 		StoreID:            storeID,
 		TupleKey:           tuple.NewTupleKey("document:2", "editor", "user:x"),
 		ResolutionMetadata: &ResolutionMetadata{Depth: 2},
@@ -111,11 +111,105 @@ func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
 		},
 	))
 
-	resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
+	resp, _, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 		StoreID:            storeID,
 		TupleKey:           tuple.NewTupleKey("document:1", "viewer", "user:jon"),
 		ResolutionMetadata: &ResolutionMetadata{Depth: 25},
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Allowed)
+}
+
+func TestCheckDbReads(t *testing.T) {
+	ds := memory.New()
+	defer ds.Close()
+
+	storeID := ulid.Make().String()
+
+	err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:x", "a", "user:maria"),
+		tuple.NewTupleKey("document:x", "b", "user:maria"),
+		tuple.NewTupleKey("document:x", "parent", "org:fga"),
+		tuple.NewTupleKey("org:fga", "member", "user:maria"),
+	})
+	require.NoError(t, err)
+
+	// 1 read at a time
+	checker := NewLocalChecker(ds, WithMaxConcurrentReads(1))
+
+	typedefs := parser.MustParse(`
+	type user
+	type org
+      relations
+		define member: [user] as self
+	type document
+	  relations
+		define a: [user] as self
+		define b: [user] as self
+		define union as a or b
+		define intersection as a and b
+		define difference as a but not b
+		define ttu as member from parent
+		define parent: [org] as self
+	`)
+
+	tests := []struct {
+		name             string
+		check            *openfgav1.TupleKey
+		contextualTuples []*openfgav1.TupleKey
+		minDBReads       uint32
+		maxDBReads       uint32
+	}{
+		{
+			name:       "direct access",
+			check:      tuple.NewTupleKey("document:x", "a", "user:maria"),
+			minDBReads: 1, // checkDirectUserTuple returns success before checkDirectUsersetTuples starts
+			maxDBReads: 2,
+		},
+		{
+			name:       "union",
+			check:      tuple.NewTupleKey("document:x", "union", "user:maria"),
+			minDBReads: 1, // one direct tuple lookup
+			maxDBReads: 4, // very unlikely but possible, depending on goroutine scheduling
+		},
+		{
+			name:       "intersection",
+			check:      tuple.NewTupleKey("document:x", "intersection", "user:maria"),
+			minDBReads: 2, // need at minimum two direct tuple checks
+			maxDBReads: 4, // at most two tuple checks + two userset checks
+		},
+		{
+			name:       "difference",
+			check:      tuple.NewTupleKey("document:x", "difference", "user:maria"),
+			minDBReads: 2, // need at minimum two direct tuple checks
+			maxDBReads: 4, // at most two tuple checks + two userset checks
+		},
+		{
+			name:       "ttu",
+			check:      tuple.NewTupleKey("document:x", "ttu", "user:maria"),
+			minDBReads: 2, // one read to find org:fga and another direct check to check membership
+			maxDBReads: 3,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := typesystem.ContextWithTypesystem(context.Background(), typesystem.New(
+				&openfgav1.AuthorizationModel{
+					Id:              ulid.Make().String(),
+					TypeDefinitions: typedefs,
+					SchemaVersion:   typesystem.SchemaVersion1_1,
+				},
+			))
+			_, dbReads, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
+				StoreID:            storeID,
+				TupleKey:           test.check,
+				ContextualTuples:   test.contextualTuples,
+				ResolutionMetadata: &ResolutionMetadata{Depth: 25},
+			})
+			require.NoError(t, err)
+			// minDBReads <= dbReads <= maxDBReads
+			require.GreaterOrEqual(t, dbReads, test.minDBReads)
+			require.LessOrEqual(t, dbReads, test.maxDBReads)
+		})
+	}
 }

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -256,7 +256,7 @@ func (q *ListObjectsQuery) evaluate(
 
 				concurrencyLimiterCh <- struct{}{}
 
-				resp, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{
+				resp, _, err := checkResolver.ResolveCheck(ctx, &graph.ResolveCheckRequest{
 					StoreID:              req.GetStoreId(),
 					AuthorizationModelID: req.GetAuthorizationModelId(),
 					TupleKey:             tuple.NewTupleKey(res.Object, req.GetRelation(), req.GetUser()),


### PR DESCRIPTION
## Description
This PR changes the Check API. It adds a header in the response with the number of database reads that led to the solution (note: this number does NOT include the database reads that were done **after** the response was sent)

## References
Closes https://github.com/openfga/openfga/issues/874

## Testing

With the complex model & tuples from this PR https://github.com/openfga/openfga/pull/830:

```
[18/07/23 1:00:25] ~ $ curl --location 'http://localhost:8080/stores/01H4SEESD718G51KWP3GHBKNE7/check' \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{
    "tuple_key": {
        "object": "folder:5",
        "relation": "can_read",
        "user": "user:harriette"
    }
}' -v
*   Trying 127.0.0.1:8080...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /stores/01H4SEESD718G51KWP3GHBKNE7/check?trace=true HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.88.1
> Content-Type: application/json
> Accept: application/json
> Content-Length: 123
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Db-Reads: 33
< Openfga-Authorization-Model-Id: 01H5N99SQ8VKXEQR746DD28QS5
< Openfga-Store-Id: 01H4SEESD718G51KWP3GHBKNE7
< Vary: Origin
< X-Request-Id: ab14b8e3-f1de-4f10-a874-d615108d4442
< Date: Tue, 18 Jul 2023 20:00:37 GMT
< Content-Length: 33
<
* Connection #0 to host localhost left intact
{"allowed":true, "resolution":""}%
[18/07/23 1:00:37] ~ $
```
