### PR TITLE
test: speed up integration tests for mysql and postgres

### DIFF
--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -91,6 +91,7 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	hostCfg := container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
+		Tmpfs:           map[string]string{"/var/lib/mysql": ""},
 	}
 
 	name := fmt.Sprintf("mysql-%s", ulid.Make().String())

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -93,6 +93,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 	hostCfg := container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
+		Tmpfs:           map[string]string{"/var/lib/postgresql/data": ""},
 	}
 
 	name := fmt.Sprintf("postgres-%s", ulid.Make().String())


### PR DESCRIPTION
## Description

For https://github.com/openfga/openfga/issues/1140.

There's probably more things that we can do, but this is a start.

Before:
```shell
[14/11/23 6:35:06] ~/GitHub/openfga (main) $  grep -E "PASS:.*?\(\d+\.\d+s\)" tests.txt | sed -E 's/.*PASS:\s*(.*)\s*\((.*)s\)/\1\t\2/g' | sed -E 's/ //g' | sort --reverse -nk2 |  head -n 20
TestValidationResult    137.92
TestValidationResult/mysql      128.92
TestServerMetricsReporting      126.89
TestMySQLDatastore      118.86
TestServerMetricsReporting/mysql        114.72
TestMigrateCommandRollbacks     100.41
TestMigrateCommandRollbacks/mysql       91.74
TestServerWithMySQLDatastoreAndExplicitCredentials      70.46
TestServerWithMySQLDatastore    66.83
TestCheckMySQL  60.59
TestListObjectsMySQL    60.56
TestListObjectsPostgres 53.80
TestMySQLDatastoreAfterCloseIsNotReady  39.33
TestCheckPostgres       38.84
TestReadEnsureNoOrder   28.06
TestServerWithPostgresDatastoreAndExplicitCredentials   23.98
TestReadEnsureNoOrder   21.52
TestReadAuthorizationModelUnmarshallError       19.29
TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/list_objects_expands_wildcard_tuple 18.35
TestReadPageEnsureOrder 17.33
```

After:
```
[14/11/23 6:35:10] ~/GitHub/openfga (speed-up-tests) $ grep -E "PASS:.*?\(\d+\.\d+s\)" tests-after.txt | sed -E 's/.*PASS:\s*(.*)\s*\((.*)s\)/\1\t\2/g' | sed -E 's/ //g' | sort --reverse -nk2 |  head -n 20
TestServerMetricsReporting      94.73
TestServerMetricsReporting/mysql        89.54
TestValidationResult    89.18
TestValidationResult/mysql      78.20
TestMySQLDatastore      72.84
TestServerWithMySQLDatastore    68.62
TestMigrateCommandRollbacks     45.61
TestMigrateCommandRollbacks/mysql       43.23
TestCheckPostgres       36.40
TestListObjectsMySQL    35.33
TestCheckMySQL  31.97
TestServerWithMySQLDatastoreAndExplicitCredentials      31.95
TestMySQLDatastoreAfterCloseIsNotReady  27.20
TestCheckPostgres/RunAllTests/Check/Schema1_1/list_objects_expands_wildcard_tuple        25.13
TestReadPageEnsureOrder 17.85
TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/computed_user_indirect_ref_same_rel_name    16.34
TestReadEnsureNoOrder   14.61
TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/computed_user_indirect_ref_extra_indirection_wildcard       14.04
TestServerWithPostgresDatastore 13.76
TestListObjectsPostgres/RunAll/ListObjects/Schema1_1/two_level_computed_user_indirect_ref        13.15
```

## References

- https://docs.docker.com/storage/#good-use-cases-for-tmpfs-mounts
<img width="811" alt="image" src="https://github.com/openfga/openfga/assets/5374887/360b37e5-d44c-4599-b5c4-b382cbda389f">
