### PR TITLE
Add env vars and username/password overwrite for migrate tool

### DIFF
--- a/cmd/migrate/flags.go
+++ b/cmd/migrate/flags.go
@@ -25,9 +25,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag(versionFlag, flags.Lookup(versionFlag))
 
 		util.MustBindPFlag(timeoutFlag, flags.Lookup(timeoutFlag))
-		util.MustBindEnv(timeoutFlag, "OPENFGA_MIGRATE_TIMEOUT")
+		util.MustBindEnv(timeoutFlag, "OPENFGA_TIMEOUT")
 
 		util.MustBindPFlag(verboseMigrationFlag, flags.Lookup(verboseMigrationFlag))
-		util.MustBindEnv(verboseMigrationFlag, "OPENFGA_MIGRATE_VERBOSE")
+		util.MustBindEnv(verboseMigrationFlag, "OPENFGA_VERBOSE")
 	}
 }

--- a/cmd/migrate/flags.go
+++ b/cmd/migrate/flags.go
@@ -11,9 +11,23 @@ import (
 func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
 		util.MustBindPFlag(datastoreEngineFlag, flags.Lookup(datastoreEngineFlag))
+		util.MustBindEnv(datastoreEngineFlag, "OPENFGA_DATASTORE_ENGINE")
+
 		util.MustBindPFlag(datastoreURIFlag, flags.Lookup(datastoreURIFlag))
+		util.MustBindEnv(datastoreURIFlag, "OPENFGA_DATASTORE_URI")
+
+		util.MustBindPFlag(datastoreUsernameFlag, flags.Lookup(datastoreUsernameFlag))
+		util.MustBindEnv(datastoreUsernameFlag, "OPENFGA_DATASTORE_USERNAME")
+
+		util.MustBindPFlag(datastorePasswordFlag, flags.Lookup(datastorePasswordFlag))
+		util.MustBindEnv(datastorePasswordFlag, "OPENFGA_DATASTORE_PASSWORD")
+
 		util.MustBindPFlag(versionFlag, flags.Lookup(versionFlag))
+
 		util.MustBindPFlag(timeoutFlag, flags.Lookup(timeoutFlag))
+		util.MustBindEnv(timeoutFlag, "OPENFGA_MIGRATE_TIMEOUT")
+
 		util.MustBindPFlag(verboseMigrationFlag, flags.Lookup(verboseMigrationFlag))
+		util.MustBindEnv(verboseMigrationFlag, "OPENFGA_MIGRATE_VERBOSE")
 	}
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"
-	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/openfga/openfga/assets"
 	"github.com/pressly/goose/v3"

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -86,20 +86,20 @@ func runMigration(_ *cobra.Command, _ []string) error {
 	}
 
 	// Parse the database uri with url.Parse() and update username/password, if set via flags
-	dbUrl, err := url.Parse(uri)
+	dbURI, err := url.Parse(uri)
 	if err != nil {
 		log.Fatalf("invalid database uri: %v\n", err)
 	}
-	if username == "" && dbUrl.User != nil {
-		username = dbUrl.User.Username()
+	if username == "" && dbURI.User != nil {
+		username = dbURI.User.Username()
 	}
-	if password == "" && dbUrl.User != nil {
-		password, _ = dbUrl.User.Password()
+	if password == "" && dbURI.User != nil {
+		password, _ = dbURI.User.Password()
 	}
-	dbUrl.User = url.UserPassword(username, password)
+	dbURI.User = url.UserPassword(username, password)
 
 	// Replace CLI uri with the one we just updated.
-	uri = dbUrl.String()
+	uri = dbURI.String()
 
 	db, err := sql.Open(driver, uri)
 	if err != nil {

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/go-sql-driver/mysql"
 	_ "github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/openfga/openfga/assets"
@@ -75,31 +76,45 @@ func runMigration(_ *cobra.Command, _ []string) error {
 		driver = "mysql"
 		dialect = "mysql"
 		migrationsPath = assets.MySQLMigrationDir
+
+		// Parse the database uri with the mysql drivers function for it and update username/password, if set via flags
+		dsn, err := mysql.ParseDSN(uri)
+		if err != nil {
+			log.Fatalf("invalid database uri: %v\n", err)
+		}
+		if username != "" {
+			dsn.User = username
+		}
+		if password != "" {
+			dsn.Passwd = password
+		}
+		uri = dsn.FormatDSN()
+
 	case "postgres":
 		driver = "pgx"
 		dialect = "postgres"
 		migrationsPath = assets.PostgresMigrationDir
+
+		// Parse the database uri with url.Parse() and update username/password, if set via flags
+		dbURI, err := url.Parse(uri)
+		if err != nil {
+			log.Fatalf("invalid database uri: %v\n", err)
+		}
+		if username == "" && dbURI.User != nil {
+			username = dbURI.User.Username()
+		}
+		if password == "" && dbURI.User != nil {
+			password, _ = dbURI.User.Password()
+		}
+		dbURI.User = url.UserPassword(username, password)
+
+		// Replace CLI uri with the one we just updated.
+		uri = dbURI.String()
 	case "":
 		return fmt.Errorf("missing datastore engine type")
 	default:
 		return fmt.Errorf("unknown datastore engine type: %s", engine)
 	}
-
-	// Parse the database uri with url.Parse() and update username/password, if set via flags
-	dbURI, err := url.Parse(uri)
-	if err != nil {
-		log.Fatalf("invalid database uri: %v\n", err)
-	}
-	if username == "" && dbURI.User != nil {
-		username = dbURI.User.Username()
-	}
-	if password == "" && dbURI.User != nil {
-		password, _ = dbURI.User.Password()
-	}
-	dbURI.User = url.UserPassword(username, password)
-
-	// Replace CLI uri with the one we just updated.
-	uri = dbURI.String()
 
 	db, err := sql.Open(driver, uri)
 	if err != nil {

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -44,6 +44,8 @@ func TestMigrateCommandNoConfigDefaultValues(t *testing.T) {
 	migrateCmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		require.Equal(t, "", viper.GetString(datastoreEngineFlag))
 		require.Equal(t, "", viper.GetString(datastoreURIFlag))
+		require.Equal(t, "", viper.GetString(datastoreUsernameFlag))
+		require.Equal(t, "", viper.GetString(datastorePasswordFlag))
 		require.Equal(t, uint(0), viper.GetUint(versionFlag))
 		require.Equal(t, defaultDuration, viper.GetDuration(timeoutFlag))
 		require.False(t, viper.GetBool(verboseMigrationFlag))


### PR DESCRIPTION
Before, openfga run had the possibility to overwrite the username / password present in the run command, but not in the migrate command.

This commit fixes it by adding the flags and the corresponding behavior to the migrate command. Furthermore it adds the env variable handling from run also to migrate

## References

Fixes #1125 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
