### PR TITLE
ci: fix benchmark reporting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,23 +26,23 @@ jobs:
           set -o pipefail
           make bench-cicd | tee bench_output.txt
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-go-benchmark
-
-      - name: Store benchmark result
+      - name: Get benchmark as JSON
         uses: benchmark-action/github-action-benchmark@70405016b032d44f409e4b1b451c40215cbe2393 # v1.18.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
           # Where the output from the benchmark tool is stored
           output-file-path: bench_output.txt
-          # Where the previous data file is stored
+          # Write benchmarks to this file
           external-data-json-path: ./cache/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
+
+      - name: Save benchmark JSON to cache
+        uses: actions/cache/save@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: ./cache/benchmark-data.json
+          # Save with commit hash to avoid "cache already exists"
+          key: ${{ github.sha }}-go-benchmark

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write # to be able to write comments
 
 jobs:
   lint:
@@ -97,6 +97,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
+        with:
+          fetch-depth: 0 # to be able to retrieve the last commit in main
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
@@ -108,23 +110,29 @@ jobs:
       - name: Run benchmark
         run: |
           set -o pipefail
-          make bench-cicd | tee ${{ github.sha }}_bench_output.txt
+          make bench | tee ${{ github.sha }}_bench_output.txt
 
-      # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+      - name: Get Main branch SHA
+        id: get-main-branch-sha
+        run: |
+          SHA=$(git rev-parse origin/main)
+          echo "sha=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Get benchmark JSON from main branch
+        uses: actions/cache/restore@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
         with:
-          path: ./cache
-          key: ${{ runner.os }}-go-benchmark
+          path: ./cache/benchmark-data.json
+          key: ${{ steps.get-main-branch-sha.outputs.sha }}-go-benchmark
+          fail-on-cache-miss: true
 
-      - name: Compare benchmark result
+      - name: Compare benchmarks
         uses: benchmark-action/github-action-benchmark@70405016b032d44f409e4b1b451c40215cbe2393 # v1.18.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
           # Where the output from the benchmark tool is stored
           output-file-path: ${{ github.sha }}_bench_output.txt
-          # Where the previous data file is stored
+          # Where the benchmarks in main are (to compare)
           external-data-json-path: ./cache/benchmark-data.json
           # Do not save the data
           save-data-file: false
@@ -132,3 +140,6 @@ jobs:
           fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-on-alert: true
+          # Enable Job Summary for PRs
+          summary-always: true
+          comment-always: true

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write # to be able to write comments
+  contents: read
 
 jobs:
   lint:
@@ -139,7 +139,5 @@ jobs:
           # Workflow will fail when an alert happens
           fail-on-alert: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
           # Enable Job Summary for PRs
           summary-always: true
-          comment-always: true

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,3 @@ functional-test: ## Run functional tests (needs build-functional-test-image)
 .PHONY: bench
 bench: go-generate ## Run benchmark test. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
 	go test ./... -bench . -benchtime 5s -timeout 0 -run=XXX -cpu 1 -benchmem
-
-.PHONY: bench-cicd
-bench-cicd: go-generate ## Run benchmark test. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
-	go test ./... -bench="BenchmarkOpenFGAServer/BenchmarkMemoryDatastore|BenchmarkCheckMemory" -benchtime 5s -timeout 0 -run=XXX -cpu 1 -benchmem


### PR DESCRIPTION
## Description

How it works after this PR: on push to `main` we generate and save benchmarks and on every commit to a PR we compare against `main`.

Tested in a personal repo: https://github.com/miparnisari/benchtest/actions/runs/6589243682/job/17903264164?pr=22

<img width="1080" alt="image" src="https://github.com/openfga/openfga/assets/5374887/34fe0e09-26a7-4281-8e0c-1d5953d75628">


