### PR TITLE
chore(go): upgrade go 1.21.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/go:1.21@sha256:eb2d1372867b054146bcd0035a83772f486f01f7f0a05ac35f0866fe87264741 AS builder
+FROM cgr.dev/chainguard/go:1.21@sha256:60abea54575553ffa39feafecc630fbc1c8d1a55e35d359f43d8160bbd4afb9c AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openfga/openfga
 
-go 1.21.3
+go 1.21.4
 
 require (
 	github.com/Masterminds/squirrel v1.5.4


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
- Upgrade go 1.21.4 to fix a vulnerability issue reported by `govulncheck`

```
Vulnerability #1: GO-2023-2185
    Insecure parsing of Windows paths with a \??\ prefix in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2185
  Standard library
    Found in: path/filepath@go1.21.3
    Fixed in: path/filepath@go1.21.4
    Platforms: windows
    Example traces found:
Error:       #1: cmd/root.go:29:22: cmd.NewRootCommand calls viper.AddConfigPath, which eventually calls filepath.Abs
Error:       #2: cmd/openfga/main.go:28:27: openfga.main calls cobra.Command.Execute, which eventually calls filepath.Base
Error:       #3: cmd/root.go:29:22: cmd.NewRootCommand calls viper.AddConfigPath, which eventually calls filepath.Clean
Error:       #4: cmd/run/run.go:623:32: run.ServerContext.Run calls template.ParseFS, which eventually calls filepath.Glob
Error:       #5: cmd/util/util.go:84:42: util.PrepareTempConfigFile calls filepath.Join
Error:       #6: pkg/storage/memory/memory.go:478:12: memory.MemoryBackend.ReadAuthorizationModels calls sort.Slice, which eventually calls filepath.Split

=== Informational ===

Found 1 vulnerability in packages that you import, but there are no call
stacks leading to the use of this vulnerability. You may not need to
take any action. See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck
for details.

Vulnerability #1: GO-2023-2186
    Incorrect detection of reserved device names on Windows in path/filepath
  More info: https://pkg.go.dev/vuln/GO-2023-2186
  Standard library
    Found in: path/filepath@go1.21.3
    Fixed in: path/filepath@go1.21.4

Your code is affected by 1 vulnerability from the Go standard library.

Share feedback at https://go.dev/s/govulncheck-feedback.
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
