### PR TITLE
chore: enable additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,3 +10,30 @@ linters:
     - gofmt
     - goimports
     - stylecheck
+
+    - importas
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - typecheck
+    - unused
+    - unconvert
+    - unparam
+    - wastedassign
+    - whitespace
+    # - gocritic
+    # - exhaustive
+    # - noctx
+    # - promlinter
+
+linters-settings:
+  importas:
+    # Do not allow unaliased imports of aliased packages.
+    no-unaliased: true
+    # Do not allow non-required aliases.
+    no-extra-aliases: false
+    alias:
+      - pkg: github.com/openfga/api/proto/openfga/v1
+        alias: openfgav1

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -943,7 +943,6 @@ func (s *ServerContext) Run(ctx context.Context, config *Config) error {
 
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 			if strings.HasPrefix(r.URL.Path, "/playground") {
 				if r.URL.Path == "/playground" || r.URL.Path == "/playground/index.html" {
 					err = tmpl.Execute(w, struct {

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -453,7 +453,6 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 	time.Sleep(sdktrace.DefaultScheduleDelay * time.Millisecond)
 
 	require.Equal(t, 1, otlpServer.GetExportCount())
-
 }
 
 func tryStreamingListObjects(t *testing.T, test authTest, httpAddr string, retryClient *retryablehttp.Client, validToken string) {
@@ -646,7 +645,6 @@ func TestHTTPServerWithCORS(t *testing.T) {
 }
 
 func TestBuildServerWithOIDCAuthentication(t *testing.T) {
-
 	oidcServerPort, oidcServerPortReleaser := TCPRandomPort()
 	localOIDCServerURL := fmt.Sprintf("http://localhost:%d", oidcServerPort)
 
@@ -1194,7 +1192,6 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 
 	runCmd := NewRunCommand()
 	runCmd.RunE = func(cmd *cobra.Command, _ []string) error {
-
 		require.Equal(t, "postgres", viper.GetString(datastoreEngineFlag))
 		require.Equal(t, "postgres://postgres:PASS2@127.0.0.1:5432/postgres", viper.GetString(datastoreURIFlag))
 		require.Equal(t, "1", viper.GetString("max-types-per-authorization-model"))

--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -107,7 +107,6 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 
 		// validate each store
 		for _, store := range stores {
-
 			latestModelID, err := db.FindLatestAuthorizationModelID(ctx, store.Id)
 			if err != nil {
 				fmt.Printf("no models in store %s \n", store.Id)

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -146,7 +146,6 @@ func (c *CachedCheckResolver) ResolveCheck(
 	ctx context.Context,
 	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
-
 	checkCacheTotalCounter.Inc()
 
 	cacheKey, err := checkRequestCacheKey(req)
@@ -176,7 +175,6 @@ func (c *CachedCheckResolver) ResolveCheck(
 // cache key. If the contextual tuples are different order, it is possible that a different
 // cache key will be produced. This will result in duplicate entries.
 func checkRequestCacheKey(req *ResolveCheckRequest) (string, error) {
-
 	var b bytes.Buffer
 	if err := gob.NewEncoder(&b).Encode(req.GetTupleKey()); err != nil {
 		return "", err

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -357,7 +357,6 @@ func TestResolveCheckFromCache(t *testing.T) {
 			actualResult, err := dut2.ResolveCheck(ctx, test.subsequentReq)
 			require.Equal(t, result.Allowed, actualResult.Allowed)
 			require.Nil(t, err)
-
 		})
 	}
 }

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -232,7 +232,6 @@ func resolver(ctx context.Context, concurrencyLimit uint32, resultChan chan<- ch
 // union implements a CheckFuncReducer that requires any of the provided CheckHandlerFunc to resolve
 // to an allowed outcome. The first allowed outcome causes premature termination of the reducer.
 func union(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandlerFunc) (*ResolveCheckResponse, error) {
-
 	ctx, cancel := context.WithCancel(ctx)
 	resultChan := make(chan checkOutcome, len(handlers))
 
@@ -275,7 +274,6 @@ func union(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandle
 // intersection implements a CheckFuncReducer that requires all of the provided CheckHandlerFunc to resolve
 // to an allowed outcome. The first falsey or erroneous outcome causes premature termination of the reducer.
 func intersection(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandlerFunc) (*ResolveCheckResponse, error) {
-
 	ctx, cancel := context.WithCancel(ctx)
 	resultChan := make(chan checkOutcome, len(handlers))
 
@@ -328,7 +326,6 @@ func intersection(ctx context.Context, concurrencyLimit uint32, handlers ...Chec
 // outcome and a 'sub' CheckHandlerFunc to resolve to a falsey outcome. The base and sub computations are
 // handled concurrently relative to one another.
 func exclusion(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandlerFunc) (*ResolveCheckResponse, error) {
-
 	if len(handlers) != 2 {
 		panic(fmt.Sprintf("expected two rewrite operands for exclusion operator, but got '%d'", len(handlers)))
 	}
@@ -424,7 +421,7 @@ func (c *LocalChecker) SetDelegate(delegate CheckResolver) {
 
 // dispatch dispatches the provided Check request to the CheckResolver this LocalChecker
 // was constructed with.
-func (c *LocalChecker) dispatch(ctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
+func (c *LocalChecker) dispatch(_ context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		return c.delegate.ResolveCheck(ctx, req)
 	}
@@ -472,7 +469,6 @@ func (c *LocalChecker) ResolveCheck(
 // while the second handler looks up relationships between the target 'object#relation' and any usersets
 // related to it.
 func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
-
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		typesys, ok := typesystem.TypesystemFromContext(parentctx) // note: use of 'parentctx' not 'ctx' - this is important
 		if !ok {
@@ -572,7 +568,6 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				// for 1.1 models, if the user value is a typed wildcard and the type of the wildcard
 				// matches the target user objectType, then we're done searching
 				if tuple.IsTypedWildcard(usersetObject) && typesys.GetSchemaVersion() == typesystem.SchemaVersion1_1 {
-
 					wildcardType := tuple.GetType(usersetObject)
 
 					if tuple.GetType(tk.GetUser()) == wildcardType {
@@ -609,8 +604,8 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 		var checkFuncs []CheckHandlerFunc
 
 		shouldCheckDirectTuple, _ := typesys.IsDirectlyRelated(
-			typesystem.DirectRelationReference(objectType, relation),                                         //target
-			typesystem.DirectRelationReference(tuple.GetType(tk.GetUser()), tuple.GetRelation(tk.GetUser())), //source
+			typesystem.DirectRelationReference(objectType, relation),                                         // target
+			typesystem.DirectRelationReference(tuple.GetType(tk.GetUser()), tuple.GetRelation(tk.GetUser())), // source
 		)
 
 		if shouldCheckDirectTuple {
@@ -619,7 +614,6 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 		if len(directlyRelatedUsersetTypes) > 0 {
 			checkFuncs = append(checkFuncs, fn2)
-
 		}
 
 		return union(ctx, c.concurrencyLimit, checkFuncs...)
@@ -627,7 +621,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 }
 
 // checkComputedUserset evaluates the Check request with the rewritten relation (e.g. the computed userset relation).
-func (c *LocalChecker) checkComputedUserset(parentctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset_ComputedUserset) CheckHandlerFunc {
+func (c *LocalChecker) checkComputedUserset(_ context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset_ComputedUserset) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		ctx, span := tracer.Start(ctx, "checkComputedUserset")
 		defer span.End()
@@ -653,7 +647,6 @@ func (c *LocalChecker) checkComputedUserset(parentctx context.Context, req *Reso
 // checkTTU looks up all tuples of the target tupleset relation on the provided object and for each one
 // of them evaluates the computed userset of the TTU rewrite rule for them.
 func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset) CheckHandlerFunc {
-
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		typesys, ok := typesystem.TypesystemFromContext(parentctx) // note: use of 'parentctx' not 'ctx' - this is important
 		if !ok {
@@ -749,7 +742,6 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		}
 
 		return unionResponse, err
-
 	}
 }
 
@@ -760,7 +752,6 @@ func (c *LocalChecker) checkSetOperation(
 	reducer CheckFuncReducer,
 	children ...*openfgav1.Userset,
 ) CheckHandlerFunc {
-
 	var handlers []CheckHandlerFunc
 
 	var reducerKey string
@@ -798,7 +789,6 @@ func (c *LocalChecker) checkRewrite(
 	req *ResolveCheckRequest,
 	rewrite *openfgav1.Userset,
 ) CheckHandlerFunc {
-
 	switch rw := rewrite.Userset.(type) {
 	case *openfgav1.Userset_This:
 		return c.checkDirect(ctx, req)

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestResolveCheckDeterministic(t *testing.T) {
-
 	ds := memory.New()
 
 	storeID := ulid.Make().String()
@@ -283,7 +282,7 @@ func TestCheckDatastoreQueryCount(t *testing.T) {
 			maxDBReads: 6,
 		},
 		{
-			name:       "intersection_of_ttus", //union_or_ttu and union_and_ttu
+			name:       "intersection_of_ttus", // union_or_ttu and union_and_ttu
 			check:      tuple.NewTupleKey("document:x", "intersection_of_ttus", "user:maria"),
 			allowed:    true,
 			minDBReads: 4, // union_or_ttu (1 read) + union_and_ttu (3 reads)
@@ -293,7 +292,6 @@ func TestCheckDatastoreQueryCount(t *testing.T) {
 
 	// run the test many times to exercise all the possible DBReads
 	for i := 1; i < 1000; i++ {
-
 		t.Run(fmt.Sprintf("iteration_%v", i), func(t *testing.T) {
 			t.Parallel()
 			for _, test := range tests {

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -114,7 +114,7 @@ type RelationshipEdge struct {
 
 func (r RelationshipEdge) String() string {
 	// TODO also print the condition
-	val := ""
+	var val string
 	if r.TuplesetRelation != nil {
 		val = fmt.Sprintf("userset %s, type %s, tupleset %s", r.TargetReference.String(), r.Type.String(), r.TuplesetRelation.String())
 	} else {
@@ -258,8 +258,8 @@ func (g *RelationshipGraph) getRelationshipEdgesWithTargetRewrite(
 		)
 		return edges, nil
 	case *openfgav1.Userset_TupleToUserset: // e.g. type document, define viewer as writer from parent
-		tupleset := t.TupleToUserset.GetTupleset().GetRelation()               //parent
-		computedUserset := t.TupleToUserset.GetComputedUserset().GetRelation() //writer
+		tupleset := t.TupleToUserset.GetTupleset().GetRelation()               // parent
+		computedUserset := t.TupleToUserset.GetComputedUserset().GetRelation() // writer
 
 		var res []*RelationshipEdge
 		// e.g. type document, define parent:[user, group] as self
@@ -311,7 +311,6 @@ func (g *RelationshipGraph) getRelationshipEdgesWithTargetRewrite(
 			}
 
 			res = append(res, subResults...)
-
 		}
 
 		return res, nil
@@ -345,7 +344,6 @@ func (g *RelationshipGraph) getRelationshipEdgesWithTargetRewrite(
 
 		var edges []*RelationshipEdge
 		for _, child := range t.Intersection.GetChild() {
-
 			res, err := g.getRelationshipEdgesWithTargetRewrite(target, source, child, visited, findEdgeOption)
 			if err != nil {
 				return nil, err

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -80,7 +80,6 @@ func TestRelationshipEdge_String(t *testing.T) {
 }
 
 func TestRelationshipEdgeType_String(t *testing.T) {
-
 	require.Equal(t, "direct", DirectEdge.String())
 	require.Equal(t, "computed_userset", ComputedUsersetEdge.String())
 	require.Equal(t, "ttu", TupleToUsersetEdge.String())
@@ -88,7 +87,6 @@ func TestRelationshipEdgeType_String(t *testing.T) {
 }
 
 func TestPrunedRelationshipEdges(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		model    string
@@ -278,7 +276,6 @@ func TestPrunedRelationshipEdges(t *testing.T) {
 }
 
 func TestRelationshipEdges(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		model    string

--- a/internal/mocks/mock_oidc_server.go
+++ b/internal/mocks/mock_oidc_server.go
@@ -52,7 +52,6 @@ func (server mockOidcServer) start() {
 	})
 
 	http.HandleFunc("/jwks.json", func(w http.ResponseWriter, r *http.Request) {
-
 		err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"keys": []map[string]string{
 				{

--- a/internal/utils/resolution_metadata_test.go
+++ b/internal/utils/resolution_metadata_test.go
@@ -24,7 +24,6 @@ func TestResolutionMetadata(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			forkedResolutionCounter.AddResolve()
-
 		}()
 	}
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -13,7 +13,6 @@ import (
 
 // ValidateUserObjectRelation checks whether a tuple is well formed
 func ValidateUserObjectRelation(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
-
 	if err := ValidateUser(typesys, tk.GetUser()); err != nil {
 		return err
 	}
@@ -31,7 +30,6 @@ func ValidateUserObjectRelation(typesys *typesystem.TypeSystem, tk *openfgav1.Tu
 
 // ValidateTuple checks whether a tuple is well formed and valid according to the provided model.
 func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
-
 	if err := ValidateUserObjectRelation(typesys, tk); err != nil {
 		return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
 	}
@@ -71,7 +69,6 @@ func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error
 // 2. `document:1#parent@*` (cannot evaluate/assign untyped wildcard to a tupleset relation (1.0 models))
 // 3. `document:1#parent@folder:*` (cannot evaluate/assign typed wildcard to a tupleset relation (1.1. models))
 func validateTuplesetRestrictions(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
-
 	objectType := tuple.GetType(tk.GetObject())
 	relation := tk.GetRelation()
 
@@ -151,7 +148,6 @@ func validateTypeRestrictions(typesys *typesystem.TypeSystem, tk *openfgav1.Tupl
 	if tuple.IsTypedWildcard(user) {
 		// case 3 documented above
 		for _, typeInformation := range relationInformation.GetDirectlyRelatedUserTypes() {
-
 			if typeInformation.GetType() == userType && typeInformation.GetWildcard() != nil {
 				return nil
 			}
@@ -175,7 +171,6 @@ func validateTypeRestrictions(typesys *typesystem.TypeSystem, tk *openfgav1.Tupl
 // out tuples that aren't valid according to the provided model, which can help filter
 // tuples that were introduced due to another authorization model.
 func FilterInvalidTuples(typesys *typesystem.TypeSystem) storage.TupleKeyFilterFunc {
-
 	return func(tupleKey *openfgav1.TupleKey) bool {
 		err := ValidateTuple(typesys, tupleKey)
 		return err == nil
@@ -186,7 +181,6 @@ func FilterInvalidTuples(typesys *typesystem.TypeSystem) storage.TupleKeyFilterF
 // model. An object is considered valid if it validates against one of the type
 // definitions included in the provided model.
 func ValidateObject(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
-
 	object := tk.GetObject()
 
 	if !tuple.IsValidObject(object) {
@@ -210,7 +204,6 @@ func ValidateObject(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) erro
 // A relation is valid if it is defined as a relation for the type definition of the given
 // objectType.
 func ValidateRelation(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
-
 	object := tk.GetObject()
 	relation := tk.GetRelation()
 
@@ -242,7 +235,6 @@ func ValidateRelation(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) er
 // user field must either be a userset or an object, and if it's an object we
 // verify the objectType is defined in the model.
 func ValidateUser(typesys *typesystem.TypeSystem, user string) error {
-
 	if !tuple.IsValidUser(user) {
 		return fmt.Errorf("the 'user' field is malformed")
 	}
@@ -270,7 +262,6 @@ func ValidateUser(typesys *typesystem.TypeSystem, user string) error {
 	// for 1.0 and 1.1 models if the 'user' field is a userset then we validate the 'object#relation'
 	// by making sure the user objectType and relation are defined in the model.
 	if tuple.IsObjectRelation(user) {
-
 		_, err := typesys.GetRelation(userObjectType, userRelation)
 		if err != nil {
 			if errors.Is(err, typesystem.ErrObjectTypeUndefined) {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestValidateTuple(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		tuple         *openfgav1.TupleKey
@@ -674,7 +673,6 @@ func TestValidateTuple(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			err := ValidateTuple(typesystem.New(test.model), test.tuple)
 			require.ErrorIs(t, err, test.expectedError)
 		})

--- a/pkg/middleware/http/handler.go
+++ b/pkg/middleware/http/handler.go
@@ -101,7 +101,6 @@ func CustomHTTPErrorHandler(ctx context.Context, w http.ResponseWriter, r *http.
 	doForwardTrailers := requestAcceptsTrailers(r)
 
 	if doForwardTrailers {
-
 		handleForwardResponseTrailerHeader(w, md)
 		w.Header().Set("Transfer-Encoding", "chunked")
 	}

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -53,7 +53,6 @@ type reporter struct {
 }
 
 func (r *reporter) PostCall(err error, _ time.Duration) {
-
 	r.fields = append(r.fields, ctxzap.TagsToFields(r.ctx)...)
 
 	code := serverErrors.ConvertToEncodedErrorCode(status.Convert(err))
@@ -78,7 +77,6 @@ func (r *reporter) PostCall(err error, _ time.Duration) {
 }
 
 func (r *reporter) PostMsgSend(msg interface{}, err error, _ time.Duration) {
-
 	protomsg, ok := msg.(protoreflect.ProtoMessage)
 	if ok {
 		if resp, err := r.protomarshaler.Marshal(protomsg); err == nil {
@@ -88,7 +86,6 @@ func (r *reporter) PostMsgSend(msg interface{}, err error, _ time.Duration) {
 }
 
 func (r *reporter) PostMsgReceive(msg interface{}, _ error, _ time.Duration) {
-
 	protomsg, ok := msg.(protoreflect.ProtoMessage)
 	if ok {
 		if req, err := r.protomarshaler.Marshal(protomsg); err == nil {

--- a/pkg/middleware/storeid/storeid.go
+++ b/pkg/middleware/storeid/storeid.go
@@ -39,7 +39,6 @@ func contextWithHandle(ctx context.Context) context.Context {
 }
 
 func SetStoreIDInContext(ctx context.Context, req interface{}) {
-
 	handle := ctx.Value(storeIDCtxKey)
 	if handle == nil {
 		return
@@ -91,7 +90,6 @@ func (r *reporter) PostMsgReceive(msg interface{}, err error, _ time.Duration) {
 
 func reportable() interceptors.CommonReportableFunc {
 	return func(ctx context.Context, c interceptors.CallMeta) (interceptors.Reporter, context.Context) {
-
 		ctx = contextWithHandle(ctx)
 
 		r := reporter{ctx}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -155,7 +155,6 @@ func (q *ListObjectsQuery) evaluate(
 	maxResults uint32,
 	resolutionMetadata *reverseexpand.ResolutionMetadata,
 ) error {
-
 	targetObjectType := req.GetType()
 	targetRelation := req.GetRelation()
 
@@ -205,7 +204,6 @@ func (q *ListObjectsQuery) evaluate(
 
 		if tuple.IsTypedWildcard(userObj) {
 			sourceUserRef = &reverseexpand.UserRefTypedWildcard{Type: tuple.GetType(userObj)}
-
 		}
 
 		if userRel != "" {
@@ -316,7 +314,6 @@ func (q *ListObjectsQuery) Execute(
 	ctx context.Context,
 	req *openfgav1.ListObjectsRequest,
 ) (*ListObjectsResponse, error) {
-
 	resultsChan := make(chan ListObjectsResult, 1)
 	maxResults := q.listObjectsMaxResults
 	if maxResults > 0 {
@@ -341,7 +338,6 @@ func (q *ListObjectsQuery) Execute(
 
 	for {
 		select {
-
 		case <-timeoutCtx.Done():
 			q.logger.WarnWithContext(
 				ctx, fmt.Sprintf("list objects timeout after %s", q.listObjectsDeadline.String()),
@@ -374,7 +370,6 @@ func (q *ListObjectsQuery) Execute(
 // It ignores the value of q.listObjectsMaxResults and returns all available results
 // until q.listObjectsDeadline is hit
 func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.StreamedListObjectsRequest, srv openfgav1.OpenFGAService_StreamedListObjectsServer) (*reverseexpand.ResolutionMetadata, error) {
-
 	maxResults := uint32(math.MaxUint32)
 	// make a buffered channel so that writer goroutines aren't blocked when attempting to send a result
 	resultsChan := make(chan ListObjectsResult, streamedBufferSize)
@@ -395,7 +390,6 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 
 	for {
 		select {
-
 		case <-timeoutCtx.Done():
 			q.logger.WarnWithContext(
 				ctx, fmt.Sprintf("list objects timeout after %s", q.listObjectsDeadline.String()),

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -60,7 +60,6 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgav1.
 	}
 
 	if len(writes) > 0 {
-
 		authModel, err := c.datastore.ReadAuthorizationModel(ctx, store, modelID)
 		if err != nil {
 			if errors.Is(err, storage.ErrNotFound) {

--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -67,7 +67,6 @@ func sanitizedMessage(message string) string {
 
 // NewEncodedError returns the encoded error with the correct http status code etc.
 func NewEncodedError(errorCode int32, message string) *EncodedError {
-
 	if !IsValidEncodedError(errorCode) {
 		return &EncodedError{
 			HTTPStatusCode: http.StatusInternalServerError,
@@ -184,7 +183,6 @@ func getCustomizedErrorCode(field string, reason string) int32 {
 		if strings.HasPrefix(reason, "value must contain at least") {
 			return int32(openfgav1.ErrorCode_type_definitions_too_few_items)
 		}
-
 	}
 	// We will need to check for regex pattern
 	if strings.HasPrefix(field, "Relations[") {
@@ -199,7 +197,6 @@ func getCustomizedErrorCode(field string, reason string) int32 {
 	// When we get to here, this is not a type or message that we know well.
 	// We needs to return the generic error type
 	return int32(openfgav1.ErrorCode_validation_error)
-
 }
 
 func ConvertToEncodedErrorCode(statusError *status.Status) int32 {

--- a/pkg/server/errors/encoded_errors_test.go
+++ b/pkg/server/errors/encoded_errors_test.go
@@ -362,7 +362,6 @@ func TestConvertToEncodedErrorCode(t *testing.T) {
 }
 
 func TestSanitizeErrorMessage(t *testing.T) {
-
 	got := sanitizedMessage(`proto: (line 1:2): unknown field "foo"`) // uses a whitespace rune of U+00a0 (see https://pkg.go.dev/unicode#IsSpace)
 	expected := `(line 1:2): unknown field "foo"`
 

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -80,7 +80,6 @@ func TypeNotFound(objectType string) error {
 }
 
 func RelationNotFound(relation string, objectType string, tk *openfgav1.TupleKey) error {
-
 	msg := fmt.Sprintf("relation '%s#%s' not found", objectType, relation)
 	if tk != nil {
 		msg += fmt.Sprintf(" for tuple '%s'", tuple.TupleKeyToString(tk))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -253,7 +253,6 @@ func MustNewServerWithOpts(opts ...OpenFGAServiceV1Option) *Server {
 }
 
 func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
-
 	s := &Server{
 		logger:                           logger.NewNoopLogger(),
 		encoder:                          encoder.NewBase64Encoder(),
@@ -311,7 +310,6 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 }
 
 func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequest) (*openfgav1.ListObjectsResponse, error) {
-
 	targetObjectType := req.GetType()
 
 	ctx, span := tracer.Start(ctx, "ListObjects", trace.WithAttributes(
@@ -388,7 +386,6 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	return &openfgav1.ListObjectsResponse{
 		Objects: result.Objects,
 	}, nil
-
 }
 
 func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, srv openfgav1.OpenFGAService_StreamedListObjectsServer) error {
@@ -464,7 +461,6 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 }
 
 func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
-
 	tk := req.GetTupleKey()
 	ctx, span := tracer.Start(ctx, "Read", trace.WithAttributes(
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
@@ -893,7 +889,6 @@ func (s *Server) ListStores(ctx context.Context, req *openfgav1.ListStoresReques
 // IsReady reports whether this OpenFGA server instance is ready to accept
 // traffic.
 func (s *Server) IsReady(ctx context.Context) (bool, error) {
-
 	// for now we only depend on the datastore being ready, but in the future
 	// server readiness may also depend on other criteria in addition to the
 	// datastore being ready.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -115,7 +115,6 @@ func TestServerWithMySQLDatastoreAndExplicitCredentials(t *testing.T) {
 }
 
 func BenchmarkOpenFGAServer(b *testing.B) {
-
 	b.Run("BenchmarkPostgresDatastore", func(b *testing.B) {
 		testDatastore := storagefixtures.RunDatastoreTestContainer(b, "postgres")
 
@@ -281,7 +280,6 @@ func TestOperationsWithInvalidModel(t *testing.T) {
 	e, ok = status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.Code(openfgav1.ErrorCode_validation_error), e.Code())
-
 }
 
 func TestShortestPathToSolutionWins(t *testing.T) {
@@ -422,7 +420,6 @@ func TestResolveAuthorizationModel(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("no_latest_authorization_model_id_found", func(t *testing.T) {
-
 		store := ulid.Make().String()
 
 		mockController := gomock.NewController(t)

--- a/pkg/server/test/create_store.go
+++ b/pkg/server/test/create_store.go
@@ -33,7 +33,6 @@ func TestCreateStore(t *testing.T, datastore storage.OpenFGADatastore) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			resp, err := commands.NewCreateStoreCommand(datastore, logger).Execute(ctx, test.request)
 			require.NoError(t, err)
 

--- a/pkg/server/test/delete_store.go
+++ b/pkg/server/test/delete_store.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestDeleteStore(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
 

--- a/pkg/server/test/get_store.go
+++ b/pkg/server/test/get_store.go
@@ -39,7 +39,6 @@ func TestGetStoreQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 
 	for _, test := range tests {
 		t.Run(test._name, func(t *testing.T) {
-
 			query := commands.NewGetStoreQuery(datastore, logger)
 			resp, err := query.Execute(ctx, test.request)
 

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -40,7 +40,7 @@ type listObjectsTestCase struct {
 	user                   string
 	relation               string
 	contextualTuples       *openfgav1.ContextualTupleKeys
-	allResults             []string //all the results. the server may return less
+	allResults             []string // all the results. the server may return less
 	maxResults             uint32
 	minimumResultsExpected uint32
 	listObjectsDeadline    time.Duration // 1 minute if not set
@@ -249,7 +249,6 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 					graph.WithExistingCache(checkCache),
 					graph.WithCacheTTL(10*time.Second),
 				))
-
 			}
 
 			opts = append(opts, commands.WithCheckOptions(checkOptions))
@@ -310,7 +309,6 @@ func TestListObjectsRespectsMaxResults(t *testing.T, ds storage.OpenFGADatastore
 var listObjectsResponse *commands.ListObjectsResponse //nolint
 
 func BenchmarkListObjectsWithReverseExpand(b *testing.B, ds storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 	store := ulid.Make().String()
 

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
-
 	tests := []struct {
 		name                 string
 		model                string

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -86,7 +86,6 @@ func TestWriteAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
 	logger := logger.NewNoopLogger()
 
 	for _, test := range tests {
-
 		t.Run(test._name, func(t *testing.T) {
 			model := githubModelReq
 

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -143,7 +143,6 @@ var _ TupleKeyIterator = &filteredTupleKeyIterator{}
 // Next returns the next most tuple in the underlying iterator that meets
 // the filter function this iterator was constructed with.
 func (f *filteredTupleKeyIterator) Next() (*openfgav1.TupleKey, error) {
-
 	for {
 		tuple, err := f.iter.Next()
 		if err != nil {
@@ -163,7 +162,6 @@ func (f *filteredTupleKeyIterator) Stop() {
 // NewFilteredTupleKeyIterator returns an iterator that filters out all tuples that don't
 // meet the conditions of the provided TupleFilterFunc.
 func NewFilteredTupleKeyIterator(iter TupleKeyIterator, filter TupleKeyFilterFunc) TupleKeyIterator {
-
 	return &filteredTupleKeyIterator{
 		iter,
 		filter,

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -38,7 +38,6 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 }
 
 func TestCombinedIterator(t *testing.T) {
-
 	expected := []*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:doc1", "viewer", "bill"),
 		tuple.NewTupleKey("document:doc2", "editor", "bob"),
@@ -72,7 +71,6 @@ func TestCombinedIterator(t *testing.T) {
 }
 
 func ExampleNewFilteredTupleKeyIterator() {
-
 	tuples := []*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
 		tuple.NewTupleKey("document:doc1", "editor", "user:elbuo"),

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -406,7 +406,6 @@ func (s *MemoryBackend) ReadStartingWithUser(
 				matches = append(matches, t)
 			}
 		}
-
 	}
 	return &staticIterator{tuples: matches}, nil
 }

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -38,7 +38,6 @@ type MySQL struct {
 var _ storage.OpenFGADatastore = (*MySQL)(nil)
 
 func New(uri string, cfg *sqlcommon.Config) (*MySQL, error) {
-
 	if cfg.Username != "" || cfg.Password != "" {
 		dsnCfg, err := mysql.ParseDSN(uri)
 		if err != nil {

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -70,7 +70,6 @@ func TestReadEnsureNoOrder(t *testing.T) {
 	curTuple, err = iter.Next()
 	require.NoError(t, err)
 	require.Equal(t, secondTuple, curTuple.Key)
-
 }
 
 // TestReadPageEnsureNoOrder asserts that the read page is ordered by ulid
@@ -115,5 +114,4 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)
-
 }

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -39,7 +39,6 @@ type Postgres struct {
 var _ storage.OpenFGADatastore = (*Postgres)(nil)
 
 func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
-
 	if cfg.Username != "" || cfg.Password != "" {
 		parsed, err := url.Parse(uri)
 		if err != nil {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -96,7 +96,6 @@ func TestReadEnsureNoOrder(t *testing.T) {
 	curTuple, err = iter.Next()
 	require.NoError(t, err)
 	require.Equal(t, secondTuple, curTuple.Key)
-
 }
 
 // TestReadPageEnsureNoOrder asserts that the read page is ordered by ulid
@@ -141,5 +140,4 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)
-
 }

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -274,7 +274,6 @@ func NewDBInfo(db *sql.DB, stbl sq.StatementBuilderType, sqlTime interface{}) *D
 
 // Write provides the common method for writing to database across sql storage
 func Write(ctx context.Context, dbInfo *DBInfo, store string, deletes storage.Deletes, writes storage.Writes, now time.Time) error {
-
 	txn, err := dbInfo.db.BeginTx(ctx, nil)
 	if err != nil {
 		return HandleSQLError(err)

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -85,7 +85,6 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 	}()
 
 	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
-
 }
 
 func (b *boundedConcurrencyTupleReader) waitForLimiter(ctx context.Context) {

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -41,7 +41,6 @@ func (c *combinedTupleReader) Read(
 	storeID string,
 	tk *openfgav1.TupleKey,
 ) (storage.TupleIterator, error) {
-
 	iter1 := storage.NewStaticTupleIterator(filterTuples(c.contextualTuples, tk.Object, tk.Relation))
 
 	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk)
@@ -58,7 +57,6 @@ func (c *combinedTupleReader) ReadPage(
 	tk *openfgav1.TupleKey,
 	opts storage.PaginationOptions,
 ) ([]*openfgav1.Tuple, []byte, error) {
-
 	// no reading from contextual tuples
 
 	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, opts)
@@ -69,7 +67,6 @@ func (c *combinedTupleReader) ReadUserTuple(
 	store string,
 	tk *openfgav1.TupleKey,
 ) (*openfgav1.Tuple, error) {
-
 	filteredContextualTuples := filterTuples(c.contextualTuples, tk.Object, tk.Relation)
 
 	for _, t := range filteredContextualTuples {
@@ -86,7 +83,6 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
 ) (storage.TupleIterator, error) {
-
 	var usersetTuples []*openfgav1.Tuple
 
 	for _, t := range filterTuples(c.contextualTuples, filter.Object, filter.Relation) {
@@ -110,7 +106,6 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 	store string,
 	filter storage.ReadStartingWithUserFilter,
 ) (storage.TupleIterator, error) {
-
 	var filteredTuples []*openfgav1.Tuple
 	for _, t := range c.contextualTuples {
 		if tuple.GetType(t.GetObject()) != filter.ObjectType {

--- a/pkg/storage/test/assertions.go
+++ b/pkg/storage/test/assertions.go
@@ -12,7 +12,6 @@ import (
 )
 
 func AssertionsTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 
 	t.Run("writing_and_reading_assertions_succeeds", func(t *testing.T) {

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -14,7 +14,6 @@ import (
 )
 
 func WriteAndReadAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 	storeID := ulid.Make().String()
 

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -14,7 +14,6 @@ import (
 )
 
 func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
-
 	ctx := context.Background()
 
 	// Create some stores

--- a/pkg/telemetry/context_test.go
+++ b/pkg/telemetry/context_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestKnownRPCInfo(t *testing.T) {
-
 	rpcInfo := RPCInfo{
 		Method:  "check",
 		Service: openfgav1.OpenFGAService_ServiceDesc.ServiceName,
@@ -21,7 +20,6 @@ func TestKnownRPCInfo(t *testing.T) {
 }
 
 func TestUnknownRPCInfo(t *testing.T) {
-
 	output := RPCInfoFromContext(context.Background())
 	require.Equal(t, RPCInfo{
 		Method:  "unknown",

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -99,7 +99,6 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	require.NoError(t, err, "failed to create mysql docker container")
 
 	stopContainer := func() {
-
 		t.Logf("stopping container %s", name)
 		timeoutSec := 5
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -25,7 +25,7 @@ const (
 )
 
 var (
-	expireTimeout = 10 * time.Minute //benchmarks take a while to run
+	expireTimeout = 10 * time.Minute // benchmarks take a while to run
 )
 
 type postgresTestContainer struct {
@@ -101,7 +101,6 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 	require.NoError(t, err, "failed to create postgres docker container")
 
 	stopContainer := func() {
-
 		t.Logf("stopping container %s", name)
 		timeoutSec := 5
 

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -28,7 +28,6 @@ type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (
 //
 // The memoized resolver function is safe for concurrent use.
 func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBackend) TypesystemResolverFunc {
-
 	lookupGroup := singleflight.Group{}
 
 	cache := ccache.New(ccache.Configure[*TypeSystem]())

--- a/pkg/typesystem/resolver_test.go
+++ b/pkg/typesystem/resolver_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestMemoizedTypesystemResolverFunc(t *testing.T) {
-
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -253,7 +253,6 @@ func GetRelationReferenceAsString(rr *openfgav1.RelationReference) string {
 }
 
 func (t *TypeSystem) GetDirectlyRelatedUserTypes(objectType, relation string) ([]*openfgav1.RelationReference, error) {
-
 	r, err := t.GetRelation(objectType, relation)
 	if err != nil {
 		return nil, err
@@ -280,7 +279,6 @@ func (t *TypeSystem) DirectlyRelatedUsersets(objectType, relation string) ([]*op
 
 // IsDirectlyRelated determines whether the type of the target DirectRelationReference contains the source DirectRelationReference.
 func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, source *openfgav1.RelationReference) (bool, error) {
-
 	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
 	if err != nil {
 		return false, err
@@ -288,7 +286,6 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
 
 	for _, typeRestriction := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 		if source.GetType() == typeRestriction.GetType() {
-
 			// type with no relation or wildcard (e.g. 'user')
 			if typeRestriction.GetRelationOrWildcard() == nil && source.GetRelationOrWildcard() == nil {
 				return true, nil
@@ -322,7 +319,6 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
  * In the example above, the 'user' objectType is publicly assignable to the 'document#viewer' relation.
  */
 func (t *TypeSystem) IsPubliclyAssignable(target *openfgav1.RelationReference, objectType string) (bool, error) {
-
 	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
 	if err != nil {
 		return false, err
@@ -361,7 +357,6 @@ func (t *TypeSystem) RelationInvolvesIntersection(objectType, relation string) (
 }
 
 func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, visited map[string]struct{}) (bool, error) {
-
 	key := tuple.ToObjectRelationString(objectType, relation)
 	if _, ok := visited[key]; ok {
 		return false, nil
@@ -377,7 +372,6 @@ func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, v
 	rewrite := rel.GetRewrite()
 
 	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-
 		switch rw := r.GetUserset().(type) {
 		case *openfgav1.Userset_ComputedUserset:
 			rewrittenRelation := rw.ComputedUserset.GetRelation()
@@ -464,7 +458,6 @@ func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, v
 
 	for _, typeRestriction := range rel.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 		if typeRestriction.GetRelation() != "" {
-
 			key := tuple.ToObjectRelationString(typeRestriction.GetType(), typeRestriction.GetRelation())
 			if _, ok := visited[key]; ok {
 				continue
@@ -494,11 +487,9 @@ func (t *TypeSystem) relationInvolvesIntersection(objectType, relation string, v
 func (t *TypeSystem) RelationInvolvesExclusion(objectType, relation string) (bool, error) {
 	visited := map[string]struct{}{}
 	return t.relationInvolvesExclusion(objectType, relation, visited)
-
 }
 
 func (t *TypeSystem) relationInvolvesExclusion(objectType, relation string, visited map[string]struct{}) (bool, error) {
-
 	key := tuple.ToObjectRelationString(objectType, relation)
 	if _, ok := visited[key]; ok {
 		return false, nil
@@ -600,7 +591,6 @@ func (t *TypeSystem) relationInvolvesExclusion(objectType, relation string, visi
 
 	for _, typeRestriction := range rel.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 		if typeRestriction.GetRelation() != "" {
-
 			key := tuple.ToObjectRelationString(typeRestriction.GetType(), typeRestriction.GetRelation())
 			if _, ok := visited[key]; ok {
 				continue
@@ -635,7 +625,6 @@ func hasEntrypoints(
 	rewrite *openfgav1.Userset,
 	visitedRelations map[string]map[string]struct{},
 ) (bool, bool, error) {
-
 	v := maps.Clone(visitedRelations)
 
 	if val, ok := v[typeName]; ok {
@@ -733,7 +722,6 @@ func hasEntrypoints(
 
 		loop := false
 		for _, child := range rw.Union.Child {
-
 			hasEntrypoints, childLoop, err := hasEntrypoints(typedefs, typeName, relationName, child, maps.Clone(visitedRelations))
 			if err != nil {
 				return false, false, err
@@ -749,7 +737,6 @@ func hasEntrypoints(
 	case *openfgav1.Userset_Intersection:
 
 		for _, child := range rw.Intersection.Child {
-
 			// all of the children must have an entrypoint
 			hasEntrypoints, childLoop, err := hasEntrypoints(typedefs, typeName, relationName, child, maps.Clone(visitedRelations))
 			if err != nil {
@@ -846,7 +833,6 @@ func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*
 		sort.Strings(relationNames)
 
 		for _, relationName := range relationNames {
-
 			err := t.validateRelation(typeName, relationName, relationMap)
 			if err != nil {
 				return nil, err
@@ -861,7 +847,6 @@ func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*
 // must meet all the rewrite validation, type restriction validation, and entrypoint validation criteria
 // for it to be valid. Otherwise, an error is returned.
 func (t *TypeSystem) validateRelation(typeName, relationName string, relationMap map[string]*openfgav1.Userset) error {
-
 	rewrite := relationMap[relationName]
 
 	err := t.isUsersetRewriteValid(typeName, relationName, rewrite)
@@ -1021,7 +1006,6 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 //     must be defined in the model.
 //  4. If the provided relation is a tupleset relation, then the type restriction must be on a direct object.
 func (t *TypeSystem) validateTypeRestrictions(objectType string, relationName string) error {
-
 	relation, err := t.GetRelation(objectType, relationName)
 	if err != nil {
 		return err
@@ -1070,7 +1054,6 @@ func (t *TypeSystem) IsDirectlyAssignable(relation *openfgav1.Relation) bool {
 // RewriteContainsSelf returns true if the provided userset rewrite
 // is defined by one or more self referencing definitions.
 func RewriteContainsSelf(rewrite *openfgav1.Userset) bool {
-
 	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
 		if _, ok := r.Userset.(*openfgav1.Userset_This); ok {
 			return true
@@ -1088,7 +1071,6 @@ func RewriteContainsSelf(rewrite *openfgav1.Userset) bool {
 // RewriteContainsIntersection returns true if the provided userset rewrite
 // is defined by one or more direct or indirect intersections.
 func RewriteContainsIntersection(rewrite *openfgav1.Userset) bool {
-
 	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
 		if _, ok := r.Userset.(*openfgav1.Userset_Intersection); ok {
 			return true
@@ -1106,7 +1088,6 @@ func RewriteContainsIntersection(rewrite *openfgav1.Userset) bool {
 // RewriteContainsExclusion returns true if the provided userset rewrite
 // is defined by one or more direct or indirect exclusions.
 func RewriteContainsExclusion(rewrite *openfgav1.Userset) bool {
-
 	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
 		if _, ok := r.Userset.(*openfgav1.Userset_Difference); ok {
 			return true
@@ -1168,7 +1149,6 @@ type RelationUndefinedError struct {
 }
 
 func (e *RelationUndefinedError) Error() string {
-
 	if e.ObjectType != "" {
 		return fmt.Sprintf("'%s#%s' relation is undefined", e.ObjectType, e.Relation)
 	}
@@ -1215,7 +1195,6 @@ func (t *TypeSystem) getAllTupleToUsersetsDefinitions() map[string]map[string][]
 // IsTuplesetRelation returns a boolean indicating if the provided relation is defined under a
 // TupleToUserset rewrite as a tupleset relation (i.e. the right hand side of a `X from Y`).
 func (t *TypeSystem) IsTuplesetRelation(objectType, relation string) (bool, error) {
-
 	_, err := t.GetRelation(objectType, relation)
 	if err != nil {
 		return false, err
@@ -1261,7 +1240,6 @@ type WalkUsersetRewriteHandler func(rewrite *openfgav1.Userset) interface{}
 // WalkUsersetRewrite recursively walks the provided userset rewrite and invokes the provided WalkUsersetRewriteHandler
 // to each node in the userset rewrite tree until the first non-nil response is encountered.
 func WalkUsersetRewrite(rewrite *openfgav1.Userset, handler WalkUsersetRewriteHandler) (interface{}, error) {
-
 	var children []*openfgav1.Userset
 
 	if result := handler(rewrite); result != nil {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestNewAndValidate(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		model         string
@@ -1468,7 +1467,6 @@ func TestRelationInvolvesIntersection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -1486,7 +1484,6 @@ func TestRelationInvolvesIntersection(t *testing.T) {
 }
 
 func TestRelationInvolvesExclusion(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		model       string
@@ -1627,7 +1624,6 @@ func TestRelationInvolvesExclusion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -1645,7 +1641,6 @@ func TestRelationInvolvesExclusion(t *testing.T) {
 }
 
 func TestIsTuplesetRelation(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		model         *openfgav1.AuthorizationModel
@@ -1936,7 +1931,6 @@ func TestIsDirectlyRelated(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 			typesys := New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   SchemaVersion1_1,
@@ -2019,7 +2013,6 @@ func TestIsPubliclyAssignable(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 			typesys := New(&openfgav1.AuthorizationModel{
 				SchemaVersion:   SchemaVersion1_1,
@@ -2058,7 +2051,6 @@ func TestRewriteContainsExclusion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -2099,7 +2091,6 @@ func TestRewriteContainsIntersection(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{
@@ -2188,7 +2179,6 @@ func TestDirectlyRelatedUsersets(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
 			typedefs := parser.MustParse(test.model)
 
 			typesys := New(&openfgav1.AuthorizationModel{

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -80,7 +80,6 @@ func testCheck(t *testing.T, client ClientInterface) {
 }
 
 func testBadAuthModelID(t *testing.T, client ClientInterface) {
-
 	ctx := context.Background()
 	resp, err := client.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: "bad auth id"})
 	require.NoError(t, err)
@@ -131,7 +130,6 @@ func runTests(t *testing.T, params testParams) {
 		test := test
 		runTest(t, test, params, false)
 		runTest(t, test, params, true)
-
 	}
 }
 
@@ -160,7 +158,6 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 		storeID := resp.GetId()
 
 		for _, stage := range test.Stages {
-
 			var typedefs []*openfgav1.TypeDefinition
 			if schemaVersion == typesystem.SchemaVersion1_1 {
 				typedefs = parser.MustParse(stage.Model)
@@ -219,5 +216,4 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 			}
 		}
 	})
-
 }

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -214,7 +214,6 @@ func TestCheckLogs(t *testing.T) {
 			require.Len(t, fields, 13)
 		})
 	}
-
 }
 
 func testRunAll(t *testing.T, engine string) {
@@ -295,7 +294,6 @@ func setupBenchmarkTest(b *testing.B, engine string) (context.CancelFunc, *grpc.
 }
 
 func benchmarkCheckWithoutTrace(b *testing.B, engine string) {
-
 	cancel, conn, client := setupBenchmarkTest(b, engine)
 	defer cancel()
 	defer conn.Close()

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -97,7 +97,6 @@ func runTests(t *testing.T, params testParams) {
 		test := test
 		runTest(t, test, params, false)
 		runTest(t, test, params, true)
-
 	}
 }
 
@@ -129,7 +128,6 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 			var typedefs []*openfgav1.TypeDefinition
 			if schemaVersion == typesystem.SchemaVersion1_1 {
 				typedefs = parser.MustParse(stage.Model)
-
 			} else {
 				typedefs = v1parser.MustParse(stage.Model)
 			}
@@ -178,7 +176,6 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 				if assertion.ErrorCode == 0 {
 					require.NoError(t, err, detailedInfo)
 					require.ElementsMatch(t, assertion.Expectation, resp.Objects, detailedInfo)
-
 				} else {
 					require.Error(t, err, detailedInfo)
 					e, ok := status.FromError(err)
@@ -214,7 +211,6 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 							}
 							break
 						}
-
 					}
 					done <- struct{}{}
 				}()
@@ -247,5 +243,4 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 			}
 		}
 	})
-
 }

--- a/tests/writemodel/writemodel.go
+++ b/tests/writemodel/writemodel.go
@@ -18,7 +18,7 @@ var testCases = map[string]struct {
 	code  int
 }{
 	// implemented in Fails_If_Using_Self_As_Type_Name
-	//"case1": {
+	// "case1": {
 	//	model: `
 	//	type user
 	//	type self


### PR DESCRIPTION
## Description

Proposing we enable some additional linters that we can also leverage for more standardization across other go-based repos

## References

https://golangci-lint.run/usage/linters/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
