### PR TITLE
chore(trace): use Noop TracerProvider if tracing is disabled

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -52,8 +52,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel"
 	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -290,7 +291,10 @@ func convertStringArrayToUintArray(stringArray []string) []uint {
 }
 
 func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
-	tp := sdktrace.NewTracerProvider()
+	otel.SetTracerProvider(trace.NewNoopTracerProvider())
+
+	var tracerProviderCloser func()
+
 	if config.Trace.Enabled {
 		s.Logger.Info(fmt.Sprintf("🕵 tracing enabled: sampling ratio is %v and sending traces to '%s', tls: %t", config.Trace.SampleRatio, config.Trace.OTLP.Endpoint, config.Trace.OTLP.TLS.Enabled))
 
@@ -309,7 +313,11 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 			options = append(options, telemetry.WithOTLPInsecure())
 		}
 
-		tp = telemetry.MustNewTracerProvider(options...)
+		tp := telemetry.MustNewTracerProvider(options...)
+		tracerProviderCloser = func() {
+			_ = tp.ForceFlush(ctx)
+			_ = tp.Shutdown(ctx)
+		}
 	}
 
 	s.Logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
@@ -706,8 +714,9 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	datastore.Close()
 
-	_ = tp.ForceFlush(ctx)
-	_ = tp.Shutdown(ctx)
+	if tracerProviderCloser != nil {
+		tracerProviderCloser()
+	}
 
 	s.Logger.Info("server exited. goodbye 👋")
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Set global tracer provider to a Noop TracerProvider if tracing is disabled.

## References
https://github.com/openfga/openfga/issues/1105

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
