### PR TITLE
fix(ipaddr): add overload for casting string to ipaddress

### DIFF
--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -69,6 +69,8 @@ func (c *EvaluableCondition) compile() error {
 		envOpts = append(envOpts, cel.Variable(paramName, paramType.CelType()))
 	}
 
+	envOpts = append(envOpts, types.IPAddressEnvOption())
+
 	env, err := cel.NewEnv(envOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to construct CEL env: %v", err)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add a converter overload to convert a CEL string to a custom IPAddress type. This adds the ability to do the following in ABAC Conditions

```
...
condition my_cond() {
    ipaddress("192.168.0.01").in_cidr("192.168.0.0/24")
}
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
