### PR TITLE
feat: badger for persisting tracing data

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -77,6 +77,12 @@ services:
     command: ["--query.max-clock-skew-adjustment", "500ms"]
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+      - SPAN_STORAGE_TYPE=badger
+      - BADGER_EPHEMERAL=false
+      - BADGER_DIRECTORY_VALUE=/badger/data
+      - BADGER_DIRECTORY_KEY=/badger/key
+    volumes:
+      - jaegar_data:/badger
     ports:
       - "16686:16686" # UI
       - "4317" # OTLP gRPC default port
@@ -115,3 +121,4 @@ services:
 volumes:
   prometheus_data:
   grafana_data:
+  jaegar_data:


### PR DESCRIPTION
## Description
Updates jaegar service to user a badger local storage backend instead of in-memory to provide persistence

## References
Fixes: #868 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
