### PR TITLE
fix: 'bad connection' error when running MySQL tests

### DIFF
--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -37,7 +37,7 @@ func (m memoryTestContainer) GetDatabaseSchemaVersion() int64 {
 	return 1
 }
 
-// RunDatastoreTestContainer constructs and runs a specifc DatastoreTestContainer for the provided
+// RunDatastoreTestContainer constructs and runs a specific DatastoreTestContainer for the provided
 // datastore engine. If applicable, it also runs all existing database migrations.
 // The resources used by the test engine will be cleaned up after the test has finished.
 func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContainer {


### PR DESCRIPTION
## Description
Fix the `failed to connect to mysql container: driver: bad connection` error that sometimes triggers when running `make unit-test` locally or, very rarely, in Github: https://github.com/openfga/openfga/actions/runs/5558243992/job/15057407607#step:5:58

## Testing

Locally (note: the failures seen below are unrelated)

```shell

[22/08/23 7:10:23] ~/GitHub/openfga (fix-mysql-bad-connection) $ for ((i=1; i<=1000; i++)); do
    echo "Running test iteration $i"
    make unit-test
done
Running test iteration 1
tools.go:7:2: import "github.com/golang/mock/mockgen" is a program, not an importable package
go generate ./...
go test -race \
                        -coverpkg=./... \
                        -coverprofile=coverageunit.tmp.out \
                        -covermode=atomic \
                        -count=1 \
                        -timeout=5m \
                        ./...
?       github.com/openfga/openfga/assets       [no test files]
?       github.com/openfga/openfga/cmd  [no test files]
?       github.com/openfga/openfga/cmd/openfga  [no test files]
?       github.com/openfga/openfga/cmd/util     [no test files]
?       github.com/openfga/openfga/internal/authn       [no test files]
?       github.com/openfga/openfga/internal/authn/presharedkey  [no test files]
?       github.com/openfga/openfga/internal/authn/oidc  [no test files]
?       github.com/openfga/openfga/internal/build       [no test files]
?       github.com/openfga/openfga/internal/middleware/authn    [no test files]
?       github.com/openfga/openfga/internal/mocks       [no test files]
?       github.com/openfga/openfga/pkg/middleware/logging       [no test files]
?       github.com/openfga/openfga/pkg/server/commands/connectedobjects [no test files]
?       github.com/openfga/openfga/pkg/server/health    [no test files]
?       github.com/openfga/openfga/pkg/server/test      [no test files]
?       github.com/openfga/openfga/pkg/storage/test     [no test files]
?       github.com/openfga/openfga/pkg/telemetry        [no test files]
?       github.com/openfga/openfga/pkg/testfixtures/storage     [no test files]
?       github.com/openfga/openfga/pkg/testutils        [no test files]
?       github.com/openfga/openfga/tests        [no test files]
ok      github.com/openfga/openfga/cmd/migrate  79.591s coverage: 15.1% of statements in ./...
ok      github.com/openfga/openfga/cmd/run      32.521s coverage: 35.7% of statements in ./...
ok      github.com/openfga/openfga/cmd/validatemodels   90.734s coverage: 32.3% of statements in ./...
ok      github.com/openfga/openfga/internal/gateway     1.561s  coverage: 8.2% of statements in ./...
ok      github.com/openfga/openfga/internal/graph       20.185s coverage: 50.1% of statements in ./...
ok      github.com/openfga/openfga/internal/utils       1.823s  coverage: 100.0% of statements in ./...
ok      github.com/openfga/openfga/internal/validation  1.643s  coverage: 24.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/encoder  1.751s  coverage: 7.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/encrypter        1.763s  coverage: 72.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/logger   1.359s  coverage: 20.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/http  1.612s  coverage: 13.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/requestid     5.159s  coverage: 92.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/storeid       1.726s  coverage: 90.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server   142.589s        coverage: 67.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/commands  1.945s  coverage: 2.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/errors    1.828s  coverage: 41.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage  1.829s  coverage: 33.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/memory   1.849s  coverage: 51.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/mysql    116.856s        coverage: 49.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/postgres 59.392s coverage: 49.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/sqlcommon        2.311s  coverage: 5.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/storagewrappers  5.712s  coverage: 10.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/tuple    1.536s  coverage: 69.8% of statements in ./...
ok      github.com/openfga/openfga/pkg/typesystem       2.590s  coverage: 43.4% of statements in ./...
ok      github.com/openfga/openfga/tests/check  85.591s coverage: 38.3% of statements in ./...
ok      github.com/openfga/openfga/tests/listobjects    85.562s coverage: 52.1% of statements in ./...
ok      github.com/openfga/openfga/tests/writemodel     2.447s  coverage: 13.9% of statements in ./...
Running test iteration 2
tools.go:7:2: import "github.com/golang/mock/mockgen" is a program, not an importable package
go generate ./...
go test -race \
                        -coverpkg=./... \
                        -coverprofile=coverageunit.tmp.out \
                        -covermode=atomic \
                        -count=1 \
                        -timeout=5m \
                        ./...
?       github.com/openfga/openfga/assets       [no test files]
?       github.com/openfga/openfga/cmd  [no test files]
?       github.com/openfga/openfga/cmd/openfga  [no test files]
?       github.com/openfga/openfga/cmd/util     [no test files]
?       github.com/openfga/openfga/internal/authn       [no test files]
?       github.com/openfga/openfga/internal/authn/oidc  [no test files]
?       github.com/openfga/openfga/internal/authn/presharedkey  [no test files]
?       github.com/openfga/openfga/internal/build       [no test files]
?       github.com/openfga/openfga/internal/middleware/authn    [no test files]
?       github.com/openfga/openfga/internal/mocks       [no test files]
?       github.com/openfga/openfga/pkg/middleware/logging       [no test files]
?       github.com/openfga/openfga/pkg/server/commands/connectedobjects [no test files]
?       github.com/openfga/openfga/pkg/server/health    [no test files]
?       github.com/openfga/openfga/pkg/server/test      [no test files]
?       github.com/openfga/openfga/pkg/storage/test     [no test files]
?       github.com/openfga/openfga/pkg/telemetry        [no test files]
?       github.com/openfga/openfga/pkg/testfixtures/storage     [no test files]
?       github.com/openfga/openfga/pkg/testutils        [no test files]
?       github.com/openfga/openfga/tests        [no test files]
ok      github.com/openfga/openfga/cmd/migrate  109.257s        coverage: 15.1% of statements in ./...
ok      github.com/openfga/openfga/cmd/run      29.180s coverage: 35.7% of statements in ./...
ok      github.com/openfga/openfga/cmd/validatemodels   129.628s        coverage: 32.3% of statements in ./...
ok      github.com/openfga/openfga/internal/gateway     2.401s  coverage: 8.2% of statements in ./...
ok      github.com/openfga/openfga/internal/graph       19.755s coverage: 50.1% of statements in ./...
ok      github.com/openfga/openfga/internal/utils       2.326s  coverage: 100.0% of statements in ./...
ok      github.com/openfga/openfga/internal/validation  1.585s  coverage: 24.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/encoder  1.625s  coverage: 7.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/encrypter        1.340s  coverage: 72.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/logger   1.324s  coverage: 20.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/http  1.702s  coverage: 13.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/requestid     4.914s  coverage: 92.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/storeid       1.690s  coverage: 90.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server   138.413s        coverage: 67.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/commands  1.912s  coverage: 2.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/errors    1.579s  coverage: 41.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage  1.647s  coverage: 33.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/memory   1.735s  coverage: 51.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/mysql    151.244s        coverage: 49.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/postgres 64.769s coverage: 49.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/sqlcommon        1.845s  coverage: 5.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/storagewrappers  5.815s  coverage: 10.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/tuple    1.669s  coverage: 69.8% of statements in ./...
ok      github.com/openfga/openfga/pkg/typesystem       3.186s  coverage: 43.4% of statements in ./...
ok      github.com/openfga/openfga/tests/check  73.482s coverage: 38.1% of statements in ./...
--- FAIL: TestListObjectsPostgres (28.63s)
    --- FAIL: TestListObjectsPostgres/RunAll (0.00s)
        --- FAIL: TestListObjectsPostgres/RunAll/ListObjects (0.00s)
            --- FAIL: TestListObjectsPostgres/RunAll/ListObjects/Schema1_1 (0.22s)
                --- FAIL: TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/list_objects_expands_wildcard_tuple (7.67s)
                    listobjects.go:142: 01H8G2Q4B4PPMN62063XFFJ10W
                    listobjects.go:142: 01H8G2Q64YY6RTGTD9566XPJ7T
                    listobjects.go:142: 01H8G2Q6DPQM5JKV13DVMDYDYY
                    listobjects.go:226: 
                                Error Trace:    /Users/mparnisari/GitHub/openfga/tests/listobjects/listobjects.go:226
                                Error:          elements differ
                                                
                                                extra elements in list A:
                                                ([]interface {}) (len=1) {
                                                 (string) (len=8) "folder:2"
                                                }
                                                
                                                
                                                listA:
                                                ([]string) (len=3) {
                                                 (string) (len=8) "folder:1",
                                                 (string) (len=8) "folder:2",
                                                 (string) (len=8) "folder:3"
                                                }
                                                
                                                
                                                listB:
                                                ([]string) (len=2) {
                                                 (string) (len=8) "folder:1",
                                                 (string) (len=8) "folder:3"
                                                }
                                Test:           TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/list_objects_expands_wildcard_tuple
                                Messages:       ListObject request: type:"folder" relation:"can_read" user:"user:anne". Contextual tuples: []. Stage 2
    postgres.go:105: stopping container postgres-01H8G2PXB5RMK8NZ1TKSHSJDRC
    postgres.go:114: stopped container postgres-01H8G2PXB5RMK8NZ1TKSHSJDRC
FAIL
coverage: 52.2% of statements in ./...
FAIL    github.com/openfga/openfga/tests/listobjects    87.962s
ok      github.com/openfga/openfga/tests/writemodel     3.961s  coverage: 13.9% of statements in ./...
FAIL
make: *** [unit-test] Error 1
Running test iteration 3
tools.go:7:2: import "github.com/golang/mock/mockgen" is a program, not an importable package
go generate ./...
go test -race \
                        -coverpkg=./... \
                        -coverprofile=coverageunit.tmp.out \
                        -covermode=atomic \
                        -count=1 \
                        -timeout=5m \
                        ./...
?       github.com/openfga/openfga/assets       [no test files]
?       github.com/openfga/openfga/cmd  [no test files]
?       github.com/openfga/openfga/cmd/openfga  [no test files]
?       github.com/openfga/openfga/cmd/util     [no test files]
?       github.com/openfga/openfga/internal/authn       [no test files]
?       github.com/openfga/openfga/internal/authn/oidc  [no test files]
?       github.com/openfga/openfga/internal/authn/presharedkey  [no test files]
?       github.com/openfga/openfga/internal/build       [no test files]
?       github.com/openfga/openfga/internal/middleware/authn    [no test files]
?       github.com/openfga/openfga/internal/mocks       [no test files]
?       github.com/openfga/openfga/pkg/middleware/logging       [no test files]
?       github.com/openfga/openfga/pkg/server/commands/connectedobjects [no test files]
?       github.com/openfga/openfga/pkg/server/health    [no test files]
?       github.com/openfga/openfga/pkg/server/test      [no test files]
?       github.com/openfga/openfga/pkg/storage/test     [no test files]
?       github.com/openfga/openfga/pkg/telemetry        [no test files]
?       github.com/openfga/openfga/pkg/testfixtures/storage     [no test files]
?       github.com/openfga/openfga/pkg/testutils        [no test files]
?       github.com/openfga/openfga/tests        [no test files]
ok      github.com/openfga/openfga/cmd/migrate  86.738s coverage: 15.1% of statements in ./...
ok      github.com/openfga/openfga/cmd/run      28.971s coverage: 35.7% of statements in ./...
ok      github.com/openfga/openfga/cmd/validatemodels   83.089s coverage: 32.3% of statements in ./...
ok      github.com/openfga/openfga/internal/gateway     2.387s  coverage: 8.2% of statements in ./...
ok      github.com/openfga/openfga/internal/graph       16.925s coverage: 50.1% of statements in ./...
ok      github.com/openfga/openfga/internal/utils       2.325s  coverage: 100.0% of statements in ./...
ok      github.com/openfga/openfga/internal/validation  1.952s  coverage: 24.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/encoder  2.010s  coverage: 7.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/encrypter        1.333s  coverage: 72.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/logger   1.348s  coverage: 20.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/http  1.545s  coverage: 13.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/requestid     4.470s  coverage: 92.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/storeid       1.519s  coverage: 90.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server   120.155s        coverage: 67.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/commands  1.694s  coverage: 2.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/errors    1.618s  coverage: 41.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage  1.657s  coverage: 33.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/memory   1.616s  coverage: 51.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/mysql    110.725s        coverage: 49.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/postgres 49.214s coverage: 49.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/sqlcommon        2.231s  coverage: 5.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/storagewrappers  5.622s  coverage: 10.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/tuple    1.466s  coverage: 69.8% of statements in ./...
ok      github.com/openfga/openfga/pkg/typesystem       2.731s  coverage: 43.4% of statements in ./...
ok      github.com/openfga/openfga/tests/check  68.492s coverage: 38.3% of statements in ./...
--- FAIL: TestListObjectsPostgres (24.86s)
    --- FAIL: TestListObjectsPostgres/RunAll (0.00s)
        --- FAIL: TestListObjectsPostgres/RunAll/ListObjects (0.00s)
            --- FAIL: TestListObjectsPostgres/RunAll/ListObjects/Schema1_1 (0.21s)
                --- FAIL: TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/list_objects_expands_wildcard_tuple (5.21s)
                    listobjects.go:142: 01H8G2W2G2CPWN2YDJSRACWJX9
                    listobjects.go:142: 01H8G2W33EPRHW2YXB5DRSVWZJ
                    listobjects.go:142: 01H8G2W3AECBEDAQAGCMNH19CY
                    listobjects.go:181: 
                                Error Trace:    /Users/mparnisari/GitHub/openfga/tests/listobjects/listobjects.go:181
                                Error:          elements differ
                                                
                                                extra elements in list A:
                                                ([]interface {}) (len=2) {
                                                 (string) (len=8) "folder:2",
                                                 (string) (len=8) "folder:3"
                                                }
                                                
                                                
                                                listA:
                                                ([]string) (len=3) {
                                                 (string) (len=8) "folder:1",
                                                 (string) (len=8) "folder:2",
                                                 (string) (len=8) "folder:3"
                                                }
                                                
                                                
                                                listB:
                                                ([]string) (len=1) {
                                                 (string) (len=8) "folder:1"
                                                }
                                Test:           TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/list_objects_expands_wildcard_tuple
                                Messages:       ListObject request: type:"folder" relation:"can_read" user:"user:anne". Contextual tuples: []. Stage 2
    postgres.go:105: stopping container postgres-01H8G2VVQ1J81YPDJT3VK2PBEH
    postgres.go:114: stopped container postgres-01H8G2VVQ1J81YPDJT3VK2PBEH
FAIL
coverage: 52.2% of statements in ./...
FAIL    github.com/openfga/openfga/tests/listobjects    71.570s
ok      github.com/openfga/openfga/tests/writemodel     2.269s  coverage: 13.9% of statements in ./...
FAIL
make: *** [unit-test] Error 1
Running test iteration 4
tools.go:7:2: import "github.com/golang/mock/mockgen" is a program, not an importable package
go generate ./...
go test -race \
                        -coverpkg=./... \
                        -coverprofile=coverageunit.tmp.out \
                        -covermode=atomic \
                        -count=1 \
                        -timeout=5m \
                        ./...
?       github.com/openfga/openfga/assets       [no test files]
?       github.com/openfga/openfga/cmd  [no test files]
?       github.com/openfga/openfga/cmd/openfga  [no test files]
?       github.com/openfga/openfga/cmd/util     [no test files]
?       github.com/openfga/openfga/internal/authn       [no test files]
?       github.com/openfga/openfga/internal/authn/oidc  [no test files]
?       github.com/openfga/openfga/internal/authn/presharedkey  [no test files]
?       github.com/openfga/openfga/internal/build       [no test files]
?       github.com/openfga/openfga/internal/middleware/authn    [no test files]
?       github.com/openfga/openfga/internal/mocks       [no test files]
?       github.com/openfga/openfga/pkg/middleware/logging       [no test files]
?       github.com/openfga/openfga/pkg/server/commands/connectedobjects [no test files]
?       github.com/openfga/openfga/pkg/server/health    [no test files]
?       github.com/openfga/openfga/pkg/server/test      [no test files]
?       github.com/openfga/openfga/pkg/storage/test     [no test files]
?       github.com/openfga/openfga/pkg/telemetry        [no test files]
?       github.com/openfga/openfga/pkg/testfixtures/storage     [no test files]
?       github.com/openfga/openfga/pkg/testutils        [no test files]
?       github.com/openfga/openfga/tests        [no test files]
ok      github.com/openfga/openfga/cmd/migrate  70.795s coverage: 15.1% of statements in ./...
ok      github.com/openfga/openfga/cmd/run      28.116s coverage: 35.7% of statements in ./...
ok      github.com/openfga/openfga/cmd/validatemodels   89.832s coverage: 32.3% of statements in ./...
ok      github.com/openfga/openfga/internal/gateway     2.205s  coverage: 8.2% of statements in ./...
ok      github.com/openfga/openfga/internal/graph       16.035s coverage: 50.1% of statements in ./...
ok      github.com/openfga/openfga/internal/utils       2.286s  coverage: 100.0% of statements in ./...
ok      github.com/openfga/openfga/internal/validation  1.667s  coverage: 24.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/encoder  1.803s  coverage: 7.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/encrypter        1.314s  coverage: 72.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/logger   1.382s  coverage: 20.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/http  1.561s  coverage: 13.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/requestid     4.050s  coverage: 92.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/middleware/storeid       1.517s  coverage: 90.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server   124.527s        coverage: 67.2% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/commands  1.777s  coverage: 2.9% of statements in ./...
ok      github.com/openfga/openfga/pkg/server/errors    1.832s  coverage: 41.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage  1.704s  coverage: 33.0% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/memory   1.762s  coverage: 51.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/mysql    108.570s        coverage: 49.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/postgres 48.114s coverage: 49.3% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/sqlcommon        2.137s  coverage: 5.7% of statements in ./...
ok      github.com/openfga/openfga/pkg/storage/storagewrappers  5.687s  coverage: 10.5% of statements in ./...
ok      github.com/openfga/openfga/pkg/tuple    1.595s  coverage: 69.8% of statements in ./...
ok      github.com/openfga/openfga/pkg/typesystem       2.754s  coverage: 43.4% of statements in ./...
ok      github.com/openfga/openfga/tests/check  71.462s coverage: 38.3% of statements in ./...
ok      github.com/openfga/openfga/tests/listobjects    79.766s coverage: 52.3% of statements in ./...
ok      github.com/openfga/openfga/tests/writemodel     3.005s  coverage: 13.9% of statements in ./...
Running test iteration 5
tools.go:7:2: import "github.com/golang/mock/mockgen" is a program, not an importable package
go generate ./...
go test -race \
                        -coverpkg=./... \
                        -coverprofile=coverageunit.tmp.out \
                        -covermode=atomic \
                        -count=1 \
                        -timeout=5m \
                        ./...
?       github.com/openfga/openfga/assets       [no test files]
?       github.com/openfga/openfga/cmd  [no test files]
?       github.com/openfga/openfga/cmd/openfga  [no test files]
?       github.com/openfga/openfga/cmd/util     [no test files]
?       github.com/openfga/openfga/internal/authn       [no test files]
?       github.com/openfga/openfga/internal/authn/oidc  [no test files]
?       github.com/openfga/openfga/internal/authn/presharedkey  [no test files]
?       github.com/openfga/openfga/internal/build       [no test files]
?       github.com/openfga/openfga/internal/middleware/authn    [no test files]
?       github.com/openfga/openfga/internal/mocks       [no test files]
?       github.com/openfga/openfga/pkg/middleware/logging       [no test files]
?       github.com/openfga/openfga/pkg/server/commands/connectedobjects [no test files]
?       github.com/openfga/openfga/pkg/server/health    [no test files]
?       github.com/openfga/openfga/pkg/server/test      [no test files]
?       github.com/openfga/openfga/pkg/storage/test     [no test files]
?       github.com/openfga/openfga/pkg/telemetry        [no test files]
?       github.com/openfga/openfga/pkg/testfixtures/storage     [no test files]
?       github.com/openfga/openfga/pkg/testutils        [no test files]
?       github.com/openfga/openfga/tests        [no test files]
ok      github.com/openfga/openfga/cmd/migrate  79.285s coverage: 15.1% of statements in ./...
ok      github.com/openfga/openfga/cmd/run      43.910s coverage: 35.7% of statements in ./...




```

## References
- https://github.com/go-sql-driver/mysql/issues/871#issuecomment-450501343 which led me to  https://github.com/ory/dockertest/blob/v3/README.md?plain=1#L91-L98
