### PR TITLE
chore: migrate grpc auth to go-grpc-middleware/v2/interceptors/auth

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	grpc_prometheus "github.com/jon-whit/go-grpc-prometheus"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -402,11 +402,11 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	unaryInterceptors = append(unaryInterceptors,
 		storeid.NewUnaryInterceptor(),
 		logging.NewLoggingInterceptor(s.Logger),
-		grpc_auth.UnaryServerInterceptor(authnmw.AuthFunc(authenticator)),
+		grpcauth.UnaryServerInterceptor(authnmw.AuthFunc(authenticator)),
 	)
 
 	streamingInterceptors = append(streamingInterceptors,
-		grpc_auth.StreamServerInterceptor(authnmw.AuthFunc(authenticator)),
+		grpcauth.StreamServerInterceptor(authnmw.AuthFunc(authenticator)),
 		// The following interceptors wrap the server stream with our own
 		// wrapper and must come last.
 		storeid.NewStreamingInterceptor(),

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/MicahParks/keyfunc"
 	"github.com/golang-jwt/jwt/v4"
-	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/hashicorp/go-retryablehttp"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"

--- a/internal/authn/presharedkey/presharedkey.go
+++ b/internal/authn/presharedkey/presharedkey.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/openfga/openfga/internal/authn"
 )
 
@@ -27,7 +27,7 @@ func NewPresharedKeyAuthenticator(validKeys []string) (*PresharedKeyAuthenticato
 }
 
 func (pka *PresharedKeyAuthenticator) Authenticate(ctx context.Context) (*authn.AuthClaims, error) {
-	authHeader, err := grpc_auth.AuthFromMD(ctx, "Bearer")
+	authHeader, err := grpcauth.AuthFromMD(ctx, "Bearer")
 	if err != nil {
 		return nil, authn.ErrMissingBearerToken
 	}

--- a/internal/middleware/authn/authn.go
+++ b/internal/middleware/authn/authn.go
@@ -3,11 +3,11 @@ package authn
 import (
 	"context"
 
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/openfga/openfga/internal/authn"
 )
 
-func AuthFunc(authenticator authn.Authenticator) grpc_auth.AuthFunc {
+func AuthFunc(authenticator authn.Authenticator) grpcauth.AuthFunc {
 	return func(ctx context.Context) (context.Context, error) {
 		claims, err := authenticator.Authenticate(ctx)
 		if err != nil {

--- a/pkg/server/health/health.go
+++ b/pkg/server/health/health.go
@@ -4,7 +4,7 @@ package health
 import (
 	"context"
 
-	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"google.golang.org/grpc/codes"
 	healthv1pb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
@@ -21,7 +21,7 @@ type Checker struct {
 	TargetServiceName string
 }
 
-var _ grpc_auth.ServiceAuthFuncOverride = (*Checker)(nil)
+var _ grpcauth.ServiceAuthFuncOverride = (*Checker)(nil)
 
 // AuthFuncOverride implements the grpc_auth.ServiceAuthFuncOverride interface by bypassing authn middleware.
 func (o *Checker) AuthFuncOverride(ctx context.Context, fullMethodName string) (context.Context, error) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

- This PR migrates the auth interceptor from `github.com/grpc-ecosystem/go-grpc-middleware/auth` to `github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth`

## References

https://github.com/grpc-ecosystem/go-grpc-middleware/tree/main/interceptors/auth

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
