### PR TITLE
tests: make sure models have ids

### DIFF
--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -581,6 +581,10 @@ condition condition1(x: int) {
 				}
 			}
 
+			if model.Id == "" {
+				model.Id = ulid.Make().String()
+			}
+
 			err := ds.WriteAuthorizationModel(ctx, storeID, model)
 			require.NoError(t, err)
 


### PR DESCRIPTION
## Description

Storage implementations might rightfully expect authorization model's id to be a non empty string.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
