### PR TITLE
fix: the misconception between 'migration timeout' and 'database connection timeout'

### DIFF
--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -39,7 +39,7 @@ func NewMigrateCommand() *cobra.Command {
 	flags.String(datastoreEngineFlag, "", "(required) the datastore engine that will be used for persistence")
 	flags.String(datastoreURIFlag, "", "(required) the connection uri of the database to run the migrations against (e.g. 'postgres://postgres:password@localhost:5432/postgres')")
 	flags.Uint(versionFlag, 0, "the version to migrate to (if omitted the latest schema will be used)")
-	flags.Duration(timeoutFlag, 1*time.Minute, "a timeout after which the migration process will terminate")
+	flags.Duration(timeoutFlag, 1*time.Minute, "a timeout for the time it takes the migrate process to connect to the database")
 	flags.Bool(verboseMigrationFlag, false, "enable verbose migration logs (default false)")
 
 	// NOTE: if you add a new flag here, update the function below, too


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->



## Description
simply fix #774 adding a more coherent description for the timeout flag.

Was suggested by @jon-whit the separation between db timeout and migration timeout on https://github.com/openfga/openfga/issues/774#issuecomment-1563085833 but as noticed in https://github.com/pressly/goose/issues/576 goose does not provide a timeout mechanism neither accepts a context as parameter (which could be potentially a `context.WithTimeout`).

So to avoid a kludge solution and address the main issue, I just adjusted the flag description.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
