### PR TITLE
chore: add testifylint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - ineffassign
     - staticcheck
     - tagalign
+    - testifylint
     - typecheck
     - unused
     - unconvert

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -46,7 +46,7 @@ func TestMigrateCommandNoConfigDefaultValues(t *testing.T) {
 		require.Equal(t, "", viper.GetString(datastoreURIFlag))
 		require.Equal(t, uint(0), viper.GetUint(versionFlag))
 		require.Equal(t, defaultDuration, viper.GetDuration(timeoutFlag))
-		require.Equal(t, false, viper.GetBool(verboseMigrationFlag))
+		require.False(t, viper.GetBool(verboseMigrationFlag))
 		return nil
 	}
 
@@ -69,7 +69,7 @@ func TestMigrateCommandConfigFileValuesAreParsed(t *testing.T) {
 		require.Equal(t, "postgres://postgres:password@127.0.0.1:5432/postgres", viper.GetString(datastoreURIFlag))
 		require.Equal(t, uint(0), viper.GetUint(versionFlag))
 		require.Equal(t, defaultDuration, viper.GetDuration(timeoutFlag))
-		require.Equal(t, false, viper.GetBool(verboseMigrationFlag))
+		require.False(t, viper.GetBool(verboseMigrationFlag))
 		return nil
 	}
 
@@ -94,7 +94,7 @@ func TestMigrateCommandConfigIsMerged(t *testing.T) {
 		require.Equal(t, "postgres://postgres:PASS2@127.0.0.1:5432/postgres", viper.GetString(datastoreURIFlag))
 		require.Equal(t, uint(0), viper.GetUint(versionFlag))
 		require.Equal(t, defaultDuration, viper.GetDuration(timeoutFlag))
-		require.Equal(t, true, viper.GetBool(verboseMigrationFlag))
+		require.True(t, viper.GetBool(verboseMigrationFlag))
 		return nil
 	}
 

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -53,7 +53,7 @@ func TestMigrateCommandNoConfigDefaultValues(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(migrateCmd)
 	cmd.SetArgs([]string{"migrate"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }
 
 func TestMigrateCommandConfigFileValuesAreParsed(t *testing.T) {
@@ -76,7 +76,7 @@ func TestMigrateCommandConfigFileValuesAreParsed(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(migrateCmd)
 	cmd.SetArgs([]string{"migrate"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }
 
 func TestMigrateCommandConfigIsMerged(t *testing.T) {
@@ -101,5 +101,5 @@ func TestMigrateCommandConfigIsMerged(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(migrateCmd)
 	cmd.SetArgs([]string{"migrate"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }

--- a/cmd/openfga/main_test.go
+++ b/cmd/openfga/main_test.go
@@ -569,7 +569,7 @@ func GRPCCreateStoreTest(t *testing.T, tester OpenFGATester) {
 			require.Equal(t, test.output.errorCode.String(), s.Code().String())
 
 			if test.output.errorCode == codes.OK {
-				require.True(t, response.Name == test.input.Name)
+				require.Equal(t, test.input.Name, response.Name)
 				_, err = ulid.Parse(response.Id)
 				require.NoError(t, err)
 			}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1038,7 +1038,7 @@ func TestRunCommandNoConfigDefaultValues(t *testing.T) {
 	rootCmd := cmd.NewRootCommand()
 	rootCmd.AddCommand(runCmd)
 	rootCmd.SetArgs([]string{"run"})
-	require.Nil(t, rootCmd.Execute())
+	require.NoError(t, rootCmd.Execute())
 }
 
 func TestRunCommandConfigFileValuesAreParsed(t *testing.T) {
@@ -1058,7 +1058,7 @@ func TestRunCommandConfigFileValuesAreParsed(t *testing.T) {
 	rootCmd := cmd.NewRootCommand()
 	rootCmd.AddCommand(runCmd)
 	rootCmd.SetArgs([]string{"run"})
-	require.Nil(t, rootCmd.Execute())
+	require.NoError(t, rootCmd.Execute())
 }
 
 func TestParseConfig(t *testing.T) {
@@ -1077,7 +1077,7 @@ requestDurationDatastoreQueryCountBuckets: [33,44]
 	rootCmd := cmd.NewRootCommand()
 	rootCmd.AddCommand(runCmd)
 	rootCmd.SetArgs([]string{"run"})
-	require.Nil(t, rootCmd.Execute())
+	require.NoError(t, rootCmd.Execute())
 
 	cfg, err := ReadConfig()
 	require.NoError(t, err)
@@ -1116,5 +1116,5 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 	rootCmd := cmd.NewRootCommand()
 	rootCmd.AddCommand(runCmd)
 	rootCmd.SetArgs([]string{"run"})
-	require.Nil(t, rootCmd.Execute())
+	require.NoError(t, rootCmd.Execute())
 }

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -85,5 +85,5 @@ func PrepareTempConfigFile(t *testing.T, config string) {
 	require.NoError(t, err)
 	_, err = confFile.WriteString(config)
 	require.NoError(t, err)
-	require.Nil(t, confFile.Close())
+	require.NoError(t, confFile.Close())
 }

--- a/cmd/util/util.go
+++ b/cmd/util/util.go
@@ -74,7 +74,7 @@ func PrepareTempConfigDir(t *testing.T) string {
 	t.Setenv("HOME", homedir)
 
 	confdir := filepath.Join(homedir, ".openfga")
-	require.Nil(t, os.Mkdir(confdir, 0750))
+	require.NoError(t, os.Mkdir(confdir, 0750))
 
 	return confdir
 }
@@ -82,8 +82,8 @@ func PrepareTempConfigDir(t *testing.T) string {
 func PrepareTempConfigFile(t *testing.T, config string) {
 	confdir := PrepareTempConfigDir(t)
 	confFile, err := os.Create(filepath.Join(confdir, "config.yaml"))
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, err = confFile.WriteString(config)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Nil(t, confFile.Close())
 }

--- a/cmd/validatemodels/validate_models_test.go
+++ b/cmd/validatemodels/validate_models_test.go
@@ -61,7 +61,7 @@ func TestValidationResult(t *testing.T) {
 			t.Run("validate returns success", func(t *testing.T) {
 				validationResults, err := ValidateAllAuthorizationModels(ctx, ds)
 				require.NoError(t, err)
-				require.Equal(t, totalModelsForOneStore, len(validationResults))
+				require.Len(t, validationResults, totalModelsForOneStore)
 				require.Contains(t, "the relation type 'user' on 'viewer' in object type 'document' is not valid", validationResults[0].Error)
 				require.True(t, validationResults[0].IsLatestModel)
 
@@ -107,7 +107,7 @@ func TestValidateModelsCommandNoConfigDefaultValues(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(validateCommand)
 	cmd.SetArgs([]string{"validate-models"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }
 
 func TestValidateModelsCommandConfigFileValuesAreParsed(t *testing.T) {
@@ -127,7 +127,7 @@ func TestValidateModelsCommandConfigFileValuesAreParsed(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(validateCmd)
 	cmd.SetArgs([]string{"validate-models"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }
 
 func TestValidateModelsCommandConfigIsMerged(t *testing.T) {
@@ -148,5 +148,5 @@ func TestValidateModelsCommandConfigIsMerged(t *testing.T) {
 	cmd := cmd.NewRootCommand()
 	cmd.AddCommand(validateCmd)
 	cmd.SetArgs([]string{"validate-models"})
-	require.Nil(t, cmd.Execute())
+	require.NoError(t, cmd.Execute())
 }

--- a/cmd/validatemodels/validate_models_test.go
+++ b/cmd/validatemodels/validate_models_test.go
@@ -63,10 +63,10 @@ func TestValidationResult(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, totalModelsForOneStore, len(validationResults))
 				require.Contains(t, "the relation type 'user' on 'viewer' in object type 'document' is not valid", validationResults[0].Error)
-				require.Equal(t, true, validationResults[0].IsLatestModel)
+				require.True(t, validationResults[0].IsLatestModel)
 
 				require.Contains(t, "the relation type 'user' on 'viewer' in object type 'document' is not valid", validationResults[1].Error)
-				require.Equal(t, false, validationResults[1].IsLatestModel)
+				require.False(t, validationResults[1].IsLatestModel)
 			})
 		})
 	}

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -356,7 +356,7 @@ func TestResolveCheckFromCache(t *testing.T) {
 
 			actualResult, err := dut2.ResolveCheck(ctx, test.subsequentReq)
 			require.Equal(t, result.Allowed, actualResult.Allowed)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -386,14 +386,14 @@ func TestResolveCheckExpired(t *testing.T) {
 
 	actualResult, err := dut.ResolveCheck(ctx, req)
 	require.Equal(t, result.Allowed, actualResult.Allowed)
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 
 	// subsequent call would have cache timeout and result in new ResolveCheck
 	time.Sleep(5 * time.Microsecond)
 
 	actualResult, err = dut.ResolveCheck(ctx, req)
 	require.Equal(t, result.Allowed, actualResult.Allowed)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestCachedCheckDatastoreQueryCount(t *testing.T) {

--- a/pkg/middleware/requestid/requestid_test.go
+++ b/pkg/middleware/requestid/requestid_test.go
@@ -51,10 +51,10 @@ type RequestIDTestSuite struct {
 
 func (s *RequestIDTestSuite) TestPing() {
 	_, err := s.Client.Ping(s.SimpleCtx(), pingReq)
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 }
 
 func (s *RequestIDTestSuite) TestStreamingPing() {
 	_, err := s.Client.PingStream(s.SimpleCtx())
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 }

--- a/pkg/middleware/validator/validator_test.go
+++ b/pkg/middleware/validator/validator_test.go
@@ -45,10 +45,10 @@ type ValidatorTestSuite struct {
 
 func (s *ValidatorTestSuite) TestPing() {
 	_, err := s.Client.Ping(s.SimpleCtx(), &testpb.PingRequest{Value: "ping"})
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 }
 
 func (s *ValidatorTestSuite) TestStreamingPing() {
 	_, err := s.Client.PingStream(s.SimpleCtx())
-	require.NoError(s.T(), err)
+	s.Require().NoError(err)
 }

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -81,7 +81,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 		cancelFunc()
 		t.Logf("after send cancellation")
 		require.NotNil(t, res.Object)
-		require.Nil(t, res.Err)
+		require.NoError(t, res.Err)
 	}()
 
 	select {

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -137,7 +137,7 @@ func TestReverseExpandRespectsContextTimeout(t *testing.T) {
 	select {
 	case res, open := <-resultChan:
 		if open {
-			require.NotNil(t, res.Err)
+			require.Error(t, res.Err)
 		} else {
 			require.Nil(t, res)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -200,7 +200,7 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 		AuthorizationModelId: modelID,
 	})
 	require.NoError(t, err)
-	require.Equal(t, true, checkResponse.Allowed)
+	require.True(t, checkResponse.Allowed)
 }
 
 func TestListObjectsReleasesConnections(t *testing.T) {
@@ -421,7 +421,7 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 	end := time.Since(start)
 
 	// we expect the Check call to be short-circuited after ReadUsersetTuples runs
-	require.Truef(t, end < 200*time.Millisecond, fmt.Sprintf("end was %s", end))
+	require.Lessf(t, end, 200*time.Millisecond, fmt.Sprintf("end was %s", end))
 	require.NoError(t, err)
 	require.Equal(t, true, checkResponse.Allowed)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -423,7 +423,7 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 	// we expect the Check call to be short-circuited after ReadUsersetTuples runs
 	require.Lessf(t, end, 200*time.Millisecond, fmt.Sprintf("end was %s", end))
 	require.NoError(t, err)
-	require.Equal(t, true, checkResponse.Allowed)
+	require.True(t, checkResponse.Allowed)
 }
 
 func TestCheckWithCachedResolution(t *testing.T) {

--- a/pkg/server/test/list_stores.go
+++ b/pkg/server/test/list_stores.go
@@ -39,7 +39,7 @@ func TestListStores(t *testing.T, datastore storage.OpenFGADatastore) {
 	// ensure there are actually no stores
 	listStoresResponse, actualError := getStoresQuery.Execute(ctx, &openfgav1.ListStoresRequest{})
 	require.NoError(t, actualError)
-	require.Equal(t, 0, len(listStoresResponse.Stores))
+	require.Empty(t, listStoresResponse.Stores)
 
 	// create two stores
 	createStoreQuery := commands.NewCreateStoreCommand(datastore, logger)
@@ -56,7 +56,7 @@ func TestListStores(t *testing.T, datastore storage.OpenFGADatastore) {
 		ContinuationToken: "",
 	})
 	require.NoError(t, actualError)
-	require.Equal(t, 1, len(listStoresResponse.Stores))
+	require.Len(t, listStoresResponse.Stores, 1)
 	require.Equal(t, firstStoreName, listStoresResponse.Stores[0].Name)
 	require.NotEmpty(t, listStoresResponse.ContinuationToken)
 
@@ -66,7 +66,7 @@ func TestListStores(t *testing.T, datastore storage.OpenFGADatastore) {
 		ContinuationToken: listStoresResponse.ContinuationToken,
 	})
 	require.NoError(t, actualError)
-	require.Equal(t, 1, len(secondListStoresResponse.Stores))
+	require.Len(t, secondListStoresResponse.Stores, 1)
 	require.Equal(t, secondStoreName, secondListStoresResponse.Stores[0].Name)
 	// no token <=> no more results
 	require.Empty(t, secondListStoresResponse.ContinuationToken)

--- a/pkg/server/test/read_authzmodels.go
+++ b/pkg/server/test/read_authzmodels.go
@@ -59,7 +59,7 @@ func TestReadAuthorizationModelsWithoutPaging(t *testing.T, datastore storage.Op
 			resp, err := query.Execute(ctx, &openfgav1.ReadAuthorizationModelsRequest{StoreId: store})
 			require.NoError(err)
 
-			require.Equal(test.expectedNumModelsReturned, len(resp.GetAuthorizationModels()))
+			require.Len(resp.GetAuthorizationModels(), test.expectedNumModelsReturned)
 			require.Empty(resp.ContinuationToken, "expected an empty continuation token")
 		})
 	}

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -124,7 +124,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		storage.NewPaginationOptions(0, ""))
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(tuples))
+	require.Len(t, tuples, 2)
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -124,7 +124,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		storage.NewPaginationOptions(0, ""))
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(tuples))
+	require.Len(t, tuples, 2)
 	// we expect that objectID2 will return first because it has a smaller ulid
 	require.Equal(t, secondTuple, tuples[0].Key)
 	require.Equal(t, firstTuple, tuples[1].Key)

--- a/pkg/storage/test/assertions.go
+++ b/pkg/storage/test/assertions.go
@@ -80,6 +80,6 @@ func AssertionsTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		gotAssertions, err := datastore.ReadAssertions(ctx, store, newModelID)
 		require.NoError(t, err)
 
-		require.Len(t, gotAssertions, 0)
+		require.Empty(t, gotAssertions)
 	})
 }

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -41,7 +41,7 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		gotStores, ct, err := datastore.ListStores(ctx, storage.PaginationOptions{PageSize: 1})
 		require.NoError(t, err)
 
-		require.Equal(t, 1, len(gotStores))
+		require.Len(t, gotStores, 1)
 		require.NotEmpty(t, len(ct))
 
 		_, ct, err = datastore.ListStores(ctx, storage.PaginationOptions{PageSize: 100, From: string(ct)})

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -233,17 +233,17 @@ func TestTupleKeyToString(t *testing.T) {
 }
 
 func TestIsWildcard(t *testing.T) {
-	require.Equal(t, true, IsWildcard("*"))
-	require.Equal(t, true, IsWildcard("user:*"))
-	require.Equal(t, false, IsWildcard("user:jon"))
-	require.Equal(t, false, IsWildcard("jon"))
+	require.True(t, IsWildcard("*"))
+	require.True(t, IsWildcard("user:*"))
+	require.False(t, IsWildcard("user:jon"))
+	require.False(t, IsWildcard("jon"))
 }
 
 func TestIsTypedWildcard(t *testing.T) {
-	require.Equal(t, false, IsTypedWildcard("*"))
-	require.Equal(t, true, IsTypedWildcard("user:*"))
-	require.Equal(t, false, IsTypedWildcard("user:jon"))
-	require.Equal(t, false, IsTypedWildcard("jon"))
+	require.False(t, IsTypedWildcard("*"))
+	require.True(t, IsTypedWildcard("user:*"))
+	require.False(t, IsTypedWildcard("user:jon"))
+	require.False(t, IsTypedWildcard("jon"))
 }
 
 func TestIsValidUser(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
- Add new linter rule `testifylint` which was introduced since golangci-lint v1.55.0
- Issues fixed

```
cmd/util/util.go:77:2: error-nil: use require.NoError (testifylint)
        require.Nil(t, os.Mkdir(confdir, 0750))
        ^
cmd/util/util.go:85:2: error-nil: use require.NoError (testifylint)
        require.Nil(t, err)
        ^
cmd/util/util.go:87:2: error-nil: use require.NoError (testifylint)
        require.Nil(t, err)
        ^
pkg/server/test/list_stores.go:42:2: empty: use require.Empty (testifylint)
        require.Equal(t, 0, len(listStoresResponse.Stores))
        ^
pkg/server/test/list_stores.go:59:2: len: use require.Len (testifylint)
        require.Equal(t, 1, len(listStoresResponse.Stores))
        ^
pkg/server/test/list_stores.go:69:2: len: use require.Len (testifylint)
        require.Equal(t, 1, len(secondListStoresResponse.Stores))
        ^
pkg/server/test/read_authzmodels.go:62:4: len: use require.Len (testifylint)
                        require.Equal(test.expectedNumModelsReturned, len(resp.GetAuthorizationModels()))
                        ^
pkg/storage/test/assertions.go:83:3: empty: use require.Empty (testifylint)
                require.Len(t, gotAssertions, 0)
                ^
cmd/migrate/migrate_test.go:49:3: bool-compare: use require.False (testifylint)
                require.Equal(t, false, viper.GetBool(verboseMigrationFlag))
                ^
cmd/migrate/migrate_test.go:72:3: bool-compare: use require.False (testifylint)
                require.Equal(t, false, viper.GetBool(verboseMigrationFlag))
                ^
cmd/migrate/migrate_test.go:97:3: bool-compare: use require.True (testifylint)
                require.Equal(t, true, viper.GetBool(verboseMigrationFlag))
                ^
cmd/openfga/main_test.go:572:5: compares: use require.Equal (testifylint)
                                require.True(t, response.Name == test.input.Name)
                                ^
cmd/validatemodels/validate_models_test.go:66:5: bool-compare: use require.True (testifylint)
                                require.Equal(t, true, validationResults[0].IsLatestModel)
                                ^
cmd/validatemodels/validate_models_test.go:69:5: bool-compare: use require.False (testifylint)
                                require.Equal(t, false, validationResults[1].IsLatestModel)
                                ^
pkg/middleware/requestid/requestid_test.go:54:2: suite-dont-use-pkg: use s.Require().NoError (testifylint)
        require.NoError(s.T(), err)
        ^
pkg/middleware/requestid/requestid_test.go:59:2: suite-dont-use-pkg: use s.Require().NoError (testifylint)
        require.NoError(s.T(), err)
        ^
pkg/middleware/validator/validator_test.go:48:2: suite-dont-use-pkg: use s.Require().NoError (testifylint)
        require.NoError(s.T(), err)
        ^
pkg/server/server_test.go:203:2: bool-compare: use require.True (testifylint)
        require.Equal(t, true, checkResponse.Allowed)
        ^
pkg/server/server_test.go:424:2: compares: use require.Lessf (testifylint)
        require.Truef(t, end < 200*time.Millisecond, fmt.Sprintf("end was %s", end))
        ^
pkg/server/commands/reverseexpand/reverse_expand_test.go:140:4: error-nil: use require.Error (testifylint)
                        require.NotNil(t, res.Err)
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
https://github.com/Antonboom/testifylint
## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
