### PR TITLE
perf: Add concurrency on PostgreSQL query

### DIFF
--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -28,6 +28,7 @@ type Config struct {
 	MaxTuplesPerWriteField int
 	MaxTypesPerModelField  int
 
+	MaxConcurrency  int
 	MaxOpenConns    int
 	MaxIdleConns    int
 	ConnMaxIdleTime time.Duration
@@ -65,6 +66,12 @@ func WithMaxTuplesPerWrite(maxTuples int) DatastoreOption {
 func WithMaxTypesPerAuthorizationModel(maxTypes int) DatastoreOption {
 	return func(cfg *Config) {
 		cfg.MaxTypesPerModelField = maxTypes
+	}
+}
+
+func WithMaxConcurrency(c int) DatastoreOption {
+	return func(cfg *Config) {
+		cfg.MaxConcurrency = c
 	}
 }
 
@@ -115,6 +122,12 @@ func NewConfig(opts ...DatastoreOption) *Config {
 
 	if cfg.MaxTypesPerModelField == 0 {
 		cfg.MaxTypesPerModelField = storage.DefaultMaxTypesPerAuthorizationModel
+	}
+
+	if cfg.MaxConcurrency < 0 {
+		cfg.MaxConcurrency = 1
+	} else if cfg.MaxConcurrency == 0 {
+		cfg.MaxConcurrency = 5
 	}
 
 	return cfg


### PR DESCRIPTION
Add concurrency query at the ReadAuthorizationModels query on PostgreSQL.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Query the database concurrently at the `ReadAuthorizationModels` at the PostgreSQL package.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
