### PR TITLE
fix: change response code to internal error for concurrency conflicts

### DIFF
--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -149,7 +149,7 @@ func (c *WriteCommand) validateNoDuplicatesAndCorrectSize(deletes []*openfgav1.T
 
 func handleError(err error) error {
 	if errors.Is(err, storage.ErrTransactionalWriteFailed) {
-		return serverErrors.WriteFailedDueToInvalidInput(nil)
+		return serverErrors.NewInternalError("concurrent write conflict", err)
 	} else if errors.Is(err, storage.ErrInvalidWriteInput) {
 		return serverErrors.WriteFailedDueToInvalidInput(err)
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
If an implementation of OpenFGA's storage adapter interface produces an `ErrTransactionalWriteFailed` error due to a transaction concurrency conflict, then OpenFGA should return an internal server error to the client indicating that the request should be retried. After retrying, if at least one of the two concurrent modifications was durably persisted, then the subsequent (retried) request should fail with a `ErrInvalidWriteInput` error because the tuple has since been written and thus the second write would otherwise cause a duplicate.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
