### PR TITLE
fix: storage conflict errors return 409 instead of 500

### DIFF
--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -165,7 +165,7 @@ func (c *WriteCommand) validateNoDuplicatesAndCorrectSize(
 
 func handleError(err error) error {
 	if errors.Is(err, storage.ErrTransactionalWriteFailed) {
-		return status.Error(codes.Aborted, "transaction aborted")
+		return status.Error(codes.Aborted, err.Error())
 	} else if errors.Is(err, storage.ErrInvalidWriteInput) {
 		return serverErrors.WriteFailedDueToInvalidInput(err)
 	}

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/server/config"
@@ -15,6 +13,8 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/server/config"
@@ -163,7 +165,7 @@ func (c *WriteCommand) validateNoDuplicatesAndCorrectSize(
 
 func handleError(err error) error {
 	if errors.Is(err, storage.ErrTransactionalWriteFailed) {
-		return serverErrors.NewInternalError("concurrent write conflict", err)
+		return status.Error(codes.Aborted, "transaction aborted")
 	} else if errors.Is(err, storage.ErrInvalidWriteInput) {
 		return serverErrors.WriteFailedDueToInvalidInput(err)
 	}

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -3,6 +3,8 @@ package commands
 import (
 	"context"
 	"fmt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -229,14 +231,8 @@ type document
 			},
 		},
 	})
-	require.ErrorIs(
-		t,
-		err,
-		serverErrors.NewInternalError(
-			"concurrent write conflict",
-			storage.ErrTransactionalWriteFailed,
-		),
-	)
+
+	require.ErrorIs(t, err, status.Error(codes.Aborted, "transaction aborted"))
 	require.Nil(t, resp)
 }
 

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -3,8 +3,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -19,6 +17,8 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -232,7 +232,7 @@ type document
 		},
 	})
 
-	require.ErrorIs(t, err, status.Error(codes.Aborted, "transaction aborted"))
+	require.ErrorIs(t, err, status.Error(codes.Aborted, storage.ErrTransactionalWriteFailed.Error()))
 	require.Nil(t, resp)
 }
 

--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -68,7 +68,6 @@ func sanitizedMessage(message string) string {
 // NewEncodedError returns the encoded error with the correct http status code etc.
 func NewEncodedError(errorCode int32, message string) *EncodedError {
 	if !IsValidEncodedError(errorCode) {
-		// Check to see if it is aborted
 		if errorCode == int32(codes.Aborted) {
 			return &EncodedError{
 				HTTPStatusCode: http.StatusConflict,

--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -68,6 +68,18 @@ func sanitizedMessage(message string) string {
 // NewEncodedError returns the encoded error with the correct http status code etc.
 func NewEncodedError(errorCode int32, message string) *EncodedError {
 	if !IsValidEncodedError(errorCode) {
+		// Check to see if it is aborted
+		if errorCode == int32(codes.Aborted) {
+			return &EncodedError{
+				HTTPStatusCode: http.StatusConflict,
+				GRPCStatusCode: codes.Aborted,
+				ActualError: ErrorResponse{
+					Code:    codes.Aborted.String(),
+					Message: sanitizedMessage(message),
+					codeInt: errorCode,
+				},
+			}
+		}
 		return &EncodedError{
 			HTTPStatusCode: http.StatusInternalServerError,
 			GRPCStatusCode: codes.Internal,
@@ -228,7 +240,7 @@ func ConvertToEncodedErrorCode(statusError *status.Status) int32 {
 	case codes.FailedPrecondition:
 		return int32(openfgav1.InternalErrorCode_failed_precondition)
 	case codes.Aborted:
-		return int32(openfgav1.InternalErrorCode_aborted)
+		return int32(codes.Aborted)
 	case codes.OutOfRange:
 		return int32(openfgav1.InternalErrorCode_out_of_range)
 	case codes.Unimplemented:

--- a/pkg/server/errors/encoded_errors_test.go
+++ b/pkg/server/errors/encoded_errors_test.go
@@ -18,9 +18,16 @@ func TestEncodedError(t *testing.T) {
 		expectedCode           int
 		expectedCodeString     string
 		expectedHTTPStatusCode int
-		isValidEncodedError    bool
 	}
 	var tests = []encodedTests{
+		{
+			_name:                  "aborted_error",
+			errorCode:              int32(codes.Aborted),
+			message:                "error message",
+			expectedHTTPStatusCode: http.StatusConflict,
+			expectedCode:           int(codes.Aborted),
+			expectedCodeString:     "Aborted",
+		},
 		{
 			_name:                  "invalid_error",
 			errorCode:              20,
@@ -28,7 +35,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusInternalServerError,
 			expectedCode:           20,
 			expectedCodeString:     "20",
-			isValidEncodedError:    false,
 		},
 		{
 			_name:                  "auth_error:_invalid subject",
@@ -37,7 +43,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1001,
 			expectedCodeString:     "auth_failed_invalid_subject",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_invalid_audience",
@@ -46,7 +51,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1002,
 			expectedCodeString:     "auth_failed_invalid_audience",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_invalid issuer",
@@ -55,7 +59,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1003,
 			expectedCodeString:     "auth_failed_invalid_issuer",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_invalid_claims",
@@ -64,7 +67,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1004,
 			expectedCodeString:     "invalid_claims",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_invalid_bearer_token",
@@ -73,7 +75,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1005,
 			expectedCodeString:     "auth_failed_invalid_bearer_token",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_missing_bearer_token",
@@ -82,7 +83,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1010,
 			expectedCodeString:     "bearer_token_missing",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "auth_error:_unauthorized",
@@ -91,7 +91,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusUnauthorized,
 			expectedCode:           1500,
 			expectedCodeString:     "unauthenticated",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "validation_error",
@@ -100,7 +99,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusBadRequest,
 			expectedCode:           2000,
 			expectedCodeString:     "validation_error",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "internal_error",
@@ -109,7 +107,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusInternalServerError,
 			expectedCode:           4000,
 			expectedCodeString:     "internal_error",
-			isValidEncodedError:    true,
 		},
 		{
 			_name:                  "undefined_endpoint",
@@ -118,7 +115,6 @@ func TestEncodedError(t *testing.T) {
 			expectedHTTPStatusCode: http.StatusNotFound,
 			expectedCode:           5000,
 			expectedCodeString:     "undefined_endpoint",
-			isValidEncodedError:    true,
 		},
 	}
 	for _, test := range tests {
@@ -128,7 +124,6 @@ func TestEncodedError(t *testing.T) {
 			require.Equal(t, test.expectedHTTPStatusCode, actualError.HTTPStatusCode)
 			require.Equal(t, test.expectedCodeString, actualError.Code())
 			require.Equal(t, int32(test.expectedCode), actualError.CodeValue())
-			require.Equal(t, test.isValidEncodedError, IsValidEncodedError(actualError.CodeValue()))
 		})
 	}
 }
@@ -188,7 +183,7 @@ func TestConvertToEncodedErrorCode(t *testing.T) {
 		{
 			_name:             "aborted",
 			status:            status.New(codes.Aborted, "other error"),
-			expectedErrorCode: int32(openfgav1.InternalErrorCode_aborted),
+			expectedErrorCode: int32(codes.Aborted),
 		},
 		{
 			_name:             "out_of_range",

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -15,7 +15,7 @@ var (
 	ErrInvalidContinuationToken = errors.New("invalid continuation token")
 	ErrInvalidWriteInput        = errors.New("invalid write input")
 	ErrNotFound                 = errors.New("not found")
-	ErrTransactionalWriteFailed = errors.New("transactional write failed due to bad input")
+	ErrTransactionalWriteFailed = errors.New("transactional write failed due to conflict")
 	ErrMismatchObjectType       = errors.New("mismatched types in request and continuation token")
 	ErrExceededWriteBatchLimit  = errors.New("number of operations exceeded write batch limit")
 	ErrCancelled                = errors.New("request has been cancelled")


### PR DESCRIPTION

## Description
In the case of error is write failure is due to ErrTransactionalWriteFailed.  We should return 409 instead of 500 error.

## References
Close https://github.com/openfga/openfga/issues/1080
Corresponding change https://github.com/openfga/api/pull/107


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
