### PR TITLE
chore: add option to build memory datastore with existing tuples

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -123,6 +123,19 @@ func New(opts ...StorageOption) storage.OpenFGADatastore {
 	return ds
 }
 
+// WithTuples defines an option that intializes the datastore with the provided tuples for the given storeID.
+//
+// This option will append/write the tuples, and as such the tuples will also have changelog entries. It was
+// added primarily for internal testing and for usage within the OpenFGA CLI. It is not generaly intended to be
+// used outside of these purposes.
+func WithTuples(storeID string, tuples []*openfgav1.TupleKey) StorageOption {
+	return func(ds *MemoryBackend) {
+		if err := ds.Write(context.Background(), storeID, nil, tuples); err != nil {
+			panic(fmt.Sprintf("failed to initialize the datastore with the provided tuples: %v", err))
+		}
+	}
+}
+
 func WithMaxTuplesPerWrite(n int) StorageOption {
 	return func(ds *MemoryBackend) { ds.maxTuplesPerWrite = n }
 }

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -1,9 +1,13 @@
 package memory
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/test"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
@@ -36,4 +40,34 @@ func TestStaticTupleIteratorNoRace(t *testing.T) {
 		_, err := iter.Next()
 		require.NoError(t, err)
 	}()
+}
+
+func TestWithTuplesOption(t *testing.T) {
+
+	storeID := ulid.Make().String()
+
+	ds := New(
+		WithTuples(storeID, []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+		}),
+	)
+
+	expectedTupleKey := tuple.NewTupleKey("document:1", "viewer", "user:jon")
+	iter, err := ds.Read(context.Background(), storeID, expectedTupleKey)
+	require.NoError(t, err)
+
+	expectedTupleKeyString := tuple.TupleKeyToString(expectedTupleKey)
+	tp, err := iter.Next()
+	require.NoError(t, err)
+	require.Equal(t, expectedTupleKeyString, tuple.TupleKeyToString(tp.GetKey()))
+
+	tp, err = iter.Next()
+	require.ErrorIs(t, err, storage.ErrIteratorDone)
+	require.Nil(t, tp)
+
+	changes, _, err := ds.ReadChanges(context.Background(), storeID, "document", storage.PaginationOptions{}, 0*time.Second)
+	require.NoError(t, err)
+	require.Len(t, changes, 1)
+	require.Equal(t, expectedTupleKeyString, tuple.TupleKeyToString(changes[0].TupleKey))
+	require.Equal(t, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE, changes[0].Operation)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add a constructor option for the memory datastore that allows creating a memory datastore from pre-existing tuples. This is to assist with tests and work being done in the CLI.

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
