### PR TITLE
test: add Check test when resolution is too complex

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -4901,3 +4901,41 @@ tests:
               - folder:2
               - folder:3
               - folder:5
+  - name: resolution_too_complex_throws_error
+    stages:
+      - model: |
+          type user
+          type resource
+            relations
+              define a1 as a2
+              define a2 as a3
+              define a3 as a4
+              define a4 as a5
+              define a5 as a6
+              define a6 as a7
+              define a7 as a8
+              define a8 as a9
+              define a9 as a10
+              define a10 as a11
+              define a11 as a12
+              define a12 as a13
+              define a13 as a14
+              define a14 as a15
+              define a15 as a16
+              define a16 as a17
+              define a17 as a18
+              define a18 as a19
+              define a19 as a20
+              define a20 as a21
+              define a21 as a22
+              define a22 as a23
+              define a23 as a24
+              define a24 as a25
+              define a25 as a26
+              define a26: [user] as self
+        checkAssertions:
+          - tuple:
+              object: resource:abc
+              relation: a1
+              user: user:maria
+            errorCode: 2002

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -364,9 +364,6 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 			DatastoreQueryCount: 0,
 		},
 	})
-
-	grpc_ctxtags.Extract(ctx).Set("datastore_query_count", int64(resp.GetResolutionMetadata().DatastoreQueryCount))
-	span.SetAttributes(attribute.Int64("datastore_query_count", int64(resp.GetResolutionMetadata().DatastoreQueryCount)))
 	if err != nil {
 		if errors.Is(err, graph.ErrResolutionDepthExceeded) {
 			return nil, serverErrors.AuthorizationModelResolutionTooComplex
@@ -374,6 +371,8 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 
 		return nil, serverErrors.HandleError("", err)
 	}
+	grpc_ctxtags.Extract(ctx).Set("datastore_query_count", int64(resp.GetResolutionMetadata().DatastoreQueryCount))
+	span.SetAttributes(attribute.Int64("datastore_query_count", int64(resp.GetResolutionMetadata().DatastoreQueryCount)))
 
 	res := &openfgav1.CheckResponse{
 		Allowed: resp.Allowed,


### PR DESCRIPTION

## Description
I introduced a regression in https://github.com/openfga/openfga/commit/24ab5f2f8197412a24449b5993d7fc12375ac7be

When there is an error in Check (e.g. a timeout or a model too complex), a panic is thrown. https://github.com/openfga/openfga/actions/runs/5753573580/job/15597084481#step:4:62
