### PR TITLE
chore: migrate grpc validator to go-grpc-middleware/v2/interceptors/validator

### DIFF
--- a/pkg/middleware/validator/validator.go
+++ b/pkg/middleware/validator/validator.go
@@ -4,7 +4,7 @@ package validator
 import (
 	"context"
 
-	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
+	grpcvalidator "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
 	"google.golang.org/grpc"
 )
 
@@ -25,8 +25,7 @@ func RequestIsValidatedFromContext(ctx context.Context) bool {
 
 // UnaryServerInterceptor returns a new unary server interceptor that runs request validations and injects a bool in the context indicating that validation has been run.
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
-
-	validator := grpc_validator.UnaryServerInterceptor()
+	validator := grpcvalidator.UnaryServerInterceptor()
 
 	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		return validator(ctx, req, info, func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -37,7 +36,7 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 // StreamServerInterceptor returns a new streaming server interceptor that runs request validations and injects a bool in the context indicating that validation has been run.
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
-	validator := grpc_validator.StreamServerInterceptor()
+	validator := grpcvalidator.StreamServerInterceptor()
 
 	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

- This PR migrates the validator interceptor from `github.com/grpc-ecosystem/go-grpc-middleware/validator` to `github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator`

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
https://github.com/grpc-ecosystem/go-grpc-middleware/tree/main/interceptors/validator
## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
