### PR TITLE
Fix protobuf comparison

### DIFF
--- a/pkg/server/test/get_store.go
+++ b/pkg/server/test/get_store.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands"
@@ -13,6 +12,8 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/protoadapt"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestGetStoreQuery(t *testing.T, datastore storage.OpenFGADatastore) {
@@ -31,8 +32,7 @@ func TestGetStoreQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 	}
 
-	ignoreStateOpts := cmpopts.IgnoreUnexported(openfgav1.GetStoreResponse{})
-	ignoreStoreFields := cmpopts.IgnoreFields(openfgav1.GetStoreResponse{}, "CreatedAt", "UpdatedAt", "Id")
+	ignoreStoreFields := protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.GetStoreResponse{}), "created_at", "updated_at", "id")
 
 	ctx := context.Background()
 	logger := logger.NewNoopLogger()
@@ -47,7 +47,7 @@ func TestGetStoreQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 				require.Nil(t, resp)
 			} else {
 				require.NoError(t, err)
-				if diff := cmp.Diff(test.expectedResponse, resp, ignoreStateOpts, ignoreStoreFields, cmpopts.EquateEmpty()); diff != "" {
+				if diff := cmp.Diff(test.expectedResponse, resp, ignoreStoreFields, protocmp.Transform()); diff != "" {
 					t.Errorf("store mismatch (-want +got):\n%s", diff)
 				}
 			}
@@ -74,10 +74,8 @@ func TestGetStoreSucceeds(t *testing.T, datastore storage.OpenFGADatastore) {
 		Name: store,
 	}
 
-	ignoreStateOpts := cmpopts.IgnoreUnexported(openfgav1.GetStoreResponse{})
-	ignoreStoreFields := cmpopts.IgnoreFields(openfgav1.GetStoreResponse{}, "CreatedAt", "UpdatedAt", "Id")
-
-	if diff := cmp.Diff(expectedResponse, actualResponse, ignoreStateOpts, ignoreStoreFields, cmpopts.EquateEmpty()); diff != "" {
+	ignoreStoreFields := protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.GetStoreResponse{}), "created_at", "updated_at", "id")
+	if diff := cmp.Diff(expectedResponse, actualResponse, ignoreStoreFields, protocmp.Transform()); diff != "" {
 		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -6,7 +6,6 @@ import (
 
 	parser "github.com/craigpastro/openfga-dsl-parser/v2"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/encoder"
@@ -15,10 +14,11 @@ import (
 	"github.com/openfga/openfga/pkg/server/commands"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/protoadapt"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -597,10 +597,9 @@ func ReadAllTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	}
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreUnexported(openfgav1.TupleKey{}, openfgav1.Tuple{}, openfgav1.TupleChange{}, openfgav1.Assertion{}),
-		cmpopts.IgnoreFields(openfgav1.Tuple{}, "Timestamp"),
-		cmpopts.IgnoreFields(openfgav1.TupleChange{}, "Timestamp"),
-		testutils.TupleKeyCmpTransformer,
+		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.Tuple{}), "timestamp"),
+		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.TupleChange{}), "timestamp"),
+		protocmp.Transform(),
 	}
 
 	if diff := cmp.Diff(writes, receivedTuples, cmpOpts...); diff != "" {

--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openfga/openfga/pkg/server/commands"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
@@ -600,6 +601,7 @@ func ReadAllTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.Tuple{}), "timestamp"),
 		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.TupleChange{}), "timestamp"),
 		protocmp.Transform(),
+		testutils.TupleKeyCmpTransformer,
 	}
 
 	if diff := cmp.Diff(writes, receivedTuples, cmpOpts...); diff != "" {

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestStaticTupleKeyIterator(t *testing.T) {
@@ -61,8 +60,7 @@ func TestCombinedIterator(t *testing.T) {
 	}
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreUnexported(openfgav1.TupleKey{}),
-		testutils.TupleKeyCmpTransformer,
+		protocmp.Transform(),
 	}
 
 	if diff := cmp.Diff(expected, actual, cmpOpts...); diff != "" {

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -60,6 +61,7 @@ func TestCombinedIterator(t *testing.T) {
 	}
 
 	cmpOpts := []cmp.Option{
+		testutils.TupleKeyCmpTransformer,
 		protocmp.Transform(),
 	}
 

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -5,29 +5,20 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/protoadapt"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 var (
 	cmpOpts = []cmp.Option{
-		cmpopts.IgnoreUnexported(
-			openfgav1.AuthorizationModel{},
-			openfgav1.TypeDefinition{},
-			openfgav1.Userset{},
-			openfgav1.Userset_This{},
-			openfgav1.DirectUserset{},
-			openfgav1.TupleKey{},
-			openfgav1.Tuple{},
-			openfgav1.TupleChange{},
-			openfgav1.Assertion{},
-		),
-		cmpopts.IgnoreFields(openfgav1.Tuple{}, "Timestamp"),
-		cmpopts.IgnoreFields(openfgav1.TupleChange{}, "Timestamp"),
+		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.Tuple{}), "timestamp"),
+		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.TupleChange{}), "timestamp"),
 		testutils.TupleKeyCmpTransformer,
+		protocmp.Transform(),
 	}
 )
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR addresses https://github.com/openfga/openfga/issues/894 by using **protocmp** functions to check that proto messages in unit tests are semantically equal

## References
https://github.com/openfga/openfga/issues/894

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
