### PR TITLE
chore: rewire request validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,9 @@
             "type": "go",
             "request": "launch",
             "mode": "auto",
-            "program": "${workspaceFolder}/cmd/openfga/openfga.go",
+            "program": "${workspaceFolder}/cmd/openfga/main.go",
+            "args": ["run"],
             "env": {
-                "OPENFGA_DATASTORE_ENGINE": "postgres"
             }
         }
     ]

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	grpc_prometheus "github.com/jon-whit/go-grpc-prometheus"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -31,6 +32,7 @@ import (
 	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/gateway"
 	authnmw "github.com/openfga/openfga/internal/middleware/authn"
+	"github.com/openfga/openfga/internal/middleware/validator"
 	"github.com/openfga/openfga/pkg/logger"
 	httpmiddleware "github.com/openfga/openfga/pkg/middleware/http"
 	"github.com/openfga/openfga/pkg/middleware/logging"
@@ -685,11 +687,15 @@ func (s *ServerContext) Run(ctx context.Context, config *Config) error {
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		requestid.NewUnaryInterceptor(),
+		grpc_validator.UnaryServerInterceptor(),
+		validator.UnaryServerInterceptor(),
 		grpc_ctxtags.UnaryServerInterceptor(),
 	}
 
 	streamingInterceptors := []grpc.StreamServerInterceptor{
 		requestid.NewStreamingInterceptor(),
+		grpc_validator.StreamServerInterceptor(),
+		validator.StreamServerInterceptor(),
 		grpc_ctxtags.StreamServerInterceptor(),
 	}
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
-	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	grpc_prometheus "github.com/jon-whit/go-grpc-prometheus"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -687,14 +686,12 @@ func (s *ServerContext) Run(ctx context.Context, config *Config) error {
 
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		requestid.NewUnaryInterceptor(),
-		grpc_validator.UnaryServerInterceptor(),
 		validator.UnaryServerInterceptor(),
 		grpc_ctxtags.UnaryServerInterceptor(),
 	}
 
 	streamingInterceptors := []grpc.StreamServerInterceptor{
 		requestid.NewStreamingInterceptor(),
-		grpc_validator.StreamServerInterceptor(),
 		validator.StreamServerInterceptor(),
 		grpc_ctxtags.StreamServerInterceptor(),
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/openfga
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/Masterminds/squirrel v1.5.4

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -42,7 +42,7 @@ func StreamServerInterceptor() grpc.StreamServerInterceptor {
 		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {
 			return handler(srv, &recvWrapper{
 				ctx:          ContextWithRequestIsValidated(stream.Context()),
-				ServerStream: stream,
+				ServerStream: ss,
 			})
 		})
 	}

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -1,0 +1,54 @@
+package validator
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+type ctxKey string
+
+var (
+	requestIsValidatedCtxKey = ctxKey("request-validated")
+)
+
+func ContextWithRequestIsValidated(ctx context.Context) context.Context {
+	return context.WithValue(ctx, requestIsValidatedCtxKey, true)
+}
+
+func RequestIsValidatedFromContext(ctx context.Context) bool {
+	validated, ok := ctx.Value(requestIsValidatedCtxKey).(bool)
+	return validated && ok
+}
+
+// UnaryServerInterceptor returns a new unary server interceptor that injects a bool indicating if validation has been run.
+//
+// It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
+// request validation middleware could lead to downstream issues.
+func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		return handler(ContextWithRequestIsValidated(ctx), req)
+	}
+}
+
+// StreamServerInterceptor returns a new streaming server interceptor that injects a bool indicating if validation has been run.
+//
+// It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
+// request validation middleware could lead to downstream issues.
+func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return handler(srv, &recvWrapper{
+			ctx:          ContextWithRequestIsValidated(stream.Context()),
+			ServerStream: stream,
+		})
+	}
+}
+
+type recvWrapper struct {
+	ctx context.Context
+	grpc.ServerStream
+}
+
+func (r *recvWrapper) Context() context.Context {
+	return r.ctx
+}

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"context"
 
+	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
 	"google.golang.org/grpc"
 )
 
@@ -26,8 +27,13 @@ func RequestIsValidatedFromContext(ctx context.Context) bool {
 // It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
 // request validation middleware could lead to downstream issues.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+
+	validator := grpc_validator.UnaryServerInterceptor()
+
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		return handler(ContextWithRequestIsValidated(ctx), req)
+		return validator(ctx, req, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+			return handler(ContextWithRequestIsValidated(ctx), req)
+		})
 	}
 }
 
@@ -36,10 +42,14 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
 // request validation middleware could lead to downstream issues.
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
+	validator := grpc_validator.StreamServerInterceptor()
+
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		return handler(srv, &recvWrapper{
-			ctx:          ContextWithRequestIsValidated(stream.Context()),
-			ServerStream: stream,
+		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {
+			return handler(srv, &recvWrapper{
+				ctx:          ContextWithRequestIsValidated(stream.Context()),
+				ServerStream: stream,
+			})
 		})
 	}
 }

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -22,10 +22,7 @@ func RequestIsValidatedFromContext(ctx context.Context) bool {
 	return validated && ok
 }
 
-// UnaryServerInterceptor returns a new unary server interceptor that injects a bool indicating if validation has been run.
-//
-// It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
-// request validation middleware could lead to downstream issues.
+// UnaryServerInterceptor returns a new unary server interceptor that runs request validations and injects a bool indicating if validation has been run.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 	validator := grpc_validator.UnaryServerInterceptor()

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -34,10 +34,7 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-// StreamServerInterceptor returns a new streaming server interceptor that injects a bool indicating if validation has been run.
-//
-// It is expected that this middleware is run after all request validation middleware. Failing to run this middleware after
-// request validation middleware could lead to downstream issues.
+// StreamServerInterceptor returns a new streaming server interceptor that runs request validations and injects a bool in the context indicating if validation has been run.
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
 	validator := grpc_validator.StreamServerInterceptor()
 

--- a/internal/middleware/validator/validator.go
+++ b/internal/middleware/validator/validator.go
@@ -22,7 +22,7 @@ func RequestIsValidatedFromContext(ctx context.Context) bool {
 	return validated && ok
 }
 
-// UnaryServerInterceptor returns a new unary server interceptor that runs request validations and injects a bool indicating if validation has been run.
+// UnaryServerInterceptor returns a new unary server interceptor that runs request validations and injects a bool in the context indicating if validation has been run.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 	validator := grpc_validator.UnaryServerInterceptor()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -17,6 +17,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/gateway"
 	"github.com/openfga/openfga/internal/graph"
+	"github.com/openfga/openfga/internal/middleware/validator"
 	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/encoder"
@@ -320,8 +321,10 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	const methodName = "listobjects"
@@ -397,8 +400,10 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	const methodName = "streamedlistobjects"
@@ -468,8 +473,10 @@ func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfga
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -490,8 +497,10 @@ func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openf
 	ctx, span := tracer.Start(ctx, "Write")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -526,8 +535,10 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -615,8 +626,10 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -645,8 +658,10 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.Read
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -662,8 +677,10 @@ func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.Wri
 	ctx, span := tracer.Start(ctx, "WriteAuthorizationModel")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -686,8 +703,10 @@ func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgav1.Rea
 	ctx, span := tracer.Start(ctx, "ReadAuthorizationModels")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -703,8 +722,10 @@ func (s *Server) WriteAssertions(ctx context.Context, req *openfgav1.WriteAssert
 	ctx, span := tracer.Start(ctx, "WriteAssertions")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -738,8 +759,10 @@ func (s *Server) ReadAssertions(ctx context.Context, req *openfgav1.ReadAssertio
 	ctx, span := tracer.Start(ctx, "ReadAssertions")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -762,8 +785,10 @@ func (s *Server) ReadChanges(ctx context.Context, req *openfgav1.ReadChangesRequ
 	))
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -779,8 +804,10 @@ func (s *Server) CreateStore(ctx context.Context, req *openfgav1.CreateStoreRequ
 	ctx, span := tracer.Start(ctx, "CreateStore")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -803,8 +830,10 @@ func (s *Server) DeleteStore(ctx context.Context, req *openfgav1.DeleteStoreRequ
 	ctx, span := tracer.Start(ctx, "DeleteStore")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -827,8 +856,10 @@ func (s *Server) GetStore(ctx context.Context, req *openfgav1.GetStoreRequest) (
 	ctx, span := tracer.Start(ctx, "GetStore")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{
@@ -844,8 +875,10 @@ func (s *Server) ListStores(ctx context.Context, req *openfgav1.ListStoresReques
 	ctx, span := tracer.Start(ctx, "ListStores")
 	defer span.End()
 
-	if err := req.Validate(); err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 	}
 
 	ctx = telemetry.ContextWithRPCInfo(ctx, telemetry.RPCInfo{


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Rewires the request validation behavior so that the validation(s) run early in the middleware chain if you're running OpenFGA as a standalone server, but if you're using OpenFGA as a library then the validation context won't be set and so the validation will run inline when the RPC handlers are invoked by the client application.

## References
This is a follow-up of https://github.com/openfga/openfga/pull/975

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
