### PR TITLE
chore: fix docker-compose.yaml

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -6,3 +6,74 @@ services:
   openfga:
     image: !reset null
     build: .
+    environment:
+      - OPENFGA_TRACE_ENABLED=true
+      - OPENFGA_TRACE_SAMPLE_RATIO=1
+      - OPENFGA_TRACE_OTLP_ENDPOINT=otel-collector:4317
+      - OPENFGA_METRICS_ENABLE_RPC_HISTOGRAMS=true
+      - OPENFGA_DATASTORE_METRICS_ENABLED=true
+      - OPENFGA_METRICS_ENABLED=TRUE
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    container_name: otel-collector
+    command: [ "--config=/etc/otel-collector-config.yaml" ]
+    volumes:
+      - "./telemetry/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
+    networks:
+      - default
+    ports:
+      - "4317:4317" #grpc OTLP receiver
+      - "2113:2113" #prometheus metrics exporter
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    command: [ "--query.max-clock-skew-adjustment", "500ms" ]
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+      - SPAN_STORAGE_TYPE=badger
+      - BADGER_EPHEMERAL=false
+      - BADGER_DIRECTORY_VALUE=/badger/data
+      - BADGER_DIRECTORY_KEY=/badger/key
+    volumes:
+      - jaegar_data:/badger
+    ports:
+      - "16686:16686" # UI
+      - "4317" # OTLP gRPC default port
+    depends_on:
+      - otel-collector
+    networks:
+      - default
+
+  prometheus:
+    image: prom/prometheus:v2.30.3
+    ports:
+      - 9090:9090 # UI
+    depends_on:
+      - otel-collector
+    volumes:
+      - ./telemetry/prometheus:/etc/prometheus
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - 3001:3000 # UI
+    restart: unless-stopped
+    depends_on:
+      prometheus:
+        condition: service_started
+    volumes:
+      - ./telemetry/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
+      - ./telemetry/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/main.yaml
+      - ./telemetry/grafana/dashboards:/etc/grafana/dashboards
+      - grafana_data:/var/lib/grafana
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  jaegar_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,8 +33,6 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
-      otel-collector:
-        condition: service_started
     image: openfga/openfga:latest
     container_name: openfga
     command: run
@@ -42,10 +40,7 @@ services:
       - OPENFGA_DATASTORE_ENGINE=postgres
       - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       - OPENFGA_DATASTORE_MAX_OPEN_CONNS=100 #see postgres container
-      - OPENFGA_TRACE_ENABLED=true
-      - OPENFGA_TRACE_SAMPLE_RATIO=1
-      - OPENFGA_TRACE_OTLP_ENDPOINT=otel-collector:4317
-      - OPENFGA_METRICS_ENABLE_RPC_HISTOGRAMS=true
+      - OPENFGA_PLAYGROUND_ENABLED=true
     networks:
       - default
     ports:
@@ -58,67 +53,3 @@ services:
       interval: 5s
       timeout: 30s
       retries: 3
-
-  otel-collector:
-    image: otel/opentelemetry-collector:latest
-    container_name: otel-collector
-    command: [ "--config=/etc/otel-collector-config.yaml" ]
-    volumes:
-      - "./telemetry/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
-    networks:
-      - default
-    ports:
-      - "4317:4317" #grpc OTLP receiver
-      - "2113:2113" #prometheus metrics exporter
-
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: jaeger
-    command: ["--query.max-clock-skew-adjustment", "500ms"]
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-      - SPAN_STORAGE_TYPE=badger
-      - BADGER_EPHEMERAL=false
-      - BADGER_DIRECTORY_VALUE=/badger/data
-      - BADGER_DIRECTORY_KEY=/badger/key
-    volumes:
-      - jaegar_data:/badger
-    ports:
-      - "16686:16686" # UI
-      - "4317" # OTLP gRPC default port
-    depends_on:
-      - otel-collector
-    networks:
-      - default
-
-  prometheus:
-    image: prom/prometheus:v2.30.3
-    ports:
-      - 9090:9090 # UI
-    depends_on:
-      - otel-collector
-    volumes:
-      - ./telemetry/prometheus:/etc/prometheus
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-
-  grafana:
-      image: grafana/grafana
-      ports:
-        - 3001:3000 # UI
-      restart: unless-stopped
-      depends_on:
-        prometheus:
-          condition: service_started
-      volumes:
-        - ./telemetry/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources
-        - ./telemetry/grafana/provisioning/dashboards/dashboards.yml:/etc/grafana/provisioning/dashboards/main.yaml
-        - ./telemetry/grafana/dashboards:/etc/grafana/dashboards
-        - grafana_data:/var/lib/grafana
-volumes:
-  prometheus_data:
-  grafana_data:
-  jaegar_data:


### PR DESCRIPTION
## Description
Fix https://github.com/openfga/openfga/issues/1047

- basic `docker-compose.yaml` will have the most minimal setup necessary (just openfga & postgres). So that the [README steps](https://github.com/openfga/openfga#docker-compose) work
- `docker-compose.override.yaml` will have all the observability enabled for easier debugging

## Testing

```
$ docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up
// spins 6 containers

$ docker-compose -f docker-compose.yaml up
// spins 2 containers
```