### PR TITLE
test: assert emitted log during Check request

### DIFF
--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/openfga/openfga/cmd"
 	"github.com/openfga/openfga/cmd/util"
 	"github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -219,6 +220,12 @@ type authTest struct {
 	expectedStatusCode    int
 }
 
+func runServer(ctx context.Context, cfg *Config) error {
+	logger := logger.MustNewLogger(cfg.Log.Format, cfg.Log.Level)
+	serverCtx := &ServerContext{Logger: logger}
+	return serverCtx.Run(ctx, cfg)
+}
+
 func TestVerifyConfig(t *testing.T) {
 	t.Run("UpstreamTimeout_cannot_be_less_than_ListObjectsDeadline", func(t *testing.T) {
 		cfg := DefaultConfig()
@@ -295,7 +302,7 @@ func TestBuildServiceWithPresharedKeyAuthenticationFailsIfZeroKeys(t *testing.T)
 	cfg.Authn.Method = "preshared"
 	cfg.Authn.AuthnPresharedKeyConfig = &AuthnPresharedKeyConfig{}
 
-	err := RunServer(context.Background(), cfg)
+	err := runServer(context.Background(), cfg)
 	require.EqualError(t, err, "failed to initialize authenticator: invalid auth configuration, please specify at least one key")
 }
 
@@ -305,7 +312,7 @@ func TestBuildServiceWithNoAuth(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -334,7 +341,7 @@ func TestBuildServiceWithPresharedKeyAuthentication(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -398,7 +405,7 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -523,7 +530,7 @@ func TestHTTPServerWithCORS(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -630,7 +637,7 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -690,7 +697,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := runServer(ctx, cfg); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -715,7 +722,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := runServer(ctx, cfg); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -750,7 +757,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := runServer(ctx, cfg); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -776,7 +783,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		defer cancel()
 
 		go func() {
-			if err := RunServer(ctx, cfg); err != nil {
+			if err := runServer(ctx, cfg); err != nil {
 				log.Fatal(err)
 			}
 		}()
@@ -797,7 +804,7 @@ func TestHTTPServerDisabled(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()
@@ -814,7 +821,7 @@ func TestHTTPServerEnabled(t *testing.T) {
 	defer cancel()
 
 	go func() {
-		if err := RunServer(ctx, cfg); err != nil {
+		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
 	}()

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -221,6 +221,10 @@ type authTest struct {
 }
 
 func runServer(ctx context.Context, cfg *Config) error {
+	if err := VerifyConfig(cfg); err != nil {
+		return err
+	}
+
 	logger := logger.MustNewLogger(cfg.Log.Format, cfg.Log.Level)
 	serverCtx := &ServerContext{Logger: logger}
 	return serverCtx.Run(ctx, cfg)

--- a/pkg/middleware/http/handler.go
+++ b/pkg/middleware/http/handler.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -69,9 +68,6 @@ func handleForwardResponseTrailer(w http.ResponseWriter, md runtime.ServerMetada
 func CustomHTTPErrorHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, err *errors.EncodedError) {
 	// convert as error object
 	pb := err.ActualError
-
-	log.Println(err)
-	log.Println(pb)
 
 	w.Header().Del("Trailer")
 	w.Header().Del("Transfer-Encoding")

--- a/pkg/middleware/http/handler.go
+++ b/pkg/middleware/http/handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"net/textproto"
 	"strconv"
@@ -68,6 +69,9 @@ func handleForwardResponseTrailer(w http.ResponseWriter, md runtime.ServerMetada
 func CustomHTTPErrorHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, err *errors.EncodedError) {
 	// convert as error object
 	pb := err.ActualError
+
+	log.Println(err)
+	log.Println(pb)
 
 	w.Header().Del("Trailer")
 	w.Header().Del("Transfer-Encoding")

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -6,6 +6,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/cmd/run"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -21,13 +22,19 @@ type TestClientBootstrapper interface {
 }
 
 func StartServer(t testing.TB, cfg *run.Config) context.CancelFunc {
+	logger := logger.MustNewLogger(cfg.Log.Format, cfg.Log.Level)
+	serverCtx := &run.ServerContext{Logger: logger}
+	return StartServerWithContext(t, cfg, serverCtx)
+}
+
+func StartServerWithContext(t testing.TB, cfg *run.Config, serverCtx *run.ServerContext) context.CancelFunc {
 	container := storage.RunDatastoreTestContainer(t, cfg.Datastore.Engine)
 	cfg.Datastore.URI = container.GetConnectionURI(true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		err := run.RunServer(ctx, cfg)
+		err := serverCtx.Run(ctx, cfg)
 		require.NoError(t, err)
 	}()
 


### PR DESCRIPTION
## Description

Add an integration test that asserts that an expected request log is emitted with the expected shape for one Check request.

## References

https://github.com/openfga/openfga/issues/918

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
