### PR TITLE
fix: avoid forgotten sender with context cancellation in ReverseExpand

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -235,7 +235,6 @@ func (q *ListObjectsQuery) evaluate(
 				}
 
 				resultsChan <- ListObjectsResult{Err: err}
-				return
 			}
 		}()
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openfga/openfga/pkg/storage/mysql"
 	"github.com/openfga/openfga/pkg/storage/postgres"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
@@ -198,6 +199,80 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, true, checkResponse.Allowed)
+}
+
+func TestListObjectsReleasesConnections(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := postgres.New(uri, sqlcommon.NewConfig(
+		sqlcommon.WithMaxOpenConns(1),
+		sqlcommon.WithMaxTuplesPerWrite(2000),
+	))
+	require.NoError(t, err)
+	defer ds.Close()
+
+	s := MustNewServerWithOpts(
+		WithDatastore(storagewrappers.NewContextWrapper(ds)),
+		WithMaxConcurrentReadsForListObjects(1),
+	)
+
+	storeID := ulid.Make().String()
+
+	writeAuthzModelResp, err := s.WriteAuthorizationModel(context.Background(), &openfgav1.WriteAuthorizationModelRequest{
+		StoreId: storeID,
+		TypeDefinitions: parser.MustParse(`
+		type user
+
+		type document
+		  relations
+		    define editor: [user] as self
+		`),
+		SchemaVersion: typesystem.SchemaVersion1_1,
+	})
+	require.NoError(t, err)
+
+	modelID := writeAuthzModelResp.GetAuthorizationModelId()
+
+	numTuples := 2000
+	tuples := make([]*openfgav1.TupleKey, 0, numTuples)
+	for i := 0; i < numTuples; i++ {
+		tk := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "editor", "user:jon")
+
+		tuples = append(tuples, tk)
+	}
+
+	_, err = s.Write(context.Background(), &openfgav1.WriteRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Writes: &openfgav1.TupleKeys{
+			TupleKeys: tuples,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.ListObjects(context.Background(), &openfgav1.ListObjectsRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Type:                 "document",
+		Relation:             "editor",
+		User:                 "user:jon",
+	})
+	require.NoError(t, err)
+
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer timeoutCancel()
+
+	checkResp, err := s.Check(timeoutCtx, &openfgav1.CheckRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		TupleKey:             tuple.NewTupleKey("document:0", "editor", "user:jon"),
+	})
+
+	// If ListObjects is still hogging the database connection pool even after responding, then this Check fails.
+	// If ListObjects is closing up its connections effectively then this Check will not fail.
+	require.NoError(t, err)
+	require.True(t, checkResp.GetAllowed())
 }
 
 func TestOperationsWithInvalidModel(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -263,16 +263,11 @@ func TestListObjectsReleasesConnections(t *testing.T) {
 	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer timeoutCancel()
 
-	checkResp, err := s.Check(timeoutCtx, &openfgav1.CheckRequest{
-		StoreId:              storeID,
-		AuthorizationModelId: modelID,
-		TupleKey:             tuple.NewTupleKey("document:0", "editor", "user:jon"),
-	})
-
-	// If ListObjects is still hogging the database connection pool even after responding, then this Check fails.
-	// If ListObjects is closing up its connections effectively then this Check will not fail.
+	// If ListObjects is still hogging the database connection pool even after responding, then this fails.
+	// If ListObjects is closing up its connections effectively then this will not fail.
+	ready, err := ds.IsReady(timeoutCtx)
 	require.NoError(t, err)
-	require.True(t, checkResp.GetAllowed())
+	require.True(t, ready)
 }
 
 func TestOperationsWithInvalidModel(t *testing.T) {

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1242,31 +1242,28 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 			reverseExpandQuery := reverseexpand.NewReverseExpandQuery(ds, typesystem.New(model), opts...)
 
 			resultChan := make(chan *reverseexpand.ReverseExpandResult, 100)
-			done := make(chan struct{})
-
-			var results []*reverseexpand.ReverseExpandResult
-			go func() {
-				for result := range resultChan {
-					results = append(results, result)
-				}
-
-				done <- struct{}{}
-			}()
 
 			timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
 			resolutionMetadata := reverseexpand.NewResolutionMetadata()
 
+			reverseExpandErrCh := make(chan error, 1)
 			go func() {
 				err := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
-				require.ErrorIs(err, test.expectedError)
+				reverseExpandErrCh <- err
 			}()
+
+			var results []*reverseexpand.ReverseExpandResult
+			for result := range resultChan {
+				results = append(results, result)
+			}
 
 			select {
 			case <-timeoutCtx.Done():
 				require.FailNow("timed out waiting for response")
-			case <-done:
+			case err := <-reverseExpandErrCh:
+				require.ErrorIs(err, test.expectedError)
 			}
 
 			if test.expectedError == nil {

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1213,8 +1213,6 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1213,6 +1213,8 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 	}
 
 	for _, test := range tests {
+		test := test
+
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
 
@@ -1257,7 +1259,7 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 			resolutionMetadata := reverseexpand.NewResolutionMetadata()
 
 			go func() {
-				err = reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				err := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
 				require.ErrorIs(err, test.expectedError)
 			}()
 

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1259,7 +1259,6 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 			go func() {
 				err = reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
 				require.ErrorIs(err, test.expectedError)
-				close(resultChan)
 			}()
 
 			select {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This fixes a problem where dangling goroutines in ReverseExpand are all blocked on a channel that no longer has a listener. Instead, we listen on context and if it is cancelled we avoid trying to send on the channel.

## References
https://github.com/openfga/openfga/issues/1033

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
