### PR TITLE
chore: add counter on expired cache entry

### DIFF
--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -31,6 +31,11 @@ var (
 		Name: "check_cache_hit_count",
 		Help: "The total number of cache hits for ResolveCheck.",
 	})
+
+	checkCacheExpiredCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "check_cache_expired_count",
+		Help: "The total number of cache misses for ResolveCheck due to entry expired.",
+	})
 )
 
 // CachedResolveCheckResponse is very similar to ResolveCheckResponse except we
@@ -158,6 +163,8 @@ func (c *CachedCheckResolver) ResolveCheck(
 	if cachedResp != nil && !cachedResp.Expired() {
 		checkCacheHitCounter.Inc()
 		return cachedResp.Value().convertToResolveCheckResponse(), nil
+	} else if cachedResp != nil && cachedResp.Expired() {
+		checkCacheExpiredCounter.Inc()
 	}
 
 	resp, err := c.delegate.ResolveCheck(ctx, req)


### PR DESCRIPTION

## Description
Add counter on number of cache miss due to entry being expired

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
