### PR TITLE
feat: list objects should limit number of DB reads on every call

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -27,10 +27,11 @@ const (
 	streamedBufferSize = 100
 
 	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
-	defaultResolveNodeLimit        = 25
-	defaultResolveNodeBreadthLimit = 100
-	defaultListObjectsDeadline     = 3 * time.Second
-	defaultListObjectsMaxResults   = 1000
+	defaultResolveNodeLimit                 = 25
+	defaultResolveNodeBreadthLimit          = 100
+	defaultListObjectsDeadline              = 3 * time.Second
+	defaultListObjectsMaxResults            = 1000
+	defaultMaxConcurrentReadsForListObjects = math.MaxUint32
 )
 
 var (
@@ -52,6 +53,7 @@ type ListObjectsQuery struct {
 	listObjectsMaxResults   uint32
 	resolveNodeLimit        uint32
 	resolveNodeBreadthLimit uint32
+	maxConcurrentReads      uint32
 
 	checkOptions []graph.LocalCheckerOption
 }
@@ -96,6 +98,13 @@ func WithCheckOptions(checkOptions []graph.LocalCheckerOption) ListObjectsQueryO
 	}
 }
 
+// WithMaxConcurrentReads see server.WithMaxConcurrentReadsForListObjects
+func WithMaxConcurrentReads(limit uint32) ListObjectsQueryOption {
+	return func(d *ListObjectsQuery) {
+		d.maxConcurrentReads = limit
+	}
+}
+
 func NewListObjectsQuery(ds storage.RelationshipTupleReader, opts ...ListObjectsQueryOption) *ListObjectsQuery {
 	query := &ListObjectsQuery{
 		datastore:               ds,
@@ -104,12 +113,15 @@ func NewListObjectsQuery(ds storage.RelationshipTupleReader, opts ...ListObjects
 		listObjectsMaxResults:   defaultListObjectsMaxResults,
 		resolveNodeLimit:        defaultResolveNodeLimit,
 		resolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
+		maxConcurrentReads:      defaultMaxConcurrentReadsForListObjects,
 		checkOptions:            []graph.LocalCheckerOption{},
 	}
 
 	for _, opt := range opts {
 		opt(query)
 	}
+
+	query.datastore = storagewrappers.NewBoundedConcurrencyTupleReader(query.datastore, query.maxConcurrentReads)
 
 	return query
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -342,6 +342,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		commands.WithResolveNodeLimit(s.resolveNodeLimit),
 		commands.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
 		commands.WithCheckOptions(checkOptions),
+		commands.WithMaxConcurrentReads(s.maxConcurrentReadsForListObjects),
 	)
 
 	return q.Execute(
@@ -391,6 +392,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		commands.WithResolveNodeLimit(s.resolveNodeLimit),
 		commands.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
 		commands.WithCheckOptions(checkOptions),
+		commands.WithMaxConcurrentReads(s.maxConcurrentReadsForListObjects),
 	)
 
 	req.AuthorizationModelId = typesys.GetAuthorizationModelID() // the resolved model id

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -72,6 +72,21 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(ctx context.Context, s
 	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
 }
 
+func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
+	ctx context.Context,
+	store string,
+	filter storage.ReadStartingWithUserFilter,
+) (storage.TupleIterator, error) {
+	b.waitForLimiter(ctx)
+
+	defer func() {
+		<-b.limiter
+	}()
+
+	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
+
+}
+
 func (b *boundedConcurrencyTupleReader) waitForLimiter(ctx context.Context) {
 	start := time.Now()
 

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -27,9 +27,9 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 	// create a limited tuple reader that allows 1 concurrent read a time
 	limitedTupleReader := NewBoundedConcurrencyTupleReader(slowBackend, 1)
 
-	// do reads from 3 goroutines - each should be run serially
+	// do reads from 4 goroutines - each should be run serially
 	var wg sync.WaitGroup
-	wg.Add(3)
+	wg.Add(4)
 
 	start := time.Now()
 
@@ -50,6 +50,21 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 
 	go func() {
 		_, err := limitedTupleReader.Read(context.Background(), store, nil)
+		require.NoError(t, err)
+		wg.Done()
+	}()
+
+	go func() {
+		_, err := limitedTupleReader.ReadStartingWithUser(
+			context.Background(),
+			store,
+			storage.ReadStartingWithUserFilter{
+				UserFilter: []*openfgav1.ObjectRelation{
+					{
+						Object:   "obj",
+						Relation: "viewer",
+					},
+				}})
 		require.NoError(t, err)
 		wg.Done()
 	}()

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -27,9 +27,11 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 	// create a limited tuple reader that allows 1 concurrent read a time
 	limitedTupleReader := NewBoundedConcurrencyTupleReader(slowBackend, 1)
 
-	// do reads from 4 goroutines - each should be run serially
+	// do reads from 4 goroutines - each should be run serially. Should be >4 seconds
+	const numRoutine = 4
+
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(numRoutine)
 
 	start := time.Now()
 
@@ -73,5 +75,5 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 
 	end := time.Now()
 
-	require.True(t, end.Sub(start) >= 3*time.Second, "Expected all reads to take at least 3 seconds")
+	require.GreaterOrEqual(t, end.Sub(start), numRoutine*time.Second)
 }


### PR DESCRIPTION
## Description
Add configurable concurrency limit for list object

## References
Close https://github.com/openfga/openfga/issues/955

## Testing

Add the following model

```
model
  schema 1.1
type doc
  relations
    define can_change_owner: owner
    define can_read: viewer or owner or viewer from parent
    define can_share: owner or owner from parent
    define can_write: owner or owner from parent
    define owner: [user]
    define parent: [folder]
    define viewer: [user,user:*,group#member]
type folder
  relations
    define can_create_file: owner
    define owner: [user]
    define parent: [folder]
    define viewer: [user,user:*,group#member] or owner or viewer from parent
type group
  relations
    define member: [user]
type user

```

With the follow tuples

```
{
    "tuples": [
        {
            "key": {
                "object": "folder:1",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:2",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:3",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:4",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:5",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:6",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:7",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:8",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:9",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "folder:10",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:22:05.476561Z"
        },
        {
            "key": {
                "object": "doc:1",
                "relation": "parent",
                "user": "folder:5"
            },
            "timestamp": "2023-08-24T22:22:33.747521Z"
        },
        {
            "key": {
                "object": "folder:11",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:12",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:13",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:14",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:15",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:16",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:17",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:18",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:19",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        },
        {
            "key": {
                "object": "folder:20",
                "relation": "owner",
                "user": "user:test_user"
            },
            "timestamp": "2023-08-24T22:27:00.171126Z"
        }
    ],
    "continuation_token": ""
}
```

Calling list objects requests for `doc#can_read@user:test_user` will result in the following metrics observation

```
# HELP check_cache_hit_count The total number of cache hits for ResolveCheck.
# TYPE check_cache_hit_count counter
check_cache_hit_count 0
# HELP check_cache_total_count The total number of calls to ResolveCheck.
# TYPE check_cache_total_count counter
check_cache_total_count 0
# HELP datastore_bounded_read_delay_ms Time spent waiting for Read, ReadUserTuple and ReadUsersetTuples calls to the datastore
# TYPE datastore_bounded_read_delay_ms histogram
datastore_bounded_read_delay_ms_bucket{le="1"} 5
datastore_bounded_read_delay_ms_bucket{le="3"} 11
datastore_bounded_read_delay_ms_bucket{le="5"} 11
datastore_bounded_read_delay_ms_bucket{le="10"} 17
datastore_bounded_read_delay_ms_bucket{le="25"} 37
datastore_bounded_read_delay_ms_bucket{le="50"} 45
datastore_bounded_read_delay_ms_bucket{le="100"} 45
datastore_bounded_read_delay_ms_bucket{le="1000"} 45
datastore_bounded_read_delay_ms_bucket{le="5000"} 45
datastore_bounded_read_delay_ms_bucket{le="+Inf"} 45
datastore_bounded_read_delay_ms_sum 662
datastore_bounded_read_delay_ms_count 45
# HELP datastore_query_count The number of database queries required to resolve a query (e.g. Check or ListObjects).
# TYPE datastore_query_count histogram
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="1"} 0
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="5"} 0
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="20"} 0
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="50"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="100"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="150"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="225"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="400"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="500"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="750"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="1000"} 1
datastore_query_count_bucket{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService",le="+Inf"} 1
datastore_query_count_sum{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService"} 45
datastore_query_count_count{grpc_method="listObjects",grpc_service="openfga.v1.OpenFGAService"} 1
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0.000180757
go_gc_duration_seconds{quantile="0.25"} 0.000301125
go_gc_duration_seconds{quantile="0.5"} 0.000419287
go_gc_duration_seconds{quantile="0.75"} 0.001047695
go_gc_duration_seconds{quantile="1"} 0.00268542
go_gc_duration_seconds_sum 0.006266298
go_gc_duration_seconds_count 8
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 30
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.21.0"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 1.128728e+07
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 2.940584e+07
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 1.456626e+06
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 109580
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 4.323224e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 1.128728e+07
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 4.931584e+06
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.5024128e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 24036
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 2.220032e+06
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 1.9955712e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.692978932360193e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 133616
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 7200
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 178416
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 179256
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.6931104e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 944726
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 1.015808e+06
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 1.015808e+06
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 2.7890952e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 11
# HELP grpc_server_handled_total Total number of RPCs completed on the server, regardless of success or failure.
# TYPE grpc_server_handled_total counter
grpc_server_handled_total{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 1
# HELP grpc_server_handling_seconds Histogram of response latency (seconds) of gRPC that had been application-level handled by the server.
# TYPE grpc_server_handling_seconds histogram
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.005"} 0
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.01"} 0
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.025"} 0
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.05"} 0
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.1"} 0
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.25"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="0.5"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="1"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="2.5"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="5"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="10"} 1
grpc_server_handling_seconds_bucket{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary",le="+Inf"} 1
grpc_server_handling_seconds_sum{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 0.176792285
grpc_server_handling_seconds_count{grpc_code="OK",grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 1
# HELP grpc_server_msg_received_total Total number of RPC stream messages received on the server.
# TYPE grpc_server_msg_received_total counter
grpc_server_msg_received_total{grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 1
# HELP grpc_server_msg_sent_total Total number of gRPC stream messages sent by the server.
# TYPE grpc_server_msg_sent_total counter
grpc_server_msg_sent_total{grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 1
# HELP grpc_server_started_total Total number of RPCs started on the server.
# TYPE grpc_server_started_total counter
grpc_server_started_total{grpc_method="ListObjects",grpc_service="openfga.v1.OpenFGAService",grpc_type="unary"} 1
# HELP list_objects_further_eval_required_count Number of objects in a ListObjects call that needed to issue a Check call to determine a final result
# TYPE list_objects_further_eval_required_count counter
list_objects_further_eval_required_count 0
# HELP list_objects_no_further_eval_required_count Number of objects in a ListObjects call that needed to issue a Check call to determine a final result
# TYPE list_objects_no_further_eval_required_count counter
list_objects_no_further_eval_required_count 1
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 0.97
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1.048576e+06
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 23
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 3.7003264e+07
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.69297888294e+09
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 1.281150976e+09
# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
# TYPE process_virtual_memory_max_bytes gauge
process_virtual_memory_max_bytes 1.8446744073709552e+19
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 56
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

We observe

<img width="1904" alt="Screenshot 2023-08-25 at 11 57 47 AM" src="https://github.com/openfga/openfga/assets/10730463/a541a66f-ce25-48f5-81b0-c6b71ba992f3">
<img width="1904" alt="Screenshot 2023-08-25 at 11 58 10 AM" src="https://github.com/openfga/openfga/assets/10730463/116d07f3-6929-499c-a583-7d8d260f39b4">


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
