### PR TITLE
feat: add datastore query count for list object on trace and histogram

### DIFF
--- a/pkg/server/commands/connectedobjects/connected_objects.go
+++ b/pkg/server/commands/connectedobjects/connected_objects.go
@@ -156,15 +156,25 @@ type ConnectedObjectsResult struct {
 	ResultStatus ConditionalResultStatus
 }
 
+type ResolutionMetadata struct {
+	QueryCount *uint32
+}
+
+func NewResolutionMetadata() *ResolutionMetadata {
+	return &ResolutionMetadata{
+		QueryCount: new(uint32),
+	}
+}
+
 // Execute yields all the objects of the provided objectType that the given user has, possibly, a specific relation with
 // and sends those objects to resultChan. It MUST guarantee no duplicate objects sent.
 func (c *ConnectedObjectsQuery) Execute(
 	ctx context.Context,
 	req *ConnectedObjectsRequest,
 	resultChan chan<- *ConnectedObjectsResult,
-	dsQueryCount *uint32,
+	resolutionMetadata *ResolutionMetadata,
 ) error {
-	return c.execute(ctx, req, resultChan, nil, dsQueryCount)
+	return c.execute(ctx, req, resultChan, nil, resolutionMetadata)
 }
 
 func (c *ConnectedObjectsQuery) execute(
@@ -172,7 +182,7 @@ func (c *ConnectedObjectsQuery) execute(
 	req *ConnectedObjectsRequest,
 	resultChan chan<- *ConnectedObjectsResult,
 	currentIngress *graph.RelationshipIngress,
-	dsQueryCount *uint32,
+	resolutionMetadata *ResolutionMetadata,
 ) error {
 	ctx, span := tracer.Start(ctx, "connectedObjects.Execute", trace.WithAttributes(
 		attribute.String("target_type", req.ObjectType),
@@ -268,7 +278,7 @@ func (c *ConnectedObjectsQuery) execute(
 
 			switch innerLoopIngress.Type {
 			case graph.DirectIngress:
-				return c.reverseExpandDirect(subgctx, r, resultChan, dsQueryCount)
+				return c.reverseExpandDirect(subgctx, r, resultChan, resolutionMetadata)
 			case graph.ComputedUsersetIngress:
 				// lookup the rewritten target relation on the computed_userset ingress
 				return c.execute(subgctx, &ConnectedObjectsRequest{
@@ -282,9 +292,9 @@ func (c *ConnectedObjectsQuery) execute(
 						},
 					},
 					ContextualTuples: r.contextualTuples,
-				}, resultChan, innerLoopIngress, dsQueryCount)
+				}, resultChan, innerLoopIngress, resolutionMetadata)
 			case graph.TupleToUsersetIngress:
-				return c.reverseExpandTupleToUserset(subgctx, r, resultChan, dsQueryCount)
+				return c.reverseExpandTupleToUserset(subgctx, r, resultChan, resolutionMetadata)
 			default:
 				return fmt.Errorf("unsupported ingress type")
 			}
@@ -306,7 +316,7 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 	ctx context.Context,
 	req *reverseExpandRequest,
 	resultChan chan<- *ConnectedObjectsResult,
-	dsQueryCount *uint32,
+	resolutionMetadata *ResolutionMetadata,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset", trace.WithAttributes(
 		attribute.String("ingress", req.ingress.String()),
@@ -345,7 +355,7 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 		return err
 	}
 	defer iter.Stop()
-	atomic.AddUint32(dsQueryCount, 1)
+	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(int(c.resolveNodeBreadthLimit))
@@ -378,7 +388,7 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 				Relation:         targetObjectRel,
 				User:             sourceUserRef,
 				ContextualTuples: req.contextualTuples,
-			}, resultChan, req.ingress, dsQueryCount)
+			}, resultChan, req.ingress, resolutionMetadata)
 		})
 	}
 
@@ -389,7 +399,7 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 	ctx context.Context,
 	req *reverseExpandRequest,
 	resultChan chan<- *ConnectedObjectsResult,
-	dsQueryCount *uint32,
+	resolutionMetadata *ResolutionMetadata,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandDirect", trace.WithAttributes(
 		attribute.String("ingress", req.ingress.String()),
@@ -452,7 +462,7 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 		return err
 	}
 	defer iter.Stop()
-	atomic.AddUint32(dsQueryCount, 1)
+	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(int(c.resolveNodeBreadthLimit))
@@ -485,7 +495,7 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 				Relation:         targetObjectRel,
 				User:             sourceUserRef,
 				ContextualTuples: req.contextualTuples,
-			}, resultChan, req.ingress, dsQueryCount)
+			}, resultChan, req.ingress, resolutionMetadata)
 		})
 	}
 

--- a/pkg/server/commands/connectedobjects/connected_objects.go
+++ b/pkg/server/commands/connectedobjects/connected_objects.go
@@ -351,11 +351,11 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 		Relation:   req.ingress.TuplesetRelation.GetRelation(),
 		UserFilter: userFilter,
 	})
+	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 	if err != nil {
 		return err
 	}
 	defer iter.Stop()
-	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(int(c.resolveNodeBreadthLimit))
@@ -458,11 +458,11 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 		Relation:   ingress.GetRelation(),
 		UserFilter: userFilter,
 	})
+	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 	if err != nil {
 		return err
 	}
 	defer iter.Stop()
-	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
 
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(int(c.resolveNodeBreadthLimit))

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -390,7 +390,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 
 	err := q.evaluate(timeoutCtx, req, resultsChan, maxResults, resolutionMetadata)
 	if err != nil {
-		return resolutionMetadata, err
+		return nil, err
 	}
 
 	for {
@@ -410,16 +410,16 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 
 			if result.Err != nil {
 				if errors.Is(result.Err, serverErrors.AuthorizationModelResolutionTooComplex) {
-					return resolutionMetadata, result.Err
+					return nil, result.Err
 				}
 
-				return resolutionMetadata, serverErrors.HandleError("", result.Err)
+				return nil, serverErrors.HandleError("", result.Err)
 			}
 
 			if err := srv.Send(&openfgav1.StreamedListObjectsResponse{
 				Object: result.ObjectID,
 			}); err != nil {
-				return resolutionMetadata, serverErrors.NewInternalError("", err)
+				return nil, serverErrors.NewInternalError("", err)
 			}
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -344,7 +344,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		commands.WithCheckOptions(checkOptions),
 	)
 
-	return q.Execute(
+	result, err := q.Execute(
 		typesystem.ContextWithTypesystem(ctx, typesys),
 		&openfgav1.ListObjectsRequest{
 			StoreId:              storeID,
@@ -355,6 +355,21 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 			User:                 req.User,
 		},
 	)
+	if err == nil {
+		queryCount := float64(result.ResolutionMetadata.QueryCount)
+
+		grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
+		span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
+		datastoreQueryCountHistogram.WithLabelValues(
+			openfgav1.OpenFGAService_ServiceDesc.ServiceName,
+			"listObjects",
+		).Observe(queryCount)
+
+		return &openfgav1.ListObjectsResponse{
+			Objects: result.Objects,
+		}, err
+	}
+	return nil, err
 }
 
 func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, srv openfgav1.OpenFGAService_StreamedListObjectsServer) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -324,7 +324,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	const methodName = "listObjects"
+	const methodName = "listobjects"
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
 		Service: openfgav1.OpenFGAService_ServiceDesc.ServiceName,
@@ -370,21 +370,22 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 			User:                 req.User,
 		},
 	)
-	if err == nil {
-		queryCount := float64(*result.ResolutionMetadata.QueryCount)
-
-		grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
-		span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
-		datastoreQueryCountHistogram.WithLabelValues(
-			openfgav1.OpenFGAService_ServiceDesc.ServiceName,
-			methodName,
-		).Observe(queryCount)
-
-		return &openfgav1.ListObjectsResponse{
-			Objects: result.Objects,
-		}, err
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	queryCount := float64(*result.ResolutionMetadata.QueryCount)
+
+	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
+	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
+	datastoreQueryCountHistogram.WithLabelValues(
+		openfgav1.OpenFGAService_ServiceDesc.ServiceName,
+		methodName,
+	).Observe(queryCount)
+
+	return &openfgav1.ListObjectsResponse{
+		Objects: result.Objects,
+	}, nil
+
 }
 
 func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, srv openfgav1.OpenFGAService_StreamedListObjectsServer) error {
@@ -400,7 +401,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	const methodName = "streamedListObjects"
+	const methodName = "streamedlistobjects"
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
 		Service: openfgav1.OpenFGAService_ServiceDesc.ServiceName,
@@ -442,18 +443,19 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		req,
 		srv,
 	)
-	if err == nil {
-		queryCount := float64(*resolutionMetadata.QueryCount)
-
-		grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
-		span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
-		datastoreQueryCountHistogram.WithLabelValues(
-			openfgav1.OpenFGAService_ServiceDesc.ServiceName,
-			methodName,
-		).Observe(queryCount)
+	if err != nil {
+		return err
 	}
+	queryCount := float64(*resolutionMetadata.QueryCount)
 
-	return err
+	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
+	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
+	datastoreQueryCountHistogram.WithLabelValues(
+		openfgav1.OpenFGAService_ServiceDesc.ServiceName,
+		methodName,
+	).Observe(queryCount)
+
+	return nil
 }
 
 func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -356,7 +356,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		},
 	)
 	if err == nil {
-		queryCount := float64(result.ResolutionMetadata.QueryCount)
+		queryCount := float64(*result.ResolutionMetadata.QueryCount)
 
 		grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
 		span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -1255,10 +1255,10 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			var dsQueryCounter uint32
+			resolutionMetadata := connectedobjects.NewResolutionMetadata()
 
 			go func() {
-				err = connectedObjectsCmd.Execute(timeoutCtx, test.request, resultChan, &dsQueryCounter)
+				err = connectedObjectsCmd.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
 				require.ErrorIs(err, test.expectedError)
 				close(resultChan)
 			}()
@@ -1271,7 +1271,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 
 			if test.expectedError == nil {
 				require.ElementsMatch(test.expectedResult, results)
-				require.Equal(test.expectedDSQueryCount, dsQueryCounter)
+				require.Equal(test.expectedDSQueryCount, *resolutionMetadata.QueryCount)
 			}
 		})
 	}

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -19,13 +19,14 @@ import (
 func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 
 	tests := []struct {
-		name             string
-		model            string
-		tuples           []*openfgav1.TupleKey
-		request          *connectedobjects.ConnectedObjectsRequest
-		resolveNodeLimit uint32
-		expectedResult   []*connectedobjects.ConnectedObjectsResult
-		expectedError    error
+		name                 string
+		model                string
+		tuples               []*openfgav1.TupleKey
+		request              *connectedobjects.ConnectedObjectsRequest
+		resolveNodeLimit     uint32
+		expectedResult       []*connectedobjects.ConnectedObjectsResult
+		expectedError        error
+		expectedDSQueryCount uint32
 	}{
 		{
 			name: "basic_intersection",
@@ -64,6 +65,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.RequiresFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "indirect_intersection",
@@ -104,6 +106,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.RequiresFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 
 		{
@@ -143,6 +146,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "direct_relations_involving_relationships_with_users_and_usersets",
@@ -182,6 +186,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "success_with_direct_relationships_and_computed_usersets",
@@ -222,6 +227,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "success_with_many_tuples",
@@ -280,6 +286,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 16,
 		},
 		{
 			name: "resolve_objects_involved_in_recursive_hierarchy",
@@ -321,6 +328,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 4,
 		},
 		{
 			name: "resolution_depth_exceeded_failure",
@@ -349,7 +357,8 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
 				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
 			},
-			expectedError: serverErrors.AuthorizationModelResolutionTooComplex,
+			expectedError:        serverErrors.AuthorizationModelResolutionTooComplex,
+			expectedDSQueryCount: 0,
 		},
 		{
 			name: "objects_connected_to_a_userset",
@@ -386,6 +395,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "objects_connected_to_a_userset_self_referencing",
@@ -414,6 +424,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_1",
@@ -447,6 +458,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_2",
@@ -483,6 +495,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "objects_connected_through_a_computed_userset_3",
@@ -520,6 +533,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "objects_connected_indirectly_through_a_ttu",
@@ -555,6 +569,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "directly_related_typed_wildcard",
@@ -586,6 +601,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "indirectly_related_typed_wildcard",
@@ -615,6 +631,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "relationship_through_multiple_indirections",
@@ -652,6 +669,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "typed_wildcard_relationship_through_multiple_indirections",
@@ -689,6 +707,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "simple_typed_wildcard_and_direct_relation",
@@ -720,6 +739,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "simple_typed_wildcard_and_indirect_relation",
@@ -759,6 +779,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "connected_objects_with_public_user_access_1",
@@ -795,6 +816,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "connected_objects_with_public_user_access_2",
@@ -828,6 +850,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_1",
@@ -859,6 +882,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_2",
@@ -885,6 +909,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "simple_typed_wildcard_with_contextual_tuples_3",
@@ -919,6 +944,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 1,
 		},
 		{
 			name: "non-assignable_ttu_relationship",
@@ -959,6 +985,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "non-assignable_ttu_relationship_without_wildcard_connectivity",
@@ -996,6 +1023,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_1",
@@ -1034,6 +1062,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_2",
@@ -1073,6 +1102,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 3,
 		},
 		{
 			name: "non-assignable_ttu_relationship_through_indirection_3",
@@ -1113,6 +1143,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 4,
 		},
 		{
 			name: "cyclical_tupleset_relation_terminates",
@@ -1142,6 +1173,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 2,
 		},
 		{
 			name: "does_not_send_duplicate_even_though_there_are_two_paths_to_same_solution",
@@ -1177,6 +1209,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 					ResultStatus: connectedobjects.NoFurtherEvalStatus,
 				},
 			},
+			expectedDSQueryCount: 4,
 		},
 	}
 
@@ -1238,6 +1271,7 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 
 			if test.expectedError == nil {
 				require.ElementsMatch(test.expectedResult, results)
+				require.Equal(test.expectedDSQueryCount, dsQueryCounter)
 			}
 		})
 	}

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -1222,8 +1222,10 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
+			var dsQueryCounter uint32
+
 			go func() {
-				err = connectedObjectsCmd.Execute(timeoutCtx, test.request, resultChan)
+				err = connectedObjectsCmd.Execute(timeoutCtx, test.request, resultChan, &dsQueryCounter)
 				require.ErrorIs(err, test.expectedError)
 				close(resultChan)
 			}()

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -271,7 +271,7 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 					done <- struct{}{}
 				}()
 
-				err := listObjectsQuery.ExecuteStreamed(ctx, &openfgav1.StreamedListObjectsRequest{
+				_, err := listObjectsQuery.ExecuteStreamed(ctx, &openfgav1.StreamedListObjectsRequest{
 					StoreId:          storeID,
 					Type:             test.objectType,
 					Relation:         test.relation,

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -307,7 +307,7 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 }
 
 // Used to avoid compiler optimizations (see https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)
-var listObjectsResponse *openfgav1.ListObjectsResponse //nolint
+var listObjectsResponse *commands.ListObjectsResponse //nolint
 
 func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatastore) {
 
@@ -360,7 +360,7 @@ func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatas
 
 	listObjectsQuery := commands.NewListObjectsQuery(ds)
 
-	var r *openfgav1.ListObjectsResponse
+	var r *commands.ListObjectsResponse
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 
@@ -422,7 +422,7 @@ func BenchmarkListObjectsWithConcurrentChecks(b *testing.B, ds storage.OpenFGADa
 
 	listObjectsQuery := commands.NewListObjectsQuery(ds)
 
-	var r *openfgav1.ListObjectsResponse
+	var r *commands.ListObjectsResponse
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesystem.New(model))
 


### PR DESCRIPTION
## Description
Adding trace information on datastore query count for list object
<img width="1959" alt="Screenshot 2023-08-23 at 3 47 14 PM" src="https://github.com/openfga/openfga/assets/10730463/c7708a16-288b-4470-a119-1cc76f285300">
<img width="1959" alt="Screenshot 2023-08-23 at 3 47 52 PM" src="https://github.com/openfga/openfga/assets/10730463/d7dcf969-84c5-4a25-b2f1-645e455ae837">


## References
Close https://github.com/openfga/openfga/issues/956
Close https://github.com/openfga/openfga/issues/938


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
