### PR TITLE
refactor: move server config defaults to pkg/server/config

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
-	"math"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -38,6 +37,7 @@ import (
 	"github.com/openfga/openfga/pkg/middleware/storeid"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/health"
 	"github.com/openfga/openfga/pkg/storage"
@@ -77,7 +77,7 @@ func NewRunCommand() *cobra.Command {
 		Args:  cobra.NoArgs,
 	}
 
-	defaultConfig := DefaultConfig()
+	defaultConfig := serverconfig.DefaultConfig()
 	flags := cmd.Flags()
 
 	flags.StringSlice("experimentals", defaultConfig.Experimentals, "a list of experimental features to enable")
@@ -198,257 +198,6 @@ func NewRunCommand() *cobra.Command {
 	return cmd
 }
 
-// DatastoreConfig defines OpenFGA server configurations for datastore specific settings.
-type DatastoreConfig struct {
-
-	// Engine is the datastore engine to use (e.g. 'memory', 'postgres', 'mysql')
-	Engine   string
-	URI      string
-	Username string
-	Password string
-
-	// MaxCacheSize is the maximum number of cache keys that the storage cache can store before evicting
-	// old keys. The storage cache is used to cache query results for various static resources
-	// such as type definitions.
-	MaxCacheSize int
-
-	// MaxOpenConns is the maximum number of open connections to the database.
-	MaxOpenConns int
-
-	// MaxIdleConns is the maximum number of connections to the datastore in the idle connection pool.
-	MaxIdleConns int
-
-	// ConnMaxIdleTime is the maximum amount of time a connection to the datastore may be idle.
-	ConnMaxIdleTime time.Duration
-
-	// ConnMaxLifetime is the maximum amount of time a connection to the datastore may be reused.
-	ConnMaxLifetime time.Duration
-}
-
-// GRPCConfig defines OpenFGA server configurations for grpc server specific settings.
-type GRPCConfig struct {
-	Addr string
-	TLS  *TLSConfig
-}
-
-// HTTPConfig defines OpenFGA server configurations for HTTP server specific settings.
-type HTTPConfig struct {
-	Enabled bool
-	Addr    string
-	TLS     *TLSConfig
-
-	// UpstreamTimeout is the timeout duration for proxying HTTP requests upstream
-	// to the grpc endpoint. It cannot be smaller than Config.ListObjectsDeadline.
-	UpstreamTimeout time.Duration
-
-	CORSAllowedOrigins []string
-	CORSAllowedHeaders []string
-}
-
-// TLSConfig defines configuration specific to Transport Layer Security (TLS) settings.
-type TLSConfig struct {
-	Enabled  bool
-	CertPath string `mapstructure:"cert"`
-	KeyPath  string `mapstructure:"key"`
-}
-
-// AuthnConfig defines OpenFGA server configurations for authentication specific settings.
-type AuthnConfig struct {
-
-	// Method is the authentication method that should be enforced (e.g. 'none', 'preshared', 'oidc')
-	Method                   string
-	*AuthnOIDCConfig         `mapstructure:"oidc"`
-	*AuthnPresharedKeyConfig `mapstructure:"preshared"`
-}
-
-// AuthnOIDCConfig defines configurations for the 'oidc' method of authentication.
-type AuthnOIDCConfig struct {
-	Issuer   string
-	Audience string
-}
-
-// AuthnPresharedKeyConfig defines configurations for the 'preshared' method of authentication.
-type AuthnPresharedKeyConfig struct {
-	// Keys define the preshared keys to verify authn tokens against.
-	Keys []string
-}
-
-// LogConfig defines OpenFGA server configurations for log specific settings. For production we
-// recommend using the 'json' log format.
-type LogConfig struct {
-	// Format is the log format to use in the log output (e.g. 'text' or 'json')
-	Format string
-
-	// Level is the log level to use in the log output (e.g. 'none', 'debug', or 'info')
-	Level string
-}
-
-type TraceConfig struct {
-	Enabled     bool
-	OTLP        OTLPTraceConfig `mapstructure:"otlp"`
-	SampleRatio float64
-	ServiceName string
-}
-
-type OTLPTraceConfig struct {
-	Endpoint string
-	TLS      OTLPTraceTLSConfig
-}
-
-type OTLPTraceTLSConfig struct {
-	Enabled bool
-}
-
-// PlaygroundConfig defines OpenFGA server configurations for the Playground specific settings.
-type PlaygroundConfig struct {
-	Enabled bool
-	Port    int
-}
-
-// ProfilerConfig defines server configurations specific to pprof profiling.
-type ProfilerConfig struct {
-	Enabled bool
-	Addr    string
-}
-
-// MetricConfig defines configurations for serving custom metrics from OpenFGA.
-type MetricConfig struct {
-	Enabled             bool
-	Addr                string
-	EnableRPCHistograms bool
-}
-
-// CheckQueryCache defines configuration for caching when resolving check
-type CheckQueryCache struct {
-	Enabled bool
-	Limit   uint32 // (in items)
-	TTL     time.Duration
-}
-
-type Config struct {
-	// If you change any of these settings, please update the documentation at https://github.com/openfga/openfga.dev/blob/main/docs/content/intro/setup-openfga.mdx
-
-	// ListObjectsDeadline defines the maximum amount of time to accumulate ListObjects results
-	// before the server will respond. This is to protect the server from misuse of the
-	// ListObjects endpoints. It cannot be larger than HTTPConfig.UpstreamTimeout.
-	ListObjectsDeadline time.Duration
-
-	// ListObjectsMaxResults defines the maximum number of results to accumulate
-	// before the non-streaming ListObjects API will respond to the client.
-	// This is to protect the server from misuse of the ListObjects endpoints.
-	ListObjectsMaxResults uint32
-
-	// MaxTuplesPerWrite defines the maximum number of tuples per Write endpoint.
-	MaxTuplesPerWrite int
-
-	// MaxTypesPerAuthorizationModel defines the maximum number of type definitions per authorization model for the WriteAuthorizationModel endpoint.
-	MaxTypesPerAuthorizationModel int
-
-	// MaxConcurrentReadsForListObjects defines the maximum number of concurrent database reads allowed in ListObjects queries
-	MaxConcurrentReadsForListObjects uint32
-
-	// MaxConcurrentReadsForCheck defines the maximum number of concurrent database reads allowed in Check queries
-	MaxConcurrentReadsForCheck uint32
-
-	// ChangelogHorizonOffset is an offset in minutes from the current time. Changes that occur after this offset will not be included in the response of ReadChanges.
-	ChangelogHorizonOffset int
-
-	// Experimentals is a list of the experimental features to enable in the OpenFGA server.
-	Experimentals []string
-
-	// ResolveNodeLimit indicates how deeply nested an authorization model can be before a query errors out.
-	ResolveNodeLimit uint32
-
-	// ResolveNodeBreadthLimit indicates how many nodes on a given level can be evaluated concurrently in a query
-	ResolveNodeBreadthLimit uint32
-
-	Datastore       DatastoreConfig
-	GRPC            GRPCConfig
-	HTTP            HTTPConfig
-	Authn           AuthnConfig
-	Log             LogConfig
-	Trace           TraceConfig
-	Playground      PlaygroundConfig
-	Profiler        ProfilerConfig
-	Metrics         MetricConfig
-	CheckQueryCache CheckQueryCache
-
-	RequestDurationDatastoreQueryCountBuckets []string
-}
-
-// DefaultConfig returns the OpenFGA server default configurations.
-func DefaultConfig() *Config {
-	return &Config{
-		MaxTuplesPerWrite:                         100,
-		MaxTypesPerAuthorizationModel:             100,
-		MaxConcurrentReadsForCheck:                math.MaxUint32,
-		MaxConcurrentReadsForListObjects:          math.MaxUint32,
-		ChangelogHorizonOffset:                    0,
-		ResolveNodeLimit:                          25,
-		ResolveNodeBreadthLimit:                   100,
-		Experimentals:                             []string{},
-		ListObjectsDeadline:                       3 * time.Second, // there is a 3-second timeout elsewhere
-		ListObjectsMaxResults:                     1000,
-		RequestDurationDatastoreQueryCountBuckets: []string{"50", "200"},
-		Datastore: DatastoreConfig{
-			Engine:       "memory",
-			MaxCacheSize: 100000,
-			MaxIdleConns: 10,
-			MaxOpenConns: 30,
-		},
-		GRPC: GRPCConfig{
-			Addr: "0.0.0.0:8081",
-			TLS:  &TLSConfig{Enabled: false},
-		},
-		HTTP: HTTPConfig{
-			Enabled:            true,
-			Addr:               "0.0.0.0:8080",
-			TLS:                &TLSConfig{Enabled: false},
-			UpstreamTimeout:    5 * time.Second,
-			CORSAllowedOrigins: []string{"*"},
-			CORSAllowedHeaders: []string{"*"},
-		},
-		Authn: AuthnConfig{
-			Method:                  "none",
-			AuthnPresharedKeyConfig: &AuthnPresharedKeyConfig{},
-			AuthnOIDCConfig:         &AuthnOIDCConfig{},
-		},
-		Log: LogConfig{
-			Format: "text",
-			Level:  "info",
-		},
-		Trace: TraceConfig{
-			Enabled: false,
-			OTLP: OTLPTraceConfig{
-				Endpoint: "0.0.0.0:4317",
-				TLS: OTLPTraceTLSConfig{
-					Enabled: false,
-				},
-			},
-			SampleRatio: 0.2,
-			ServiceName: "openfga",
-		},
-		Playground: PlaygroundConfig{
-			Enabled: true,
-			Port:    3000,
-		},
-		Profiler: ProfilerConfig{
-			Enabled: false,
-			Addr:    ":3001",
-		},
-		Metrics: MetricConfig{
-			Enabled:             true,
-			Addr:                "0.0.0.0:2112",
-			EnableRPCHistograms: false,
-		},
-		CheckQueryCache: CheckQueryCache{
-			Enabled: false,
-			Limit:   10000,
-			TTL:     10 * time.Second,
-		},
-	}
-}
-
 // TCPRandomPort tries to find a random TCP Port. If it can't find one, it panics. Else, it returns the port and a function that releases the port.
 // It is the responsibility of the caller to call the release function.
 func TCPRandomPort() (int, func()) {
@@ -463,8 +212,8 @@ func TCPRandomPort() (int, func()) {
 
 // MustDefaultConfigWithRandomPorts returns the DefaultConfig, but with random ports for the grpc and http addresses.
 // This function may panic if somehow a random port cannot be chosen.
-func MustDefaultConfigWithRandomPorts() *Config {
-	config := DefaultConfig()
+func MustDefaultConfigWithRandomPorts() *serverconfig.Config {
+	config := serverconfig.DefaultConfig()
 
 	// Since this is used for tests, turn the following off:
 	config.Playground.Enabled = false
@@ -484,8 +233,8 @@ func MustDefaultConfigWithRandomPorts() *Config {
 // ReadConfig returns the OpenFGA server configuration based on the values provided in the server's 'config.yaml' file.
 // The 'config.yaml' file is loaded from '/etc/openfga', '$HOME/.openfga', or the current working directory. If no configuration
 // file is present, the default values are returned.
-func ReadConfig() (*Config, error) {
-	config := DefaultConfig()
+func ReadConfig() (*serverconfig.Config, error) {
+	config := serverconfig.DefaultConfig()
 
 	viper.SetTypeByDefaultValue(true)
 	err := viper.ReadInConfig()
@@ -502,7 +251,7 @@ func ReadConfig() (*Config, error) {
 	return config, nil
 }
 
-func VerifyConfig(cfg *Config) error {
+func VerifyConfig(cfg *serverconfig.Config) error {
 	if int(cfg.MaxConcurrentReadsForCheck) > cfg.Datastore.MaxOpenConns {
 		fmt.Printf("config 'maxConcurrentReadsForCheck' (%d) should not be higher than 'datastore.maxOpenConns' config (%d)\n", cfg.MaxConcurrentReadsForCheck, cfg.Datastore.MaxOpenConns)
 	}
@@ -598,7 +347,7 @@ func convertStringArrayToUintArray(stringArray []string) []uint {
 	return uintArray
 }
 
-func (s *ServerContext) Run(ctx context.Context, config *Config) error {
+func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
 	tp := sdktrace.NewTracerProvider()
 	if config.Trace.Enabled {
 		s.Logger.Info(fmt.Sprintf("🕵 tracing enabled: sampling ratio is %v and sending traces to '%s', tls: %t", config.Trace.SampleRatio, config.Trace.OTLP.Endpoint, config.Trace.OTLP.TLS.Enabled))

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"sync"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/validation"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -20,12 +20,6 @@ import (
 )
 
 var tracer = otel.Tracer("internal/graph/check")
-
-const (
-	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
-	defaultResolveNodeBreadthLimit    = 25
-	defaultMaxConcurrentReadsForCheck = math.MaxUint32
-)
 
 var (
 	ErrCycleDetected = errors.New("a cycle has been detected")
@@ -158,8 +152,8 @@ func WithCachedResolver(opts ...CachedCheckResolverOpt) LocalCheckerOption {
 func NewLocalChecker(ds storage.RelationshipTupleReader, opts ...LocalCheckerOption) CheckResolver {
 	checker := &LocalChecker{
 		ds:                 ds,
-		concurrencyLimit:   defaultResolveNodeBreadthLimit,
-		maxConcurrentReads: defaultMaxConcurrentReadsForCheck,
+		concurrencyLimit:   serverconfig.DefaultResolveNodeBreadthLimit,
+		maxConcurrentReads: serverconfig.DefaultMaxConcurrentReadsForCheck,
 	}
 	checker.delegate = checker // by default, a LocalChecker delegates/dispatchs subproblems to itself (e.g. local dispatch) unless otherwise configured.
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands/reverseexpand"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -23,16 +24,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	streamedBufferSize = 100
-
-	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
-	defaultResolveNodeLimit                 = 25
-	defaultResolveNodeBreadthLimit          = 100
-	defaultListObjectsDeadline              = 3 * time.Second
-	defaultListObjectsMaxResults            = 1000
-	defaultMaxConcurrentReadsForListObjects = math.MaxUint32
-)
+const streamedBufferSize = 100
 
 var (
 	furtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
@@ -114,11 +106,11 @@ func NewListObjectsQuery(ds storage.RelationshipTupleReader, opts ...ListObjects
 	query := &ListObjectsQuery{
 		datastore:               ds,
 		logger:                  logger.NewNoopLogger(),
-		listObjectsDeadline:     defaultListObjectsDeadline,
-		listObjectsMaxResults:   defaultListObjectsMaxResults,
-		resolveNodeLimit:        defaultResolveNodeLimit,
-		resolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
-		maxConcurrentReads:      defaultMaxConcurrentReadsForListObjects,
+		listObjectsDeadline:     serverconfig.DefaultListObjectsDeadline,
+		listObjectsMaxResults:   serverconfig.DefaultListObjectsMaxResults,
+		resolveNodeLimit:        serverconfig.DefaultResolveNodeLimit,
+		resolveNodeBreadthLimit: serverconfig.DefaultResolveNodeBreadthLimit,
+		maxConcurrentReads:      serverconfig.DefaultMaxConcurrentReadsForListObjects,
 		checkOptions:            []graph.LocalCheckerOption{},
 	}
 

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -10,6 +10,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/graph"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -21,12 +22,6 @@ import (
 )
 
 var tracer = otel.Tracer("openfga/pkg/server/commands/reverse_expand")
-
-const (
-	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
-	defaultResolveNodeLimit        = 25
-	defaultResolveNodeBreadthLimit = 100
-)
 
 type ReverseExpandRequest struct {
 	StoreID          string
@@ -139,8 +134,8 @@ func NewReverseExpandQuery(ds storage.RelationshipTupleReader, ts *typesystem.Ty
 	query := &ReverseExpandQuery{
 		datastore:               ds,
 		typesystem:              ts,
-		resolveNodeLimit:        defaultResolveNodeLimit,
-		resolveNodeBreadthLimit: defaultResolveNodeBreadthLimit,
+		resolveNodeLimit:        serverconfig.DefaultResolveNodeLimit,
+		resolveNodeBreadthLimit: serverconfig.DefaultResolveNodeBreadthLimit,
 		candidateObjectsMap:     new(sync.Map),
 		visitedUsersetsMap:      new(sync.Map),
 	}

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -1,0 +1,326 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+)
+
+const (
+	DefaultChangelogHorizonOffset           = 0
+	DefaultResolveNodeLimit                 = 25
+	DefaultResolveNodeBreadthLimit          = 100
+	DefaultListObjectsDeadline              = 3 * time.Second
+	DefaultListObjectsMaxResults            = 1000
+	DefaultMaxConcurrentReadsForCheck       = math.MaxUint32
+	DefaultMaxConcurrentReadsForListObjects = math.MaxUint32
+	DefaultCheckQueryCacheLimit             = 10000
+	DefaultCheckQueryCacheTTL               = 10 * time.Second
+	DefaultCheckQueryCacheEnable            = false
+)
+
+// DatastoreConfig defines OpenFGA server configurations for datastore specific settings.
+type DatastoreConfig struct {
+	// Engine is the datastore engine to use (e.g. 'memory', 'postgres', 'mysql')
+	Engine   string
+	URI      string
+	Username string
+	Password string
+
+	// MaxCacheSize is the maximum number of cache keys that the storage cache can store before evicting
+	// old keys. The storage cache is used to cache query results for various static resources
+	// such as type definitions.
+	MaxCacheSize int
+
+	// MaxOpenConns is the maximum number of open connections to the database.
+	MaxOpenConns int
+
+	// MaxIdleConns is the maximum number of connections to the datastore in the idle connection pool.
+	MaxIdleConns int
+
+	// ConnMaxIdleTime is the maximum amount of time a connection to the datastore may be idle.
+	ConnMaxIdleTime time.Duration
+
+	// ConnMaxLifetime is the maximum amount of time a connection to the datastore may be reused.
+	ConnMaxLifetime time.Duration
+}
+
+// GRPCConfig defines OpenFGA server configurations for grpc server specific settings.
+type GRPCConfig struct {
+	Addr string
+	TLS  *TLSConfig
+}
+
+// HTTPConfig defines OpenFGA server configurations for HTTP server specific settings.
+type HTTPConfig struct {
+	Enabled bool
+	Addr    string
+	TLS     *TLSConfig
+
+	// UpstreamTimeout is the timeout duration for proxying HTTP requests upstream
+	// to the grpc endpoint. It cannot be smaller than Config.ListObjectsDeadline.
+	UpstreamTimeout time.Duration
+
+	CORSAllowedOrigins []string
+	CORSAllowedHeaders []string
+}
+
+// TLSConfig defines configuration specific to Transport Layer Security (TLS) settings.
+type TLSConfig struct {
+	Enabled  bool
+	CertPath string `mapstructure:"cert"`
+	KeyPath  string `mapstructure:"key"`
+}
+
+// AuthnConfig defines OpenFGA server configurations for authentication specific settings.
+type AuthnConfig struct {
+
+	// Method is the authentication method that should be enforced (e.g. 'none', 'preshared', 'oidc')
+	Method                   string
+	*AuthnOIDCConfig         `mapstructure:"oidc"`
+	*AuthnPresharedKeyConfig `mapstructure:"preshared"`
+}
+
+// AuthnOIDCConfig defines configurations for the 'oidc' method of authentication.
+type AuthnOIDCConfig struct {
+	Issuer   string
+	Audience string
+}
+
+// AuthnPresharedKeyConfig defines configurations for the 'preshared' method of authentication.
+type AuthnPresharedKeyConfig struct {
+	// Keys define the preshared keys to verify authn tokens against.
+	Keys []string
+}
+
+// LogConfig defines OpenFGA server configurations for log specific settings. For production we
+// recommend using the 'json' log format.
+type LogConfig struct {
+	// Format is the log format to use in the log output (e.g. 'text' or 'json')
+	Format string
+
+	// Level is the log level to use in the log output (e.g. 'none', 'debug', or 'info')
+	Level string
+}
+
+type TraceConfig struct {
+	Enabled     bool
+	OTLP        OTLPTraceConfig `mapstructure:"otlp"`
+	SampleRatio float64
+	ServiceName string
+}
+
+type OTLPTraceConfig struct {
+	Endpoint string
+	TLS      OTLPTraceTLSConfig
+}
+
+type OTLPTraceTLSConfig struct {
+	Enabled bool
+}
+
+// PlaygroundConfig defines OpenFGA server configurations for the Playground specific settings.
+type PlaygroundConfig struct {
+	Enabled bool
+	Port    int
+}
+
+// ProfilerConfig defines server configurations specific to pprof profiling.
+type ProfilerConfig struct {
+	Enabled bool
+	Addr    string
+}
+
+// MetricConfig defines configurations for serving custom metrics from OpenFGA.
+type MetricConfig struct {
+	Enabled             bool
+	Addr                string
+	EnableRPCHistograms bool
+}
+
+// CheckQueryCache defines configuration for caching when resolving check
+type CheckQueryCache struct {
+	Enabled bool
+	Limit   uint32 // (in items)
+	TTL     time.Duration
+}
+
+type Config struct {
+	// If you change any of these settings, please update the documentation at https://github.com/openfga/openfga.dev/blob/main/docs/content/intro/setup-openfga.mdx
+
+	// ListObjectsDeadline defines the maximum amount of time to accumulate ListObjects results
+	// before the server will respond. This is to protect the server from misuse of the
+	// ListObjects endpoints. It cannot be larger than HTTPConfig.UpstreamTimeout.
+	ListObjectsDeadline time.Duration
+
+	// ListObjectsMaxResults defines the maximum number of results to accumulate
+	// before the non-streaming ListObjects API will respond to the client.
+	// This is to protect the server from misuse of the ListObjects endpoints.
+	ListObjectsMaxResults uint32
+
+	// MaxTuplesPerWrite defines the maximum number of tuples per Write endpoint.
+	MaxTuplesPerWrite int
+
+	// MaxTypesPerAuthorizationModel defines the maximum number of type definitions per authorization model for the WriteAuthorizationModel endpoint.
+	MaxTypesPerAuthorizationModel int
+
+	// MaxConcurrentReadsForListObjects defines the maximum number of concurrent database reads allowed in ListObjects queries
+	MaxConcurrentReadsForListObjects uint32
+
+	// MaxConcurrentReadsForCheck defines the maximum number of concurrent database reads allowed in Check queries
+	MaxConcurrentReadsForCheck uint32
+
+	// ChangelogHorizonOffset is an offset in minutes from the current time. Changes that occur after this offset will not be included in the response of ReadChanges.
+	ChangelogHorizonOffset int
+
+	// Experimentals is a list of the experimental features to enable in the OpenFGA server.
+	Experimentals []string
+
+	// ResolveNodeLimit indicates how deeply nested an authorization model can be before a query errors out.
+	ResolveNodeLimit uint32
+
+	// ResolveNodeBreadthLimit indicates how many nodes on a given level can be evaluated concurrently in a query
+	ResolveNodeBreadthLimit uint32
+
+	Datastore       DatastoreConfig
+	GRPC            GRPCConfig
+	HTTP            HTTPConfig
+	Authn           AuthnConfig
+	Log             LogConfig
+	Trace           TraceConfig
+	Playground      PlaygroundConfig
+	Profiler        ProfilerConfig
+	Metrics         MetricConfig
+	CheckQueryCache CheckQueryCache
+
+	RequestDurationDatastoreQueryCountBuckets []string
+}
+
+func (cfg *Config) Verify() error {
+	if cfg.ListObjectsDeadline > cfg.HTTP.UpstreamTimeout {
+		return fmt.Errorf("config 'http.upstreamTimeout' (%s) cannot be lower than 'listObjectsDeadline' config (%s)", cfg.HTTP.UpstreamTimeout, cfg.ListObjectsDeadline)
+	}
+
+	if cfg.Log.Format != "text" && cfg.Log.Format != "json" {
+		return fmt.Errorf("config 'log.format' must be one of ['text', 'json']")
+	}
+
+	if cfg.Log.Level != "none" &&
+		cfg.Log.Level != "debug" &&
+		cfg.Log.Level != "info" &&
+		cfg.Log.Level != "warn" &&
+		cfg.Log.Level != "error" &&
+		cfg.Log.Level != "panic" &&
+		cfg.Log.Level != "fatal" {
+		return fmt.Errorf("config 'log.level' must be one of ['none', 'debug', 'info', 'warn', 'error', 'panic', 'fatal']")
+	}
+
+	if cfg.Playground.Enabled {
+		if !cfg.HTTP.Enabled {
+			return errors.New("the HTTP server must be enabled to run the openfga playground")
+		}
+
+		if !(cfg.Authn.Method == "none" || cfg.Authn.Method == "preshared") {
+			return errors.New("the playground only supports authn methods 'none' and 'preshared'")
+		}
+	}
+
+	if cfg.HTTP.TLS.Enabled {
+		if cfg.HTTP.TLS.CertPath == "" || cfg.HTTP.TLS.KeyPath == "" {
+			return errors.New("'http.tls.cert' and 'http.tls.key' configs must be set")
+		}
+	}
+
+	if cfg.GRPC.TLS.Enabled {
+		if cfg.GRPC.TLS.CertPath == "" || cfg.GRPC.TLS.KeyPath == "" {
+			return errors.New("'grpc.tls.cert' and 'grpc.tls.key' configs must be set")
+		}
+	}
+
+	if len(cfg.RequestDurationDatastoreQueryCountBuckets) == 0 {
+		return errors.New("request duration datastore query count buckets must not be empty")
+	}
+	for _, val := range cfg.RequestDurationDatastoreQueryCountBuckets {
+		valInt, err := strconv.Atoi(val)
+		if err != nil || valInt < 0 {
+			return errors.New("request duration datastore query count bucket items must be non-negative integer")
+		}
+	}
+
+	return nil
+}
+
+// DefaultConfig is the OpenFGA server default configurations.
+func DefaultConfig() *Config {
+	return &Config{
+		MaxTuplesPerWrite:                         100,
+		MaxTypesPerAuthorizationModel:             100,
+		MaxConcurrentReadsForCheck:                DefaultMaxConcurrentReadsForCheck,
+		MaxConcurrentReadsForListObjects:          DefaultMaxConcurrentReadsForListObjects,
+		ChangelogHorizonOffset:                    DefaultChangelogHorizonOffset,
+		ResolveNodeLimit:                          DefaultResolveNodeLimit,
+		ResolveNodeBreadthLimit:                   DefaultResolveNodeBreadthLimit,
+		Experimentals:                             []string{},
+		ListObjectsDeadline:                       DefaultListObjectsDeadline, // there is a 3-second timeout elsewhere
+		ListObjectsMaxResults:                     DefaultListObjectsMaxResults,
+		RequestDurationDatastoreQueryCountBuckets: []string{"50", "200"},
+		Datastore: DatastoreConfig{
+			Engine:       "memory",
+			MaxCacheSize: 100000,
+			MaxIdleConns: 10,
+			MaxOpenConns: 30,
+		},
+		GRPC: GRPCConfig{
+			Addr: "0.0.0.0:8081",
+			TLS:  &TLSConfig{Enabled: false},
+		},
+		HTTP: HTTPConfig{
+			Enabled:            true,
+			Addr:               "0.0.0.0:8080",
+			TLS:                &TLSConfig{Enabled: false},
+			UpstreamTimeout:    5 * time.Second,
+			CORSAllowedOrigins: []string{"*"},
+			CORSAllowedHeaders: []string{"*"},
+		},
+		Authn: AuthnConfig{
+			Method:                  "none",
+			AuthnPresharedKeyConfig: &AuthnPresharedKeyConfig{},
+			AuthnOIDCConfig:         &AuthnOIDCConfig{},
+		},
+		Log: LogConfig{
+			Format: "text",
+			Level:  "info",
+		},
+		Trace: TraceConfig{
+			Enabled: false,
+			OTLP: OTLPTraceConfig{
+				Endpoint: "0.0.0.0:4317",
+				TLS: OTLPTraceTLSConfig{
+					Enabled: false,
+				},
+			},
+			SampleRatio: 0.2,
+			ServiceName: "openfga",
+		},
+		Playground: PlaygroundConfig{
+			Enabled: true,
+			Port:    3000,
+		},
+		Profiler: ProfilerConfig{
+			Enabled: false,
+			Addr:    ":3001",
+		},
+		Metrics: MetricConfig{
+			Enabled:             true,
+			Addr:                "0.0.0.0:2112",
+			EnableRPCHistograms: false,
+		},
+		CheckQueryCache: CheckQueryCache{
+			Enabled: DefaultCheckQueryCacheEnable,
+			Limit:   DefaultCheckQueryCacheLimit,
+			TTL:     DefaultCheckQueryCacheTTL,
+		},
+	}
+}

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyConfig(t *testing.T) {
+	t.Run("UpstreamTimeout_cannot_be_less_than_ListObjectsDeadline", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.ListObjectsDeadline = 5 * time.Minute
+		cfg.HTTP.UpstreamTimeout = 2 * time.Second
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "config 'http.upstreamTimeout' (2s) cannot be lower than 'listObjectsDeadline' config (5m0s)")
+	})
+
+	t.Run("failing_to_set_http_cert_path_will_not_allow_server_to_start", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.HTTP.TLS = &TLSConfig{
+			Enabled: true,
+			KeyPath: "some/path",
+		}
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "'http.tls.cert' and 'http.tls.key' configs must be set")
+	})
+
+	t.Run("failing_to_set_grpc_cert_path_will_not_allow_server_to_start", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.GRPC.TLS = &TLSConfig{
+			Enabled: true,
+			KeyPath: "some/path",
+		}
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "'grpc.tls.cert' and 'grpc.tls.key' configs must be set")
+	})
+
+	t.Run("failing_to_set_http_key_path_will_not_allow_server_to_start", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.HTTP.TLS = &TLSConfig{
+			Enabled:  true,
+			CertPath: "some/path",
+		}
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "'http.tls.cert' and 'http.tls.key' configs must be set")
+	})
+
+	t.Run("failing_to_set_grpc_key_path_will_not_allow_server_to_start", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.GRPC.TLS = &TLSConfig{
+			Enabled:  true,
+			CertPath: "some/path",
+		}
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "'grpc.tls.cert' and 'grpc.tls.key' configs must be set")
+	})
+
+	t.Run("non_log_format", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.Format = "notaformat"
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+
+	t.Run("non_log_level", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.Level = "notalevel"
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+
+	t.Run("empty_request_duration_datastore_query_count_buckets", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.RequestDurationDatastoreQueryCountBuckets = []string{}
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+
+	t.Run("non_int_request_duration_datastore_query_count_buckets", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.RequestDurationDatastoreQueryCountBuckets = []string{"12", "45a", "66"}
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+
+	t.Run("negative_request_duration_datastore_query_count_buckets", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.RequestDurationDatastoreQueryCountBuckets = []string{"12", "-45", "66"}
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"slices"
 	"sort"
@@ -24,6 +23,7 @@ import (
 	httpmiddleware "github.com/openfga/openfga/pkg/middleware/http"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -47,18 +47,6 @@ const (
 	AuthorizationModelIDHeader                          = "openfga-authorization-model-id"
 	authorizationModelIDKey                             = "authorization_model_id"
 	ExperimentalCheckQueryCache ExperimentalFeatureFlag = "check-query-cache"
-
-	// same values as run.DefaultConfig() (TODO break the import cycle, remove these hardcoded values and import those constants here)
-	defaultChangelogHorizonOffset           = 0
-	defaultResolveNodeLimit                 = 25
-	defaultResolveNodeBreadthLimit          = 100
-	defaultListObjectsDeadline              = 3 * time.Second
-	defaultListObjectsMaxResults            = 1000
-	defaultMaxConcurrentReadsForCheck       = math.MaxUint32
-	defaultMaxConcurrentReadsForListObjects = math.MaxUint32
-	defaultCheckQueryCacheLimit             = 10000
-	defaultCheckQueryCacheTTL               = 10 * time.Second
-	defaultCheckQueryCacheEnable            = false
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -257,18 +245,18 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		logger:                           logger.NewNoopLogger(),
 		encoder:                          encoder.NewBase64Encoder(),
 		transport:                        gateway.NewNoopTransport(),
-		changelogHorizonOffset:           defaultChangelogHorizonOffset,
-		resolveNodeLimit:                 defaultResolveNodeLimit,
-		resolveNodeBreadthLimit:          defaultResolveNodeBreadthLimit,
-		listObjectsDeadline:              defaultListObjectsDeadline,
-		listObjectsMaxResults:            defaultListObjectsMaxResults,
-		maxConcurrentReadsForCheck:       defaultMaxConcurrentReadsForCheck,
-		maxConcurrentReadsForListObjects: defaultMaxConcurrentReadsForListObjects,
+		changelogHorizonOffset:           serverconfig.DefaultChangelogHorizonOffset,
+		resolveNodeLimit:                 serverconfig.DefaultResolveNodeLimit,
+		resolveNodeBreadthLimit:          serverconfig.DefaultResolveNodeBreadthLimit,
+		listObjectsDeadline:              serverconfig.DefaultListObjectsDeadline,
+		listObjectsMaxResults:            serverconfig.DefaultListObjectsMaxResults,
+		maxConcurrentReadsForCheck:       serverconfig.DefaultMaxConcurrentReadsForCheck,
+		maxConcurrentReadsForListObjects: serverconfig.DefaultMaxConcurrentReadsForListObjects,
 		experimentals:                    make([]ExperimentalFeatureFlag, 0, 10),
 
-		checkQueryCacheEnabled: defaultCheckQueryCacheEnable,
-		checkQueryCacheLimit:   defaultCheckQueryCacheLimit,
-		checkQueryCacheTTL:     defaultCheckQueryCacheTTL,
+		checkQueryCacheEnabled: serverconfig.DefaultCheckQueryCacheEnable,
+		checkQueryCacheLimit:   serverconfig.DefaultCheckQueryCacheLimit,
+		checkQueryCacheTTL:     serverconfig.DefaultCheckQueryCacheTTL,
 		checkCache:             nil,
 
 		requestDurationByQueryHistogramBuckets: []uint{50, 200},

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/test"
 	"github.com/openfga/openfga/pkg/storage"
@@ -573,7 +574,7 @@ func TestListObjects_ErrorCases(t *testing.T) {
 			SchemaVersion: typesystem.SchemaVersion1_1,
 			TypeDefinitions: parser.MustParse(`
 			type user
-	
+
 			type document
 			  relations
 				define viewer: [user, user:*] as self
@@ -810,8 +811,9 @@ func TestAuthorizationModelInvalidSchemaVersion(t *testing.T) {
 }
 
 func TestDefaultMaxConcurrentReadSettings(t *testing.T) {
-	require.EqualValues(t, math.MaxUint32, defaultMaxConcurrentReadsForCheck)
-	require.EqualValues(t, math.MaxUint32, defaultMaxConcurrentReadsForListObjects)
+	cfg := serverconfig.DefaultConfig()
+	require.EqualValues(t, math.MaxUint32, cfg.MaxConcurrentReadsForCheck)
+	require.EqualValues(t, math.MaxUint32, cfg.MaxConcurrentReadsForListObjects)
 
 	s := MustNewServerWithOpts(
 		WithDatastore(memory.New()),

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -7,6 +7,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/cmd/run"
 	"github.com/openfga/openfga/pkg/logger"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -21,13 +22,13 @@ type TestClientBootstrapper interface {
 	Write(ctx context.Context, in *openfgav1.WriteRequest, opts ...grpc.CallOption) (*openfgav1.WriteResponse, error)
 }
 
-func StartServer(t testing.TB, cfg *run.Config) context.CancelFunc {
+func StartServer(t testing.TB, cfg *serverconfig.Config) context.CancelFunc {
 	logger := logger.MustNewLogger(cfg.Log.Format, cfg.Log.Level)
 	serverCtx := &run.ServerContext{Logger: logger}
 	return StartServerWithContext(t, cfg, serverCtx)
 }
 
-func StartServerWithContext(t testing.TB, cfg *run.Config, serverCtx *run.ServerContext) context.CancelFunc {
+func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *run.ServerContext) context.CancelFunc {
 	container := storage.RunDatastoreTestContainer(t, cfg.Datastore.Engine)
 	cfg.Datastore.URI = container.GetConnectionURI(true)
 


### PR DESCRIPTION
## Description

Move server related default config values out from `cmd/run` into `pkg/server/config`, preventing import cycles and hard coded values in various places.

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
