### PR TITLE
fix: concurrency read settings should be unbounded by default

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -13,15 +13,15 @@
             "x-env-variable": "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL"
         },
         "maxConcurrentReadsForCheck": {
-            "description": "The maximum allowed number of concurrent reads in a single Check query. The default is MaxUint32",
+            "description": "The maximum allowed number of concurrent reads in a single Check query (default is MaxUint32).",
             "type": "integer",
             "default": 4294967295,
             "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_CHECK"
         },
         "maxConcurrentReadsForListObjects": {
-            "description": "The maximum allowed number of concurrent reads in a single ListObjects query.",
+            "description": "The maximum allowed number of concurrent reads in a single ListObjects query (default is MaxUint32).",
             "type": "integer",
-            "default": 30,
+            "default": 4294967295,
             "x-env-variable": "OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS"
         },
         "changelogHorizonOffset": {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -355,7 +355,7 @@ func DefaultConfig() *Config {
 		MaxTuplesPerWrite:                100,
 		MaxTypesPerAuthorizationModel:    100,
 		MaxConcurrentReadsForCheck:       math.MaxUint32,
-		MaxConcurrentReadsForListObjects: 30,
+		MaxConcurrentReadsForListObjects: math.MaxUint32,
 		ChangelogHorizonOffset:           0,
 		ResolveNodeLimit:                 25,
 		ResolveNodeBreadthLimit:          100,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -41,8 +42,8 @@ const (
 	defaultResolveNodeBreadthLimit          = 100
 	defaultListObjectsDeadline              = 3 * time.Second
 	defaultListObjectsMaxResults            = 1000
-	defaultMaxConcurrentReadsForCheck       = 100
-	defaultMaxConcurrentReadsForListObjects = 30
+	defaultMaxConcurrentReadsForCheck       = math.MaxUint32
+	defaultMaxConcurrentReadsForListObjects = math.MaxUint32
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path"
 	"runtime"
@@ -864,6 +865,17 @@ func TestAuthorizationModelInvalidSchemaVersion(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, codes.Code(openfgav1.ErrorCode_validation_error), e.Code())
 	})
+}
+
+func TestDefaultMaxConcurrentReadSettings(t *testing.T) {
+	require.EqualValues(t, math.MaxUint32, defaultMaxConcurrentReadsForCheck)
+	require.EqualValues(t, math.MaxUint32, defaultMaxConcurrentReadsForListObjects)
+
+	s := MustNewServerWithOpts(
+		WithDatastore(memory.New()),
+	)
+	require.EqualValues(t, math.MaxUint32, s.maxConcurrentReadsForCheck)
+	require.EqualValues(t, math.MaxUint32, s.maxConcurrentReadsForListObjects)
 }
 
 func MustBootstrapDatastore(t testing.TB, engine string) storage.OpenFGADatastore {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The defaults for concurrency read limits should be unbounded to match preexisting behavior. Constraining the concurrency limits should be an "opt in" setting.

## References
Close https://github.com/openfga/openfga/issues/915

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
