### PR TITLE
test: add test for datastore.IsReady

### DIFF
--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -677,12 +677,5 @@ func (m *MySQL) ReadChanges(
 // IsReady reports whether this MySQL datastore instance is ready
 // to accept connections.
 func (m *MySQL) IsReady(ctx context.Context) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	if err := m.db.PingContext(ctx); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return sqlcommon.IsReady(ctx, m.db)
 }

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -27,6 +27,18 @@ func TestMySQLDatastore(t *testing.T) {
 	test.RunAllTests(t, ds)
 }
 
+func TestMySQLDatastoreAfterCloseIsNotReady(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	ds.Close()
+	ready, err := ds.IsReady(context.Background())
+	require.Error(t, err)
+	require.False(t, ready)
+}
+
 // TestReadEnsureNoOrder asserts that the read response is not ordered by ulid
 func TestReadEnsureNoOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -668,12 +668,5 @@ func (p *Postgres) ReadChanges(
 // IsReady reports whether this Postgres datastore instance is ready
 // to accept connections.
 func (p *Postgres) IsReady(ctx context.Context) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
-	if err := p.db.PingContext(ctx); err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return sqlcommon.IsReady(ctx, p.db)
 }

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -26,6 +26,18 @@ func TestPostgresDatastore(t *testing.T) {
 	test.RunAllTests(t, ds)
 }
 
+func TestPostgresDatastoreAfterCloseIsNotReady(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	ds.Close()
+	ready, err := ds.IsReady(context.Background())
+	require.Error(t, err)
+	require.False(t, ready)
+}
+
 // TestReadEnsureNoOrder asserts that the read response is not ordered by ulid
 func TestReadEnsureNoOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -444,3 +444,15 @@ func ReadAuthorizationModel(ctx context.Context, dbInfo *DBInfo, store, modelID 
 		TypeDefinitions: typeDefs,
 	}, nil
 }
+
+// IsReady returns true if the connection to the datastore is successful
+func IsReady(ctx context.Context, db *sql.DB) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	if err := db.PingContext(ctx); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -8,6 +9,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -30,6 +32,11 @@ var (
 )
 
 func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
+	t.Run("TestDatastoreIsReady", func(t *testing.T) {
+		ready, err := ds.IsReady(context.Background())
+		require.NoError(t, err)
+		require.True(t, ready)
+	})
 	// tuples
 	t.Run("TestTupleWriteAndRead", func(t *testing.T) { TupleWritingAndReadingTest(t, ds) })
 	t.Run("TestTuplePaginationOptions", func(t *testing.T) { TuplePaginationOptionsTest(t, ds) })


### PR DESCRIPTION
## Description

- Reduce code duplication
- Improve code coverage

## References
Originally suggested in https://github.com/openfga/openfga/pull/702 but put here so it's faster to merge.