### PR TITLE
test: adding unit tests to validate result of read assertion

### DIFF
--- a/pkg/server/commands/read_assertions.go
+++ b/pkg/server/commands/read_assertions.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"

--- a/pkg/server/commands/read_assertions.go
+++ b/pkg/server/commands/read_assertions.go
@@ -2,8 +2,6 @@ package commands
 
 import (
 	"context"
-	"errors"
-
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
@@ -25,9 +23,6 @@ func NewReadAssertionsQuery(backend storage.AssertionsBackend, logger logger.Log
 func (q *ReadAssertionsQuery) Execute(ctx context.Context, store, authorizationModelID string) (*openfgav1.ReadAssertionsResponse, error) {
 	assertions, err := q.backend.ReadAssertions(ctx, store, authorizationModelID)
 	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, serverErrors.AssertionsNotForAuthorizationModelFound(authorizationModelID)
-		}
 		return nil, serverErrors.HandleError("", err)
 	}
 	return &openfgav1.ReadAssertionsResponse{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -488,7 +488,7 @@ func TestCheckWithCachedResolution(t *testing.T) {
 	require.True(t, checkResponse.Allowed)
 }
 
-func TestWriteAndReadAssertionModelDSError(t *testing.T) {
+func TestWriteAssertionModelDSError(t *testing.T) {
 	ctx := context.Background()
 
 	storeID := ulid.Make().String()
@@ -568,7 +568,6 @@ func TestWriteAndReadAssertionModelDSError(t *testing.T) {
 	}
 
 	for _, curTest := range tests {
-		curTest := curTest
 		t.Run(curTest.name, func(t *testing.T) {
 			request := &openfgav1.WriteAssertionsRequest{
 				StoreId:              storeID,
@@ -582,7 +581,6 @@ func TestWriteAndReadAssertionModelDSError(t *testing.T) {
 			require.ErrorIs(t, curTest.expectedError, err)
 		})
 	}
-
 }
 
 func TestReadAssertionModelDSError(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -17,6 +17,8 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
+	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/server/commands"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/test"
 	"github.com/openfga/openfga/pkg/storage"
@@ -484,6 +486,127 @@ func TestCheckWithCachedResolution(t *testing.T) {
 
 	require.NoError(t, err)
 	require.True(t, checkResponse.Allowed)
+}
+
+func TestWriteAndReadAssertionModelDSError(t *testing.T) {
+	ctx := context.Background()
+
+	storeID := ulid.Make().String()
+	modelID := ulid.Make().String()
+
+	typedefs := parser.MustParse(`
+	type user
+
+	type repo
+	  relations
+	    define reader: [user] as self
+	`)
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDSOldSchema := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	mockDSOldSchema.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		AnyTimes().
+		Return(&openfgav1.AuthorizationModel{
+			SchemaVersion:   typesystem.SchemaVersion1_0,
+			TypeDefinitions: typedefs,
+		}, nil)
+
+	mockDSBadReadAuthModel := mockstorage.NewMockOpenFGADatastore(mockController)
+
+	mockDSBadReadAuthModel.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		AnyTimes().
+		Return(nil, fmt.Errorf("unable to read"))
+
+	mockDSBadWriteAssertions := mockstorage.NewMockOpenFGADatastore(mockController)
+	mockDSBadWriteAssertions.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		AnyTimes().
+		Return(&openfgav1.AuthorizationModel{
+			SchemaVersion:   typesystem.SchemaVersion1_1,
+			TypeDefinitions: typedefs,
+		}, nil)
+	mockDSBadWriteAssertions.EXPECT().
+		WriteAssertions(gomock.Any(), storeID, modelID, gomock.Any()).
+		AnyTimes().
+		Return(fmt.Errorf("unable to write"))
+
+	tests := []struct {
+		name          string
+		assertions    []*openfgav1.Assertion
+		mockDatastore *mockstorage.MockOpenFGADatastore
+		expectedError error
+	}{
+		{
+			name:          "unsupported_schema",
+			assertions:    []*openfgav1.Assertion{},
+			mockDatastore: mockDSOldSchema,
+			expectedError: serverErrors.ValidationError(
+				fmt.Errorf("invalid schema version"),
+			),
+		},
+		{
+			name:          "failed_to_read",
+			assertions:    []*openfgav1.Assertion{},
+			mockDatastore: mockDSBadReadAuthModel,
+			expectedError: serverErrors.NewInternalError(
+				"", fmt.Errorf("unable to read"),
+			),
+		},
+		{
+			name:          "failed_to_write",
+			assertions:    []*openfgav1.Assertion{},
+			mockDatastore: mockDSBadWriteAssertions,
+			expectedError: serverErrors.NewInternalError(
+				"", fmt.Errorf("unable to write"),
+			),
+		},
+	}
+
+	for _, curTest := range tests {
+		curTest := curTest
+		t.Run(curTest.name, func(t *testing.T) {
+			request := &openfgav1.WriteAssertionsRequest{
+				StoreId:              storeID,
+				Assertions:           curTest.assertions,
+				AuthorizationModelId: modelID,
+			}
+			logger := logger.NewNoopLogger()
+
+			writeAssertionCmd := commands.NewWriteAssertionsCommand(curTest.mockDatastore, logger)
+			_, err := writeAssertionCmd.Execute(ctx, request)
+			require.ErrorIs(t, curTest.expectedError, err)
+		})
+	}
+
+}
+
+func TestReadAssertionModelDSError(t *testing.T) {
+	ctx := context.Background()
+
+	storeID := ulid.Make().String()
+	modelID := ulid.Make().String()
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDSBadReadAssertions := mockstorage.NewMockOpenFGADatastore(mockController)
+	mockDSBadReadAssertions.EXPECT().
+		ReadAssertions(gomock.Any(), storeID, modelID).
+		AnyTimes().
+		Return(nil, fmt.Errorf("unable to read"))
+	logger := logger.NewNoopLogger()
+
+	readAssertionQuery := commands.NewReadAssertionsQuery(mockDSBadReadAssertions, logger)
+	_, err := readAssertionQuery.Execute(ctx, storeID, modelID)
+	expectedError := serverErrors.NewInternalError(
+		"", fmt.Errorf("unable to read"),
+	)
+	require.ErrorIs(t, expectedError, err)
 }
 
 func TestResolveAuthorizationModel(t *testing.T) {

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -23,7 +23,6 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestListStores", func(t *testing.T) { TestListStores(t, ds) })
 
 	t.Run("TestReadAssertionQuery", func(t *testing.T) { TestReadAssertionQuery(t, ds) })
-
 	t.Run("TestReadQuerySuccess", func(t *testing.T) { ReadQuerySuccessTest(t, ds) })
 	t.Run("TestReadQueryError", func(t *testing.T) { ReadQueryErrorTest(t, ds) })
 	t.Run("TestReadAllTuples", func(t *testing.T) { ReadAllTuplesTest(t, ds) })
@@ -56,7 +55,8 @@ func RunQueryTests(t *testing.T, ds storage.OpenFGADatastore) {
 func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestWriteCommand", func(t *testing.T) { TestWriteCommand(t, ds) })
 	t.Run("TestWriteAuthorizationModel", func(t *testing.T) { WriteAuthorizationModelTest(t, ds) })
-	t.Run("TestWriteAssertions", func(t *testing.T) { TestWriteAssertions(t, ds) })
+	t.Run("TestWriteAndReadAssertions", func(t *testing.T) { TestWriteAndReadAssertions(t, ds) })
+	t.Run("TestWriteAssertionsFailure", func(t *testing.T) { TestWriteAssertionsFailure(t, ds) })
 	t.Run("TestCreateStore", func(t *testing.T) { TestCreateStore(t, ds) })
 	t.Run("TestDeleteStore", func(t *testing.T) { TestDeleteStore(t, ds) })
 }

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	parser "github.com/craigpastro/openfga-dsl-parser/v2"
+	"github.com/google/go-cmp/cmp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/pkg/logger"
@@ -16,13 +17,14 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestWriteAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
 	type writeAssertionsTestSettings struct {
-		_name   string
-		request *openfgav1.WriteAssertionsRequest
-		err     error
+		_name      string
+		assertions []*openfgav1.Assertion
+		err        error
 	}
 
 	store := testutils.CreateRandomString(10)
@@ -43,44 +45,70 @@ func TestWriteAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
 	var tests = []writeAssertionsTestSettings{
 		{
 			_name: "writing_assertions_succeeds",
-			request: &openfgav1.WriteAssertionsRequest{
-				StoreId: store,
-				Assertions: []*openfgav1.Assertion{{
-					TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
-					Expectation: false,
-				}},
-			},
+			assertions: []*openfgav1.Assertion{{
+				TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
+				Expectation: false,
+			}},
 		},
 		{
 			_name: "writing_assertions_succeeds_when_it_is_not_directly_assignable",
-			request: &openfgav1.WriteAssertionsRequest{
-				StoreId: store,
-				Assertions: []*openfgav1.Assertion{{
-					TupleKey:    tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
+			assertions: []*openfgav1.Assertion{{
+				TupleKey:    tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
+				Expectation: false,
+			}},
+		},
+		{
+			_name: "writing_multiple_assertions_succeeds",
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
 					Expectation: false,
-				}},
+				},
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:maria"),
+					Expectation: true,
+				},
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:jon"),
+					Expectation: false,
+				},
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "reader", "user:jose"),
+					Expectation: true,
+				},
 			},
 		},
 		{
-			_name: "writing_empty_assertions_succeeds",
-			request: &openfgav1.WriteAssertionsRequest{
-				StoreId:    store,
-				Assertions: []*openfgav1.Assertion{},
+			_name: "writing_multiple_assertions_succeeds_when_it_is_not_directly_assignable",
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+				},
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "can_read", "user:maria"),
+					Expectation: false,
+				},
+				{
+					TupleKey:    tuple.NewTupleKey("repo:test", "can_read", "user:jon"),
+					Expectation: true,
+				},
 			},
+		},
+		{
+			_name:      "writing_empty_assertions_succeeds",
+			assertions: []*openfgav1.Assertion{},
 		},
 		{
 			_name: "writing_assertion_with_invalid_relation_fails",
-			request: &openfgav1.WriteAssertionsRequest{
-				StoreId: store,
-				Assertions: []*openfgav1.Assertion{
-					{
-						TupleKey: tuple.NewTupleKey(
-							"repo:test",
-							"invalidrelation",
-							"user:elbuo",
-						),
-						Expectation: false,
-					},
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey: tuple.NewTupleKey(
+						"repo:test",
+						"invalidrelation",
+						"user:elbuo",
+					),
+					Expectation: false,
 				},
 			},
 			err: serverErrors.ValidationError(
@@ -102,12 +130,28 @@ func TestWriteAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
 
 			modelID, err := writeAuthzModelCmd.Execute(ctx, model)
 			require.NoError(t, err)
+			request := &openfgav1.WriteAssertionsRequest{
+				StoreId:              store,
+				Assertions:           test.assertions,
+				AuthorizationModelId: modelID.AuthorizationModelId,
+			}
 
-			test.request.AuthorizationModelId = modelID.AuthorizationModelId
-
-			writeAssetionCmd := commands.NewWriteAssertionsCommand(datastore, logger)
-			_, err = writeAssetionCmd.Execute(ctx, test.request)
+			writeAssertionCmd := commands.NewWriteAssertionsCommand(datastore, logger)
+			_, err = writeAssertionCmd.Execute(ctx, request)
 			require.ErrorIs(t, test.err, err)
+			if err == nil {
+				query := commands.NewReadAssertionsQuery(datastore, logger)
+				actualResponse, actualError := query.Execute(ctx, store, modelID.AuthorizationModelId)
+				require.NoError(t, actualError)
+
+				expectedResponse := &openfgav1.ReadAssertionsResponse{
+					AuthorizationModelId: modelID.AuthorizationModelId,
+					Assertions:           test.assertions,
+				}
+				if diff := cmp.Diff(expectedResponse, actualResponse, protocmp.Transform()); diff != "" {
+					t.Errorf("store mismatch (-want +got):\n%s", diff)
+				}
+			}
 		})
 	}
 }

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -203,7 +203,6 @@ func TestWriteAssertionsFailure(t *testing.T, datastore storage.OpenFGADatastore
 
 	for _, test := range tests {
 		t.Run(test._name, func(t *testing.T) {
-
 			request := &openfgav1.WriteAssertionsRequest{
 				StoreId:              store,
 				Assertions:           test.assertions,


### PR DESCRIPTION
## Description
Update unit test so that we read assertion after write assertion

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
