### PR TITLE
chore(abac): return errors instead of deny decision with ABAC conditions

### DIFF
--- a/assets/tests/abac_tests.yaml
+++ b/assets/tests/abac_tests.yaml
@@ -586,3 +586,125 @@ tests:
             context:
               "y": 10
             errorCode: 2000
+  - name: prior_conditions_ignored
+    stages:
+      - model: | 
+          model
+            schema 1.1
+          type user
+
+          type document
+            relations
+              define viewer: [user with oldcondition]
+          
+          condition oldcondition(x: int) {
+            x > 100
+          }
+        tuples:
+          - object: document:1
+            relation: viewer
+            user: user:jon
+            condition:
+              name: oldcondition
+        checkAssertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            context:
+              "x": 101
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              "x": 101
+            expectation:
+              - document:1
+      - model: |
+          model
+            schema 1.1
+          type user
+
+          type document
+            relations
+              define viewer: [user with newcondition]
+          
+          condition newcondition(x: int) {
+            x > 200
+          }
+        checkAssertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            context:
+              "x": 101
+            expectation: false
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            context:
+              "x": 201
+            expectation: false
+        listObjectsAssertions:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              "x": 101
+            expectation:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              "x": 201
+            expectation:
+      - model: |
+          model
+            schema 1.1
+          type user
+          
+          type document
+            relations
+              define viewer: [user with oldcondition]
+          
+          condition oldcondition(x: int) {
+            x > 200
+          }
+        checkAssertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            context:
+              "x": 101
+            expectation: false
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:jon
+            context:
+              "x": 201
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              "x": 101
+            expectation:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              "x": 201
+            expectation:
+              - document:1

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -5318,7 +5318,7 @@ tests:
               user: user:jon
               relation: viewer
               object: document:1
-            expectation: false
+            errorCode: 2000
           - tuple:
               user: user:jon
               relation: viewer
@@ -5338,7 +5338,7 @@ tests:
               user: user:jon
               type: document
               relation: viewer
-            expectation:
+            errorCode: 2000
           - request:
               user: user:jon
               type: document
@@ -5354,3 +5354,201 @@ tests:
             context:
               x: 101
             expectation:
+  - name: direct_relations_with_condition_through_intersection
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+
+          type document
+            relations
+              define allowed: [user with condx]
+              define viewer: [user with condy] and allowed
+
+          condition condx(x: int) {
+            x < 100
+          }
+
+          condition condy(y: int) {
+            y < 50
+          }
+        tuples:
+          - user: user:jon
+            relation: viewer
+            object: document:1
+            condition:
+              name: condy
+          - user: user:jon
+            relation: allowed
+            object: document:1
+            condition:
+              name: condx
+        checkAssertions:
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 10
+              y: 5
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            errorCode: 2000
+          - request:
+              user: user:jon
+              type: document
+              relation: viewer
+            context:
+              x: 10
+              y: 5
+            expectation:
+              - document:1
+  - name: relation_through_ttu_with_condition
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+
+          type folder
+            relations
+              define viewer: [user]
+
+          type document
+            relations
+              define parent: [folder with str_cond, folder with xcond]
+              define viewer: [user] or viewer from parent
+
+          condition str_cond(s: string) {
+            s == "hello"
+          }
+
+          condition xcond(x: int) {
+            x == 10
+          }
+        tuples:
+          - user: folder:a
+            relation: parent
+            object: document:1
+            condition:
+              name: str_cond
+          - user: folder:b
+            relation: parent
+            object: document:1
+            condition:
+              name: xcond
+          - user: user:jon
+            relation: viewer
+            object: folder:a
+          - user: user:jon
+            relation: viewer
+            object: folder:b
+        checkAssertions:
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              s: "hello"
+            expectation: true
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 10
+            expectation: true
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              s: "foo"
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 15
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: user:jon
+            expectation: true
+  - name: direct_relations_with_condition
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+
+          type document
+            relations
+              define viewer: [user with condxy]
+
+          condition condxy(x: int, y: int) {
+            x < 100 || y < 50
+          }
+        tuples:
+          - user: user:jon
+            relation: viewer
+            object: document:1
+            condition:
+              name: condxy
+        checkAssertions:
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 10
+              y: 5
+            expectation: true
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 101
+              y: 51
+            expectation: false
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              x: 10
+            errorCode: 2000
+          - tuple:
+              user: user:jon
+              relation: viewer
+              object: document:1
+            context:
+              y: 10
+            errorCode: 2000

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,78 @@
+package errors
+
+import (
+	"errors"
+	reflectlite "reflect"
+)
+
+// With returns an error that represents top wrapped on top of the base error.
+func With(base, top error) error {
+	if base == nil && top == nil {
+		return nil
+	}
+	if top == nil {
+		return base
+	}
+	if base == nil {
+		return top
+	}
+	return union{error: base, top: top}
+}
+
+type union struct {
+	error
+	top error
+}
+
+func (u union) Is(target error) bool {
+	// Copied from errors.Is, but without iterative unwrapping.
+	// If top doesn't match, errors.Is will Unwrap, which does the right thing.
+	if target == nil {
+		return false
+	}
+
+	isComparable := reflectlite.TypeOf(target).Comparable()
+	if isComparable && u.top == target {
+		return true
+	}
+	if x, ok := u.top.(interface{ Is(error) bool }); ok && x.Is(target) {
+		return true
+	}
+	return false
+}
+
+func (u union) As(target any) bool {
+	// copied from errors.As, but without the iterative unwrapping.
+	// If top doesn't match, errors.Is will Unwrap, which does the right thing.
+
+	if target == nil {
+		panic("errors: target cannot be nil")
+	}
+	val := reflectlite.ValueOf(target)
+	typ := val.Type()
+	if typ.Kind() != reflectlite.Ptr || val.IsNil() {
+		panic("errors: target must be a non-nil pointer")
+	}
+	targetType := typ.Elem()
+	if targetType.Kind() != reflectlite.Interface && !targetType.Implements(errorType) {
+		panic("errors: *target must be interface or implement error")
+	}
+	if reflectlite.TypeOf(u.top).AssignableTo(targetType) {
+		val.Elem().Set(reflectlite.ValueOf(u.top))
+		return true
+	}
+	if x, ok := u.top.(interface{ As(any) bool }); ok && x.As(target) {
+		return true
+	}
+	return false
+}
+
+var errorType = reflectlite.TypeOf((*error)(nil)).Elem()
+
+func (u union) Unwrap() error {
+	if err := errors.Unwrap(u.top); err != nil {
+		return union{error: u.error, top: err}
+	}
+	// otherwise we ran out of errors on top to unwrap, so return the underlying error.
+	return u.error
+}

--- a/internal/test/check/check.go
+++ b/internal/test/check/check.go
@@ -2,12 +2,13 @@ package checktest
 
 import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type Assertion struct {
 	Tuple            *openfgav1.TupleKey
 	ContextualTuples []*openfgav1.TupleKey `yaml:"contextualTuples"`
-	Context          map[string]interface{}
+	Context          *structpb.Struct
 	Expectation      bool
 	ErrorCode        int `yaml:"errorCode"` // If ErrorCode is non-zero then we expect that the check call failed.
 }

--- a/internal/test/listobjects/listobjects.go
+++ b/internal/test/listobjects/listobjects.go
@@ -2,12 +2,13 @@ package listobjectstest
 
 import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type Assertion struct {
 	Request          *openfgav1.ListObjectsRequest
 	ContextualTuples []*openfgav1.TupleKey `yaml:"contextualTuples"`
-	Context          map[string]interface{}
+	Context          *structpb.Struct
 	Expectation      []string
 	ErrorCode        int `yaml:"errorCode"` // If ErrorCode is non-zero then we expect that the ListObjects call failed.
 }

--- a/pkg/condition/errors.go
+++ b/pkg/condition/errors.go
@@ -2,7 +2,11 @@ package condition
 
 import (
 	"fmt"
+
+	"github.com/openfga/openfga/internal/errors"
 )
+
+var ErrEvaluationFailed = fmt.Errorf("failed to evaluate relationship condition")
 
 type CompilationError struct {
 	Condition string
@@ -22,12 +26,19 @@ type EvaluationError struct {
 	Cause     error
 }
 
+func NewEvaluationError(condition string, cause error) error {
+	return errors.With(&EvaluationError{
+		Condition: condition,
+		Cause:     cause,
+	}, ErrEvaluationFailed)
+}
+
 func (e *EvaluationError) Error() string {
 	if _, ok := e.Cause.(*ParameterTypeError); ok {
 		return e.Unwrap().Error()
 	}
 
-	return fmt.Sprintf("failed to evaluate relationship condition '%s': %v", e.Condition, e.Cause)
+	return fmt.Sprintf("%s '%s': %v", ErrEvaluationFailed.Error(), e.Condition, e.Cause)
 }
 
 func (e *EvaluationError) Unwrap() error {

--- a/pkg/condition/eval/eval.go
+++ b/pkg/condition/eval/eval.go
@@ -1,16 +1,11 @@
 package eval
 
 import (
-	"errors"
 	"fmt"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/typesystem"
-)
-
-var (
-	ErrEvaluatingCondition = errors.New("condition evaluation failed")
 )
 
 // TupleConditionMet returns a bool indicating if the provided tupleKey's condition (if any) was met.
@@ -24,10 +19,7 @@ func EvaluateTupleCondition(
 	if conditionName != "" {
 		evaluableCondition, ok := typesys.GetCondition(conditionName)
 		if !ok {
-			return nil, &condition.EvaluationError{
-				Condition: conditionName,
-				Cause:     fmt.Errorf("condition was not found"),
-			}
+			return nil, condition.NewEvaluationError(conditionName, fmt.Errorf("condition was not found"))
 		}
 
 		// merge both contexts

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -9,10 +9,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/graph"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/internal/validation"
+	"github.com/openfga/openfga/pkg/condition/eval"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands/reverseexpand"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
@@ -350,6 +352,7 @@ func (q *ListObjectsQuery) Execute(
 
 	objects := make([]string, 0)
 
+	var errs *multierror.Error
 	for {
 		select {
 		case <-timeoutCtx.Done():
@@ -367,14 +370,23 @@ func (q *ListObjectsQuery) Execute(
 					return nil, result.Err
 				}
 
-				if !(errors.Is(result.Err, context.Canceled) || errors.Is(result.Err, context.DeadlineExceeded)) {
-					return nil, serverErrors.HandleError("", result.Err)
+				if errors.Is(result.Err, eval.ErrEvaluatingCondition) {
+					errs = multierror.Append(errs, result.Err)
+					continue
 				}
 
-				continue
+				if errors.Is(result.Err, context.Canceled) || errors.Is(result.Err, context.DeadlineExceeded) {
+					continue
+				}
+
+				return nil, serverErrors.HandleError("", result.Err)
 			}
 
 			if !channelOpen {
+				if len(objects) < int(maxResults) && errs.ErrorOrNil() != nil {
+					return nil, errs
+				}
+
 				return &ListObjectsResponse{
 					Objects:            objects,
 					ResolutionMetadata: *resolutionMetadata,
@@ -424,6 +436,10 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 			if result.Err != nil {
 				if errors.Is(result.Err, serverErrors.AuthorizationModelResolutionTooComplex) {
 					return nil, result.Err
+				}
+
+				if errors.Is(result.Err, eval.ErrEvaluatingCondition) {
+					return nil, serverErrors.ValidationError(result.Err)
 				}
 
 				return nil, serverErrors.HandleError("", result.Err)

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openfga/openfga/internal/graph"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/internal/validation"
-	"github.com/openfga/openfga/pkg/condition/eval"
+	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands/reverseexpand"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
@@ -370,7 +370,7 @@ func (q *ListObjectsQuery) Execute(
 					return nil, result.Err
 				}
 
-				if errors.Is(result.Err, eval.ErrEvaluatingCondition) {
+				if _, ok := result.Err.(*condition.EvaluationError); ok {
 					errs = multierror.Append(errs, result.Err)
 					continue
 				}
@@ -436,10 +436,6 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 			if result.Err != nil {
 				if errors.Is(result.Err, serverErrors.AuthorizationModelResolutionTooComplex) {
 					return nil, result.Err
-				}
-
-				if errors.Is(result.Err, eval.ErrEvaluatingCondition) {
-					return nil, serverErrors.ValidationError(result.Err)
 				}
 
 				return nil, serverErrors.HandleError("", result.Err)

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -12,6 +12,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/graph"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
+	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/condition/eval"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -410,7 +411,10 @@ func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 
 		if !condEvalResult.ConditionMet {
 			if len(condEvalResult.MissingParameters) > 0 {
-				errs = multierror.Append(errs, fmt.Errorf("some error"))
+				errs = multierror.Append(errs, condition.NewEvaluationError(
+					tk.GetCondition().GetName(),
+					fmt.Errorf("context is missing parameters '%v'", condEvalResult.MissingParameters),
+				))
 			}
 
 			continue
@@ -528,12 +532,9 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 
 		if !condEvalResult.ConditionMet {
 			if len(condEvalResult.MissingParameters) > 0 {
-				errs = multierror.Append(errs, fmt.Errorf(
-					"%w: evaluation of condition '%s' on '%s' failed, context is missing parameters '%v'",
-					eval.ErrEvaluatingCondition,
+				errs = multierror.Append(errs, condition.NewEvaluationError(
 					tk.GetCondition().GetName(),
-					tuple.TupleKeyToString(tk),
-					condEvalResult.MissingParameters,
+					fmt.Errorf("context is missing parameters '%v'", condEvalResult.MissingParameters),
 				))
 			}
 

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -127,7 +127,7 @@ func HandleError(public string, err error) error {
 	case *condition.CompilationError,
 		*condition.EvaluationError,
 		*condition.ParameterTypeError:
-		return status.Error(codes.InvalidArgument, t.Error())
+		return ValidationError(t)
 	}
 
 	return NewInternalError(public, err)

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/tuple"
 	"google.golang.org/grpc/codes"
@@ -121,13 +120,6 @@ func HandleError(public string, err error) error {
 		return MismatchObjectType
 	} else if errors.Is(err, storage.ErrCancelled) {
 		return RequestCancelled
-	}
-
-	switch t := err.(type) {
-	case *condition.CompilationError,
-		*condition.EvaluationError,
-		*condition.ParameterTypeError:
-		return ValidationError(t)
 	}
 
 	return NewInternalError(public, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,7 +18,7 @@ import (
 	serverconfig "github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/internal/validation"
-	"github.com/openfga/openfga/pkg/condition/eval"
+	"github.com/openfga/openfga/pkg/condition"
 	"github.com/openfga/openfga/pkg/encoder"
 	"github.com/openfga/openfga/pkg/logger"
 	httpmiddleware "github.com/openfga/openfga/pkg/middleware/http"
@@ -369,7 +369,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		},
 	)
 	if err != nil {
-		if errors.Is(err, eval.ErrEvaluatingCondition) {
+		if errors.Is(err, condition.ErrEvaluationFailed) {
 			return nil, serverErrors.ValidationError(err)
 		}
 
@@ -588,7 +588,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 			return nil, serverErrors.AuthorizationModelResolutionTooComplex
 		}
 
-		if errors.Is(err, eval.ErrEvaluatingCondition) {
+		if errors.Is(err, condition.ErrEvaluationFailed) {
 			return nil, serverErrors.ValidationError(err)
 		}
 

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openfga/openfga/assets"
 	checktest "github.com/openfga/openfga/internal/test/check"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/tests"
@@ -225,7 +224,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					ContextualTuples: &openfgav1.ContextualTupleKeys{
 						TupleKeys: ctxTuples,
 					},
-					Context: testutils.MustNewStruct(t, assertion.Context),
+					Context: assertion.Context,
 					Trace:   true,
 				})
 

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -108,7 +108,6 @@ func runSchema1_1CheckTests(t *testing.T, client ClientInterface) {
 }
 
 func runTests(t *testing.T, params testParams) {
-
 	files := []string{
 		"tests/consolidated_1_1_tests.yaml",
 		"tests/abac_tests.yaml",

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -14,7 +14,6 @@ import (
 	parser "github.com/openfga/language/pkg/go/transformer"
 	"github.com/openfga/openfga/assets"
 	listobjectstest "github.com/openfga/openfga/internal/test/listobjects"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/tests/check"
@@ -170,7 +169,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					ContextualTuples: &openfgav1.ContextualTupleKeys{
 						TupleKeys: ctxTuples,
 					},
-					Context: testutils.MustNewStruct(t, assertion.Context),
+					Context: assertion.Context,
 				})
 
 				if assertion.ErrorCode == 0 {
@@ -196,7 +195,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					ContextualTuples: &openfgav1.ContextualTupleKeys{
 						TupleKeys: ctxTuples,
 					},
-					Context: testutils.MustNewStruct(t, assertion.Context),
+					Context: assertion.Context,
 				}, []grpc.CallOption{}...)
 				require.NoError(t, err)
 
@@ -238,7 +237,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 							ContextualTuples: &openfgav1.ContextualTupleKeys{
 								TupleKeys: ctxTuples,
 							},
-							Context: testutils.MustNewStruct(t, assertion.Context),
+							Context: assertion.Context,
 						})
 						require.NoError(t, err, detailedInfo)
 						require.True(t, checkResp.Allowed, detailedInfo)

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -75,19 +75,30 @@ func runSchema1_1ListObjectsTests(t *testing.T, client ClientInterface) {
 }
 
 func runTests(t *testing.T, params testParams) {
-	var b []byte
-	var err error
-	schemaVersion := params.schemaVersion
-	if schemaVersion == typesystem.SchemaVersion1_1 {
-		b, err = assets.EmbedTests.ReadFile("tests/consolidated_1_1_tests.yaml")
+	files := []string{
+		"tests/consolidated_1_1_tests.yaml",
+		"tests/abac_tests.yaml",
 	}
-	require.NoError(t, err)
 
-	var testCases listObjectTests
-	err = yaml.Unmarshal(b, &testCases)
-	require.NoError(t, err)
+	var allTestCases []individualTest
 
-	for _, test := range testCases.Tests {
+	for _, file := range files {
+		var b []byte
+		var err error
+		schemaVersion := params.schemaVersion
+		if schemaVersion == typesystem.SchemaVersion1_1 {
+			b, err = assets.EmbedTests.ReadFile(file)
+		}
+		require.NoError(t, err)
+
+		var testCases listObjectTests
+		err = yaml.Unmarshal(b, &testCases)
+		require.NoError(t, err)
+
+		allTestCases = append(allTestCases, testCases.Tests...)
+	}
+
+	for _, test := range allTestCases {
 		test := test
 		runTest(t, test, params, false)
 		runTest(t, test, params, true)


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
These changes modify the server behavior to return errors instead of deny decisions when we attempt to evaluate an ABAC Condition that we cannot fully evaluate. For example,

```
type user

type document
  relations
    define viewer: [user with condxy]

condition condxy(x: int, y: int) {
  x < 10 || y < 10
}

- document:1#viewer@user:jon, {condition: "condxy"}
```

Evaluating `Check(document:1#viewer@user:jon, { context: { } })` would return an error instead of `{allowed: false}`.

The changes also are strict about requiring every parameter of an condition to be specified even if it is not necessary to fully evaluate the condition. We chose to do this to be explicit about the type system. We may change this at a later time. Using the example above,

`Check(document:1#viewer@user:jon, { context: { "x": 10 } })` would return an error, because we want the developer to be explicit about providing `x` and `y` along with the context to evaluate the condition `condxy`.

## References

https://github.com/openfga/openfga/pull/1038

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
