### PR TITLE
test: add logs to reverse expand test

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -44,7 +44,9 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 		Times(1).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
 			// simulate many goroutines trying to write to the results channel
-			return storage.NewStaticTupleIterator(tuples), nil
+			iterator := storage.NewStaticTupleIterator(tuples)
+			t.Logf("returning tuple iterator")
+			return iterator, nil
 		})
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
@@ -55,6 +57,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 	// process query in one goroutine, but it will be cancelled almost right away
 	go func() {
 		reverseExpandQuery := NewReverseExpandQuery(mockDatastore, typeSystem)
+		t.Logf("before execute reverse expand")
 		reverseExpandQuery.Execute(ctx, &ReverseExpandRequest{
 			StoreID:    store,
 			ObjectType: "document",
@@ -67,19 +70,24 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 			},
 			ContextualTuples: []*openfgav1.TupleKey{},
 		}, resultChan, NewResolutionMetadata())
+		t.Logf("after execute reverse expand")
 		done <- struct{}{}
 	}()
 	go func() {
 		// simulate max_results=1
+		t.Logf("before receive one result")
 		res := <-resultChan
+		t.Logf("after receive one result")
 		cancelFunc()
+		t.Logf("after send cancellation")
 		require.NotNil(t, res.Object)
 		require.Nil(t, res.Err)
 	}()
 
 	select {
 	case <-done:
-	// OK!
+		t.Log("OK!")
+		return
 	case <-time.After(10 * time.Millisecond):
 		require.FailNow(t, "timed out")
 	}


### PR DESCRIPTION
## Description
Goal: debug flaky test https://github.com/openfga/openfga/actions/runs/6723611407/job/18274057202?pr=1096

It is hard to reproduce locally. Adding logs so when it happens again we can debug it. E.g.

```
=== RUN   TestReverseExpandRespectsContextCancellation
    reverse_expand_test.go:60: before execute reverse expand
    reverse_expand_test.go:78: before receive one result
    reverse_expand_test.go:48: returning tuple iterator
    reverse_expand_test.go:80: after receive one result
    reverse_expand_test.go:82: after send cancellation
    reverse_expand_test.go:73: after execute reverse expand
    reverse_expand_test.go:89: OK!
--- PASS: TestReverseExpandRespectsContextCancellation (0.01s)
PASS

Process finished with the exit code 0

```