### PR TITLE
chore: only run memory check in regular cicd benchmark

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Run benchmark
         run: |
           set -o pipefail
-          make bench | tee bench_output.txt
+          make bench-cicd | tee bench_output.txt
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -106,7 +106,7 @@ jobs:
       - name: Run benchmark
         run: |
           set -o pipefail
-          make bench | tee ${{ github.sha }}_bench_output.txt
+          make bench-cicd | tee ${{ github.sha }}_bench_output.txt
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,7 @@ functional-test: ## Run functional tests (needs build-functional-test-image)
 .PHONY: bench
 bench: go-generate ## Run benchmark test. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
 	go test ./... -bench . -benchtime 5s -timeout 0 -run=XXX -cpu 1 -benchmem
+
+.PHONY: bench-cicd
+bench-cicd: go-generate ## Run benchmark test. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
+	go test ./... -bench="BenchmarkOpenFGAServer/BenchmarkMemoryDatastore|BenchmarkCheckMemory" -benchtime 5s -timeout 0 -run=XXX -cpu 1 -benchmem


### PR DESCRIPTION
## Description
To optimize CICD time, only run benchmark test against memory datastore.

## References
Close https://github.com/openfga/openfga/issues/939


## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
