### PR TITLE
ci(stale-bot): add stale bot to check for stale PRs and issues

### DIFF
--- a/.github/workflows/stale-bot.yaml
+++ b/.github/workflows/stale-bot.yaml
@@ -1,4 +1,4 @@
-name: 'Close stale issues and PRs'
+name: 'Comment on stale issues and PRs'
 on:
   schedule:
     - cron: '30 1 * * *'

--- a/.github/workflows/stale-bot.yaml
+++ b/.github/workflows/stale-bot.yaml
@@ -1,0 +1,22 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: "It appears this issue has been stale for at least 14 days 🗓️. If no action is taken the maintainer team may consider closing the issue. Please reach out if you need feedback or follow up actions from the maintainer team."
+          stale-pr-message: "It appears this PR has been stale for at least 14 days 🗓️. If no action is taken the maintainer team may consider closing the PR. Please reach out if you need assistance or help to finish the work 👍🏼."
+          days-before-stale: 14
+          days-before-close: -1
+          days-before-issue-close: -1
+          remove-issue-stale-when-updated: true
+          remove-pr-stale-when-updated: true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds a bot to detect stale PRs and issues. The staleness check has been configured to not automatically close any PR or issue, but we do give warning that if action is not taken then the maintainer reserves the right to close it without further activity.

By default PRs and issues will be labeled with the `stale` label. So that will allow us as a maintainer team to quickly search/filter for the issues and PRs that are inactive.

## References
https://github.com/actions/stale

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
