### PR TITLE
test: add test for ReadChanges when writes happen concurrently

### DIFF
--- a/pkg/server/test/read_changes.go
+++ b/pkg/server/test/read_changes.go
@@ -255,7 +255,7 @@ func TestReadChangesReturnsSameContTokenWhenNoChanges(t *testing.T, datastore st
 	require.Equal(t, res1.ContinuationToken, res2.ContinuationToken)
 }
 
-func TestReadChangesAfterConcurrentWrites(t *testing.T, datastore storage.OpenFGADatastore) {
+func TestReadChangesAfterConcurrentWritesReturnsUniqueResults(t *testing.T, datastore storage.OpenFGADatastore) {
 	store := testutils.CreateRandomString(10)
 	ctx, backend := writeFourTuplesConcurrently(t, store, datastore)
 

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -45,8 +45,8 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadChangesReturnsSameContTokenWhenNoChanges",
 		func(t *testing.T) { TestReadChangesReturnsSameContTokenWhenNoChanges(t, ds) },
 	)
-	t.Run("TestReadChangesAfterConcurrentWrites",
-		func(t *testing.T) { TestReadChangesAfterConcurrentWrites(t, ds) },
+	t.Run("TestReadChangesAfterConcurrentWritesReturnsUniqueResults",
+		func(t *testing.T) { TestReadChangesAfterConcurrentWritesReturnsUniqueResults(t, ds) },
 	)
 
 	t.Run("TestListObjectsRespectsMaxResults", func(t *testing.T) { TestListObjectsRespectsMaxResults(t, ds) })

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -45,6 +45,9 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadChangesReturnsSameContTokenWhenNoChanges",
 		func(t *testing.T) { TestReadChangesReturnsSameContTokenWhenNoChanges(t, ds) },
 	)
+	t.Run("TestReadChangesAfterConcurrentWrites",
+		func(t *testing.T) { TestReadChangesAfterConcurrentWrites(t, ds) },
+	)
 
 	t.Run("TestListObjectsRespectsMaxResults", func(t *testing.T) { TestListObjectsRespectsMaxResults(t, ds) })
 	t.Run("TestReverseExpand", func(t *testing.T) { TestReverseExpand(t, ds) })


### PR DESCRIPTION
## Description
Add a test that ensures that concurrent tuple writes do not impact ReadChanges API (as in, return duplicate results).
