### PR TITLE
build: speed up docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,16 @@ FROM cgr.dev/chainguard/go:1.20@sha256:8ed3fdc8f6375a3fd84b4b8b696a2366c3a639931
 
 WORKDIR /app
 
+# install and cache dependencies
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+      go mod download -x
+
+# build
 COPY . .
-RUN CGO_ENABLED=0 go build -o openfga ./cmd/openfga
+RUN --mount=type=cache,target=/root/.cache/go-build \
+     CGO_ENABLED=0 go build -o openfga ./cmd/openfga
 
 FROM cgr.dev/chainguard/static@sha256:54b589146d4dbc80a094fcbcd6b09414f3df94cde8ea6d31c44fd02692c58203
 


### PR DESCRIPTION
## Description
Speed up docker builds by not downloading every dependency every time.

## References
https://docs.docker.com/build/guide/mounts/#add-a-cache-mount

