### PR TITLE
feat: optimizing check call by pruning user lookup

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -588,22 +588,19 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 		var checkFuncs []CheckHandlerFunc
 
-		if typesys.GetSchemaVersion() == typesystem.SchemaVersion1_0 {
-			checkFuncs = []CheckHandlerFunc{fn1, fn2}
-		} else {
-			shouldCheckDirectTuple, _ := typesys.IsDirectlyRelated(
-				typesystem.DirectRelationReference(objectType, relation),                                         //target
-				typesystem.DirectRelationReference(tuple.GetType(tk.GetUser()), tuple.GetRelation(tk.GetUser())), //source
-			)
+		shouldCheckDirectTuple, _ := typesys.IsDirectlyRelated(
+			typesystem.DirectRelationReference(objectType, relation),                                         //target
+			typesystem.DirectRelationReference(tuple.GetType(tk.GetUser()), tuple.GetRelation(tk.GetUser())), //source
+		)
 
-			if shouldCheckDirectTuple {
-				checkFuncs = []CheckHandlerFunc{fn1}
-			}
+		if shouldCheckDirectTuple {
+			checkFuncs = []CheckHandlerFunc{fn1}
+		}
 
-			directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
-			if directlyRelatedUserTypesHasUsersetTuples {
-				checkFuncs = append(checkFuncs, fn2)
-			}
+		directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
+		if directlyRelatedUserTypesHasUsersetTuples {
+			checkFuncs = append(checkFuncs, fn2)
+
 		}
 
 		return union(ctx, c.concurrencyLimit, checkFuncs...)

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -218,6 +218,7 @@ func resolver(ctx context.Context, concurrencyLimit uint32, resultChan chan<- ch
 // union implements a CheckFuncReducer that requires any of the provided CheckHandlerFunc to resolve
 // to an allowed outcome. The first allowed outcome causes premature termination of the reducer.
 func union(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandlerFunc) (*ResolveCheckResponse, error) {
+
 	ctx, cancel := context.WithCancel(ctx)
 	resultChan := make(chan checkOutcome, len(handlers))
 
@@ -594,8 +595,8 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			checkFuncs = []CheckHandlerFunc{fn1}
 		}
 
-		directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUsersets(objectType, relation)
-		if len(directlyRelatedUserTypesHasUsersetTuples) > 0 {
+		directlyRelatedUsersetTypes, _ := typesys.DirectlyRelatedUsersets(objectType, relation)
+		if len(directlyRelatedUsersetTypes) > 0 {
 			checkFuncs = append(checkFuncs, fn2)
 
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -499,8 +499,8 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			ctx, span := tracer.Start(ctx, "checkDirectUsersetTuples", trace.WithAttributes(attribute.String("userset", tuple.ToObjectRelationString(tk.Object, tk.Relation))))
 			defer span.End()
 
-			// allowedUserTypeRestrictions could be "user" or "user:*" or "group#member"
-			allowedUserTypeRestrictions, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
+			// allowedUsersetsTypeRestrictions could be "user:*" or "group#member"
+			allowedUsersetsTypeRestrictions, _ := typesys.DirectlyRelatedUsersets(objectType, relation)
 
 			response := &ResolveCheckResponse{
 				Allowed: false,
@@ -512,7 +512,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			iter, err := c.ds.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 				Object:                      tk.Object,
 				Relation:                    tk.Relation,
-				AllowedUserTypeRestrictions: allowedUserTypeRestrictions,
+				AllowedUserTypeRestrictions: allowedUsersetsTypeRestrictions,
 			})
 			if err != nil {
 				return response, err
@@ -594,7 +594,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			checkFuncs = []CheckHandlerFunc{fn1}
 		}
 
-		directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
+		directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUsersets(objectType, relation)
 		if len(directlyRelatedUserTypesHasUsersetTuples) > 0 {
 			checkFuncs = append(checkFuncs, fn2)
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -499,11 +499,8 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			ctx, span := tracer.Start(ctx, "checkDirectUsersetTuples", trace.WithAttributes(attribute.String("userset", tuple.ToObjectRelationString(tk.Object, tk.Relation))))
 			defer span.End()
 
-			var allowedUserTypeRestrictions []*openfgav1.RelationReference
-			if typesys.GetSchemaVersion() == typesystem.SchemaVersion1_1 {
-				// allowedUserTypeRestrictions could be "user" or "user:*" or "group#member"
-				allowedUserTypeRestrictions, _ = typesys.GetDirectlyRelatedUserTypes(objectType, relation)
-			}
+			// allowedUserTypeRestrictions could be "user" or "user:*" or "group#member"
+			allowedUserTypeRestrictions, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
 
 			response := &ResolveCheckResponse{
 				Allowed: false,
@@ -598,7 +595,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 		}
 
 		directlyRelatedUserTypesHasUsersetTuples, _ := typesys.DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation)
-		if directlyRelatedUserTypesHasUsersetTuples {
+		if len(directlyRelatedUserTypesHasUsersetTuples) > 0 {
 			checkFuncs = append(checkFuncs, fn2)
 
 		}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -269,6 +269,7 @@ func (t *TypeSystem) DirectlyRelatedUsersets(objectType, relation string) ([]*op
 	if err != nil {
 		return usersetRelationReferences, err
 	}
+
 	for _, ref := range refs {
 		if ref.GetRelation() != "" || ref.GetWildcard() != nil {
 			usersetRelationReferences = append(usersetRelationReferences, ref)

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -262,8 +262,8 @@ func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([
 	return r.GetTypeInfo().GetDirectlyRelatedUserTypes(), nil
 }
 
-// DirectlyRelatedUserTypesHasUsersetTuples returns whether any of the directly user related types is a userset
-func (t *TypeSystem) DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation string) ([]*openfgav1.RelationReference, error) {
+// DirectlyRelatedUsersets returns a list of the directly user related types that are usersets
+func (t *TypeSystem) DirectlyRelatedUsersets(objectType, relation string) ([]*openfgav1.RelationReference, error) {
 	refs, err := t.GetDirectlyRelatedUserTypes(objectType, relation)
 	var usersetRelationReferences []*openfgav1.RelationReference
 	if err != nil {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -262,6 +262,21 @@ func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([
 	return r.GetTypeInfo().GetDirectlyRelatedUserTypes(), nil
 }
 
+// DirectlyRelatedUserTypesHasUsersetTuples returns whether any of the directly user related types requires lookup
+// for userset tuples
+func (t *TypeSystem) DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation string) (bool, error) {
+	refs, err := t.GetDirectlyRelatedUserTypes(objectType, relation)
+	if err != nil {
+		return false, err
+	}
+	for _, ref := range refs {
+		if ref.GetRelation() != "" || ref.GetWildcard() != nil {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // IsDirectlyRelated determines whether the type of the target DirectRelationReference contains the source DirectRelationReference.
 func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, source *openfgav1.RelationReference) (bool, error) {
 

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -263,17 +263,18 @@ func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([
 }
 
 // DirectlyRelatedUserTypesHasUsersetTuples returns whether any of the directly user related types is a userset
-func (t *TypeSystem) DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation string) (bool, error) {
+func (t *TypeSystem) DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation string) ([]*openfgav1.RelationReference, error) {
 	refs, err := t.GetDirectlyRelatedUserTypes(objectType, relation)
+	var usersetRelationReferences []*openfgav1.RelationReference
 	if err != nil {
-		return false, err
+		return usersetRelationReferences, err
 	}
 	for _, ref := range refs {
 		if ref.GetRelation() != "" || ref.GetWildcard() != nil {
-			return true, nil
+			usersetRelationReferences = append(usersetRelationReferences, ref)
 		}
 	}
-	return false, nil
+	return usersetRelationReferences, nil
 }
 
 // IsDirectlyRelated determines whether the type of the target DirectRelationReference contains the source DirectRelationReference.

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -262,8 +262,7 @@ func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([
 	return r.GetTypeInfo().GetDirectlyRelatedUserTypes(), nil
 }
 
-// DirectlyRelatedUserTypesHasUsersetTuples returns whether any of the directly user related types requires lookup
-// for userset tuples
+// DirectlyRelatedUserTypesHasUsersetTuples returns whether any of the directly user related types is a userset
 func (t *TypeSystem) DirectlyRelatedUserTypesHasUsersetTuples(objectType, relation string) (bool, error) {
 	refs, err := t.GetDirectlyRelatedUserTypes(objectType, relation)
 	if err != nil {


### PR DESCRIPTION
## Description

Do not get userset if only direct relations are possible

## References
First step for https://github.com/openfga/openfga/issues/852


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
