### PR TITLE
style: stricter govet linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,11 @@ linters:
     # - promlinter
 
 linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - shadow
+      - fieldalignment
   importas:
     # Do not allow unaliased imports of aliased packages.
     no-unaliased: true

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -452,10 +452,6 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 		})
 	}
 
-	sourceRelationRef := &openfgav1.RelationReference{
-		Type: req.sourceUserRef.GetObjectType(),
-	}
-
 	// e.g. 'user:bob'
 	if val, ok := req.sourceUserRef.(*UserRefObject); ok {
 		userFilter = append(userFilter, &openfgav1.ObjectRelation{
@@ -465,10 +461,6 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 
 	// e.g. 'group:eng#member'
 	if val, ok := req.sourceUserRef.(*UserRefObjectRelation); ok {
-		sourceRelationRef.RelationOrWildcard = &openfgav1.RelationReference_Relation{
-			Relation: val.ObjectRelation.Relation,
-		}
-
 		userFilter = append(userFilter, val.ObjectRelation)
 	}
 


### PR DESCRIPTION
```
[2/11/23 2:58:19] ~/GitHub/openfga (main) $ make lint
pkg/server/commands/reverseexpand/reverse_expand.go:456:7: unusedwrite: unused write to field Type (govet)
                Type: req.sourceUserRef.GetObjectType(),
                    ^
pkg/server/commands/reverseexpand/reverse_expand.go:468:21: unusedwrite: unused write to field RelationOrWildcard (govet)
                sourceRelationRef.RelationOrWildcard = &openfgav1.RelationReference_Relation{
                                  ^
make: *** [lint] Error 1
```