### PR TITLE
Healthcheck in `OpenFGA` Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,8 @@ EXPOSE 3000
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.22 /ko-app/grpc-health-probe /user/local/bin/grpc_health_probe
 COPY --from=builder /bin/openfga /openfga
 
+# Healthcheck configuration for the container using grpc_health_probe
+# The container will be considered healthy if the gRPC health probe returns a successful response.
+HEALTHCHECK --interval=5s --timeout=30s --retries=3 CMD ["/usr/local/bin/grpc_health_probe", "-addr=:8081"]
+
 ENTRYPOINT ["/openfga"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,8 +48,3 @@ services:
       - "8081:8081" #grpc
       - "3000:3000" #playground
       - "2112:2112" #prometheus metrics
-    healthcheck:
-      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=openfga:8081"]
-      interval: 5s
-      timeout: 30s
-      retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=password
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -48,3 +48,8 @@ services:
       - "8081:8081" #grpc
       - "3000:3000" #playground
       - "2112:2112" #prometheus metrics
+    healthcheck:
+      test: ["CMD", "/usr/local/bin/grpc_health_probe", "-addr=openfga:8081"]
+      interval: 5s
+      timeout: 30s
+      retries: 3


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request adds a gRPC health probe to the Dockerfile, which will be used to check the health of the container. The healthcheck configuration in `docker-compose.yaml` file has been removed and replaced with the new gRPC health probe. This change ensures that the container is considered healthy only if the gRPC health probe returns a successful response.


## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #1117

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
