### PR TITLE
chore: memory storage stores TupleRecords internally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ go-generate: install-tools
 
 .PHONY: unit-test
 unit-test: go-generate ## Run unit tests
-	go test -v -race \
+	go test -race \
 			-coverpkg=./... \
 			-coverprofile=coverageunit.tmp.out \
 			-covermode=atomic \
@@ -77,7 +77,7 @@ build-functional-test-image: ## Build Docker image needed to run functional test
 
 .PHONY: functional-test
 functional-test: ## Run functional tests (needs build-functional-test-image)
-	go test -v -race \
+	go test -race \
 			-count=1 \
 			-timeout=5m \
 			-tags=functional \

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ go-generate: install-tools
 
 .PHONY: unit-test
 unit-test: go-generate ## Run unit tests
-	go test -race \
+	go test -v -race \
 			-coverpkg=./... \
 			-coverprofile=coverageunit.tmp.out \
 			-covermode=atomic \
@@ -77,7 +77,7 @@ build-functional-test-image: ## Build Docker image needed to run functional test
 
 .PHONY: functional-test
 functional-test: ## Run functional tests (needs build-functional-test-image)
-	go test -race \
+	go test -v -race \
 			-count=1 \
 			-timeout=5m \
 			-tags=functional \

--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -354,33 +354,32 @@ func ReadQuerySuccessTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		},
 	}
 
-	require := require.New(t)
 	ctx := context.Background()
 
 	for _, test := range tests {
 		t.Run(test._name, func(t *testing.T) {
 			store := ulid.Make().String()
 			err := datastore.WriteAuthorizationModel(ctx, store, test.model)
-			require.NoError(err)
+			require.NoError(t, err)
 
 			if test.tuples != nil {
 				err = datastore.Write(ctx, store, []*openfgav1.TupleKey{}, test.tuples)
-				require.NoError(err)
+				require.NoError(t, err)
 			}
 
 			test.request.StoreId = store
 			resp, err := commands.NewReadQuery(datastore).Execute(ctx, test.request)
-			require.NoError(err)
+			require.NoError(t, err)
 
 			if test.response.Tuples != nil {
-				require.Equal(len(test.response.Tuples), len(resp.Tuples))
+				require.Equal(t, len(test.response.Tuples), len(resp.Tuples))
 
 				for i, responseTuple := range test.response.Tuples {
 					responseTupleKey := responseTuple.Key
 					actualTupleKey := resp.Tuples[i].Key
-					require.Equal(responseTupleKey.Object, actualTupleKey.Object)
-					require.Equal(responseTupleKey.Relation, actualTupleKey.Relation)
-					require.Equal(responseTupleKey.User, actualTupleKey.User)
+					require.Equal(t, responseTupleKey.Object, actualTupleKey.Object)
+					require.Equal(t, responseTupleKey.Relation, actualTupleKey.Relation)
+					require.Equal(t, responseTupleKey.User, actualTupleKey.User)
 				}
 			}
 		})

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/telemetry"
@@ -21,48 +22,39 @@ import (
 var tracer = otel.Tracer("openfga/pkg/storage/memory")
 
 type staticIterator struct {
-	tuples            []*openfgav1.Tuple
+	records           []*storage.TupleRecord
 	continuationToken []byte
 	mu                sync.Mutex
-}
-
-func match(key *openfgav1.TupleKey, target *openfgav1.TupleKey) bool {
-	if key.Object != "" {
-		td, objectid := tupleUtils.SplitObject(key.Object)
-		if objectid == "" {
-			if td != tupleUtils.GetType(target.Object) {
-				return false
-			}
-		} else {
-			if key.Object != target.Object {
-				return false
-			}
-		}
-	}
-	if key.Relation != "" && key.Relation != target.Relation {
-		return false
-	}
-	if key.User != "" && key.User != target.User {
-		return false
-	}
-	return true
 }
 
 func (s *staticIterator) Next() (*openfgav1.Tuple, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if len(s.tuples) == 0 {
+	if len(s.records) == 0 {
 		return nil, storage.ErrIteratorDone
 	}
 
-	next, rest := s.tuples[0], s.tuples[1:]
-	s.tuples = rest
-
-	return next, nil
+	next, rest := s.records[0], s.records[1:]
+	s.records = rest
+	return next.AsTuple(), nil
 }
 
 func (s *staticIterator) Stop() {}
+
+func (s *staticIterator) ToArray() ([]*openfgav1.Tuple, []byte, error) {
+	var res []*openfgav1.Tuple
+	for range s.records {
+		t, err := s.Next()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		res = append(res, t)
+	}
+
+	return res, s.continuationToken, nil
+}
 
 type StorageOption func(ds *MemoryBackend)
 
@@ -71,7 +63,7 @@ const (
 	defaultMaxTypesPerAuthorizationModel = 100
 )
 
-// A MemoryBackend provides an ephemeral memory-backed implementation of TupleBackend and AuthorizationModelBackend.
+// A MemoryBackend provides an ephemeral memory-backed implementation of storage.OpenFGADatastore.
 // MemoryBackend instances may be safely shared by multiple go-routines.
 type MemoryBackend struct {
 	maxTuplesPerWrite             int
@@ -80,7 +72,7 @@ type MemoryBackend struct {
 
 	// TupleBackend
 	// map: store => set of tuples
-	tuples map[string][]*openfgav1.Tuple /* GUARDED_BY(mu) */
+	tuples map[string][]*storage.TupleRecord /* GUARDED_BY(mu) */
 
 	// ChangelogBackend
 	// map: store => set of changes
@@ -109,7 +101,7 @@ func New(opts ...StorageOption) storage.OpenFGADatastore {
 	ds := &MemoryBackend{
 		maxTuplesPerWrite:             defaultMaxTuplesPerWrite,
 		maxTypesPerAuthorizationModel: defaultMaxTypesPerAuthorizationModel,
-		tuples:                        make(map[string][]*openfgav1.Tuple, 0),
+		tuples:                        make(map[string][]*storage.TupleRecord, 0),
 		changes:                       make(map[string][]*openfgav1.TupleChange, 0),
 		authorizationModels:           make(map[string]map[string]*AuthorizationModelEntry),
 		stores:                        make(map[string]*openfgav1.Store, 0),
@@ -153,7 +145,7 @@ func (s *MemoryBackend) ReadPage(ctx context.Context, store string, key *openfga
 		return nil, nil, err
 	}
 
-	return it.tuples, it.continuationToken, nil
+	return it.ToArray()
 }
 
 func (s *MemoryBackend) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
@@ -226,13 +218,13 @@ func (s *MemoryBackend) read(ctx context.Context, store string, tk *openfgav1.Tu
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var matches []*openfgav1.Tuple
+	var matches []*storage.TupleRecord
 	if tk.GetObject() == "" && tk.GetRelation() == "" && tk.GetUser() == "" {
-		matches = make([]*openfgav1.Tuple, len(s.tuples[store]))
+		matches = make([]*storage.TupleRecord, len(s.tuples[store]))
 		copy(matches, s.tuples[store])
 	} else {
 		for _, t := range s.tuples[store] {
-			if match(tk, t.Key) {
+			if t.Match(tk) {
 				matches = append(matches, t)
 			}
 		}
@@ -254,10 +246,10 @@ func (s *MemoryBackend) read(ctx context.Context, store string, tk *openfgav1.Tu
 
 	to := paginationOptions.PageSize
 	if to != 0 && to < len(matches) {
-		return &staticIterator{tuples: matches[:to], continuationToken: []byte(strconv.Itoa(from + to))}, nil
+		return &staticIterator{records: matches[:to], continuationToken: []byte(strconv.Itoa(from + to))}, nil
 	}
 
-	return &staticIterator{tuples: matches}, nil
+	return &staticIterator{records: matches}, nil
 }
 
 // Write See storage.TupleBackend.Write
@@ -274,53 +266,56 @@ func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage
 		return err
 	}
 
-	var tuples []*openfgav1.Tuple
+	var records []*storage.TupleRecord
 Delete:
 	for _, t := range s.tuples[store] {
 		for _, k := range deletes {
-			if match(k, t.Key) {
-				s.changes[store] = append(s.changes[store], &openfgav1.TupleChange{TupleKey: t.Key, Operation: openfgav1.TupleOperation_TUPLE_OPERATION_DELETE, Timestamp: now})
+			if t.Match(k) {
+				s.changes[store] = append(s.changes[store], &openfgav1.TupleChange{TupleKey: t.AsTuple().Key, Operation: openfgav1.TupleOperation_TUPLE_OPERATION_DELETE, Timestamp: now})
 				continue Delete
 			}
 		}
-		tuples = append(tuples, t)
+		records = append(records, t)
 	}
 
 Write:
 	for _, t := range writes {
-		for _, et := range tuples {
-			if match(t, et.Key) {
+		for _, et := range records {
+			if et.Match(t) {
 				continue Write
 			}
 		}
-		tuples = append(tuples, &openfgav1.Tuple{Key: t, Timestamp: now})
+
+		objectType, objectID := tupleUtils.SplitObject(t.Object)
+
+		records = append(records, &storage.TupleRecord{
+			Store:      store,
+			ObjectType: objectType,
+			ObjectID:   objectID,
+			Relation:   t.Relation,
+			User:       t.User,
+			Ulid:       ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
+			InsertedAt: now.AsTime(),
+		})
+
 		s.changes[store] = append(s.changes[store], &openfgav1.TupleChange{TupleKey: t, Operation: openfgav1.TupleOperation_TUPLE_OPERATION_WRITE, Timestamp: now})
 	}
-	s.tuples[store] = tuples
+	s.tuples[store] = records
 	return nil
 }
 
-func validateTuples(tuples []*openfgav1.Tuple, deletes, writes []*openfgav1.TupleKey) error {
+func validateTuples(records []*storage.TupleRecord, deletes, writes []*openfgav1.TupleKey) error {
 	for _, tk := range deletes {
-		if !find(tuples, tk) {
+		if !storage.Find(records, tk) {
 			return storage.InvalidWriteInputError(tk, openfgav1.TupleOperation_TUPLE_OPERATION_DELETE)
 		}
 	}
 	for _, tk := range writes {
-		if find(tuples, tk) {
+		if storage.Find(records, tk) {
 			return storage.InvalidWriteInputError(tk, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)
 		}
 	}
 	return nil
-}
-
-func find(tuples []*openfgav1.Tuple, tupleKey *openfgav1.TupleKey) bool {
-	for _, tuple := range tuples {
-		if match(tuple.Key, tupleKey) {
-			return true
-		}
-	}
-	return false
 }
 
 // ReadUserTuple See storage.TupleBackend.ReadUserTuple
@@ -332,8 +327,8 @@ func (s *MemoryBackend) ReadUserTuple(ctx context.Context, store string, key *op
 	defer s.mu.Unlock()
 
 	for _, t := range s.tuples[store] {
-		if match(key, t.Key) {
-			return t, nil
+		if t.Match(key) {
+			return t.AsTuple(), nil
 		}
 	}
 
@@ -349,20 +344,20 @@ func (s *MemoryBackend) ReadUsersetTuples(ctx context.Context, store string, fil
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var matches []*openfgav1.Tuple
+	var matches []*storage.TupleRecord
 	for _, t := range s.tuples[store] {
-		if match(&openfgav1.TupleKey{
+		if t.Match(&openfgav1.TupleKey{
 			Object:   filter.Object,
 			Relation: filter.Relation,
-		}, t.Key) && tupleUtils.GetUserTypeFromUser(t.GetKey().GetUser()) == tupleUtils.UserSet {
+		}) && tupleUtils.GetUserTypeFromUser(t.User) == tupleUtils.UserSet {
 			if len(filter.AllowedUserTypeRestrictions) == 0 { // 1.0 model
 				matches = append(matches, t)
 				continue
 			}
 
 			// 1.1 model: see if the tuple found is of an allowed type
-			userType := tupleUtils.GetType(t.GetKey().GetUser())
-			_, userRelation := tupleUtils.SplitObjectRelation(t.GetKey().GetUser())
+			userType := tupleUtils.GetType(t.User)
+			_, userRelation := tupleUtils.SplitObjectRelation(t.User)
 			for _, allowedType := range filter.AllowedUserTypeRestrictions {
 				if allowedType.Type == userType && allowedType.GetRelation() == userRelation {
 					matches = append(matches, t)
@@ -372,7 +367,7 @@ func (s *MemoryBackend) ReadUsersetTuples(ctx context.Context, store string, fil
 		}
 	}
 
-	return &staticIterator{tuples: matches}, nil
+	return &staticIterator{records: matches}, nil
 }
 
 func (s *MemoryBackend) ReadStartingWithUser(
@@ -386,13 +381,13 @@ func (s *MemoryBackend) ReadStartingWithUser(
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var matches []*openfgav1.Tuple
+	var matches []*storage.TupleRecord
 	for _, t := range s.tuples[store] {
-		if tupleUtils.GetType(t.Key.GetObject()) != filter.ObjectType {
+		if t.ObjectType != filter.ObjectType {
 			continue
 		}
 
-		if t.Key.GetRelation() != filter.Relation {
+		if t.Relation != filter.Relation {
 			continue
 		}
 
@@ -402,12 +397,12 @@ func (s *MemoryBackend) ReadStartingWithUser(
 				targetUser = tupleUtils.GetObjectRelationAsString(userFilter)
 			}
 
-			if targetUser == t.Key.GetUser() {
+			if targetUser == t.User {
 				matches = append(matches, t)
 			}
 		}
 	}
-	return &staticIterator{tuples: matches}, nil
+	return &staticIterator{records: matches}, nil
 }
 
 func findAuthorizationModelByID(id string, configurations map[string]*AuthorizationModelEntry) (*openfgav1.AuthorizationModel, bool) {

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -114,7 +114,7 @@ func TestTupleRecordMatchTupleKey(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.match, Match(test.source, test.target))
+			require.Equal(t, test.match, match(test.source, test.target))
 		})
 	}
 }
@@ -148,7 +148,7 @@ func TestFindTupleKey(t *testing.T) {
 	}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.found, Find(test.records, test.tupleKey))
+			require.Equal(t, test.found, find(test.records, test.tupleKey))
 		})
 	}
 }

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -4,8 +4,10 @@ import (
 	"testing"
 
 	"github.com/oklog/ulid/v2"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/test"
+	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -51,4 +53,102 @@ func TestStaticTupleIteratorNoRace(t *testing.T) {
 		_, err := iter.Next()
 		require.NoError(t, err)
 	}()
+}
+
+func TestTupleRecordMatchTupleKey(t *testing.T) {
+	var testCases = map[string]struct {
+		target *openfgav1.TupleKey
+		source *storage.TupleRecord
+		match  bool
+	}{
+		`no_match_in_user`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &storage.TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:2",
+			},
+			match: false,
+		},
+		`no_match_in_relation`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &storage.TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "writer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`no_match_in_object_type`: {
+			target: tuple.NewTupleKey("document", "viewer", "user:1"),
+			source: &storage.TupleRecord{
+				ObjectType: "group",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`no_match_in_object_id`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &storage.TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "z",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`match`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &storage.TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.match, Match(test.source, test.target))
+		})
+	}
+}
+
+func TestFindTupleKey(t *testing.T) {
+	var testCases = map[string]struct {
+		records  []*storage.TupleRecord
+		tupleKey *openfgav1.TupleKey
+		found    bool
+	}{
+		`not_find`: {
+			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			records: []*storage.TupleRecord{{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:2",
+			}},
+			found: false,
+		},
+		`find`: {
+			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			records: []*storage.TupleRecord{{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			}},
+			found: true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.found, Find(test.records, test.tupleKey))
+		})
+	}
 }

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -3,10 +3,11 @@ package memory
 import (
 	"testing"
 
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/oklog/ulid/v2"
+	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/test"
-	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestMemdbStorage(t *testing.T) {
@@ -15,13 +16,27 @@ func TestMemdbStorage(t *testing.T) {
 }
 
 func TestStaticTupleIteratorNoRace(t *testing.T) {
+	now := timestamppb.Now()
+
 	iter := &staticIterator{
-		tuples: []*openfgav1.Tuple{
+		records: []*storage.TupleRecord{
 			{
-				Key: tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+				Store:      "store",
+				ObjectType: "document",
+				ObjectID:   "1",
+				Relation:   "viewer",
+				User:       "user:jon",
+				Ulid:       ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
+				InsertedAt: now.AsTime(),
 			},
 			{
-				Key: tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+				Store:      "store",
+				ObjectType: "document",
+				ObjectID:   "1",
+				Relation:   "viewer",
+				User:       "user:jon",
+				Ulid:       ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
+				InsertedAt: now.AsTime(),
 			},
 		},
 	}

--- a/pkg/storage/record.go
+++ b/pkg/storage/record.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"time"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type TupleRecord struct {
+	Store      string
+	ObjectType string
+	ObjectID   string
+	Relation   string
+	User       string
+	Ulid       string
+	InsertedAt time.Time
+}
+
+func (t *TupleRecord) AsTuple() *openfgav1.Tuple {
+	tk := &openfgav1.TupleKey{
+		Object:   tupleUtils.BuildObject(t.ObjectType, t.ObjectID),
+		Relation: t.Relation,
+		User:     t.User,
+	}
+
+	return &openfgav1.Tuple{
+		Key:       tk,
+		Timestamp: timestamppb.New(t.InsertedAt),
+	}
+}
+
+// Match returns true if all the fields in *TupleRecord are equal to the same field in the target *TupleKey.
+// If the input Object doesn't specify an ID, only the Object Types are compared.
+// If a field in the input parameter is empty, it is ignored in the comparison.
+func (t *TupleRecord) Match(target *openfgav1.TupleKey) bool {
+	if target.Object != "" {
+		td, objectid := tupleUtils.SplitObject(target.Object)
+		if objectid == "" {
+			if td != t.ObjectType {
+				return false
+			}
+		} else {
+			if td != t.ObjectType || objectid != t.ObjectID {
+				return false
+			}
+		}
+	}
+	if target.Relation != "" && t.Relation != target.Relation {
+		return false
+	}
+	if target.User != "" && t.User != target.User {
+		return false
+	}
+	return true
+}
+
+// Find returns true if there is any *TupleRecord for which storage.Match returns true
+func Find(records []*TupleRecord, tupleKey *openfgav1.TupleKey) bool {
+	for _, tr := range records {
+		if tr.Match(tupleKey) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/storage/record.go
+++ b/pkg/storage/record.go
@@ -30,38 +30,3 @@ func (t *TupleRecord) AsTuple() *openfgav1.Tuple {
 		Timestamp: timestamppb.New(t.InsertedAt),
 	}
 }
-
-// Match returns true if all the fields in *TupleRecord are equal to the same field in the target *TupleKey.
-// If the input Object doesn't specify an ID, only the Object Types are compared.
-// If a field in the input parameter is empty, it is ignored in the comparison.
-func (t *TupleRecord) Match(target *openfgav1.TupleKey) bool {
-	if target.Object != "" {
-		td, objectid := tupleUtils.SplitObject(target.Object)
-		if objectid == "" {
-			if td != t.ObjectType {
-				return false
-			}
-		} else {
-			if td != t.ObjectType || objectid != t.ObjectID {
-				return false
-			}
-		}
-	}
-	if target.Relation != "" && t.Relation != target.Relation {
-		return false
-	}
-	if target.User != "" && t.User != target.User {
-		return false
-	}
-	return true
-}
-
-// Find returns true if there is any *TupleRecord for which storage.Match returns true
-func Find(records []*TupleRecord, tupleKey *openfgav1.TupleKey) bool {
-	for _, tr := range records {
-		if tr.Match(tupleKey) {
-			return true
-		}
-	}
-	return false
-}

--- a/pkg/storage/record_test.go
+++ b/pkg/storage/record_test.go
@@ -5,74 +5,8 @@ import (
 	"time"
 
 	"github.com/oklog/ulid/v2"
-	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/stretchr/testify/require"
 )
-
-func TestTupleRecordMatchTupleKey(t *testing.T) {
-	var testCases = map[string]struct {
-		target *openfgav1.TupleKey
-		source *TupleRecord
-		match  bool
-	}{
-		`no_match_in_user`: {
-			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			source: &TupleRecord{
-				ObjectType: "document",
-				ObjectID:   "x",
-				Relation:   "viewer",
-				User:       "user:2",
-			},
-			match: false,
-		},
-		`no_match_in_relation`: {
-			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			source: &TupleRecord{
-				ObjectType: "document",
-				ObjectID:   "x",
-				Relation:   "writer",
-				User:       "user:1",
-			},
-			match: false,
-		},
-		`no_match_in_object_type`: {
-			target: tuple.NewTupleKey("document", "viewer", "user:1"),
-			source: &TupleRecord{
-				ObjectType: "group",
-				ObjectID:   "x",
-				Relation:   "viewer",
-				User:       "user:1",
-			},
-			match: false,
-		},
-		`no_match_in_object_id`: {
-			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			source: &TupleRecord{
-				ObjectType: "document",
-				ObjectID:   "z",
-				Relation:   "viewer",
-				User:       "user:1",
-			},
-			match: false,
-		},
-		`match`: {
-			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			source: &TupleRecord{
-				ObjectType: "document",
-				ObjectID:   "x",
-				Relation:   "viewer",
-				User:       "user:1",
-			},
-			match: true,
-		},
-	}
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.match, test.source.Match(test.target))
-		})
-	}
-}
 
 func TestAsTuple(t *testing.T) {
 	now := time.Now().UTC()
@@ -91,38 +25,4 @@ func TestAsTuple(t *testing.T) {
 	require.Equal(t, "object-type:object-id", tuple.Key.GetObject())
 	require.Equal(t, "relation", tuple.Key.GetRelation())
 	require.Equal(t, now, tuple.GetTimestamp().AsTime().UTC())
-}
-
-func TestFindTupleKey(t *testing.T) {
-	var testCases = map[string]struct {
-		records  []*TupleRecord
-		tupleKey *openfgav1.TupleKey
-		found    bool
-	}{
-		`not_find`: {
-			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			records: []*TupleRecord{{
-				ObjectType: "document",
-				ObjectID:   "x",
-				Relation:   "viewer",
-				User:       "user:2",
-			}},
-			found: false,
-		},
-		`find`: {
-			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
-			records: []*TupleRecord{{
-				ObjectType: "document",
-				ObjectID:   "x",
-				Relation:   "viewer",
-				User:       "user:1",
-			}},
-			found: true,
-		},
-	}
-	for name, test := range testCases {
-		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.found, Find(test.records, test.tupleKey))
-		})
-	}
 }

--- a/pkg/storage/record_test.go
+++ b/pkg/storage/record_test.go
@@ -1,0 +1,128 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTupleRecordMatchTupleKey(t *testing.T) {
+	var testCases = map[string]struct {
+		target *openfgav1.TupleKey
+		source *TupleRecord
+		match  bool
+	}{
+		`no_match_in_user`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:2",
+			},
+			match: false,
+		},
+		`no_match_in_relation`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "writer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`no_match_in_object_type`: {
+			target: tuple.NewTupleKey("document", "viewer", "user:1"),
+			source: &TupleRecord{
+				ObjectType: "group",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`no_match_in_object_id`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "z",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: false,
+		},
+		`match`: {
+			target: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			source: &TupleRecord{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			},
+			match: true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.match, test.source.Match(test.target))
+		})
+	}
+}
+
+func TestAsTuple(t *testing.T) {
+	now := time.Now().UTC()
+	tr := &TupleRecord{
+		Store:      "store-id",
+		ObjectType: "object-type",
+		ObjectID:   "object-id",
+		Relation:   "relation",
+		User:       "user-id",
+		Ulid:       ulid.Make().String(),
+		InsertedAt: now,
+	}
+
+	tuple := tr.AsTuple()
+	require.Equal(t, "user-id", tuple.Key.GetUser())
+	require.Equal(t, "object-type:object-id", tuple.Key.GetObject())
+	require.Equal(t, "relation", tuple.Key.GetRelation())
+	require.Equal(t, now, tuple.GetTimestamp().AsTime().UTC())
+}
+
+func TestFindTupleKey(t *testing.T) {
+	var testCases = map[string]struct {
+		records  []*TupleRecord
+		tupleKey *openfgav1.TupleKey
+		found    bool
+	}{
+		`not_find`: {
+			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			records: []*TupleRecord{{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:2",
+			}},
+			found: false,
+		},
+		`find`: {
+			tupleKey: tuple.NewTupleKey("document:x", "viewer", "user:1"),
+			records: []*TupleRecord{{
+				ObjectType: "document",
+				ObjectID:   "x",
+				Relation:   "viewer",
+				User:       "user:1",
+			}},
+			found: true,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.found, Find(test.records, test.tupleKey))
+		})
+	}
+}


### PR DESCRIPTION
## Description
Bring these changes over to `main`: 
- https://github.com/openfga/openfga/pull/999/files#diff-76e1d9c2639fc6c407f987f2698d74723cbe632c79cb31a5e0c1140dd33783b7
- https://github.com/openfga/openfga/pull/999/files#diff-bae0ac15d10001bd5dd35974bc2075e71b6dbc7d590a3157b40ded4480ace797

(I removed all the ABAC-related stuff in this PR)

The reason for this change is to lay the groundwork for `feat/abac`. Currently, the `feat/abac` branch has a regression for the memory storage adapter. See https://github.com/openfga/openfga/actions/runs/7009608156/job/19068427402?pr=1038. Specifically, the regression is that we are introducing lots of calls to `AsTuple`:

```shell
git checkout feat/abac
go test -run=XXX -bench=BenchmarkCheckMemory/BenchmarkCheckWithDirectResolution -benchtime 5s -memprofile heapprofileabac.out 
git checkout origin/main
go test -run=XXX -bench=BenchmarkCheckMemory/BenchmarkCheckWithDirectResolution -benchtime 5s -memprofile heapprofilemain.out

go tool pprof -http=localhost:8084 -diff_base heapprofilemain.out heapprofileabac.out
```

<img width="1930" alt="image" src="https://github.com/openfga/openfga/assets/5374887/4d0f4553-a845-47d7-9d79-ee58762428e8">
