### PR TITLE
feat(tracing): configurable security

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -321,6 +321,12 @@
                             "type": "string",
                             "default": "0.0.0.0:4317",
                             "x-env-variable": "OPENFGA_TRACE_OTLP_ENDPOINT"
+                        },
+                        "insecure": {
+                            "description": "Whether to use insecure connectio for the trace collector",
+                            "type": "boolean",
+                            "default": false,
+                            "x-env-variable": "OPENFGA_TRACE_OTLP_INSECURE"
                         }
                     }
                 },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -322,11 +322,16 @@
                             "default": "0.0.0.0:4317",
                             "x-env-variable": "OPENFGA_TRACE_OTLP_ENDPOINT"
                         },
-                        "insecure": {
-                            "description": "Whether to use insecure connectio for the trace collector",
-                            "type": "boolean",
-                            "default": false,
-                            "x-env-variable": "OPENFGA_TRACE_OTLP_INSECURE"
+                        "tls": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "description": "Whether to use TLS connection for the trace collector",
+                                    "type": "boolean",
+                                    "default": false,
+                                    "x-env-variable": "OPENFGA_TRACE_OTLP_TLS_ENABLED"
+                                }
+                            }
                         }
                     }
                 },

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -116,6 +116,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("trace.otlp.endpoint", flags.Lookup("trace-otlp-endpoint"))
 		util.MustBindEnv("trace.otlp.endpoint", "OPENFGA_TRACE_OTLP_ENDPOINT")
 
+		util.MustBindPFlag("trace.otlp.tls.enabled", flags.Lookup("trace-otlp-tls-enabled"))
+		util.MustBindEnv("trace.otlp.tls.enabled", "OPENFGA_TRACE_OTLP_TLS_ENABLED")
+
 		util.MustBindPFlag("trace.sampleRatio", flags.Lookup("trace-sample-ratio"))
 		util.MustBindEnv("trace.sampleRatio", "OPENFGA_TRACE_SAMPLE_RATIO")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -417,7 +417,7 @@ func DefaultConfig() *Config {
 			Enabled: false,
 			OTLP: OTLPTraceConfig{
 				Endpoint: "0.0.0.0:4317",
-				Insecure: true,
+				Insecure: false,
 			},
 			SampleRatio: 0.2,
 			ServiceName: "openfga",

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -431,6 +431,7 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 	cfg.Trace.Enabled = true
 	cfg.Trace.SampleRatio = 1
 	cfg.Trace.OTLP.Endpoint = localOTLPServerURL
+	cfg.Trace.OTLP.Insecure = true
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1086,11 +1086,11 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.Trace.ServiceName)
 
-	val = res.Get("properties.trace.properties.OTLP.properties.endpoint.default")
+	val = res.Get("properties.trace.properties.otlp.properties.endpoint.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.Trace.OTLP.Endpoint)
 
-	val = res.Get("properties.trace.properties.OTLP.properties.tls.properties.enabled.default")
+	val = res.Get("properties.trace.properties.otlp.properties.tls.properties.enabled.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.Bool(), cfg.Trace.OTLP.TLS.Enabled)
 

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -431,7 +431,7 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 	cfg.Trace.Enabled = true
 	cfg.Trace.SampleRatio = 1
 	cfg.Trace.OTLP.Endpoint = localOTLPServerURL
-	cfg.Trace.OTLP.Insecure = true
+	cfg.Trace.OTLP.TLS.Enabled = false
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1085,6 +1085,14 @@ func TestDefaultConfig(t *testing.T) {
 	val = res.Get("properties.trace.properties.serviceName.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.Trace.ServiceName)
+
+	val = res.Get("properties.trace.properties.OTLP.properties.endpoint.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.String(), cfg.Trace.OTLP.Endpoint)
+
+	val = res.Get("properties.trace.properties.OTLP.properties.tls.properties.enabled.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.Bool(), cfg.Trace.OTLP.TLS.Enabled)
 
 	val = res.Get("properties.checkQueryCache.properties.enabled.default")
 	require.True(t, val.Exists())

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,6 +45,7 @@ services:
       - OPENFGA_TRACE_ENABLED=true
       - OPENFGA_TRACE_SAMPLE_RATIO=1
       - OPENFGA_TRACE_OTLP_ENDPOINT=otel-collector:4317
+      - OPENFGA_TRACE_OTLP_INSECURE=true
       - OPENFGA_METRICS_ENABLE_RPC_HISTOGRAMS=true
     networks:
       - default

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,7 +45,6 @@ services:
       - OPENFGA_TRACE_ENABLED=true
       - OPENFGA_TRACE_SAMPLE_RATIO=1
       - OPENFGA_TRACE_OTLP_ENDPOINT=otel-collector:4317
-      - OPENFGA_TRACE_OTLP_INSECURE=true
       - OPENFGA_METRICS_ENABLE_RPC_HISTOGRAMS=true
     networks:
       - default

--- a/pkg/telemetry/tracing.go
+++ b/pkg/telemetry/tracing.go
@@ -19,10 +19,15 @@ import (
 
 type TracerOption func(d *customTracer)
 
-func WithOTLPEndpoint(endpoint string, insecure bool) TracerOption {
+func WithOTLPEndpoint(endpoint string) TracerOption {
 	return func(d *customTracer) {
 		d.endpoint = endpoint
-		d.insecure = insecure
+	}
+}
+
+func WithOTLPInsecure() TracerOption {
+	return func(d *customTracer) {
+		d.insecure = true
 	}
 }
 


### PR DESCRIPTION
## Description

Right now, OTEL tracing uses gRPC with the insecure option. This PR makes the insecure option optional. Users are free to opt in for secure traces export using `OPENFGA_TRACE_OTLP_TLS_ENABLED`.

Related PR on `openfga.dev`: https://github.com/openfga/openfga.dev/pull/485

## References

Also see: https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/otlp/otlpmetric/internal/oconf/options.go#L134 which is called from here: https://github.com/open-telemetry/opentelemetry-go/blob/main/exporters/otlp/otlptrace/otlptracegrpc/client.go#L65 when setting up new otlptracegrpc exporter/client. The `Insecure` configuration is handled internally based on env variables.

## Review Checklist

- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
