### PR TITLE
fix: send 403 instead of 500 when unauthenticated

### DIFF
--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -211,6 +211,8 @@ func ConvertToEncodedErrorCode(statusError *status.Status) int32 {
 	switch statusError.Code() {
 	case codes.OK:
 		return int32(codes.OK)
+	case codes.Unauthenticated:
+		return int32(openfgav1.AuthErrorCode_unauthenticated)
 	case codes.Canceled:
 		return int32(openfgav1.InternalErrorCode_cancelled)
 	case codes.Unknown:

--- a/pkg/server/errors/encoded_errors_test.go
+++ b/pkg/server/errors/encoded_errors_test.go
@@ -211,6 +211,11 @@ func TestConvertToEncodedErrorCode(t *testing.T) {
 			expectedErrorCode: int32(openfgav1.InternalErrorCode_unavailable),
 		},
 		{
+			_name:             "unauthenticated",
+			status:            status.New(codes.Unauthenticated, "other error"),
+			expectedErrorCode: int32(openfgav1.AuthErrorCode_unauthenticated),
+		},
+		{
 			_name:             "data_loss",
 			status:            status.New(codes.DataLoss, "other error"),
 			expectedErrorCode: int32(openfgav1.InternalErrorCode_data_loss),


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
