### PR TITLE
fix: log when ListObjects call times out

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"go.uber.org/zap"
 )
 
 const (
@@ -319,8 +318,7 @@ func (q *ListObjectsQuery) Execute(
 
 		case <-timeoutCtx.Done():
 			q.logger.WarnWithContext(
-				ctx, "list objects timeout with list object configuration timeout",
-				zap.String("timeout duration", q.listObjectsDeadline.String()),
+				ctx, fmt.Sprintf("list objects timeout after %s", q.listObjectsDeadline.String()),
 			)
 			return &openfgav1.ListObjectsResponse{
 				Objects: objects,
@@ -374,8 +372,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(
 
 		case <-timeoutCtx.Done():
 			q.logger.WarnWithContext(
-				ctx, "list objects timeout with list object configuration timeout",
-				zap.String("timeout duration", q.listObjectsDeadline.String()),
+				ctx, fmt.Sprintf("list objects timeout after %s", q.listObjectsDeadline.String()),
 			)
 			return nil
 


### PR DESCRIPTION
## Description

Change log message emitted when a ListObjects call times out.

Before

```go
openfga  | {"level":"warn","timestamp":1692656780.110943,"msg":"list objects timeout with list object configuration timeout","build.version":"dev","build.commit":"none","timeout duration":"1ms"}
```

After

```go
openfga  | {"level":"warn","timestamp":1692656654.7408397,"msg":"list objects timeout after 1ms","build.version":"dev","build.commit":"none"}
```
