### PR TITLE
build: openfga depends on otel-collector

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -6,6 +6,9 @@ services:
   openfga:
     image: !reset null
     build: .
+    depends_on:
+      otel-collector:
+        condition: service_started
     environment:
       - OPENFGA_TRACE_ENABLED=true
       - OPENFGA_TRACE_SAMPLE_RATIO=1


### PR DESCRIPTION
## Description
Bring a change lost in https://github.com/openfga/openfga/pull/1092/files#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9

Before this PR:
```
$ docker-compose up --build openfga
 ✔ Container postgres       Created                                                                      0.1s 
 ✔ Container migrate        Created                                                                      0.1s 
 ✔ Container openfga        Created                                                                      0.1s 
Attaching to openfga
openfga  | 2023-11-14T23:53:46.923Z     INFO    🕵 tracing enabled: sampling ratio is 1 and sending traces to 'otel-collector:4317', tls: false
openfga  | panic: failed to establish a connection with the otlp exporter: context deadline exceeded
openfga  | 
openfga  | goroutine 1 [running]:
openfga  | github.com/openfga/openfga/pkg/telemetry.MustNewTracerProvider({0xc00012ea80, 0x4, 0xc0005bf700?})
openfga  |      /app/pkg/telemetry/tracing.go:87 +0x739
openfga  | github.com/openfga/openfga/cmd/run.(*ServerContext).Run(0xc00024c780, {0x1230180, 0x1a5da00}, 0xc00049cb40)
openfga  |      /app/cmd/run/run.go:316 +0x586
openfga  | github.com/openfga/openfga/cmd/run.run(0xc0001b6100?, {0x1a5da00?, 0x4?, 0x109877c?})
openfga  |      /app/cmd/run/run.go:272 +0xce
openfga  | github.com/spf13/cobra.(*Command).execute(0xc00028e300, {0x1a5da00, 0x0, 0x0})
openfga  |      /root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
openfga  | github.com/spf13/cobra.(*Command).ExecuteC(0xc00028e000)
openfga  |      /root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
openfga  | github.com/spf13/cobra.(*Command).Execute(0xc00028e000?)
openfga  |      /root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
openfga  | main.main()
openfga  |      /app/cmd/openfga/main.go:28 +0x12f
openfga exited with code 2

```

Now:

```
 $ docker-compose up --build openfga
 ✔ Network openfga_default   Created                                                                     0.1s 
 ✔ Container postgres        Created                                                                     0.1s 
 ✔ Container otel-collector  Created                                                                     0.1s 
 ✔ Container migrate         Created                                                                     0.2s 
 ✔ Container openfga         Created                                                                     0.1s 
Attaching to openfga
openfga  | 2023-11-14T23:53:02.696Z     INFO    🕵 tracing enabled: sampling ratio is 1 and sending traces to 'otel-collector:4317', tls: false
openfga  | 2023-11-14T23:53:02.700Z     INFO    🧪 experimental features enabled: []
openfga  | 2023-11-14T23:53:02.711Z     INFO    using 'postgres' storage engine
openfga  | 2023-11-14T23:53:02.711Z     WARN    authentication is disabled
openfga  | 2023-11-14T23:53:02.711Z     WARN    grpc TLS is disabled, serving connections using insecure plaintext
openfga  | 2023-11-14T23:53:02.711Z     INFO    📈 starting metrics server on '0.0.0.0:2112'
openfga  | 2023-11-14T23:53:02.711Z     INFO    🚀 starting openfga service...  {"version": "dev", "date": "unknown", "commit": "none", "go-version": "go1.21.4"}
openfga  | 2023-11-14T23:53:02.711Z     INFO    grpc server listening on '0.0.0.0:8081'...
openfga  | 2023-11-14T23:53:02.713Z     INFO    HTTP server listening on '0.0.0.0:8080'...
openfga  | 2023-11-14T23:53:02.713Z     INFO    🛝 starting openfga playground on http://localhost:3000/playground

```