### PR TITLE
chore: speed up tests

### DIFF
--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -73,7 +73,9 @@ func TestRelationshipIngress_String(t *testing.T) {
 			},
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			require.Equal(t, tc.expected, tc.ingress.String())
 		})
 	}
@@ -228,7 +230,9 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 			typesys := typesystem.New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   typesystem.SchemaVersion1_1,
@@ -1357,7 +1361,9 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 			typesys := typesystem.New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   typesystem.SchemaVersion1_1,

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -673,8 +673,9 @@ func TestValidateTuple(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			err := ValidateTuple(typesystem.New(test.model), test.tuple)
 			require.ErrorIs(t, err, test.expectedError)
 		})

--- a/pkg/server/test/connected_objects.go
+++ b/pkg/server/test/connected_objects.go
@@ -1158,7 +1158,9 @@ func ConnectedObjectsTest(t *testing.T, ds storage.OpenFGADatastore) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			require := require.New(t)
 
 			ctx := context.Background()

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -48,6 +48,7 @@ func TestSplitObjectId(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			td, oid := SplitObject(tc.objectID)
 
 			require.Equal(t, tc.expectedType, td)
@@ -97,7 +98,9 @@ func TestSplitObjectRelation(t *testing.T) {
 			expectedRelation: "reader",
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			obj, rel := SplitObjectRelation(tc.objectRelation)
 
 			require.Equal(t, tc.expectedObject, obj)
@@ -132,7 +135,9 @@ func TestIsObjectRelation(t *testing.T) {
 			expected:       true,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := IsObjectRelation(tc.objectRelation)
 			require.Equal(t, tc.expected, got)
 		})
@@ -169,7 +174,9 @@ func TestIsValidObject(t *testing.T) {
 			valid: false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := IsValidObject(tc.name)
 			require.Equal(t, tc.valid, got)
 		})
@@ -198,7 +205,9 @@ func TestIsValidRelation(t *testing.T) {
 			valid: true,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := IsValidRelation(tc.name)
 			require.Equal(t, tc.valid, got)
 		})
@@ -288,7 +297,9 @@ func TestIsValidUser(t *testing.T) {
 			valid: false,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := IsValidUser(tc.name)
 			require.Equal(t, tc.valid, got)
 		})
@@ -325,7 +336,9 @@ func TestGetUsertypeFromUser(t *testing.T) {
 			want: User,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := GetUserTypeFromUser(tc.name)
 			require.Equal(t, tc.want, got)
 		})
@@ -354,7 +367,9 @@ func TestGetObjectRelationAsString(t *testing.T) {
 			want: "team:fga",
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := GetObjectRelationAsString(tc.input)
 			require.Equal(t, tc.want, got)
 		})

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -135,7 +135,9 @@ func TestNewAndValidate(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewAndValidate(context.Background(), &openfgav1.AuthorizationModel{
 				SchemaVersion:   SchemaVersion1_1,
 				TypeDefinitions: parser.MustParse(test.model),
@@ -216,7 +218,9 @@ func TestSuccessfulRewriteValidations(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewAndValidate(context.Background(), test.model)
 			require.NoError(t, err)
 		})
@@ -653,7 +657,9 @@ func TestInvalidRewriteValidations(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewAndValidate(context.Background(), test.model)
 			require.ErrorIs(t, err, test.err)
 		})
@@ -754,7 +760,9 @@ func TestSuccessfulRelationTypeRestrictionsValidations(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewAndValidate(context.Background(), test.model)
 			require.NoError(t, err)
 		})
@@ -1228,7 +1236,9 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := NewAndValidate(context.Background(), test.model)
 			require.EqualError(t, err, test.err.Error())
 		})
@@ -1450,8 +1460,9 @@ func TestRelationInvolvesIntersection(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -1609,8 +1620,9 @@ func TestRelationInvolvesExclusion(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -1815,7 +1827,9 @@ func TestIsTuplesetRelation(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			typesys := New(test.model)
 
 			actual, err := typesys.IsTuplesetRelation(test.objectType, test.relation)
@@ -1918,8 +1932,9 @@ func TestIsDirectlyRelated(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 			typesys := New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   SchemaVersion1_1,
@@ -2001,8 +2016,9 @@ func TestIsPubliclyAssignable(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 			typesys := New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   SchemaVersion1_1,
@@ -2040,8 +2056,9 @@ func TestRewriteContainsExclusion(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -2081,8 +2098,9 @@ func TestRewriteContainsIntersection(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -2170,8 +2188,9 @@ func TestDirectlyRelatedUsersets(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test
 		t.Run(test.name, func(t *testing.T) {
-
+			t.Parallel()
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{


### PR DESCRIPTION
## Description
Try to reduce test time by parallelizing tests.

More ideas:
- [ ] Parallelize the `migration` and `rollback` tests. Right now we can't because of a race condition with Goose (https://github.com/pressly/goose/issues/587)
- [ ] `make unit-test` -> `make test` and `make test-mysql` and `make test-postgres`.
