### PR TITLE
feat: limit size in bytes of authz models

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -12,6 +12,12 @@
             "default": 100,
             "x-env-variable": "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL"
         },
+        "maxAuthorizationModelSizeInBytes": {
+            "description": "The maximum size in bytes allowed for persisting an Authorization Model (default is 256KB).",
+            "type": "integer",
+            "default": 262144,
+            "x-env-variable": "OPENFGA_MAX_AUTHORIZATION_MODEL_SIZE_IN_BYTES"
+        },
         "maxConcurrentReadsForCheck": {
             "description": "The maximum allowed number of concurrent reads in a single Check query (default is MaxUint32).",
             "type": "integer",

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -140,6 +140,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("maxTypesPerAuthorizationModel", flags.Lookup("max-types-per-authorization-model"))
 		util.MustBindEnv("maxTypesPerAuthorizationModel", "OPENFGA_MAX_TYPES_PER_AUTHORIZATION_MODEL", "OPENFGA_MAXTYPESPERAUTHORIZATIONMODEL")
 
+		util.MustBindPFlag("maxAuthorizationModelSizeInBytes", flags.Lookup("max-authorization-model-size-in-bytes"))
+		util.MustBindEnv("maxAuthorizationModelSizeInBytes", "OPENFGA_MAX_AUTHORIZATION_MODEL_SIZE_IN_BYTES", "OPENFGA_MAXAUTHORIZATIONMODELSIZEINBYTES")
+
 		util.MustBindPFlag("maxConcurrentReadsForListObjects", flags.Lookup("max-concurrent-reads-for-list-objects"))
 		util.MustBindEnv("maxConcurrentReadsForListObjects", "OPENFGA_MAX_CONCURRENT_READS_FOR_LIST_OBJECTS", "OPENFGA_MAXCONCURRENTREADSFORLISTOBJECTS")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -168,6 +168,8 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Int("max-types-per-authorization-model", defaultConfig.MaxTypesPerAuthorizationModel, "the maximum allowed number of type definitions per authorization model")
 
+	flags.Int("max-authorization-model-size-in-bytes", defaultConfig.MaxAuthorizationModelSizeInBytes, "the maximum size in bytes allowed for persisting an Authorization Model.")
+
 	flags.Uint32("max-concurrent-reads-for-list-objects", defaultConfig.MaxConcurrentReadsForListObjects, "the maximum allowed number of concurrent datastore reads in a single ListObjects query. A high number means that you want ListObjects latency to be low, at the expense of other queries performance")
 
 	flags.Uint32("max-concurrent-reads-for-check", defaultConfig.MaxConcurrentReadsForCheck, "the maximum allowed number of concurrent datastore reads in a single Check query. A high number means that you want Check latency to be low, at the expense of other queries performance")
@@ -344,6 +346,9 @@ type Config struct {
 	// MaxTypesPerAuthorizationModel defines the maximum number of type definitions per authorization model for the WriteAuthorizationModel endpoint.
 	MaxTypesPerAuthorizationModel int
 
+	// MaxAuthorizationModelSizeInBytes defines the maximum size in bytes allowed for persisting an Authorization Model.
+	MaxAuthorizationModelSizeInBytes int
+
 	// MaxConcurrentReadsForListObjects defines the maximum number of concurrent database reads allowed in ListObjects queries
 	MaxConcurrentReadsForListObjects uint32
 
@@ -381,6 +386,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		MaxTuplesPerWrite:                         100,
 		MaxTypesPerAuthorizationModel:             100,
+		MaxAuthorizationModelSizeInBytes:          256 * 1_024,
 		MaxConcurrentReadsForCheck:                math.MaxUint32,
 		MaxConcurrentReadsForListObjects:          math.MaxUint32,
 		ChangelogHorizonOffset:                    0,
@@ -792,6 +798,7 @@ func (s *ServerContext) Run(ctx context.Context, config *Config) error {
 		server.WithCheckQueryCacheLimit(config.CheckQueryCache.Limit),
 		server.WithCheckQueryCacheTTL(config.CheckQueryCache.TTL),
 		server.WithRequestDurationByQueryHistogramBuckets(convertStringArrayToUintArray(config.RequestDurationDatastoreQueryCountBuckets)),
+		server.WithMaxAuthorizationModelSizeInBytes(config.MaxAuthorizationModelSizeInBytes),
 		server.WithExperimentals(experimentals...),
 	)
 

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -89,7 +89,7 @@ func TestWriteAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
 		t.Run(test._name, func(t *testing.T) {
 			model := githubModelReq
 
-			modelID, err := commands.NewWriteAuthorizationModelCommand(datastore, logger).Execute(ctx, model)
+			modelID, err := commands.NewWriteAuthorizationModelCommand(datastore, logger, 256*1_024).Execute(ctx, model)
 			require.NoError(t, err)
 
 			cmd := commands.NewWriteAssertionsCommand(datastore, logger)


### PR DESCRIPTION
## Description

Following up on #1028, we're introducing a new config knob `MAX_AUTHORIZATION_MODEL_SIZE_IN_BYTES` with a default of `256KB`, providing a consistent size limit across datastores.

We're picking a default value of `262144` bytes which is a fraction of the size limits in Postgres' BYTEA datatype (1GB) and MySQL's LONGBLOB datatype (4GB) which are used in the `serialized_protobuf` column of the `authorization_model` table.

## References

https://github.com/openfga/openfga/pull/1028

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
