### PR TITLE
chore: add workflow to check markdown links

### DIFF
--- a/.github/.mlc_config.json
+++ b/.github/.mlc_config.json
@@ -1,0 +1,18 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "^(https?)://localhost"
+    },
+    {
+      "pattern": "^https://github.com/openfga/rfcs/blob"
+    },
+    {
+      "pattern": "https://app.fossa.com/api/projects/git\%2Bgithub.com\%2Fopenfga%2Fopenfga.svg?type=shield"
+    }
+],
+  "aliveStatusCodes": [
+      0,
+      200,
+      429
+  ]
+}

--- a/.github/workflows/markdown-links.yaml
+++ b/.github/workflows/markdown-links.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # v1.0.15
         with:
           use-verbose-mode: 'yes'
           folder-path: 'docs/'

--- a/.github/workflows/markdown-links.yaml
+++ b/.github/workflows/markdown-links.yaml
@@ -1,0 +1,23 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 9 * * 1" # At 09:00 on Monday
+
+permissions:
+  contents: read
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v3.5.2
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          use-verbose-mode: 'yes'
+          folder-path: 'docs/'
+          file-path: './README.md, ./CHANGELOG.md'
+          config-file: '.github/.mlc_config.json'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -388,7 +388,7 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
   ./openfga run --experimentals=otel-metrics --otel-telemetry-endpoint=127.0.0.1:4317 --otel-telemetry-protocol=http
   ```
 
-  For more information see the official documentation on [Experimental Features](https://openfga.dev/docs/getting-started/setup-openfga#experimental-features) and [Telemetry](https://openfga.dev/docs/getting-started/setup-openfga#telemetry-metrics-and-tracing).
+  For more information see the official documentation on [Experimental Features](https://openfga.dev/docs/getting-started/setup-openfga/docker#experimental-features) and [Telemetry](https://openfga.dev/docs/getting-started/setup-openfga/docker#telemetry).
 
 * Type-bound public access support in the optimized ListObjects implementation (when the `list-objects-optimized` experimental feature is enabled) ([#444](https://github.com/openfga/openfga/pull/444))
 
@@ -412,7 +412,7 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
   `--log-level` (can be one of ['none', 'debug', 'info', 'warn', 'error', 'panic', 'fatal'])
 
 * Support for Experimental Feature flags
-  A new flag `--experimentals` has been added to enable certain experimental features in OpenFGA. For more information see [Experimental Features](https://openfga.dev/docs/getting-started/setup-openfga#experimental-features).
+  A new flag `--experimentals` has been added to enable certain experimental features in OpenFGA. For more information see [Experimental Features](https://openfga.dev/docs/getting-started/setup-openfga/docker#experimental-features).
 
 ### Security
 * Patches [CVE-2022-23542](https://github.com/openfga/openfga/security/advisories/GHSA-m3q4-7qmj-657m) - relationship reads now respect type restrictions from prior models ([#422](https://github.com/openfga/openfga/pull/422)).

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Take a look at examples of how to:
 - [Write an Authorization Model](https://openfga.dev/api/service#/Authorization%20Models/WriteAuthorizationModel)
 - [Write Relationship Tuples](https://openfga.dev/api/service#/Relationship%20Tuples/Write)
 - [Perform Authorization Checks](https://openfga.dev/api/service#/Relationship%20Queries/Check)
-- [Add Authentication to your OpenFGA server](https://openfga.dev/docs/getting-started/setup-openfga#configuring-authentication)
+- [Add Authentication to your OpenFGA server](https://openfga.dev/docs/getting-started/setup-openfga/docker#configuring-authentication)
 
 Don't hesitate to browse the official [Documentation](https://openfga.dev/), [API Reference](https://openfga.dev/api/service).
 


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->

## Description
This PR adds a new Github Actions workflow to check if the links in the markdown files are alive or dead. It uses a third-party action [markdown-link-check](https://github.com/marketplace/actions/markdown-link-check), to accomplish this.

## References
Closes #1013, #1014

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
