### PR TITLE
fix: expose errors from conditions

### DIFF
--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -15,7 +15,7 @@ func TestNewCompiled(t *testing.T) {
 	var tests = []struct {
 		name      string
 		condition *openfgav1.Condition
-		err       error
+		err       *condition.CompilationError
 	}{
 		{
 			name: "valid",
@@ -41,7 +41,10 @@ func TestNewCompiled(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Errorf("failed to decode parameter type for parameter 'param1': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
+			err: &condition.CompilationError{
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("failed to decode parameter type for parameter 'param1': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
+			},
 		},
 		{
 			name: "invalid_expression",
@@ -55,7 +58,8 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Cause: fmt.Errorf("ERROR: condition1:1:1: undeclared reference to 'invalid' (in container '')\n | invalid\n | ^"),
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("ERROR: condition1:1:1: undeclared reference to 'invalid' (in container '')\n | invalid\n | ^"),
 			},
 		},
 		{
@@ -70,7 +74,8 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Cause: fmt.Errorf("expected a bool condition expression output, but got 'string'"),
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("expected a bool condition expression output, but got 'string'"),
 			},
 		},
 		{
@@ -81,7 +86,8 @@ func TestNewCompiled(t *testing.T) {
 				Parameters: map[string]*openfgav1.ConditionParamTypeRef{},
 			},
 			err: &condition.CompilationError{
-				Cause: fmt.Errorf("ERROR: condition1:1:10: found no matching overload for 'ipaddress' applied to '(bool)'\n | ipaddress(true).in_cidr(\"192.168.0.0/24\")\n | .........^"),
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("ERROR: condition1:1:10: found no matching overload for 'ipaddress' applied to '(bool)'\n | ipaddress(true).in_cidr(\"192.168.0.0/24\")\n | .........^"),
 			},
 		},
 	}
@@ -91,7 +97,7 @@ func TestNewCompiled(t *testing.T) {
 			_, err := condition.NewCompiled(test.condition)
 
 			if test.err != nil {
-				require.Equal(t, err, test.err)
+				require.EqualError(t, err, test.err.Error())
 			} else {
 				require.NoError(t, err)
 			}
@@ -105,7 +111,7 @@ func TestEvaluate(t *testing.T) {
 		condition *openfgav1.Condition
 		context   map[string]interface{}
 		result    condition.EvaluationResult
-		err       error
+		err       *condition.EvaluationError
 	}{
 		{
 			name: "success_condition_met",
@@ -122,7 +128,6 @@ func TestEvaluate(t *testing.T) {
 				"param1": "ok",
 			},
 			result: condition.EvaluationResult{ConditionMet: true},
-			err:    nil,
 		},
 		{
 			name: "success_condition_unmet",
@@ -137,7 +142,6 @@ func TestEvaluate(t *testing.T) {
 			},
 			context: map[string]interface{}{"param1": "notok"},
 			result:  condition.EvaluationResult{ConditionMet: false},
-			err:     nil,
 		},
 		{
 			name: "fail_no_such_attribute_nil_context",
@@ -207,7 +211,13 @@ func TestEvaluate(t *testing.T) {
 				"param1": true,
 			},
 			result: condition.EvaluationResult{ConditionMet: false},
-			err:    fmt.Errorf("failed to evaluate relationship condition: failed to convert context parameter 'param1': expected type value 'string', but found '\"bool\"'"),
+			err: &condition.EvaluationError{
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause: &condition.ParameterTypeError{
+					Condition: &openfgav1.Condition{Name: "condition1"},
+					Cause:     fmt.Errorf("failed to convert context parameter 'param1': expected type value 'string', but found 'bool'"),
+				},
+			},
 		},
 		{
 			name: "ipaddress_literal",
@@ -229,7 +239,8 @@ func TestEvaluate(t *testing.T) {
 			context: map[string]interface{}{},
 			result:  condition.EvaluationResult{ConditionMet: false},
 			err: &condition.EvaluationError{
-				Cause: fmt.Errorf("failed to evaluate condition expression: ParseAddr(\"192.168.0\"): IPv4 address too short"),
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("failed to evaluate condition expression: ParseAddr(\"192.168.0\"): IPv4 address too short"),
 			},
 		},
 	}
@@ -257,7 +268,7 @@ func TestCastContextToTypedParameters(t *testing.T) {
 		contextMap              map[string]any
 		conditionParameterTypes map[string]*openfgav1.ConditionParamTypeRef
 		expectedParams          map[string]any
-		expectedError           error
+		expectedError           *condition.ParameterTypeError
 	}{
 		{
 			name: "valid",
@@ -272,14 +283,12 @@ func TestCastContextToTypedParameters(t *testing.T) {
 			expectedParams: map[string]any{
 				"param1": mustConvertValue(types.StringParamType, "ok"),
 			},
-			expectedError: nil,
 		},
 		{
 			name:                    "empty_context_map",
 			contextMap:              map[string]any{},
 			conditionParameterTypes: map[string]*openfgav1.ConditionParamTypeRef{},
 			expectedParams:          nil,
-			expectedError:           nil,
 		},
 		{
 			name: "empty_parameter_types",
@@ -288,7 +297,10 @@ func TestCastContextToTypedParameters(t *testing.T) {
 			},
 			conditionParameterTypes: map[string]*openfgav1.ConditionParamTypeRef{},
 			expectedParams:          nil,
-			expectedError:           fmt.Errorf("no parameters defined for the condition"),
+			expectedError: &condition.ParameterTypeError{
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("no parameters defined for the condition"),
+			},
 		},
 		{
 			name: "failed_to_decode_condition_parameter_type",
@@ -301,7 +313,10 @@ func TestCastContextToTypedParameters(t *testing.T) {
 				},
 			},
 			expectedParams: nil,
-			expectedError:  fmt.Errorf("failed to decode condition parameter type 'TYPE_NAME_UNSPECIFIED': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
+			expectedError: &condition.ParameterTypeError{
+				Condition: &openfgav1.Condition{Name: "condition1"},
+				Cause:     fmt.Errorf("failed to decode condition parameter type 'TYPE_NAME_UNSPECIFIED': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
+			},
 		},
 	}
 

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -42,7 +42,7 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("failed to decode parameter type for parameter 'param1': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
 			},
 		},
@@ -58,7 +58,7 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("ERROR: condition1:1:1: undeclared reference to 'invalid' (in container '')\n | invalid\n | ^"),
 			},
 		},
@@ -74,7 +74,7 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("expected a bool condition expression output, but got 'string'"),
 			},
 		},
@@ -86,7 +86,7 @@ func TestNewCompiled(t *testing.T) {
 				Parameters: map[string]*openfgav1.ConditionParamTypeRef{},
 			},
 			err: &condition.CompilationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("ERROR: condition1:1:10: found no matching overload for 'ipaddress' applied to '(bool)'\n | ipaddress(true).in_cidr(\"192.168.0.0/24\")\n | .........^"),
 			},
 		},
@@ -212,9 +212,9 @@ func TestEvaluate(t *testing.T) {
 			},
 			result: condition.EvaluationResult{ConditionMet: false},
 			err: &condition.EvaluationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause: &condition.ParameterTypeError{
-					Condition: &openfgav1.Condition{Name: "condition1"},
+					Condition: "condition1",
 					Cause:     fmt.Errorf("failed to convert context parameter 'param1': expected type value 'string', but found 'bool'"),
 				},
 			},
@@ -239,7 +239,7 @@ func TestEvaluate(t *testing.T) {
 			context: map[string]interface{}{},
 			result:  condition.EvaluationResult{ConditionMet: false},
 			err: &condition.EvaluationError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("failed to evaluate condition expression: ParseAddr(\"192.168.0\"): IPv4 address too short"),
 			},
 		},
@@ -298,7 +298,7 @@ func TestCastContextToTypedParameters(t *testing.T) {
 			conditionParameterTypes: map[string]*openfgav1.ConditionParamTypeRef{},
 			expectedParams:          nil,
 			expectedError: &condition.ParameterTypeError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("no parameters defined for the condition"),
 			},
 		},
@@ -314,7 +314,7 @@ func TestCastContextToTypedParameters(t *testing.T) {
 			},
 			expectedParams: nil,
 			expectedError: &condition.ParameterTypeError{
-				Condition: &openfgav1.Condition{Name: "condition1"},
+				Condition: "condition1",
 				Cause:     fmt.Errorf("failed to decode condition parameter type 'TYPE_NAME_UNSPECIFIED': unknown condition parameter type `TYPE_NAME_UNSPECIFIED`"),
 			},
 		},

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -81,8 +81,7 @@ func TestNewCompiled(t *testing.T) {
 				Parameters: map[string]*openfgav1.ConditionParamTypeRef{},
 			},
 			err: &condition.CompilationError{
-				Expression: `ipaddress(true).in_cidr("192.168.0.0/24")`,
-				Cause:      fmt.Errorf("ERROR: condition1:1:10: found no matching overload for 'ipaddress' applied to '(bool)'\n | ipaddress(true).in_cidr(\"192.168.0.0/24\")\n | .........^"),
+				Cause: fmt.Errorf("ERROR: condition1:1:10: found no matching overload for 'ipaddress' applied to '(bool)'\n | ipaddress(true).in_cidr(\"192.168.0.0/24\")\n | .........^"),
 			},
 		},
 	}
@@ -229,7 +228,9 @@ func TestEvaluate(t *testing.T) {
 			},
 			context: map[string]interface{}{},
 			result:  condition.EvaluationResult{ConditionMet: false},
-			err:     fmt.Errorf("failed to evaluate condition expression: ParseAddr(\"192.168.0\"): IPv4 address too short"),
+			err: &condition.EvaluationError{
+				Cause: fmt.Errorf("failed to evaluate condition expression: ParseAddr(\"192.168.0\"): IPv4 address too short"),
+			},
 		},
 	}
 

--- a/pkg/condition/condition_test.go
+++ b/pkg/condition/condition_test.go
@@ -55,8 +55,7 @@ func TestNewCompiled(t *testing.T) {
 				},
 			},
 			err: &condition.CompilationError{
-				Expression: "invalid",
-				Cause:      fmt.Errorf("ERROR: condition1:1:1: undeclared reference to 'invalid' (in container '')\n | invalid\n | ^"),
+				Cause: fmt.Errorf("ERROR: condition1:1:1: undeclared reference to 'invalid' (in container '')\n | invalid\n | ^"),
 			},
 		},
 		{
@@ -70,7 +69,9 @@ func TestNewCompiled(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Errorf("expected a bool condition expression output, but got 'string'"),
+			err: &condition.CompilationError{
+				Cause: fmt.Errorf("expected a bool condition expression output, but got 'string'"),
+			},
 		},
 	}
 
@@ -195,7 +196,7 @@ func TestEvaluate(t *testing.T) {
 				"param1": true,
 			},
 			result: condition.EvaluationResult{ConditionMet: false},
-			err:    fmt.Errorf("failed to convert context parameter 'param1': for string: unexpected type value '\"bool\"', expected 'string'"),
+			err:    fmt.Errorf("failed to evaluate relationship condition: failed to convert context parameter 'param1': expected type value 'string', but found '\"bool\"'"),
 		},
 	}
 

--- a/pkg/condition/errors.go
+++ b/pkg/condition/errors.go
@@ -1,16 +1,41 @@
 package condition
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type CompilationError struct {
-	Expression string
-	Cause      error
+	Cause error
 }
 
 func (e *CompilationError) Error() string {
-	return fmt.Sprintf("failed to compile condition expression '%s'", e.Expression)
+	return fmt.Sprintf("failed to compile condition expression: %v", e.Cause)
 }
 
 func (e *CompilationError) Unwrap() error {
+	return e.Cause
+}
+
+type EvaluationError struct {
+	Cause error
+}
+
+func (e *EvaluationError) Error() string {
+	return fmt.Sprintf("failed to evaluate relationship condition: %v", e.Cause)
+}
+
+func (e *EvaluationError) Unwrap() error {
+	return e.Cause
+}
+
+type ParameterTypeError struct {
+	Cause error
+}
+
+func (e *ParameterTypeError) Error() string {
+	return e.Cause.Error()
+}
+
+func (e *ParameterTypeError) Unwrap() error {
 	return e.Cause
 }

--- a/pkg/condition/errors.go
+++ b/pkg/condition/errors.go
@@ -2,17 +2,15 @@ package condition
 
 import (
 	"fmt"
-
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
 
 type CompilationError struct {
-	Condition *openfgav1.Condition
+	Condition string
 	Cause     error
 }
 
 func (e *CompilationError) Error() string {
-	return fmt.Sprintf("failed to compile expression on condition '%s': %v", e.Condition.Name, e.Cause)
+	return fmt.Sprintf("failed to compile expression on condition '%s': %v", e.Condition, e.Cause)
 }
 
 func (e *CompilationError) Unwrap() error {
@@ -20,12 +18,12 @@ func (e *CompilationError) Unwrap() error {
 }
 
 type EvaluationError struct {
-	Condition *openfgav1.Condition
+	Condition string
 	Cause     error
 }
 
 func (e *EvaluationError) Error() string {
-	return fmt.Sprintf("failed to evaluate relationship condition '%s': %v", e.Condition.Name, e.Cause)
+	return fmt.Sprintf("failed to evaluate relationship condition '%s': %v", e.Condition, e.Cause)
 }
 
 func (e *EvaluationError) Unwrap() error {
@@ -33,12 +31,12 @@ func (e *EvaluationError) Unwrap() error {
 }
 
 type ParameterTypeError struct {
-	Condition *openfgav1.Condition
+	Condition string
 	Cause     error
 }
 
 func (e *ParameterTypeError) Error() string {
-	return fmt.Sprintf("parameter type error on condition '%s': %v", e.Condition.Name, e.Cause)
+	return fmt.Sprintf("parameter type error on condition '%s': %v", e.Condition, e.Cause)
 }
 
 func (e *ParameterTypeError) Unwrap() error {

--- a/pkg/condition/errors.go
+++ b/pkg/condition/errors.go
@@ -2,14 +2,17 @@ package condition
 
 import (
 	"fmt"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
 
 type CompilationError struct {
-	Cause error
+	Condition *openfgav1.Condition
+	Cause     error
 }
 
 func (e *CompilationError) Error() string {
-	return fmt.Sprintf("failed to compile condition expression: %v", e.Cause)
+	return fmt.Sprintf("failed to compile expression on condition '%s': %v", e.Condition.Name, e.Cause)
 }
 
 func (e *CompilationError) Unwrap() error {
@@ -17,11 +20,12 @@ func (e *CompilationError) Unwrap() error {
 }
 
 type EvaluationError struct {
-	Cause error
+	Condition *openfgav1.Condition
+	Cause     error
 }
 
 func (e *EvaluationError) Error() string {
-	return fmt.Sprintf("failed to evaluate relationship condition: %v", e.Cause)
+	return fmt.Sprintf("failed to evaluate relationship condition '%s': %v", e.Condition.Name, e.Cause)
 }
 
 func (e *EvaluationError) Unwrap() error {
@@ -29,11 +33,12 @@ func (e *EvaluationError) Unwrap() error {
 }
 
 type ParameterTypeError struct {
-	Cause error
+	Condition *openfgav1.Condition
+	Cause     error
 }
 
 func (e *ParameterTypeError) Error() string {
-	return e.Cause.Error()
+	return fmt.Sprintf("parameter type error on condition '%s': %v", e.Condition.Name, e.Cause)
 }
 
 func (e *ParameterTypeError) Unwrap() error {

--- a/pkg/condition/eval/eval.go
+++ b/pkg/condition/eval/eval.go
@@ -1,8 +1,6 @@
 package eval
 
 import (
-	"fmt"
-
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
@@ -22,7 +20,7 @@ func TupleConditionMet(
 			tupleCondition.GetContext().AsMap(),
 		)
 		if err != nil {
-			return false, fmt.Errorf("failed to evaluate relationship condition: %v", err)
+			return false, err
 		}
 
 		if !conditionResult.ConditionMet {

--- a/pkg/condition/eval/eval.go
+++ b/pkg/condition/eval/eval.go
@@ -1,7 +1,10 @@
 package eval
 
 import (
+	"fmt"
+
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
@@ -17,7 +20,10 @@ func TupleConditionMet(
 	if conditionName != "" {
 		evaluableCondition, ok := typesys.GetCondition(conditionName)
 		if !ok {
-			return false, fmt.Errorf("failed to evaluate relationship condition: condition '%s' was not found", conditionName)
+			return false, &condition.EvaluationError{
+				Condition: conditionName,
+				Cause:     fmt.Errorf("condition was not found"),
+			}
 		}
 
 		// merge both contexts

--- a/pkg/condition/eval/eval_test.go
+++ b/pkg/condition/eval/eval_test.go
@@ -36,7 +36,7 @@ condition correct_ip(ip: string) {
 }`),
 			context:      map[string]interface{}{"ip": "192.168.0.1"},
 			conditionMet: false,
-			expectedErr:  "failed to evaluate relationship condition: condition 'unknown' was not found",
+			expectedErr:  "failed to evaluate relationship condition 'unknown': condition was not found",
 		},
 		{
 			name:     "condition_not_met",

--- a/pkg/condition/types/converters.go
+++ b/pkg/condition/types/converters.go
@@ -10,7 +10,7 @@ import (
 func primitiveTypeConverterFunc[T any](value any) (any, error) {
 	v, ok := value.(T)
 	if !ok {
-		return nil, fmt.Errorf("expected type value '%T', but found '%q'", *new(T), reflect.TypeOf(value))
+		return nil, fmt.Errorf("expected type value '%T', but found '%s'", *new(T), reflect.TypeOf(value))
 	}
 
 	return v, nil
@@ -27,7 +27,7 @@ func numericTypeConverterFunc[T int64 | uint64 | float64](value any) (any, error
 	if !ok {
 		stringValue, ok := value.(string)
 		if !ok {
-			return nil, fmt.Errorf("expected type value '%T', but found '%q'", *new(T), reflect.TypeOf(value))
+			return nil, fmt.Errorf("expected type value '%T', but found '%s'", *new(T), reflect.TypeOf(value))
 		}
 
 		f, _, err := big.ParseFloat(stringValue, 10, 64, 0)

--- a/pkg/condition/types/converters.go
+++ b/pkg/condition/types/converters.go
@@ -10,7 +10,7 @@ import (
 func primitiveTypeConverterFunc[T any](value any) (any, error) {
 	v, ok := value.(T)
 	if !ok {
-		return nil, fmt.Errorf("unexpected type value '%q', expected '%T'", reflect.TypeOf(value), *new(T))
+		return nil, fmt.Errorf("expected type value '%T', but found '%q'", *new(T), reflect.TypeOf(value))
 	}
 
 	return v, nil
@@ -27,12 +27,12 @@ func numericTypeConverterFunc[T int64 | uint64 | float64](value any) (any, error
 	if !ok {
 		stringValue, ok := value.(string)
 		if !ok {
-			return nil, fmt.Errorf("unexpected type value '%q', expected '%T'", reflect.TypeOf(value), *new(T))
+			return nil, fmt.Errorf("expected type value '%T', but found '%q'", *new(T), reflect.TypeOf(value))
 		}
 
 		f, _, err := big.ParseFloat(stringValue, 10, 64, 0)
 		if err != nil {
-			return nil, fmt.Errorf("a %T value is expected, but found invalid string value `%v`", *new(T), value)
+			return nil, fmt.Errorf("expected a %T value, but found invalid string value '%v'", *new(T), value)
 		}
 
 		bigFloat = f
@@ -42,7 +42,7 @@ func numericTypeConverterFunc[T int64 | uint64 | float64](value any) (any, error
 	switch any(n).(type) {
 	case int64:
 		if !bigFloat.IsInt() {
-			return nil, fmt.Errorf("a int value is expected, but found numeric value `%s`", bigFloat.String())
+			return nil, fmt.Errorf("expected an int value, but found numeric value '%s'", bigFloat.String())
 		}
 
 		numericValue, _ := bigFloat.Int64()
@@ -50,12 +50,12 @@ func numericTypeConverterFunc[T int64 | uint64 | float64](value any) (any, error
 
 	case uint64:
 		if !bigFloat.IsInt() {
-			return nil, fmt.Errorf("a uint value is expected, but found numeric value `%s`", bigFloat.String())
+			return nil, fmt.Errorf("expected a uint value, but found numeric value '%s'", bigFloat.String())
 		}
 
 		numericValue, _ := bigFloat.Int64()
 		if numericValue < 0 {
-			return nil, fmt.Errorf("a uint value is expected, but found int64 value `%s`", bigFloat.String())
+			return nil, fmt.Errorf("expected a uint value, but found int64 value '%s'", bigFloat.String())
 		}
 		return uint64(numericValue), nil
 
@@ -75,12 +75,12 @@ func anyTypeConverterFunc(value any) (any, error) {
 func durationTypeConverterFunc(value any) (any, error) {
 	v, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("duration require a duration string, found: %T", value)
+		return nil, fmt.Errorf("expected a duration string, but found: %T '%v'", value, value)
 	}
 
 	d, err := time.ParseDuration(v)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse duration string '%s': %w", v, err)
+		return nil, fmt.Errorf("expected a valid duration string, but found: '%v'", value)
 	}
 
 	return d, nil
@@ -89,12 +89,12 @@ func durationTypeConverterFunc(value any) (any, error) {
 func timestampTypeConverterFunc(value any) (any, error) {
 	v, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("timestamps requires a RFC 3339 formatted timestamp string, found: %T `%v`", value, value)
+		return nil, fmt.Errorf("expected RFC 3339 formatted timestamp string, but found: %T '%v'", value, value)
 	}
 
 	d, err := time.Parse(time.RFC3339, v)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse RFC 3339 formatted timestamp string `%s`: %w", v, err)
+		return nil, fmt.Errorf("expected RFC 3339 formatted timestamp string, but found '%s'", v)
 	}
 
 	return d, nil
@@ -108,12 +108,12 @@ func ipaddressTypeConverterFunc(value any) (any, error) {
 
 	v, ok := value.(string)
 	if !ok {
-		return nil, fmt.Errorf("an ipaddress string is required for an ipaddress parameter type, got: %T `%v`", value, value)
+		return nil, fmt.Errorf("expected an ipaddress string, but found: %T '%v'", value, value)
 	}
 
 	d, err := ParseIPAddress(v)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse string as an ipaddress `%s`: %w", v, err)
+		return nil, fmt.Errorf("expected a well-formed IP address, but found: '%s'", v)
 	}
 
 	return d, nil

--- a/pkg/condition/types/generic.go
+++ b/pkg/condition/types/generic.go
@@ -22,7 +22,7 @@ func mapTypeConverterFunc(genericTypes []ParameterType) ParameterType {
 			for key, item := range v {
 				convertedItem, err := genericTypes[0].ConvertValue(item)
 				if err != nil {
-					return nil, fmt.Errorf("found an invalid value for key `%s`: %w", key, err)
+					return nil, fmt.Errorf("found an invalid value for key '%s': %w", key, err)
 				}
 
 				converted[key] = convertedItem

--- a/pkg/condition/types/types.go
+++ b/pkg/condition/types/types.go
@@ -158,7 +158,7 @@ func (pt ParameterType) String() string {
 func (pt ParameterType) ConvertValue(value any) (any, error) {
 	converted, err := pt.typedParamConverter(value)
 	if err != nil {
-		return nil, fmt.Errorf("for %s: %w", pt.String(), err)
+		return nil, err
 	}
 
 	return converted, nil

--- a/pkg/condition/types/types_test.go
+++ b/pkg/condition/types/types_test.go
@@ -45,7 +45,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "string",
 			expectedError: fmt.Errorf(
-				"for string: unexpected type value '\"int64\"', expected 'string'",
+				"expected type value 'string', but found '\"int64\"'",
 			),
 		},
 		{
@@ -83,7 +83,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "uint",
 			expectedError: fmt.Errorf(
-				"for uint: a uint value is expected, but found numeric value `10.5`",
+				"expected a uint value, but found numeric value '10.5'",
 			),
 		},
 		{
@@ -93,7 +93,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "uint",
 			expectedError: fmt.Errorf(
-				"for uint: a uint value is expected, but found numeric value `-10.5`",
+				"expected a uint value, but found numeric value '-10.5'",
 			),
 		},
 		{
@@ -103,7 +103,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "int",
 			expectedError: fmt.Errorf(
-				"for int: a int value is expected, but found numeric value `10.5`",
+				"expected an int value, but found numeric value '10.5'",
 			),
 		},
 		{
@@ -127,7 +127,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "bool",
 			expectedError: fmt.Errorf(
-				"for bool: unexpected type value '\"string\"', expected 'bool'",
+				"expected type value 'bool', but found '\"string\"'",
 			),
 		},
 		{
@@ -137,7 +137,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "double",
 			expectedError: fmt.Errorf(
-				"for double: a float64 value is expected, but found invalid string value `invalid`",
+				"expected a float64 value, but found invalid string value 'invalid'",
 			),
 		},
 		{
@@ -154,7 +154,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "duration",
 			expectedError: fmt.Errorf(
-				"for duration: failed to parse duration string '2sm': time: unknown unit \"sm\" in duration \"2sm\"",
+				"expected a valid duration string, but found: '2sm'",
 			),
 		},
 		{
@@ -171,7 +171,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "timestamp",
 			expectedError: fmt.Errorf(
-				"for timestamp: could not parse RFC 3339 formatted timestamp string `2023-0914`: parsing time \"2023-0914\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"14\" as \"-\"",
+				"expected RFC 3339 formatted timestamp string, but found '2023-0914'",
 			),
 		},
 		{
@@ -188,7 +188,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "ipaddress",
 			expectedError: fmt.Errorf(
-				"for ipaddress: could not parse string as an ipaddress `invalid`: ParseAddr(\"invalid\"): unable to parse IP",
+				"expected a well-formed IP address, but found: 'invalid'",
 			),
 		},
 		{
@@ -203,7 +203,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustMapParamType(StringParamType),
 			input:     map[int]any{123: "world"},
 			expectedError: fmt.Errorf(
-				"for TYPE_NAME_MAP<string>: map requires a map, found: map[int]interface {}",
+				"map requires a map, found: map[int]interface {}",
 			),
 			repr: "TYPE_NAME_MAP<string>",
 		},
@@ -212,7 +212,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustMapParamType(StringParamType),
 			input:     map[string]any{"hello": 1},
 			expectedError: fmt.Errorf(
-				"for TYPE_NAME_MAP<string>: found an invalid value for key `hello`: for string: unexpected type value '\"int\"', expected 'string'",
+				"found an invalid value for key 'hello': expected type value 'string', but found '\"int\"'",
 			),
 			repr: "TYPE_NAME_MAP<string>",
 		},
@@ -228,7 +228,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustListParamType(StringParamType),
 			input:     "hello",
 			expectedError: fmt.Errorf(
-				"for TYPE_NAME_LIST<string>: list requires a list, found: string",
+				"list requires a list, found: string",
 			),
 			repr: "TYPE_NAME_LIST<string>",
 		},
@@ -237,7 +237,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustListParamType(StringParamType),
 			input:     []any{"hello", 1},
 			expectedError: fmt.Errorf(
-				"for TYPE_NAME_LIST<string>: found an invalid list item at index `1`: for string: unexpected type value '\"int\"', expected 'string'",
+				"found an invalid list item at index `1`: expected type value 'string', but found '\"int\"'",
 			),
 			repr: "TYPE_NAME_LIST<string>",
 		},

--- a/pkg/condition/types/types_test.go
+++ b/pkg/condition/types/types_test.go
@@ -45,7 +45,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "string",
 			expectedError: fmt.Errorf(
-				"expected type value 'string', but found '\"int64\"'",
+				"expected type value 'string', but found 'int64'",
 			),
 		},
 		{
@@ -127,7 +127,7 @@ func TestPrimitives(t *testing.T) {
 			output:    nil,
 			repr:      "bool",
 			expectedError: fmt.Errorf(
-				"expected type value 'bool', but found '\"string\"'",
+				"expected type value 'bool', but found 'string'",
 			),
 		},
 		{
@@ -212,7 +212,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustMapParamType(StringParamType),
 			input:     map[string]any{"hello": 1},
 			expectedError: fmt.Errorf(
-				"found an invalid value for key 'hello': expected type value 'string', but found '\"int\"'",
+				"found an invalid value for key 'hello': expected type value 'string', but found 'int'",
 			),
 			repr: "TYPE_NAME_MAP<string>",
 		},
@@ -237,7 +237,7 @@ func TestPrimitives(t *testing.T) {
 			paramType: mustListParamType(StringParamType),
 			input:     []any{"hello", 1},
 			expectedError: fmt.Errorf(
-				"found an invalid list item at index `1`: expected type value 'string', but found '\"int\"'",
+				"found an invalid list item at index `1`: expected type value 'string', but found 'int'",
 			),
 			repr: "TYPE_NAME_LIST<string>",
 		},

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/tuple"
 	"google.golang.org/grpc/codes"
@@ -121,6 +122,14 @@ func HandleError(public string, err error) error {
 	} else if errors.Is(err, storage.ErrCancelled) {
 		return RequestCancelled
 	}
+
+	switch t := err.(type) {
+	case *condition.CompilationError,
+		*condition.EvaluationError,
+		*condition.ParameterTypeError:
+		return status.Error(codes.InvalidArgument, t.Error())
+	}
+
 	return NewInternalError(public, err)
 }
 


### PR DESCRIPTION
## Description

- Expose `CompilationError`, `EvaluationError`, and `ParameterTypeError`
- Tweak error messages
- Expose these errors instead of returning internal server errors

## References

https://github.com/openfga/openfga/pull/1038

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
