### PR TITLE
chore: set jaeger image version to v1.49 (openfga#1102)

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -26,7 +26,7 @@ services:
       - "2113:2113" #prometheus metrics exporter
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:1.49
     container_name: jaeger
     command: [ "--query.max-clock-skew-adjustment", "500ms" ]
     environment:


### PR DESCRIPTION
## Pull Request Description

This pull request change the Jaeger image version from` latest `to `1.49`.