### PR TITLE
feat: persist authz model serialized protobuf

### DIFF
--- a/assets/migrations/mysql/004_add_authorization_model_serialized_protobuf.sql
+++ b/assets/migrations/mysql/004_add_authorization_model_serialized_protobuf.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE authorization_model ADD COLUMN serialized_protobuf LONGBLOB;
+
+-- +goose Down
+ALTER TABLE authorization_model DROP COLUMN serialized_protobuf;

--- a/assets/migrations/postgres/004_add_authorization_model_serialized_protobuf.sql
+++ b/assets/migrations/postgres/004_add_authorization_model_serialized_protobuf.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE authorization_model ADD COLUMN serialized_protobuf BYTEA;
+
+-- +goose Down
+ALTER TABLE authorization_model DROP COLUMN serialized_protobuf;

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -18,7 +18,6 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
-	"github.com/openfga/openfga/pkg/typesystem"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -285,75 +284,7 @@ func (m *MySQL) ReadAuthorizationModel(ctx context.Context, store string, modelI
 	ctx, span := tracer.Start(ctx, "mysql.ReadAuthorizationModel")
 	defer span.End()
 
-	rows, err := m.stbl.
-		Select("schema_version", "type", "type_definition", "serialized_protobuf").
-		From("authorization_model").
-		Where(sq.Eq{
-			"store":                  store,
-			"authorization_model_id": modelID,
-		}).
-		QueryContext(ctx)
-	if err != nil {
-		return nil, sqlcommon.HandleSQLError(err)
-	}
-	defer rows.Close()
-
-	var schemaVersion string
-	var typeDefs []*openfgav1.TypeDefinition
-	for rows.Next() {
-		var typeName string
-		var marshalledTypeDef []byte
-		var marshalledModel []byte
-		err = rows.Scan(&schemaVersion, &typeName, &marshalledTypeDef, &marshalledModel)
-		if err != nil {
-			return nil, sqlcommon.HandleSQLError(err)
-		}
-
-		if len(marshalledModel) > 0 {
-			// Prefer building an authorization model from the first row that has it available.
-			var model openfgav1.AuthorizationModel
-			if err := proto.Unmarshal(marshalledModel, &model); err != nil {
-				return nil, err
-			}
-
-			return &model, nil
-		}
-
-		var typeDef openfgav1.TypeDefinition
-		if err := proto.Unmarshal(marshalledTypeDef, &typeDef); err != nil {
-			return nil, err
-		}
-
-		typeDefs = append(typeDefs, &typeDef)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, sqlcommon.HandleSQLError(err)
-	}
-
-	if len(typeDefs) == 0 {
-		return nil, storage.ErrNotFound
-	}
-
-	// Update the schema version lazily if it is not a valid typesystem.SchemaVersion.
-	if schemaVersion != typesystem.SchemaVersion1_0 && schemaVersion != typesystem.SchemaVersion1_1 {
-		schemaVersion = typesystem.SchemaVersion1_0
-		_, err = m.stbl.
-			Update("authorization_model").
-			Set("schema_version", schemaVersion).
-			Where(sq.Eq{"store": store, "authorization_model_id": modelID}).
-			ExecContext(ctx)
-		if err != nil {
-			// Don't worry if we error, we'll update it lazily next time, but let's log:
-			m.logger.Warn("failed to lazily update schema version", zap.String("store", store), zap.String("authorization_model_id", modelID))
-		}
-	}
-
-	return &openfgav1.AuthorizationModel{
-		SchemaVersion:   schemaVersion,
-		Id:              modelID,
-		TypeDefinitions: typeDefs,
-	}, nil
+	return sqlcommon.ReadAuthorizationModel(ctx, sqlcommon.NewDBInfo(m.db, m.stbl, "NOW()"), store, modelID)
 }
 
 func (m *MySQL) ReadAuthorizationModels(ctx context.Context, store string, opts storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
@@ -452,41 +383,13 @@ func (m *MySQL) WriteAuthorizationModel(ctx context.Context, store string, model
 	ctx, span := tracer.Start(ctx, "mysql.WriteAuthorizationModel")
 	defer span.End()
 
-	schemaVersion := model.GetSchemaVersion()
 	typeDefinitions := model.GetTypeDefinitions()
 
 	if len(typeDefinitions) > m.MaxTypesPerAuthorizationModel() {
 		return storage.ExceededMaxTypeDefinitionsLimitError(m.maxTypesPerModelField)
 	}
 
-	if len(typeDefinitions) < 1 {
-		return nil
-	}
-
-	pbdata, err := proto.Marshal(model)
-	if err != nil {
-		return err
-	}
-
-	sb := m.stbl.
-		Insert("authorization_model").
-		Columns("store", "authorization_model_id", "schema_version", "type", "type_definition", "serialized_protobuf")
-
-	for _, td := range typeDefinitions {
-		marshalledTypeDef, err := proto.Marshal(td)
-		if err != nil {
-			return err
-		}
-
-		sb = sb.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef, pbdata)
-	}
-
-	_, err = sb.ExecContext(ctx)
-	if err != nil {
-		return sqlcommon.HandleSQLError(err)
-	}
-
-	return nil
+	return sqlcommon.WriteAuthorizationModel(ctx, sqlcommon.NewDBInfo(m.db, m.stbl, "NOW()"), store, model)
 }
 
 // CreateStore is slightly different between Postgres and MySQL

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/openfga/openfga/pkg/storage/test"
 	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMySQLDatastore(t *testing.T) {
@@ -114,4 +116,29 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)
+}
+
+func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	defer ds.Close()
+	store := "store"
+	modelID := "foo"
+	schemaVersion := typesystem.SchemaVersion1_0
+
+	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+	pbdata := []byte{0x01, 0x02, 0x03}
+
+	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?)", store, modelID, schemaVersion, "document", bytes, pbdata)
+	require.NoError(t, err)
+
+	_, err = ds.ReadAuthorizationModel(ctx, store, modelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/openfga/openfga/pkg/storage/test"
 	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMySQLDatastore(t *testing.T) {
@@ -23,7 +25,6 @@ func TestMySQLDatastore(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 	test.RunAllTests(t, ds)
-	test.ReadAuthorizationModelUnmarshallErrorTest(t, "mysql", uri, ds)
 }
 
 // TestReadEnsureNoOrder asserts that the read response is not ordered by ulid
@@ -115,4 +116,29 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)
+}
+
+func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	defer ds.Close()
+	store := "store"
+	modelID := "foo"
+	schemaVersion := typesystem.SchemaVersion1_0
+
+	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+	pbdata := []byte{0x01, 0x02, 0x03}
+
+	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?)", store, modelID, schemaVersion, "document", bytes, pbdata)
+	require.NoError(t, err)
+
+	_, err = ds.ReadAuthorizationModel(ctx, store, modelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
-	"github.com/openfga/openfga/pkg/typesystem"
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -299,75 +298,7 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 	ctx, span := tracer.Start(ctx, "postgres.ReadAuthorizationModel")
 	defer span.End()
 
-	rows, err := p.stbl.
-		Select("schema_version", "type", "type_definition", "serialized_protobuf").
-		From("authorization_model").
-		Where(sq.Eq{
-			"store":                  store,
-			"authorization_model_id": modelID,
-		}).
-		QueryContext(ctx)
-	if err != nil {
-		return nil, sqlcommon.HandleSQLError(err)
-	}
-	defer rows.Close()
-
-	var schemaVersion string
-	var typeDefs []*openfgav1.TypeDefinition
-	for rows.Next() {
-		var typeName string
-		var marshalledTypeDef []byte
-		var marshalledModel []byte
-		err = rows.Scan(&schemaVersion, &typeName, &marshalledTypeDef, &marshalledModel)
-		if err != nil {
-			return nil, sqlcommon.HandleSQLError(err)
-		}
-
-		if len(marshalledModel) > 0 {
-			// Prefer building an authorization model from the first row that has it available.
-			var model openfgav1.AuthorizationModel
-			if err := proto.Unmarshal(marshalledModel, &model); err != nil {
-				return nil, err
-			}
-
-			return &model, nil
-		}
-
-		var typeDef openfgav1.TypeDefinition
-		if err := proto.Unmarshal(marshalledTypeDef, &typeDef); err != nil {
-			return nil, err
-		}
-
-		typeDefs = append(typeDefs, &typeDef)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, sqlcommon.HandleSQLError(err)
-	}
-
-	if len(typeDefs) == 0 {
-		return nil, storage.ErrNotFound
-	}
-
-	// Update the schema version lazily if it is not a valid typesystem.SchemaVersion.
-	if schemaVersion != typesystem.SchemaVersion1_0 && schemaVersion != typesystem.SchemaVersion1_1 {
-		schemaVersion = typesystem.SchemaVersion1_0
-		_, err = p.stbl.
-			Update("authorization_model").
-			Set("schema_version", schemaVersion).
-			Where(sq.Eq{"store": store, "authorization_model_id": modelID}).
-			ExecContext(ctx)
-		if err != nil {
-			// Don't worry if we error, we'll update it lazily next time, but let's log:
-			p.logger.Warn("failed to lazily update schema version", zap.String("store", store), zap.String("authorization_model_id", modelID))
-		}
-	}
-
-	return &openfgav1.AuthorizationModel{
-		SchemaVersion:   schemaVersion,
-		Id:              modelID,
-		TypeDefinitions: typeDefs,
-	}, nil
+	return sqlcommon.ReadAuthorizationModel(ctx, sqlcommon.NewDBInfo(p.db, p.stbl, "NOW()"), store, modelID)
 }
 
 func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, opts storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
@@ -466,41 +397,13 @@ func (p *Postgres) WriteAuthorizationModel(ctx context.Context, store string, mo
 	ctx, span := tracer.Start(ctx, "postgres.WriteAuthorizationModel")
 	defer span.End()
 
-	schemaVersion := model.GetSchemaVersion()
 	typeDefinitions := model.GetTypeDefinitions()
 
 	if len(typeDefinitions) > p.MaxTypesPerAuthorizationModel() {
 		return storage.ExceededMaxTypeDefinitionsLimitError(p.maxTypesPerModelField)
 	}
 
-	if len(typeDefinitions) < 1 {
-		return nil
-	}
-
-	pbdata, err := proto.Marshal(model)
-	if err != nil {
-		return err
-	}
-
-	sb := p.stbl.
-		Insert("authorization_model").
-		Columns("store", "authorization_model_id", "schema_version", "type", "type_definition", "serialized_protobuf")
-
-	for _, td := range typeDefinitions {
-		marshalledTypeDef, err := proto.Marshal(td)
-		if err != nil {
-			return err
-		}
-
-		sb = sb.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef, pbdata)
-	}
-
-	_, err = sb.ExecContext(ctx)
-	if err != nil {
-		return sqlcommon.HandleSQLError(err)
-	}
-
-	return nil
+	return sqlcommon.WriteAuthorizationModel(ctx, sqlcommon.NewDBInfo(p.db, p.stbl, "NOW()"), store, model)
 }
 
 // CreateStore is slightly different between Postgres and MySQL

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -300,12 +300,13 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 	defer span.End()
 
 	rows, err := p.stbl.
-		Select("schema_version", "type", "type_definition").
+		Select("schema_version", "type", "type_definition", "serialized_protobuf").
 		From("authorization_model").
 		Where(sq.Eq{
 			"store":                  store,
 			"authorization_model_id": modelID,
-		}).QueryContext(ctx)
+		}).
+		QueryContext(ctx)
 	if err != nil {
 		return nil, sqlcommon.HandleSQLError(err)
 	}
@@ -316,9 +317,20 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 	for rows.Next() {
 		var typeName string
 		var marshalledTypeDef []byte
-		err = rows.Scan(&schemaVersion, &typeName, &marshalledTypeDef)
+		var marshalledModel []byte
+		err = rows.Scan(&schemaVersion, &typeName, &marshalledTypeDef, &marshalledModel)
 		if err != nil {
 			return nil, sqlcommon.HandleSQLError(err)
+		}
+
+		if len(marshalledModel) > 0 {
+			// Prefer building an authorization model from the first row that has it available.
+			var model openfgav1.AuthorizationModel
+			if err := proto.Unmarshal(marshalledModel, &model); err != nil {
+				return nil, err
+			}
+
+			return &model, nil
 		}
 
 		var typeDef openfgav1.TypeDefinition
@@ -465,9 +477,14 @@ func (p *Postgres) WriteAuthorizationModel(ctx context.Context, store string, mo
 		return nil
 	}
 
+	pbdata, err := proto.Marshal(model)
+	if err != nil {
+		return err
+	}
+
 	sb := p.stbl.
 		Insert("authorization_model").
-		Columns("store", "authorization_model_id", "schema_version", "type", "type_definition")
+		Columns("store", "authorization_model_id", "schema_version", "type", "type_definition", "serialized_protobuf")
 
 	for _, td := range typeDefinitions {
 		marshalledTypeDef, err := proto.Marshal(td)
@@ -475,10 +492,10 @@ func (p *Postgres) WriteAuthorizationModel(ctx context.Context, store string, mo
 			return err
 		}
 
-		sb = sb.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef)
+		sb = sb.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef, pbdata)
 	}
 
-	_, err := sb.ExecContext(ctx)
+	_, err = sb.ExecContext(ctx)
 	if err != nil {
 		return sqlcommon.HandleSQLError(err)
 	}

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -26,30 +26,6 @@ func TestPostgresDatastore(t *testing.T) {
 	test.RunAllTests(t, ds)
 }
 
-func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
-	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
-
-	uri := testDatastore.GetConnectionURI(true)
-	ds, err := New(uri, sqlcommon.NewConfig())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	defer ds.Close()
-	store := "store"
-	modelID := "foo"
-	schemaVersion := "7.8"
-
-	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
-	require.NoError(t, err)
-
-	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition) VALUES ($1, $2, $3, $4, $5)", store, modelID, schemaVersion, "document", bytes)
-	require.NoError(t, err)
-
-	model, err := ds.ReadAuthorizationModel(ctx, store, modelID)
-	require.NoError(t, err)
-	require.Equal(t, typesystem.SchemaVersion1_0, model.SchemaVersion)
-}
-
 // TestReadEnsureNoOrder asserts that the read response is not ordered by ulid
 func TestReadEnsureNoOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -24,6 +24,7 @@ func TestPostgresDatastore(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 	test.RunAllTests(t, ds)
+	test.ReadAuthorizationModelUnmarshallErrorTest(t, "postgres", uri, ds)
 }
 
 func TestReadAuthorizationModelPostgresSpecificCases(t *testing.T) {
@@ -140,29 +141,4 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)
-}
-
-func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
-	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
-
-	uri := testDatastore.GetConnectionURI(true)
-	ds, err := New(uri, sqlcommon.NewConfig())
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	defer ds.Close()
-	store := "store"
-	modelID := "foo"
-	schemaVersion := typesystem.SchemaVersion1_0
-
-	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
-	require.NoError(t, err)
-	pbdata := []byte{0x01, 0x02, 0x03}
-
-	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, pbdata)
-	require.NoError(t, err)
-
-	_, err = ds.ReadAuthorizationModel(ctx, store, modelID)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -350,4 +351,96 @@ func Write(ctx context.Context, dbInfo *DBInfo, store string, deletes storage.De
 	}
 
 	return nil
+}
+
+func WriteAuthorizationModel(ctx context.Context, dbInfo *DBInfo, store string, model *openfgav1.AuthorizationModel) error {
+	schemaVersion := model.GetSchemaVersion()
+	typeDefinitions := model.GetTypeDefinitions()
+
+	if len(typeDefinitions) < 1 {
+		return nil
+	}
+
+	pbdata, err := proto.Marshal(model)
+	if err != nil {
+		return err
+	}
+
+	sb := dbInfo.stbl.
+		Insert("authorization_model").
+		Columns("store", "authorization_model_id", "schema_version", "type", "type_definition", "serialized_protobuf")
+
+	for _, td := range typeDefinitions {
+		marshalledTypeDef, err := proto.Marshal(td)
+		if err != nil {
+			return err
+		}
+
+		sb = sb.Values(store, model.Id, schemaVersion, td.GetType(), marshalledTypeDef, pbdata)
+	}
+
+	_, err = sb.ExecContext(ctx)
+	if err != nil {
+		return HandleSQLError(err)
+	}
+
+	return nil
+}
+
+func ReadAuthorizationModel(ctx context.Context, dbInfo *DBInfo, store, modelID string) (*openfgav1.AuthorizationModel, error) {
+	rows, err := dbInfo.stbl.
+		Select("schema_version", "type", "type_definition", "serialized_protobuf").
+		From("authorization_model").
+		Where(sq.Eq{
+			"store":                  store,
+			"authorization_model_id": modelID,
+		}).
+		QueryContext(ctx)
+	if err != nil {
+		return nil, HandleSQLError(err)
+	}
+	defer rows.Close()
+
+	var schemaVersion string
+	var typeDefs []*openfgav1.TypeDefinition
+	for rows.Next() {
+		var typeName string
+		var marshalledTypeDef []byte
+		var marshalledModel []byte
+		err = rows.Scan(&schemaVersion, &typeName, &marshalledTypeDef, &marshalledModel)
+		if err != nil {
+			return nil, HandleSQLError(err)
+		}
+
+		if len(marshalledModel) > 0 {
+			// Prefer building an authorization model from the first row that has it available.
+			var model openfgav1.AuthorizationModel
+			if err := proto.Unmarshal(marshalledModel, &model); err != nil {
+				return nil, err
+			}
+
+			return &model, nil
+		}
+
+		var typeDef openfgav1.TypeDefinition
+		if err := proto.Unmarshal(marshalledTypeDef, &typeDef); err != nil {
+			return nil, err
+		}
+
+		typeDefs = append(typeDefs, &typeDef)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, HandleSQLError(err)
+	}
+
+	if len(typeDefs) == 0 {
+		return nil, storage.ErrNotFound
+	}
+
+	return &openfgav1.AuthorizationModel{
+		SchemaVersion:   schemaVersion,
+		Id:              modelID,
+		TypeDefinitions: typeDefs,
+	}, nil
 }

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -11,6 +12,7 @@ import (
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func WriteAndReadAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastore) {
@@ -159,4 +161,44 @@ func FindLatestAuthorizationModelIDTest(t *testing.T, datastore storage.OpenFGAD
 		require.NoError(t, err)
 		require.Equal(t, newModel.Id, latestID)
 	})
+}
+
+func ReadAuthorizationModelUnmarshallErrorTest(t *testing.T, engine string, uri string, ds storage.OpenFGADatastore) {
+	ctx := context.Background()
+
+	var (
+		stmt string
+		db   *sql.DB
+		err  error
+	)
+
+	switch engine {
+	case "postgres":
+		db, err = sql.Open("pgx", uri)
+		require.NoError(t, err)
+		defer db.Close()
+		stmt = "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6);"
+	case "mysql":
+		db, err = sql.Open("mysql", uri)
+		require.NoError(t, err)
+		defer db.Close()
+		stmt = "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?);"
+	default:
+		t.Fatalf("'%s' is not a supported datastore engine", engine)
+	}
+
+	store := "store"
+	modelID := "foo"
+	schemaVersion := typesystem.SchemaVersion1_0
+
+	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+	pbdata := []byte{0x01, 0x02, 0x03}
+
+	_, err = db.ExecContext(ctx, stmt, store, modelID, schemaVersion, "document", bytes, pbdata)
+	require.NoError(t, err)
+
+	_, err = ds.ReadAuthorizationModel(ctx, store, modelID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }


### PR DESCRIPTION
## Description

- Migration: Add new `serialized_protobuf` column
- WriteAuthorizationModel: create rows for each type definition but including `serialized_protobuf`
- ReadAuthorizationModel: if a row containing a non-null value for `serialized_protobuf`, return this as the model.

## References

https://github.com/openfga/openfga/issues/1025

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
