### PR TITLE
feat(storage): track db metrics

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -175,6 +175,12 @@
                     "type": "duration",
                     "default": "connections are not closed due to connection's age - database/sql default",
                     "x-env-variable": "OPENFGA_DATASTORE_CONN_MAX_LIFETIME"
+                },
+                "metricsEnabled": {
+                    "description": "enabled or disable sql metrics",
+                    "type": "boolean",
+                    "default": false,
+                    "x-env-variable": "OPENFGA_DATASTORE_METRICS_ENABLED"
                 }
             }
         },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -176,11 +176,16 @@
                     "default": "connections are not closed due to connection's age - database/sql default",
                     "x-env-variable": "OPENFGA_DATASTORE_CONN_MAX_LIFETIME"
                 },
-                "metricsEnabled": {
-                    "description": "enabled or disable sql metrics",
-                    "type": "boolean",
-                    "default": false,
-                    "x-env-variable": "OPENFGA_DATASTORE_METRICS_ENABLED"
+                "metrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "description": "enable/disable sql metrics for the datastore",
+                            "type": "boolean",
+                            "default": false,
+                            "x-env-variable": "OPENFGA_DATASTORE_METRICS_ENABLED"
+                        }
+                    }
                 }
             }
         },

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -92,8 +92,8 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("datastore.connMaxLifetime", flags.Lookup("datastore-conn-max-lifetime"))
 		util.MustBindEnv("datastore.connMaxLifetime", "OPENFGA_DATASTORE_CONN_MAX_LIFETIME", "OPENFGA_DATASTORE_CONNMAXLIFETIME")
 
-		util.MustBindPFlag("datastore.metricsEnabled", flags.Lookup("datastore-metrics-enabled"))
-		util.MustBindEnv("datastore.metricsEnabled", "OPENFGA_DATASTORE_METRICS_ENABLED", "OPENFGA_DATASTORE_METRICSENABLED")
+		util.MustBindPFlag("datastore.metrics.enabled", flags.Lookup("datastore-metrics-enabled"))
+		util.MustBindEnv("datastore.metrics.enabled", "OPENFGA_DATASTORE_METRICS_ENABLED")
 
 		util.MustBindPFlag("playground.enabled", flags.Lookup("playground-enabled"))
 		util.MustBindEnv("playground.enabled", "OPENFGA_PLAYGROUND_ENABLED")

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -92,6 +92,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("datastore.connMaxLifetime", flags.Lookup("datastore-conn-max-lifetime"))
 		util.MustBindEnv("datastore.connMaxLifetime", "OPENFGA_DATASTORE_CONN_MAX_LIFETIME", "OPENFGA_DATASTORE_CONNMAXLIFETIME")
 
+		util.MustBindPFlag("datastore.metricsEnabled", flags.Lookup("datastore-metrics-enabled"))
+		util.MustBindEnv("datastore.metricsEnabled", "OPENFGA_DATASTORE_METRICS_ENABLED", "OPENFGA_DATASTORE_METRICSENABLED")
+
 		util.MustBindPFlag("playground.enabled", flags.Lookup("playground-enabled"))
 		util.MustBindEnv("playground.enabled", "OPENFGA_PLAYGROUND_ENABLED")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -136,7 +136,7 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Duration("datastore-conn-max-lifetime", defaultConfig.Datastore.ConnMaxLifetime, "the maximum amount of time a connection to the datastore may be reused")
 
-	flags.Bool("datastore-metrics-enabled", defaultConfig.Datastore.MetricsEnabled, "enable/disable sql metrics")
+	flags.Bool("datastore-metrics-enabled", defaultConfig.Datastore.Metrics.Enabled, "enable/disable sql metrics")
 
 	flags.Bool("playground-enabled", defaultConfig.Playground.Enabled, "enable/disable the OpenFGA Playground")
 
@@ -331,7 +331,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		sqlcommon.WithConnMaxLifetime(config.Datastore.ConnMaxLifetime),
 	}
 
-	if config.Datastore.MetricsEnabled {
+	if config.Datastore.Metrics.Enabled {
 		datastoreOptions = append(datastoreOptions, sqlcommon.WithMetrics())
 	}
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -327,6 +327,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		sqlcommon.WithMaxIdleConns(config.Datastore.MaxIdleConns),
 		sqlcommon.WithConnMaxIdleTime(config.Datastore.ConnMaxIdleTime),
 		sqlcommon.WithConnMaxLifetime(config.Datastore.ConnMaxLifetime),
+		sqlcommon.WithMetrics(config.Metrics.Enabled),
 	)
 
 	var datastore storage.OpenFGADatastore
@@ -341,12 +342,12 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	case "mysql":
 		datastore, err = mysql.New(config.Datastore.URI, dsCfg)
 		if err != nil {
-			return fmt.Errorf("failed to initialize mysql datastore: %w", err)
+			return fmt.Errorf("initialize mysql datastore: %w", err)
 		}
 	case "postgres":
 		datastore, err = postgres.New(config.Datastore.URI, dsCfg)
 		if err != nil {
-			return fmt.Errorf("failed to initialize postgres datastore: %w", err)
+			return fmt.Errorf("initialize postgres datastore: %w", err)
 		}
 	default:
 		return fmt.Errorf("storage engine '%s' is unsupported", config.Datastore.Engine)

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -890,7 +890,7 @@ func TestDefaultConfig(t *testing.T) {
 	val = res.Get("properties.datastore.properties.connMaxLifetime.default")
 	require.True(t, val.Exists())
 
-	val = res.Get("properties.datastore.properties.metricsEnabled.default")
+	val = res.Get("properties.datastore.properties.metrics.properties.enabled.default")
 	require.True(t, val.Exists())
 	require.False(t, val.Bool())
 

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -890,6 +890,10 @@ func TestDefaultConfig(t *testing.T) {
 	val = res.Get("properties.datastore.properties.connMaxLifetime.default")
 	require.True(t, val.Exists())
 
+	val = res.Get("properties.datastore.properties.metricsEnabled.default")
+	require.True(t, val.Exists())
+	require.False(t, val.Bool())
+
 	val = res.Get("properties.grpc.properties.addr.default")
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.GRPC.Addr)

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -53,6 +53,9 @@ type DatastoreConfig struct {
 
 	// ConnMaxLifetime is the maximum amount of time a connection to the datastore may be reused.
 	ConnMaxLifetime time.Duration
+
+	// MetricsEnabled enables export of SQL metrics.
+	MetricsEnabled bool
 }
 
 // GRPCConfig defines OpenFGA server configurations for grpc server specific settings.

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -27,6 +27,11 @@ const (
 	DefaultCheckQueryCacheEnable = false
 )
 
+type DatastoreMetricsConfig struct {
+	// Enabled enables export of the Datastore metrics.
+	Enabled bool
+}
+
 // DatastoreConfig defines OpenFGA server configurations for datastore specific settings.
 type DatastoreConfig struct {
 	// Engine is the datastore engine to use (e.g. 'memory', 'postgres', 'mysql')
@@ -54,8 +59,8 @@ type DatastoreConfig struct {
 	// ConnMaxLifetime is the maximum amount of time a connection to the datastore may be reused.
 	ConnMaxLifetime time.Duration
 
-	// MetricsEnabled enables export of SQL metrics.
-	MetricsEnabled bool
+	// Metrics is configuration for the Datastore metrics.
+	Metrics DatastoreMetricsConfig
 }
 
 // GRPCConfig defines OpenFGA server configurations for grpc server specific settings.

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -18,6 +18,8 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -40,7 +42,7 @@ func New(uri string, cfg *sqlcommon.Config) (*MySQL, error) {
 	if cfg.Username != "" || cfg.Password != "" {
 		dsnCfg, err := mysql.ParseDSN(uri)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse mysql connection dsn: %w", err)
+			return nil, fmt.Errorf("parse mysql connection dsn: %w", err)
 		}
 
 		if cfg.Username != "" {
@@ -55,7 +57,7 @@ func New(uri string, cfg *sqlcommon.Config) (*MySQL, error) {
 
 	db, err := sql.Open("mysql", uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize mysql connection: %w", err)
+		return nil, fmt.Errorf("initialize mysql connection: %w", err)
 	}
 
 	if cfg.MaxOpenConns != 0 {
@@ -87,7 +89,13 @@ func New(uri string, cfg *sqlcommon.Config) (*MySQL, error) {
 		return nil
 	}, policy)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize mysql connection: %w", err)
+		return nil, fmt.Errorf("ping db: %w", err)
+	}
+
+	if cfg.Metrics {
+		if err := prometheus.Register(collectors.NewDBStatsCollector(db, "openfga")); err != nil {
+			return nil, fmt.Errorf("initialize metrics: %w", err)
+		}
 	}
 
 	return &MySQL{

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -92,7 +92,7 @@ func New(uri string, cfg *sqlcommon.Config) (*MySQL, error) {
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
 
-	if cfg.Metrics {
+	if cfg.ExportMetrics {
 		if err := prometheus.Register(collectors.NewDBStatsCollector(db, "openfga")); err != nil {
 			return nil, fmt.Errorf("initialize metrics: %w", err)
 		}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -105,7 +105,7 @@ func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 		return nil, fmt.Errorf("ping db: %w", err)
 	}
 
-	if cfg.Metrics {
+	if cfg.ExportMetrics {
 		if err := prometheus.Register(collectors.NewDBStatsCollector(db, "openfga")); err != nil {
 			return nil, fmt.Errorf("initialize metrics: %w", err)
 		}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -41,7 +43,7 @@ func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 	if cfg.Username != "" || cfg.Password != "" {
 		parsed, err := url.Parse(uri)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse postgres connection uri: %w", err)
+			return nil, fmt.Errorf("parse postgres connection uri: %w", err)
 		}
 
 		username := ""
@@ -68,7 +70,7 @@ func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 
 	db, err := sql.Open("pgx", uri)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize postgres connection: %w", err)
+		return nil, fmt.Errorf("initialize postgres connection: %w", err)
 	}
 
 	if cfg.MaxOpenConns != 0 {
@@ -100,7 +102,13 @@ func New(uri string, cfg *sqlcommon.Config) (*Postgres, error) {
 		return nil
 	}, policy)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize postgres connection: %w", err)
+		return nil, fmt.Errorf("ping db: %w", err)
+	}
+
+	if cfg.Metrics {
+		if err := prometheus.Register(collectors.NewDBStatsCollector(db, "openfga")); err != nil {
+			return nil, fmt.Errorf("initialize metrics: %w", err)
+		}
 	}
 
 	return &Postgres{

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -33,7 +33,7 @@ type Config struct {
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
 
-	Metrics bool
+	ExportMetrics bool
 }
 
 type DatastoreOption func(*Config)
@@ -92,9 +92,9 @@ func WithConnMaxLifetime(d time.Duration) DatastoreOption {
 	}
 }
 
-func WithMetrics(enabled bool) DatastoreOption {
+func WithMetrics() DatastoreOption {
 	return func(cfg *Config) {
-		cfg.Metrics = enabled
+		cfg.ExportMetrics = true
 	}
 }
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -32,6 +32,8 @@ type Config struct {
 	MaxIdleConns    int
 	ConnMaxIdleTime time.Duration
 	ConnMaxLifetime time.Duration
+
+	Metrics bool
 }
 
 type DatastoreOption func(*Config)
@@ -87,6 +89,12 @@ func WithConnMaxIdleTime(d time.Duration) DatastoreOption {
 func WithConnMaxLifetime(d time.Duration) DatastoreOption {
 	return func(cfg *Config) {
 		cfg.ConnMaxLifetime = d
+	}
+}
+
+func WithMetrics(enabled bool) DatastoreOption {
+	return func(cfg *Config) {
+		cfg.Metrics = enabled
 	}
 }
 


### PR DESCRIPTION
Exports DB metrics (if metrics are enabled) via prometheus.

Question: shuld this be added behind additional config field under `metrics`?

## Description

Exports DB metrics, such as time spent waiting for free connection, pool stats, query stats, and more if the metrics are enabled. For full list of metrics you can see [prometheus/client_golang](https://github.com/prometheus/client_golang/blob/main/prometheus/collectors/dbstats_collector.go).

## References


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
  - Didn't find any section where this would need to be added.
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
