### PR TITLE
style: rename connected objects -> reverse expand

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -19,15 +19,13 @@ const (
 
 var (
 	ErrResolutionDepthExceeded = errors.New("resolution depth exceeded")
-	ErrTargetError             = errors.New("graph: target incorrectly specified")
-	ErrNotImplemented          = errors.New("graph: intersection and exclusion are not yet implemented")
 )
 
-type findIngressOption int
+type findEdgeOption int
 
 const (
-	resolveAllIngresses findIngressOption = iota
-	resolveAnyIngress
+	resolveAllEdges findEdgeOption = iota
+	resolveAnyEdge
 )
 
 // ContextWithResolutionDepth attaches the provided graph resolution depth to the parent context.
@@ -52,120 +50,101 @@ type ResolutionMetadata struct {
 	DatastoreQueryCount uint32
 }
 
-// RelationshipIngressType is used to define an enum of the type of ingresses between
-// source object references and target user references that exist in the graph of
-// relationships.
-type RelationshipIngressType int
+type RelationshipEdgeType int
 
 const (
-	// DirectIngress defines a direct ingress connection between a source object reference
+	// DirectEdge defines a direct connection between a source object reference
 	// and some target user reference.
-	DirectIngress RelationshipIngressType = iota
-	TupleToUsersetIngress
-	ComputedUsersetIngress
+	DirectEdge RelationshipEdgeType = iota
+	// TupleToUsersetEdge defines a connection between a source object reference
+	// and some target user reference that is conditional to a third user reference.
+	TupleToUsersetEdge
+	// ComputedUsersetEdge defines a direct connection between a source object reference
+	// and some target user reference. The difference with DirectEdge is that DirectEdge will involve
+	// a read of tuples and this one will not.
+	ComputedUsersetEdge
 )
 
-func (r RelationshipIngressType) String() string {
+func (r RelationshipEdgeType) String() string {
 	switch r {
-	case DirectIngress:
+	case DirectEdge:
 		return "direct"
-	case ComputedUsersetIngress:
+	case ComputedUsersetEdge:
 		return "computed_userset"
-	case TupleToUsersetIngress:
+	case TupleToUsersetEdge:
 		return "ttu"
 	default:
 		return "undefined"
 	}
 }
 
-type IngressCondition int
+type EdgeCondition int
 
 const (
 
-	// RequiresFurtherEvalCondition indicates an ingress condition whereby results expanded
-	// under such an ingress require further Check evaluation before a determination of the
-	// outcome can be made.
+	// RequiresFurtherEvalCondition indicates an edge condition whereby results found with ReverseExpandQuery
+	// require further Check evaluation before a determination of the outcome can be made.
 	//
 	// Relationships involving intersection ('and') and/or exclusion ('but not') fall under
-	// ingresses with this condition.
-	RequiresFurtherEvalCondition IngressCondition = iota
+	// edges with this condition.
+	RequiresFurtherEvalCondition EdgeCondition = iota
 
-	// NoFurtherEvalCondition indicates an ingress condition whereby results are factual and
+	// NoFurtherEvalCondition indicates an edge condition whereby results found with ReverseExpandQuery are factual and
 	// known to be true and require no further evaluation before a determination of the outcome
 	// can be made.
 	NoFurtherEvalCondition
 )
 
-// RelationshipIngress represents a possible ingress point between some source object reference
-// and a target user reference.
-type RelationshipIngress struct {
+// RelationshipEdge represents a possible relationship some source object reference
+// and a target user reference. The possibility is realized depending on the tuples and on the edge's type.
+type RelationshipEdge struct {
+	Type RelationshipEdgeType
 
-	// The type of the relationship ingress
-	Type RelationshipIngressType
+	// The edge is directed towards this node, which can be like group:*, or group, or group:member
+	TailUsersetNode *openfgav1.RelationReference
 
-	// The relationship reference that defines the ingress to some target relation
-	Ingress *openfgav1.RelationReference
-
-	// TuplesetRelation defines the tupleset relation reference that relates a source
-	// object reference with a target if the type of the relationship ingress is that
-	// of a TupleToUserset
-	// TODO this can be just a string for the relation (since the type will be the same as Ingress.Type)
+	// If the type is TupleToUsersetEdge, this defines the TTU condition
+	// TODO this can be just a string for the relation (since the type will be the same as TailUsersetNode.Type)
 	TuplesetRelation *openfgav1.RelationReference
 
-	Condition IngressCondition
+	// TODO this is leaking implementation details of ReverseExpand. This can be a boolean saying
+	// if `TailUsersetNode` is intersection or exclusion.
+	Condition EdgeCondition
 }
 
-func (r RelationshipIngress) String() string {
+func (r RelationshipEdge) String() string {
 	// TODO also print the condition
 	val := ""
 	if r.TuplesetRelation != nil {
-		val = fmt.Sprintf("ingress %s, type %s, tupleset %s", r.Ingress.String(), r.Type.String(), r.TuplesetRelation.String())
+		val = fmt.Sprintf("userset %s, type %s, tupleset %s", r.TailUsersetNode.String(), r.Type.String(), r.TuplesetRelation.String())
 	} else {
-		val = fmt.Sprintf("ingress %s, type %s", r.Ingress.String(), r.Type.String())
+		val = fmt.Sprintf("userset %s, type %s", r.TailUsersetNode.String(), r.Type.String())
 	}
 	return strings.ReplaceAll(val, "  ", " ")
 }
 
-// ConnectedObjectGraph represents a graph of relationships and the connectivity between
+// TypesystemGraph represents a graph of relationships and the connectivity between
 // object and relation references within the graph through direct or indirect relationships.
-// The ConnectedObjectGraph should be used to introspect what kind of relationships between
-// object types can exist.
-type ConnectedObjectGraph struct {
+type TypesystemGraph struct {
 	typesystem *typesystem.TypeSystem
 }
 
-// BuildConnectedObjectGraph builds an object graph representing the graph of relationships between connected
-// object types either through direct or indirect relationships.
-func BuildConnectedObjectGraph(typesystem *typesystem.TypeSystem) *ConnectedObjectGraph {
-	return &ConnectedObjectGraph{
+// New returns a TypesystemGraph. The TypesystemGraph should be used to introspect what kind of relationships between
+// object types can exist. To visualize this graph, use https://github.com/jon-whit/openfga-graphviz-gen
+func New(typesystem *typesystem.TypeSystem) *TypesystemGraph {
+	return &TypesystemGraph{
 		typesystem: typesystem,
 	}
 }
 
-// RelationshipIngresses computes the incoming edges (ingresses) that are possible between the target relation reference
-// and the source relational reference.
-//
-// To look up Ingresses(`document#viewer`, `source`), where `source` is a type with no relation, look up the definition of relation `document#viewer` and:
-// 1. If `source` is a directly related type then add `source, direct` to the result.
-// 2. If `objectType#relation` is a type and `objectType#relation` can be a `source` then add `objectType#relation, direct` to the result.
-// 3. If computed userset, say `define viewer as writer`, then recurse on `document#writer, source`.
-// 4. If tuple-to-userset, say, `define viewer as viewer from parent`. Go to parent and find its types. In this case, `folder`. Go to `folder` and see if it has a `viewer` relation. If so, recurse on `folder#viewer, source`.
-//
-// To look up Ingresses(`document#viewer`, `folder#viewer`), look up the definition of relation `document#viewer` and:
-// 1. If `folder#viewer` is a directly related type then add `folder#viewer, direct` to the result.
-// 2. If computed userset, say `define viewer as writer`, then recurse on `document#writer, folder#viewer`.
-// 3. If tuple-to-userset, say, `define viewer as viewer from parent`. Go to parent and find its related types.
-//  1. If parent's types includes `folder` type, and `folder` contains `viewer` relation then this is exactly a ttu rewrite and....?
-//  2. Otherwise, suppose the types contains `objectType` which has a relation `viewer`, then recurse on `objectType#viewer, folder#viewer`
-func (g *ConnectedObjectGraph) RelationshipIngresses(target *openfgav1.RelationReference, source *openfgav1.RelationReference) ([]*RelationshipIngress, error) {
-	return g.findIngresses(target, source, map[string]struct{}{}, resolveAllIngresses)
+// GetRelationshipEdges finds all paths from a source to a target and then returns all the edges at distance 0 or 1 of the source in those paths.
+func (g *TypesystemGraph) GetRelationshipEdges(target *openfgav1.RelationReference, source *openfgav1.RelationReference) ([]*RelationshipEdge, error) {
+	return g.relationshipEdges(target, source, map[string]struct{}{}, resolveAllEdges)
 }
 
-// PrunedRelationshipIngresses compute the minimum incoming endges (ingresses) that are possible between the target and the source.
-//
-// PrunedRelationshipIngresses is primarily used as the driver behind ingresses that work for models including intersection and exclusion.
-// If the ingresses from the source to the target pass through a relationship involving intersection or exclusion (directly or indirectly),
-// then the PrunedRelationshipIngresses will just return the first-most ingress involved in the rewrite.
+// GetPrunedRelationshipEdges finds all paths from a source to a target and then returns all the edges at distance 0 or 1 of the source in those paths.
+// If the edges from the source to the target pass through a relationship involving intersection or exclusion (directly or indirectly),
+// then GetPrunedRelationshipEdges will just return the first-most edge involved in that rewrite.
 //
 // Consider the following model:
 //
@@ -176,19 +155,19 @@ func (g *ConnectedObjectGraph) RelationshipIngresses(target *openfgav1.RelationR
 //	  define allowed: [user]
 //	  define viewer: [user] and allowed
 //
-// The pruned relationship ingresses from the 'user' type to 'document#viewer' returns only the `document#viewer` ingress but with a 'RequiresFurtherEvalCondition' ingress condition.
+// The pruned relationship edges from the 'user' type to 'document#viewer' returns only the edge from 'user' to 'document#viewer' and with a 'RequiresFurtherEvalCondition'.
 // This is because when evaluating relationships involving intersection or exclusion we choose to only evaluate one operand of the rewrite rule, and for each result found
 // we call Check on the result to evaluate the sub-condition on the 'and allowed' bit.
-func (g *ConnectedObjectGraph) PrunedRelationshipIngresses(target *openfgav1.RelationReference, source *openfgav1.RelationReference) ([]*RelationshipIngress, error) {
-	return g.findIngresses(target, source, map[string]struct{}{}, resolveAnyIngress)
+func (g *TypesystemGraph) GetPrunedRelationshipEdges(target *openfgav1.RelationReference, source *openfgav1.RelationReference) ([]*RelationshipEdge, error) {
+	return g.relationshipEdges(target, source, map[string]struct{}{}, resolveAnyEdge)
 }
 
-func (g *ConnectedObjectGraph) findIngresses(
+func (g *TypesystemGraph) relationshipEdges(
 	target *openfgav1.RelationReference,
 	source *openfgav1.RelationReference,
 	visited map[string]struct{},
-	findIngressOption findIngressOption,
-) ([]*RelationshipIngress, error) {
+	findEdgeOption findEdgeOption,
+) ([]*RelationshipEdge, error) {
 	key := tuple.ToObjectRelationString(target.GetType(), target.GetRelation())
 	if _, ok := visited[key]; ok {
 		// We've already visited the target so no need to do so again.
@@ -201,36 +180,35 @@ func (g *ConnectedObjectGraph) findIngresses(
 		return nil, err
 	}
 
-	return g.findIngressesWithTargetRewrite(
+	return g.getRelationshipEdgesWithTargetRewrite(
 		target,
 		source,
 		relation.GetRewrite(),
 		visited,
-		findIngressOption,
+		findEdgeOption,
 	)
 }
 
-// findIngressesWithTargetRewrite is what we use for recursive calls on the targetRewrite, particularly union where we don't
-// update the target and source, and only the targetRewrite.
-func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
+// getRelationshipEdgesWithTargetRewrite does a BFS on the graph starting at `target` and trying to reach `source`.
+func (g *TypesystemGraph) getRelationshipEdgesWithTargetRewrite(
 	target *openfgav1.RelationReference,
 	source *openfgav1.RelationReference,
 	targetRewrite *openfgav1.Userset,
 	visited map[string]struct{},
-	findIngressOption findIngressOption,
-) ([]*RelationshipIngress, error) {
+	findEdgeOption findEdgeOption,
+) ([]*RelationshipEdge, error) {
 	switch t := targetRewrite.GetUserset().(type) {
 	case *openfgav1.Userset_This: // e.g. define viewer:[user] as self
-		var res []*RelationshipIngress
+		var res []*RelationshipEdge
 		directlyRelated, _ := g.typesystem.IsDirectlyRelated(target, source)
 		publiclyAssignable, _ := g.typesystem.IsPubliclyAssignable(target, source.GetType())
 
 		if directlyRelated || publiclyAssignable {
 			// if source=user, or define viewer:[user:*] as self
-			res = append(res, &RelationshipIngress{
-				Type:      DirectIngress,
-				Ingress:   typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
-				Condition: NoFurtherEvalCondition,
+			res = append(res, &RelationshipEdge{
+				Type:            DirectEdge,
+				TailUsersetNode: typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
+				Condition:       NoFurtherEvalCondition,
 			})
 		}
 
@@ -238,52 +216,52 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 
 		for _, typeRestriction := range typeRestrictions {
 			if typeRestriction.GetRelation() != "" { // e.g. define viewer:[team#member] as self
-				// recursively sub-collect any ingresses for (team#member, source)
-				ingresses, err := g.findIngresses(typeRestriction, source, visited, findIngressOption)
+				// recursively sub-collect any edges for (team#member, source)
+				edges, err := g.relationshipEdges(typeRestriction, source, visited, findEdgeOption)
 				if err != nil {
 					return nil, err
 				}
 
-				res = append(res, ingresses...)
+				res = append(res, edges...)
 			}
 		}
 
 		return res, nil
 	case *openfgav1.Userset_ComputedUserset: // e.g. target = define viewer as writer
 
-		var ingresses []*RelationshipIngress
+		var edges []*RelationshipEdge
 
 		// if source=document#writer
 		sourceRelMatchesRewritten := target.GetType() == source.GetType() && t.ComputedUserset.GetRelation() == source.GetRelation()
 
 		if sourceRelMatchesRewritten {
-			ingresses = append(ingresses, &RelationshipIngress{
-				Type:      ComputedUsersetIngress,
-				Ingress:   typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
-				Condition: NoFurtherEvalCondition,
+			edges = append(edges, &RelationshipEdge{
+				Type:            ComputedUsersetEdge,
+				TailUsersetNode: typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
+				Condition:       NoFurtherEvalCondition,
 			})
 		}
 
-		collected, err := g.findIngresses(
+		collected, err := g.relationshipEdges(
 			typesystem.DirectRelationReference(target.GetType(), t.ComputedUserset.GetRelation()),
 			source,
 			visited,
-			findIngressOption,
+			findEdgeOption,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		ingresses = append(
-			ingresses,
+		edges = append(
+			edges,
 			collected...,
 		)
-		return ingresses, nil
+		return edges, nil
 	case *openfgav1.Userset_TupleToUserset: // e.g. type document, define viewer as writer from parent
 		tupleset := t.TupleToUserset.GetTupleset().GetRelation()               //parent
 		computedUserset := t.TupleToUserset.GetComputedUserset().GetRelation() //writer
 
-		var res []*RelationshipIngress
+		var res []*RelationshipEdge
 		// e.g. type document, define parent:[user, group] as self
 		tuplesetTypeRestrictions, _ := g.typesystem.GetDirectlyRelatedUserTypes(target.GetType(), tupleset)
 
@@ -314,19 +292,19 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 					condition = RequiresFurtherEvalCondition
 				}
 
-				res = append(res, &RelationshipIngress{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
+				res = append(res, &RelationshipEdge{
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference(target.GetType(), target.GetRelation()),
 					TuplesetRelation: typesystem.DirectRelationReference(target.GetType(), tupleset),
 					Condition:        condition,
 				})
 			}
 
-			subResults, err := g.findIngresses(
+			subResults, err := g.relationshipEdges(
 				typesystem.DirectRelationReference(typeRestriction.GetType(), computedUserset),
 				source,
 				visited,
-				findIngressOption,
+				findEdgeOption,
 			)
 			if err != nil {
 				return nil, err
@@ -338,10 +316,10 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 
 		return res, nil
 	case *openfgav1.Userset_Union: // e.g. target = define viewer as self or writer
-		var res []*RelationshipIngress
+		var res []*RelationshipEdge
 		for _, child := range t.Union.GetChild() {
 			// we recurse through each child rewrite
-			childResults, err := g.findIngressesWithTargetRewrite(target, source, child, visited, findIngressOption)
+			childResults, err := g.getRelationshipEdgesWithTargetRewrite(target, source, child, visited, findEdgeOption)
 			if err != nil {
 				return nil, err
 			}
@@ -350,10 +328,10 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 		return res, nil
 	case *openfgav1.Userset_Intersection:
 
-		if findIngressOption == resolveAnyIngress {
+		if findEdgeOption == resolveAnyEdge {
 			child := t.Intersection.GetChild()[0]
 
-			childresults, err := g.findIngressesWithTargetRewrite(target, source, child, visited, findIngressOption)
+			childresults, err := g.getRelationshipEdgesWithTargetRewrite(target, source, child, visited, findEdgeOption)
 			if err != nil {
 				return nil, err
 			}
@@ -365,25 +343,25 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 			return childresults, nil
 		}
 
-		var ingresses []*RelationshipIngress
+		var edges []*RelationshipEdge
 		for _, child := range t.Intersection.GetChild() {
 
-			res, err := g.findIngressesWithTargetRewrite(target, source, child, visited, findIngressOption)
+			res, err := g.getRelationshipEdgesWithTargetRewrite(target, source, child, visited, findEdgeOption)
 			if err != nil {
 				return nil, err
 			}
 
-			ingresses = append(ingresses, res...)
+			edges = append(edges, res...)
 		}
 
-		if len(ingresses) > 0 {
-			ingresses[0].Condition = RequiresFurtherEvalCondition
+		if len(edges) > 0 {
+			edges[0].Condition = RequiresFurtherEvalCondition
 		}
 
-		return ingresses, nil
+		return edges, nil
 	case *openfgav1.Userset_Difference:
 
-		if findIngressOption == resolveAnyIngress {
+		if findEdgeOption == resolveAnyEdge {
 			// if we have 'a but not b', then we prune 'b' and only resolve 'a' with a
 			// condition that requires further evaluation. It's more likely the blacklist
 			// on 'but not b' is a larger set than the base set 'a', and so pruning the
@@ -391,7 +369,7 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 
 			child := t.Difference.GetBase()
 
-			childresults, err := g.findIngressesWithTargetRewrite(target, source, child, visited, findIngressOption)
+			childresults, err := g.getRelationshipEdgesWithTargetRewrite(target, source, child, visited, findEdgeOption)
 			if err != nil {
 				return nil, err
 			}
@@ -403,30 +381,30 @@ func (g *ConnectedObjectGraph) findIngressesWithTargetRewrite(
 			return childresults, nil
 		}
 
-		var ingresses []*RelationshipIngress
+		var edges []*RelationshipEdge
 
 		baseRewrite := t.Difference.GetBase()
 
-		baseIngresses, err := g.findIngressesWithTargetRewrite(target, source, baseRewrite, visited, findIngressOption)
+		baseEdges, err := g.getRelationshipEdgesWithTargetRewrite(target, source, baseRewrite, visited, findEdgeOption)
 		if err != nil {
 			return nil, err
 		}
 
-		if len(baseIngresses) > 0 {
-			baseIngresses[0].Condition = RequiresFurtherEvalCondition
+		if len(baseEdges) > 0 {
+			baseEdges[0].Condition = RequiresFurtherEvalCondition
 		}
 
-		ingresses = append(ingresses, baseIngresses...)
+		edges = append(edges, baseEdges...)
 
 		subtractRewrite := t.Difference.GetSubtract()
 
-		subIngresses, err := g.findIngressesWithTargetRewrite(target, source, subtractRewrite, visited, findIngressOption)
+		subEdges, err := g.getRelationshipEdgesWithTargetRewrite(target, source, subtractRewrite, visited, findEdgeOption)
 		if err != nil {
 			return nil, err
 		}
-		ingresses = append(ingresses, subIngresses...)
+		edges = append(edges, subEdges...)
 
-		return ingresses, nil
+		return edges, nil
 	default:
 		panic("unexpected userset rewrite encountered")
 	}

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -23,7 +23,7 @@ var (
 				return false
 			}
 
-			if typesystem.GetRelationReferenceAsString(out[i].TailUsersetNode) > typesystem.GetRelationReferenceAsString(out[j].TailUsersetNode) {
+			if typesystem.GetRelationReferenceAsString(out[i].TargetReference) > typesystem.GetRelationReferenceAsString(out[j].TargetReference) {
 				return false
 			}
 
@@ -49,7 +49,7 @@ func TestRelationshipEdge_String(t *testing.T) {
 			expected: "userset type:\"document\" relation:\"viewer\", type ttu, tupleset type:\"document\" relation:\"parent\"",
 			relationshipEdge: RelationshipEdge{
 				Type:             TupleToUsersetEdge,
-				TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+				TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 				TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 				Condition:        NoFurtherEvalCondition,
 			},
@@ -59,7 +59,7 @@ func TestRelationshipEdge_String(t *testing.T) {
 			expected: "userset type:\"document\" relation:\"viewer\", type computed_userset",
 			relationshipEdge: RelationshipEdge{
 				Type:            ComputedUsersetEdge,
-				TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+				TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 				Condition:       NoFurtherEvalCondition,
 			},
 		},
@@ -68,7 +68,7 @@ func TestRelationshipEdge_String(t *testing.T) {
 			expected: "userset type:\"document\" relation:\"viewer\", type direct",
 			relationshipEdge: RelationshipEdge{
 				Type:            DirectEdge,
-				TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+				TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 				Condition:       NoFurtherEvalCondition,
 			},
 		},
@@ -111,7 +111,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
@@ -136,7 +136,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
@@ -166,7 +166,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        RequiresFurtherEvalCondition,
 				},
@@ -193,7 +193,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "writer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "writer"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
@@ -219,7 +219,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        RequiresFurtherEvalCondition,
 				},
@@ -246,7 +246,7 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("organization", "repo_admin"),
+					TargetReference: typesystem.DirectRelationReference("organization", "repo_admin"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -305,12 +305,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -330,7 +330,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -358,17 +358,17 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -392,17 +392,17 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -425,7 +425,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -445,7 +445,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -486,12 +486,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -519,7 +519,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -543,7 +543,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -569,7 +569,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -588,7 +588,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -611,7 +611,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("organization", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("organization", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -630,7 +630,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -662,7 +662,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -682,7 +682,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -720,12 +720,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "relation1"),
+					TargetReference: typesystem.DirectRelationReference("document", "relation1"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "relation4"),
+					TargetReference: typesystem.DirectRelationReference("document", "relation4"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -745,7 +745,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "relation2"),
+					TargetReference: typesystem.DirectRelationReference("document", "relation2"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -768,7 +768,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -795,17 +795,17 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					TargetReference: typesystem.DirectRelationReference("team", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -850,7 +850,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "view"),
+					TargetReference:  typesystem.DirectRelationReference("document", "view"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -874,7 +874,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("organization", "can_view"),
+					TargetReference: typesystem.DirectRelationReference("organization", "can_view"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -897,7 +897,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "view"),
+					TargetReference:  typesystem.DirectRelationReference("document", "view"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -928,7 +928,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("organization", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("organization", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -954,27 +954,27 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("trial", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("trial", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("trial", "editor"),
+					TargetReference: typesystem.DirectRelationReference("trial", "editor"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("trial", "owner"),
+					TargetReference: typesystem.DirectRelationReference("trial", "owner"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					TargetReference: typesystem.DirectRelationReference("team", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("team", "admin"),
+					TargetReference: typesystem.DirectRelationReference("team", "admin"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1000,7 +1000,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					TargetReference: typesystem.DirectRelationReference("team", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1020,7 +1020,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					TargetReference: typesystem.DirectRelationReference("team", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1044,7 +1044,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1072,7 +1072,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					TargetReference: typesystem.DirectRelationReference("group", "member"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1100,7 +1100,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("org", "dept_member"),
+					TargetReference:  typesystem.DirectRelationReference("org", "dept_member"),
 					TuplesetRelation: typesystem.DirectRelationReference("org", "dept"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1129,7 +1129,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("resource", "writer"),
+					TargetReference: typesystem.DirectRelationReference("resource", "writer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1169,12 +1169,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "can_view"),
+					TargetReference: typesystem.DirectRelationReference("document", "can_view"),
 					Condition:       NoFurtherEvalCondition,
 				},
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1199,7 +1199,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            ComputedUsersetEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1221,7 +1221,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1242,12 +1242,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					TargetReference: typesystem.DirectRelationReference("document", "allowed"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1268,12 +1268,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					TargetReference: typesystem.DirectRelationReference("document", "allowed"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1294,12 +1294,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					TargetReference: typesystem.DirectRelationReference("document", "allowed"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1319,12 +1319,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "restricted"),
+					TargetReference: typesystem.DirectRelationReference("document", "restricted"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1345,12 +1345,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					TargetReference: typesystem.DirectRelationReference("document", "editor"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "restricted"),
+					TargetReference: typesystem.DirectRelationReference("document", "restricted"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1370,12 +1370,12 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					TargetReference: typesystem.DirectRelationReference("document", "allowed"),
 					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("document", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},
@@ -1397,7 +1397,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:             TupleToUsersetEdge,
-					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
+					TargetReference:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1420,7 +1420,7 @@ func TestRelationshipEdges(t *testing.T) {
 			expected: []*RelationshipEdge{
 				{
 					Type:            DirectEdge,
-					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					TargetReference: typesystem.DirectRelationReference("folder", "viewer"),
 					Condition:       NoFurtherEvalCondition,
 				},
 			},

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -14,16 +14,16 @@ import (
 )
 
 var (
-	RelationshipIngressTransformer = cmp.Transformer("Sort", func(in []*RelationshipIngress) []*RelationshipIngress {
-		out := append([]*RelationshipIngress(nil), in...) // Copy input to avoid mutating it
+	RelationshipEdgeTransformer = cmp.Transformer("Sort", func(in []*RelationshipEdge) []*RelationshipEdge {
+		out := append([]*RelationshipEdge(nil), in...) // Copy input to avoid mutating it
 
-		// Sort by Type and then by ingress and then by tupleset relation
+		// Sort by Type and then by edge and then by tupleset relation
 		sort.SliceStable(out, func(i, j int) bool {
 			if out[i].Type > out[j].Type {
 				return false
 			}
 
-			if typesystem.GetRelationReferenceAsString(out[i].Ingress) > typesystem.GetRelationReferenceAsString(out[j].Ingress) {
+			if typesystem.GetRelationReferenceAsString(out[i].TailUsersetNode) > typesystem.GetRelationReferenceAsString(out[j].TailUsersetNode) {
 				return false
 			}
 
@@ -38,63 +38,63 @@ var (
 	})
 )
 
-func TestRelationshipIngress_String(t *testing.T) {
+func TestRelationshipEdge_String(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		expected string
-		ingress  RelationshipIngress
+		name             string
+		expected         string
+		relationshipEdge RelationshipEdge
 	}{
 		{
-			name:     "TupleToUsersetIngress",
-			expected: "ingress type:\"document\" relation:\"viewer\", type ttu, tupleset type:\"document\" relation:\"parent\"",
-			ingress: RelationshipIngress{
-				Type:             TupleToUsersetIngress,
-				Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+			name:     "TupleToUsersetEdge",
+			expected: "userset type:\"document\" relation:\"viewer\", type ttu, tupleset type:\"document\" relation:\"parent\"",
+			relationshipEdge: RelationshipEdge{
+				Type:             TupleToUsersetEdge,
+				TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 				TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 				Condition:        NoFurtherEvalCondition,
 			},
 		},
 		{
-			name:     "ComputedUsersetIngress",
-			expected: "ingress type:\"document\" relation:\"viewer\", type computed_userset",
-			ingress: RelationshipIngress{
-				Type:      ComputedUsersetIngress,
-				Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-				Condition: NoFurtherEvalCondition,
+			name:     "ComputedUsersetEdge",
+			expected: "userset type:\"document\" relation:\"viewer\", type computed_userset",
+			relationshipEdge: RelationshipEdge{
+				Type:            ComputedUsersetEdge,
+				TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+				Condition:       NoFurtherEvalCondition,
 			},
 		},
 		{
-			name:     "DirectIngress",
-			expected: "ingress type:\"document\" relation:\"viewer\", type direct",
-			ingress: RelationshipIngress{
-				Type:      DirectIngress,
-				Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-				Condition: NoFurtherEvalCondition,
+			name:     "DirectEdge",
+			expected: "userset type:\"document\" relation:\"viewer\", type direct",
+			relationshipEdge: RelationshipEdge{
+				Type:            DirectEdge,
+				TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+				Condition:       NoFurtherEvalCondition,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, tc.ingress.String())
+			require.Equal(t, tc.expected, tc.relationshipEdge.String())
 		})
 	}
 }
 
-func TestRelationshipIngressType_String(t *testing.T) {
+func TestRelationshipEdgeType_String(t *testing.T) {
 
-	require.Equal(t, "direct", DirectIngress.String())
-	require.Equal(t, "computed_userset", ComputedUsersetIngress.String())
-	require.Equal(t, "ttu", TupleToUsersetIngress.String())
-	require.Equal(t, "undefined", RelationshipIngressType(4).String())
+	require.Equal(t, "direct", DirectEdge.String())
+	require.Equal(t, "computed_userset", ComputedUsersetEdge.String())
+	require.Equal(t, "ttu", TupleToUsersetEdge.String())
+	require.Equal(t, "undefined", RelationshipEdgeType(4).String())
 }
 
-func TestPrunedRelationshipIngresses(t *testing.T) {
+func TestPrunedRelationshipEdges(t *testing.T) {
 
 	tests := []struct {
 		name     string
 		model    string
 		target   *openfgav1.RelationReference
 		source   *openfgav1.RelationReference
-		expected []*RelationshipIngress
+		expected []*RelationshipEdge
 	}{
 		{
 			name: "basic_intersection",
@@ -108,11 +108,11 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
 		},
@@ -133,11 +133,11 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
 		},
@@ -163,10 +163,10 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        RequiresFurtherEvalCondition,
 				},
@@ -190,11 +190,11 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "writer"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "writer"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 			},
 		},
@@ -216,10 +216,10 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        RequiresFurtherEvalCondition,
 				},
@@ -243,11 +243,11 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("repo", "admin"),
 			source: typesystem.DirectRelationReference("organization", "member"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("organization", "repo_admin"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("organization", "repo_admin"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -261,33 +261,33 @@ func TestPrunedRelationshipIngresses(t *testing.T) {
 				TypeDefinitions: typedefs,
 			})
 
-			g := BuildConnectedObjectGraph(typesys)
+			g := New(typesys)
 
-			ingresses, err := g.PrunedRelationshipIngresses(test.target, test.source)
+			edges, err := g.GetPrunedRelationshipEdges(test.target, test.source)
 			require.NoError(t, err)
 
 			cmpOpts := []cmp.Option{
 				cmpopts.IgnoreUnexported(openfgav1.RelationReference{}),
-				RelationshipIngressTransformer,
+				RelationshipEdgeTransformer,
 			}
-			if diff := cmp.Diff(test.expected, ingresses, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(test.expected, edges, cmpOpts...); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 }
 
-func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
+func TestRelationshipEdges(t *testing.T) {
 
 	tests := []struct {
 		name     string
 		model    string
 		target   *openfgav1.RelationReference
 		source   *openfgav1.RelationReference
-		expected []*RelationshipIngress
+		expected []*RelationshipEdge
 	}{
 		{
-			name: "direct_ingress_through_ComputedUserset_with_multiple_type_restrictions",
+			name: "direct_edge_through_ComputedUserset_with_multiple_type_restrictions",
 			model: `
 			type user
 
@@ -302,21 +302,21 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "direct_ingress_through_ComputedUserset",
+			name: "direct_edge_through_ComputedUserset",
 			model: `
 			type user
 
@@ -327,16 +327,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "direct_ingress_through_TupleToUserset_with_multiple_type_restrictions",
+			name: "direct_edge_through_TupleToUserset_with_multiple_type_restrictions",
 			model: `
 			type user
 
@@ -355,26 +355,26 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "direct_ingress_with_union_involving_self_and_computed_userset",
+			name: "direct_edge_with_union_involving_self_and_computed_userset",
 			model: `
 			type user
 
@@ -389,21 +389,21 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -422,11 +422,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("team", "member"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -442,11 +442,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("folder", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -461,7 +461,7 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target:   typesystem.DirectRelationReference("team", "member"),
 			source:   typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{},
+			expected: []*RelationshipEdge{},
 		},
 		{
 			name: "test1",
@@ -483,16 +483,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -516,11 +516,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("group", "member"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -540,10 +540,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -566,16 +566,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "nested_group_membership_returns_only_top-level_ingress",
+			name: "nested_group_membership_returns_only_top-level_edge",
 			model: `
 			type user
 
@@ -585,16 +585,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("group", "member"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "ingresses_for_non-assignable_relation",
+			name: "edges_for_non-assignable_relation",
 			model: `
 			type organization
 			  relations
@@ -608,11 +608,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "view"),
 			source: typesystem.DirectRelationReference("organization", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("organization", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("organization", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -627,11 +627,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -646,7 +646,7 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target:   typesystem.DirectRelationReference("document", "viewer"),
 			source:   typesystem.WildcardRelationReference("user"),
-			expected: []*RelationshipIngress{},
+			expected: []*RelationshipEdge{},
 		},
 		{
 			name: "user_*_is_related_to_user_*",
@@ -659,16 +659,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.WildcardRelationReference("user"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "ingresses_involving_wildcard_in_types",
+			name: "edges_involving_wildcard_in_types",
 			model: `
 			type user
 
@@ -679,16 +679,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "ingresses_involving_wildcard_in_source",
+			name: "edges_involving_wildcard_in_source",
 			model: `
 			type user
 
@@ -699,10 +699,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target:   typesystem.DirectRelationReference("document", "viewer"),
 			source:   typesystem.WildcardRelationReference("user"),
-			expected: []*RelationshipIngress{},
+			expected: []*RelationshipEdge{},
 		},
 		{
-			name: "ingresses_involving_wildcards_1",
+			name: "edges_involving_wildcards_1",
 			model: `
 			type user
 			type employee
@@ -717,21 +717,21 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "relation1"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "relation1"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "relation1"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "relation4"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "relation4"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
 		{
-			name: "ingresses_involving_wildcards_2",
+			name: "edges_involving_wildcards_2",
 			model: `
 			type user
 
@@ -742,11 +742,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "relation1"),
 			source: typesystem.WildcardRelationReference("user"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "relation2"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "relation2"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -765,11 +765,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -792,21 +792,21 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("team", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -830,10 +830,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target:   typesystem.DirectRelationReference("document", "viewer"),
 			source:   typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{},
+			expected: []*RelationshipEdge{},
 		},
 		{
-			name: "ingress_through_ttu_on_non-assignable_relation",
+			name: "edge_through_ttu_on_non-assignable_relation",
 			model: `
 			type organization
 			  relations
@@ -847,10 +847,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "view"),
 			source: typesystem.DirectRelationReference("organization", "can_view"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "view"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "view"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -871,11 +871,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "view"),
 			source: typesystem.DirectRelationReference("organization", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("organization", "can_view"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("organization", "can_view"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -894,10 +894,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "view"),
 			source: typesystem.DirectRelationReference("organization", "can_view"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "view"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "view"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -925,11 +925,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "view"),
 			source: typesystem.DirectRelationReference("organization", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("organization", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("organization", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -951,31 +951,31 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("trial", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("trial", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("trial", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("trial", "editor"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("trial", "editor"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("trial", "owner"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("trial", "owner"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("team", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("team", "admin"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("team", "admin"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -997,11 +997,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("trial", "viewer"),
 			source: typesystem.DirectRelationReference("team", "admin"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("team", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1017,11 +1017,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("team", "member"),
 			source: typesystem.DirectRelationReference("team", "admin"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("team", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("team", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1041,11 +1041,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("group", "manager"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1069,11 +1069,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("resource", "writer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("group", "member"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("group", "member"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1097,10 +1097,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("resource", "writer"),
 			source: typesystem.DirectRelationReference("group", "member"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("org", "dept_member"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("org", "dept_member"),
 					TuplesetRelation: typesystem.DirectRelationReference("org", "dept"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1126,11 +1126,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("resource", "writer"),
 			source: typesystem.DirectRelationReference("org", "dept_member"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("resource", "writer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("resource", "writer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1151,7 +1151,7 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target:   typesystem.DirectRelationReference("document", "can_read"),
 			source:   typesystem.DirectRelationReference("document", ""),
-			expected: []*RelationshipIngress{},
+			expected: []*RelationshipEdge{},
 		},
 		{
 			name: "simple_computeduserset_indirect_ref",
@@ -1166,15 +1166,15 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "can_view"),
 			source: typesystem.DirectRelationReference("document", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "can_view"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "can_view"),
+					Condition:       NoFurtherEvalCondition,
 				},
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1196,11 +1196,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "can_read"),
 			source: typesystem.DirectRelationReference("folder", "owner"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      ComputedUsersetIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            ComputedUsersetEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1218,10 +1218,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1239,16 +1239,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "allowed"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1265,16 +1265,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "allowed"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1291,16 +1291,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "allowed"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1316,16 +1316,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "restricted"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "restricted"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1342,16 +1342,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "editor"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "editor"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "restricted"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "restricted"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1367,16 +1367,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("user", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "allowed"),
-					Condition: RequiresFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "allowed"),
+					Condition:       RequiresFurtherEvalCondition,
 				},
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("document", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("document", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1394,10 +1394,10 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", "viewer"),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:             TupleToUsersetIngress,
-					Ingress:          typesystem.DirectRelationReference("document", "viewer"),
+					Type:             TupleToUsersetEdge,
+					TailUsersetNode:  typesystem.DirectRelationReference("document", "viewer"),
 					TuplesetRelation: typesystem.DirectRelationReference("document", "parent"),
 					Condition:        NoFurtherEvalCondition,
 				},
@@ -1417,11 +1417,11 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 			`,
 			target: typesystem.DirectRelationReference("document", "viewer"),
 			source: typesystem.DirectRelationReference("folder", ""),
-			expected: []*RelationshipIngress{
+			expected: []*RelationshipEdge{
 				{
-					Type:      DirectIngress,
-					Ingress:   typesystem.DirectRelationReference("folder", "viewer"),
-					Condition: NoFurtherEvalCondition,
+					Type:            DirectEdge,
+					TailUsersetNode: typesystem.DirectRelationReference("folder", "viewer"),
+					Condition:       NoFurtherEvalCondition,
 				},
 			},
 		},
@@ -1435,16 +1435,16 @@ func TestConnectedObjectGraph_RelationshipIngresses(t *testing.T) {
 				TypeDefinitions: typedefs,
 			})
 
-			g := BuildConnectedObjectGraph(typesys)
+			g := New(typesys)
 
-			ingresses, err := g.RelationshipIngresses(test.target, test.source)
+			edges, err := g.GetRelationshipEdges(test.target, test.source)
 			require.NoError(t, err)
 
 			cmpOpts := []cmp.Option{
 				cmpopts.IgnoreUnexported(openfgav1.RelationReference{}),
-				RelationshipIngressTransformer,
+				RelationshipEdgeTransformer,
 			}
-			if diff := cmp.Diff(test.expected, ingresses, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(test.expected, edges, cmpOpts...); diff != "" {
 				t.Errorf("mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/logger"
-	"github.com/openfga/openfga/pkg/server/commands/connectedobjects"
+	"github.com/openfga/openfga/pkg/server/commands/reverseexpand"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -177,8 +177,8 @@ func (q *ListObjectsQuery) evaluate(
 		userObj, userRel := tuple.SplitObjectRelation(req.GetUser())
 		userObjType, userObjID := tuple.SplitObject(userObj)
 
-		var sourceUserRef connectedobjects.IsUserRef
-		sourceUserRef = &connectedobjects.UserRefObject{
+		var sourceUserRef reverseexpand.IsUserRef
+		sourceUserRef = &reverseexpand.UserRefObject{
 			Object: &openfgav1.Object{
 				Type: userObjType,
 				Id:   userObjID,
@@ -186,12 +186,12 @@ func (q *ListObjectsQuery) evaluate(
 		}
 
 		if tuple.IsTypedWildcard(userObj) {
-			sourceUserRef = &connectedobjects.UserRefTypedWildcard{Type: tuple.GetType(userObj)}
+			sourceUserRef = &reverseexpand.UserRefTypedWildcard{Type: tuple.GetType(userObj)}
 
 		}
 
 		if userRel != "" {
-			sourceUserRef = &connectedobjects.UserRefObjectRelation{
+			sourceUserRef = &reverseexpand.UserRefObjectRelation{
 				ObjectRelation: &openfgav1.ObjectRelation{
 					Object:   userObj,
 					Relation: userRel,
@@ -199,28 +199,28 @@ func (q *ListObjectsQuery) evaluate(
 			}
 		}
 
-		connectedObjectsResChan := make(chan *connectedobjects.ConnectedObjectsResult, 1)
+		reverseExpandResultsChan := make(chan *reverseexpand.ReverseExpandResult, 1)
 		var objectsFound = new(uint32)
 
-		connectedObjectsQuery := connectedobjects.NewConnectedObjectsQuery(q.datastore, typesys,
-			connectedobjects.WithResolveNodeLimit(q.resolveNodeLimit),
-			connectedobjects.WithResolveNodeBreadthLimit(q.resolveNodeBreadthLimit),
+		reverseExpandQuery := reverseexpand.NewReverseExpandQuery(q.datastore, typesys,
+			reverseexpand.WithResolveNodeLimit(q.resolveNodeLimit),
+			reverseexpand.WithResolveNodeBreadthLimit(q.resolveNodeBreadthLimit),
 		)
 
 		go func() {
-			err = connectedObjectsQuery.Execute(ctx, &connectedobjects.ConnectedObjectsRequest{
+			err = reverseExpandQuery.Execute(ctx, &reverseexpand.ReverseExpandRequest{
 				StoreID:          req.GetStoreId(),
 				ObjectType:       targetObjectType,
 				Relation:         targetRelation,
 				User:             sourceUserRef,
 				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
-			}, connectedObjectsResChan)
+			}, reverseExpandResultsChan)
 			if err != nil {
 				resultsChan <- ListObjectsResult{Err: err}
 			}
 
 			// this is necessary to terminate the range loop below
-			close(connectedObjectsResChan)
+			close(reverseExpandResultsChan)
 		}()
 
 		checkResolver := graph.NewLocalChecker(
@@ -233,11 +233,11 @@ func (q *ListObjectsQuery) evaluate(
 
 		wg := sync.WaitGroup{}
 
-		for res := range connectedObjectsResChan {
+		for res := range reverseExpandResultsChan {
 			if atomic.LoadUint32(objectsFound) >= maxResults {
 				break
 			}
-			if res.ResultStatus == connectedobjects.NoFurtherEvalStatus {
+			if res.ResultStatus == reverseexpand.NoFurtherEvalStatus {
 				noFurtherEvalRequiredCounter.Inc()
 				trySendObject(res.Object, objectsFound, maxResults, resultsChan)
 				continue
@@ -246,7 +246,7 @@ func (q *ListObjectsQuery) evaluate(
 			furtherEvalRequiredCounter.Inc()
 
 			wg.Add(1)
-			go func(res *connectedobjects.ConnectedObjectsResult) {
+			go func(res *reverseexpand.ReverseExpandResult) {
 				defer func() {
 					<-concurrencyLimiterCh
 					wg.Done()

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -1,5 +1,5 @@
-// Package connectedobjects contains the code that handles the ConnectedObjects API
-package connectedobjects
+// Package reverseexpand contains the code that handles the ReverseExpand API
+package reverseexpand
 
 import (
 	"context"
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var tracer = otel.Tracer("openfga/pkg/server/commands/connected_objects")
+var tracer = otel.Tracer("openfga/pkg/server/commands/reverse_expand")
 
 const (
 	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
@@ -28,12 +28,21 @@ const (
 	defaultResolveNodeBreadthLimit = 100
 )
 
-type ConnectedObjectsRequest struct {
+type ReverseExpandRequest struct {
 	StoreID          string
 	ObjectType       string
 	Relation         string
 	User             IsUserRef
 	ContextualTuples []*openfgav1.TupleKey
+}
+
+// TODO combine with above?
+type reverseExpandRequest struct {
+	storeID          string
+	edge             *graph.RelationshipEdge
+	targetObjectRef  *openfgav1.RelationReference
+	sourceUserRef    IsUserRef
+	contextualTuples []*openfgav1.TupleKey
 }
 
 type IsUserRef interface {
@@ -100,34 +109,34 @@ type UserRef struct {
 	Ref IsUserRef
 }
 
-type ConnectedObjectsQuery struct {
+type ReverseExpandQuery struct {
 	datastore               storage.RelationshipTupleReader
 	typesystem              *typesystem.TypeSystem
 	resolveNodeLimit        uint32
 	resolveNodeBreadthLimit uint32
 
-	// visitedUsersetsMap map prevents visiting the same userset through the same ingress twice
+	// visitedUsersetsMap map prevents visiting the same userset through the same edge twice
 	visitedUsersetsMap *sync.Map
 	// candidateObjectsMap map prevents returning the same object twice
 	candidateObjectsMap *sync.Map
 }
 
-type ConnectedObjectsQueryOption func(d *ConnectedObjectsQuery)
+type ReverseExpandQueryOption func(d *ReverseExpandQuery)
 
-func WithResolveNodeLimit(limit uint32) ConnectedObjectsQueryOption {
-	return func(d *ConnectedObjectsQuery) {
+func WithResolveNodeLimit(limit uint32) ReverseExpandQueryOption {
+	return func(d *ReverseExpandQuery) {
 		d.resolveNodeLimit = limit
 	}
 }
 
-func WithResolveNodeBreadthLimit(limit uint32) ConnectedObjectsQueryOption {
-	return func(d *ConnectedObjectsQuery) {
+func WithResolveNodeBreadthLimit(limit uint32) ReverseExpandQueryOption {
+	return func(d *ReverseExpandQuery) {
 		d.resolveNodeBreadthLimit = limit
 	}
 }
 
-func NewConnectedObjectsQuery(ds storage.RelationshipTupleReader, ts *typesystem.TypeSystem, opts ...ConnectedObjectsQueryOption) *ConnectedObjectsQuery {
-	query := &ConnectedObjectsQuery{
+func NewReverseExpandQuery(ds storage.RelationshipTupleReader, ts *typesystem.TypeSystem, opts ...ReverseExpandQueryOption) *ReverseExpandQuery {
+	query := &ReverseExpandQuery{
 		datastore:               ds,
 		typesystem:              ts,
 		resolveNodeLimit:        defaultResolveNodeLimit,
@@ -150,36 +159,36 @@ const (
 	NoFurtherEvalStatus
 )
 
-type ConnectedObjectsResult struct {
+type ReverseExpandResult struct {
 	Object       string
 	ResultStatus ConditionalResultStatus
 }
 
 // Execute yields all the objects of the provided objectType that the given user has, possibly, a specific relation with
 // and sends those objects to resultChan. It MUST guarantee no duplicate objects sent.
-func (c *ConnectedObjectsQuery) Execute(
+func (c *ReverseExpandQuery) Execute(
 	ctx context.Context,
-	req *ConnectedObjectsRequest,
-	resultChan chan<- *ConnectedObjectsResult,
+	req *ReverseExpandRequest,
+	resultChan chan<- *ReverseExpandResult,
 ) error {
 	return c.execute(ctx, req, resultChan, nil)
 }
 
-func (c *ConnectedObjectsQuery) execute(
+func (c *ReverseExpandQuery) execute(
 	ctx context.Context,
-	req *ConnectedObjectsRequest,
-	resultChan chan<- *ConnectedObjectsResult,
-	currentIngress *graph.RelationshipIngress,
+	req *ReverseExpandRequest,
+	resultChan chan<- *ReverseExpandResult,
+	currentEdge *graph.RelationshipEdge,
 ) error {
-	ctx, span := tracer.Start(ctx, "connectedObjects.Execute", trace.WithAttributes(
+	ctx, span := tracer.Start(ctx, "reverseExpand.Execute", trace.WithAttributes(
 		attribute.String("target_type", req.ObjectType),
 		attribute.String("target_relation", req.Relation),
 		attribute.String("source", req.User.String()),
 	))
 	defer span.End()
 
-	if currentIngress != nil {
-		span.SetAttributes(attribute.String("ingress", currentIngress.String()))
+	if currentEdge != nil {
+		span.SetAttributes(attribute.String("edge", currentEdge.String()))
 	}
 
 	depth, ok := graph.ResolutionDepthFromContext(ctx)
@@ -198,48 +207,44 @@ func (c *ConnectedObjectsQuery) execute(
 	var sourceUserRef *openfgav1.RelationReference
 	var sourceUserType, sourceUserObj string
 
-	// e.g. 'user:bob'
+	// e.graph. 'user:bob'
 	if val, ok := req.User.(*UserRefObject); ok {
 		sourceUserType = val.Object.GetType()
 		sourceUserObj = tuple.BuildObject(sourceUserType, val.Object.GetId())
 		sourceUserRef = typesystem.DirectRelationReference(sourceUserType, "")
 	}
 
-	// e.g. 'user:*'
+	// e.graph. 'user:*'
 	if val, ok := req.User.(*UserRefTypedWildcard); ok {
 		sourceUserType = val.Type
 		sourceUserRef = typesystem.WildcardRelationReference(sourceUserType)
 	}
 
-	// e.g. 'group:eng#member'
+	// e.graph. 'group:eng#member'
 	if val, ok := req.User.(*UserRefObjectRelation); ok {
 		sourceUserType = tuple.GetType(val.ObjectRelation.GetObject())
 		sourceUserObj = val.ObjectRelation.Object
 		sourceUserRef = typesystem.DirectRelationReference(sourceUserType, val.ObjectRelation.GetRelation())
 		sourceUserRel := val.ObjectRelation.GetRelation()
 
-		if currentIngress != nil {
-			key := fmt.Sprintf("%s#%s", sourceUserObj, currentIngress.String())
+		if currentEdge != nil {
+			key := fmt.Sprintf("%s#%s", sourceUserObj, currentEdge.String())
 			if _, loaded := c.visitedUsersetsMap.LoadOrStore(key, struct{}{}); loaded {
-				// we've already visited this userset through this ingress, exit to avoid an infinite cycle
+				// we've already visited this userset through this edge, exit to avoid an infinite cycle
 				return nil
 			}
 
 			if sourceUserType == req.ObjectType && sourceUserRel == req.Relation {
-				c.trySendCandidate(ctx, currentIngress, sourceUserObj, resultChan)
+				c.trySendCandidate(ctx, currentEdge, sourceUserObj, resultChan)
 			}
 		}
 	}
 
 	targetObjRef := typesystem.DirectRelationReference(req.ObjectType, req.Relation)
 
-	// build the graph of possible edges between object types in the graph based on the authz model's type info
-	g := graph.BuildConnectedObjectGraph(c.typesystem)
+	g := graph.New(c.typesystem)
 
-	// find all paths from target to source and then returns all the edges at distance 0 or 1 in those paths
-	// if the target relation is an intersection or a difference, e.g. viewer: can_view but not blocked
-	// it returns only one of those edges (the first one - e.g. can_view)
-	ingresses, err := g.PrunedRelationshipIngresses(targetObjRef, sourceUserRef)
+	edges, err := g.GetPrunedRelationshipEdges(targetObjRef, sourceUserRef)
 	if err != nil {
 		return err
 	}
@@ -247,43 +252,43 @@ func (c *ConnectedObjectsQuery) execute(
 	subg, subgctx := errgroup.WithContext(ctx)
 	subg.SetLimit(int(c.resolveNodeBreadthLimit))
 
-	for _, ingress := range ingresses {
-		innerLoopIngress := ingress
-		if currentIngress != nil && currentIngress.Condition == graph.RequiresFurtherEvalCondition {
+	for _, edge := range edges {
+		innerLoopEdge := edge
+		if currentEdge != nil && currentEdge.Condition == graph.RequiresFurtherEvalCondition {
 			// propagate the condition to upcoming reverse expansions
-			// TODO don't mutate the ingress, keep track of the previous ingress's condition and use it in trySendCandidate
-			innerLoopIngress.Condition = graph.RequiresFurtherEvalCondition
+			// TODO don't mutate the edge, keep track of the previous edge's condition and use it in trySendCandidate
+			innerLoopEdge.Condition = graph.RequiresFurtherEvalCondition
 		}
 		subg.Go(func() error {
 			r := &reverseExpandRequest{
 				storeID:          storeID,
-				ingress:          innerLoopIngress,
+				edge:             innerLoopEdge,
 				targetObjectRef:  targetObjRef,
 				sourceUserRef:    req.User,
 				contextualTuples: req.ContextualTuples,
 			}
 
-			switch innerLoopIngress.Type {
-			case graph.DirectIngress:
+			switch innerLoopEdge.Type {
+			case graph.DirectEdge:
 				return c.reverseExpandDirect(subgctx, r, resultChan)
-			case graph.ComputedUsersetIngress:
-				// lookup the rewritten target relation on the computed_userset ingress
-				return c.execute(subgctx, &ConnectedObjectsRequest{
+			case graph.ComputedUsersetEdge:
+				// lookup the rewritten target relation on the computed_userset edge
+				return c.execute(subgctx, &ReverseExpandRequest{
 					StoreID:    storeID,
 					ObjectType: req.ObjectType,
 					Relation:   req.Relation,
 					User: &UserRefObjectRelation{
 						ObjectRelation: &openfgav1.ObjectRelation{
 							Object:   sourceUserObj,
-							Relation: innerLoopIngress.Ingress.GetRelation(),
+							Relation: innerLoopEdge.TailUsersetNode.GetRelation(),
 						},
 					},
 					ContextualTuples: r.contextualTuples,
-				}, resultChan, innerLoopIngress)
-			case graph.TupleToUsersetIngress:
+				}, resultChan, innerLoopEdge)
+			case graph.TupleToUsersetEdge:
 				return c.reverseExpandTupleToUserset(subgctx, r, resultChan)
 			default:
-				return fmt.Errorf("unsupported ingress type")
+				return fmt.Errorf("unsupported edge type")
 			}
 		})
 	}
@@ -291,35 +296,25 @@ func (c *ConnectedObjectsQuery) execute(
 	return subg.Wait()
 }
 
-type reverseExpandRequest struct {
-	storeID          string
-	ingress          *graph.RelationshipIngress
-	targetObjectRef  *openfgav1.RelationReference
-	sourceUserRef    IsUserRef
-	contextualTuples []*openfgav1.TupleKey
-}
-
-func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
+func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 	ctx context.Context,
 	req *reverseExpandRequest,
-	resultChan chan<- *ConnectedObjectsResult,
+	resultChan chan<- *ReverseExpandResult,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset", trace.WithAttributes(
-		attribute.String("ingress", req.ingress.String()),
+		attribute.String("edge", req.edge.String()),
 		attribute.String("source.user", req.sourceUserRef.String()),
 	))
 	defer span.End()
 
 	store := req.storeID
 
-	ingress := req.ingress.Ingress
-
 	targetObjectType := req.targetObjectRef.GetType()
 	targetObjectRel := req.targetObjectRef.GetRelation()
 
 	var userFilter []*openfgav1.ObjectRelation
 
-	// a TTU ingress can only have a userset as a source node
+	// a TTU edge can only have a userset as a source node
 	// e.g. 'group:eng#member'
 	if val, ok := req.sourceUserRef.(*UserRefObjectRelation); ok {
 		userFilter = append(userFilter, &openfgav1.ObjectRelation{
@@ -331,10 +326,10 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 
 	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
-	// find all tuples of the form req.ingress.Type:...#req.ingress.TuplesetRelation@req.sourceUserRef
+	// find all tuples of the form req.edge.TailUsersetNode.Type:...#req.edge.TuplesetRelation@req.sourceUserRef
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
-		ObjectType: req.ingress.Ingress.GetType(),
-		Relation:   req.ingress.TuplesetRelation.GetRelation(),
+		ObjectType: req.edge.TailUsersetNode.GetType(),
+		Relation:   req.edge.TuplesetRelation.GetRelation(),
 		UserFilter: userFilter,
 	})
 	if err != nil {
@@ -362,38 +357,36 @@ func (c *ConnectedObjectsQuery) reverseExpandTupleToUserset(
 		sourceUserRef := &UserRefObjectRelation{
 			ObjectRelation: &openfgav1.ObjectRelation{
 				Object:   foundObject,
-				Relation: ingress.GetRelation(),
+				Relation: req.edge.TailUsersetNode.GetRelation(),
 			},
 		}
 
 		subg.Go(func() error {
-			return c.execute(subgctx, &ConnectedObjectsRequest{
+			return c.execute(subgctx, &ReverseExpandRequest{
 				StoreID:          store,
 				ObjectType:       targetObjectType,
 				Relation:         targetObjectRel,
 				User:             sourceUserRef,
 				ContextualTuples: req.contextualTuples,
-			}, resultChan, req.ingress)
+			}, resultChan, req.edge)
 		})
 	}
 
 	return subg.Wait()
 }
 
-func (c *ConnectedObjectsQuery) reverseExpandDirect(
+func (c *ReverseExpandQuery) reverseExpandDirect(
 	ctx context.Context,
 	req *reverseExpandRequest,
-	resultChan chan<- *ConnectedObjectsResult,
+	resultChan chan<- *ReverseExpandResult,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandDirect", trace.WithAttributes(
-		attribute.String("ingress", req.ingress.String()),
+		attribute.String("edgeUserset", req.edge.String()),
 		attribute.String("source.user", req.sourceUserRef.String()),
 	))
 	defer span.End()
 
 	store := req.storeID
-
-	ingress := req.ingress.Ingress
 
 	targetObjectType := req.targetObjectRef.GetType()
 	targetObjectRel := req.targetObjectRef.GetRelation()
@@ -402,7 +395,7 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 
 	targetUserObjectType := req.sourceUserRef.GetObjectType()
 
-	publiclyAssignable, err := c.typesystem.IsPubliclyAssignable(ingress, targetUserObjectType)
+	publiclyAssignable, err := c.typesystem.IsPubliclyAssignable(req.edge.TailUsersetNode, targetUserObjectType)
 	if err != nil {
 		return err
 	}
@@ -436,10 +429,10 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 
 	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
-	// find all tuples of the form req.ingress.Type:...#req.ingress.Relation@req.sourceUserRef
+	// find all tuples of the form req.edge.TailUsersetNode.Type:...#req.edge.TailUsersetNode.Relation@req.sourceUserRef
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
-		ObjectType: ingress.GetType(),
-		Relation:   ingress.GetRelation(),
+		ObjectType: req.edge.TailUsersetNode.GetType(),
+		Relation:   req.edge.TailUsersetNode.GetRelation(),
 		UserFilter: userFilter,
 	})
 	if err != nil {
@@ -472,20 +465,20 @@ func (c *ConnectedObjectsQuery) reverseExpandDirect(
 		}
 
 		subg.Go(func() error {
-			return c.execute(subgctx, &ConnectedObjectsRequest{
+			return c.execute(subgctx, &ReverseExpandRequest{
 				StoreID:          store,
 				ObjectType:       targetObjectType,
 				Relation:         targetObjectRel,
 				User:             sourceUserRef,
 				ContextualTuples: req.contextualTuples,
-			}, resultChan, req.ingress)
+			}, resultChan, req.edge)
 		})
 	}
 
 	return subg.Wait()
 }
 
-func (c *ConnectedObjectsQuery) trySendCandidate(ctx context.Context, ingress *graph.RelationshipIngress, candidateObject string, candidateChan chan<- *ConnectedObjectsResult) {
+func (c *ReverseExpandQuery) trySendCandidate(ctx context.Context, edge *graph.RelationshipEdge, candidateObject string, candidateChan chan<- *ReverseExpandResult) {
 	_, span := tracer.Start(ctx, "trySendCandidate", trace.WithAttributes(
 		attribute.String("object", candidateObject),
 		attribute.Bool("sent", false),
@@ -493,11 +486,11 @@ func (c *ConnectedObjectsQuery) trySendCandidate(ctx context.Context, ingress *g
 	defer span.End()
 	if _, ok := c.candidateObjectsMap.LoadOrStore(candidateObject, struct{}{}); !ok {
 		resultStatus := NoFurtherEvalStatus
-		if ingress != nil && ingress.Condition == graph.RequiresFurtherEvalCondition {
+		if edge != nil && edge.Condition == graph.RequiresFurtherEvalCondition {
 			span.SetAttributes(attribute.Bool("requires_further_eval", true))
 			resultStatus = RequiresFurtherEvalStatus
 		}
-		candidateChan <- &ConnectedObjectsResult{
+		candidateChan <- &ReverseExpandResult{
 			Object:       candidateObject,
 			ResultStatus: resultStatus,
 		}

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -381,7 +381,7 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 	resultChan chan<- *ReverseExpandResult,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandDirect", trace.WithAttributes(
-		attribute.String("edgeUserset", req.edge.String()),
+		attribute.String("edge", req.edge.String()),
 		attribute.String("source.user", req.sourceUserRef.String()),
 	))
 	defer span.End()

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -280,7 +280,7 @@ func (c *ReverseExpandQuery) execute(
 					User: &UserRefObjectRelation{
 						ObjectRelation: &openfgav1.ObjectRelation{
 							Object:   sourceUserObj,
-							Relation: innerLoopEdge.TailUsersetNode.GetRelation(),
+							Relation: innerLoopEdge.TargetReference.GetRelation(),
 						},
 					},
 					ContextualTuples: r.contextualTuples,
@@ -326,9 +326,9 @@ func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 
 	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
-	// find all tuples of the form req.edge.TailUsersetNode.Type:...#req.edge.TuplesetRelation@req.sourceUserRef
+	// find all tuples of the form req.edge.TargetReference.Type:...#req.edge.TuplesetRelation@req.sourceUserRef
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
-		ObjectType: req.edge.TailUsersetNode.GetType(),
+		ObjectType: req.edge.TargetReference.GetType(),
 		Relation:   req.edge.TuplesetRelation.GetRelation(),
 		UserFilter: userFilter,
 	})
@@ -357,7 +357,7 @@ func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 		sourceUserRef := &UserRefObjectRelation{
 			ObjectRelation: &openfgav1.ObjectRelation{
 				Object:   foundObject,
-				Relation: req.edge.TailUsersetNode.GetRelation(),
+				Relation: req.edge.TargetReference.GetRelation(),
 			},
 		}
 
@@ -395,7 +395,7 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 
 	targetUserObjectType := req.sourceUserRef.GetObjectType()
 
-	publiclyAssignable, err := c.typesystem.IsPubliclyAssignable(req.edge.TailUsersetNode, targetUserObjectType)
+	publiclyAssignable, err := c.typesystem.IsPubliclyAssignable(req.edge.TargetReference, targetUserObjectType)
 	if err != nil {
 		return err
 	}
@@ -429,10 +429,10 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 
 	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.contextualTuples)
 
-	// find all tuples of the form req.edge.TailUsersetNode.Type:...#req.edge.TailUsersetNode.Relation@req.sourceUserRef
+	// find all tuples of the form req.edge.TargetReference.Type:...#req.edge.TargetReference.Relation@req.sourceUserRef
 	iter, err := combinedTupleReader.ReadStartingWithUser(ctx, store, storage.ReadStartingWithUserFilter{
-		ObjectType: req.edge.TailUsersetNode.GetType(),
-		Relation:   req.edge.TailUsersetNode.GetRelation(),
+		ObjectType: req.edge.TargetReference.GetType(),
+		Relation:   req.edge.TargetReference.GetRelation(),
 		UserFilter: userFilter,
 	})
 	if err != nil {

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -207,20 +207,20 @@ func (c *ReverseExpandQuery) execute(
 	var sourceUserRef *openfgav1.RelationReference
 	var sourceUserType, sourceUserObj string
 
-	// e.graph. 'user:bob'
+	// e.g. 'user:bob'
 	if val, ok := req.User.(*UserRefObject); ok {
 		sourceUserType = val.Object.GetType()
 		sourceUserObj = tuple.BuildObject(sourceUserType, val.Object.GetId())
 		sourceUserRef = typesystem.DirectRelationReference(sourceUserType, "")
 	}
 
-	// e.graph. 'user:*'
+	// e.g. 'user:*'
 	if val, ok := req.User.(*UserRefTypedWildcard); ok {
 		sourceUserType = val.Type
 		sourceUserRef = typesystem.WildcardRelationReference(sourceUserType)
 	}
 
-	// e.graph. 'group:eng#member'
+	// e.g. 'group:eng#member'
 	if val, ok := req.User.(*UserRefObjectRelation); ok {
 		sourceUserType = tuple.GetType(val.ObjectRelation.GetObject())
 		sourceUserObj = val.ObjectRelation.Object

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -47,7 +47,7 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	)
 
 	t.Run("TestListObjectsRespectsMaxResults", func(t *testing.T) { TestListObjectsRespectsMaxResults(t, ds) })
-	t.Run("TestConnectedObjects", func(t *testing.T) { ConnectedObjectsTest(t, ds) })
+	t.Run("TestReverseExpand", func(t *testing.T) { TestReverseExpand(t, ds) })
 }
 
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {


### PR DESCRIPTION
## Description
Changes:
- Rename `ConnectedObjects -> ReverseExpand`
- Rename `ConnectedObjectsGraph -> RelationshipGraph`
- Rename `RelationshipIngress -> RelationshipEdge` (or sometimes `edge` when used as a variable)
- Updated a few comments
- Added a few TODOs (subject to discussion) which are added to https://github.com/openfga/openfga/issues/957

## References
This is a requisite of https://github.com/openfga/openfga/pull/934
