### PR TITLE
fix: improve param type errors during evaluation

### DIFF
--- a/pkg/condition/errors.go
+++ b/pkg/condition/errors.go
@@ -23,6 +23,10 @@ type EvaluationError struct {
 }
 
 func (e *EvaluationError) Error() string {
+	if _, ok := e.Cause.(*ParameterTypeError); ok {
+		return e.Unwrap().Error()
+	}
+
 	return fmt.Sprintf("failed to evaluate relationship condition '%s': %v", e.Condition, e.Cause)
 }
 


### PR DESCRIPTION
## Description

before

```
ⅹ Check(user=user:jon,relation=has_feature,object=feature:one): expected=true, got=N/A, error=rpc error: code = InvalidArgument desc = failed to evaluate relationship condition 'is_valid': parameter type error on condition 'is_valid': failed to convert context parameter '_timestamp': expected RFC 3339 formatted timestamp string, but found '1990-02-01'
```

after

```
ⅹ Check(user=user:jon,relation=has_feature,object=feature:one): expected=true, got=N/A, error=rpc error: code = InvalidArgument desc = parameter type error on condition 'is_valid': failed to convert context parameter '_timestamp': expected RFC 3339 formatted timestamp string, but found '1990-02-01'
```

## References

https://github.com/openfga/openfga/pull/1038

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
