### PR TITLE
build: update docker default command and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=bind,target=. \
     CGO_ENABLED=0 go build -o /bin/openfga ./cmd/openfga
 
-FROM cgr.dev/chainguard/static@sha256:676e989769aa9a5254fbfe14abb698804674b91c4d574bb33368d87930c5c472
+FROM alpine:3.18.4
 
 EXPOSE 8081
 EXPOSE 8080
@@ -22,9 +22,11 @@ EXPOSE 3000
 
 COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.22 /ko-app/grpc-health-probe /user/local/bin/grpc_health_probe
 COPY --from=builder /bin/openfga /openfga
+COPY docker-entrypoint.sh /
 
 # Healthcheck configuration for the container using grpc_health_probe
 # The container will be considered healthy if the gRPC health probe returns a successful response.
 HEALTHCHECK --interval=5s --timeout=30s --retries=3 CMD ["/usr/local/bin/grpc_health_probe", "-addr=:8081"]
 
-ENTRYPOINT ["/openfga"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/openfga", "run"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+set -e
+
+if [ "$OPENFGA_MIGRATE_ON_INIT" = "1" ] && [ -n "$OPENFGA_DATASTORE_URI" ] ; then
+  /openfga migrate
+fi
+
+exec "${@}"


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->
Closes #1189


## Description
<!-- Provide a detailed description of the changes -->

- Updates the default command so that the server starts on run by default
- Adds an entrypoint which may optionally run migrations on start if env variables: `OPENFGA_MIGRATE_ON_INIT=1` and `OPENFGA_DATASTORE_URI` are present
- Changes the resulting base image to alpine so that `sh` is available

```
$ docker build .
$ docker run -e "OPENFGA_DATASTORE_ENGINE=postgres" -e "OPENFGA_MIGRATE_ON_INIT=1" -e "OPENFGA_DATASTORE_URI=postgres://$PGUSER:$PGPASS@host.docker.internal:15433/$PGDB?sslmode=disable" 9e8ffc8c798709f8fde373b9537e6f1a0f1e83d5d3889c4e402519f7d7d9a485

2023/11/30 17:20:19 current version 4
2023/11/30 17:20:19 running all migrations
2023/11/30 17:20:19 migration done
2023-11-30T17:20:19.812Z	INFO	🧪 experimental features enabled: []
2023-11-30T17:20:19.818Z	INFO	using 'postgres' storage engine
2023-11-30T17:20:19.818Z	WARN	authentication is disabled
2023-11-30T17:20:19.818Z	WARN	grpc TLS is disabled, serving connections using insecure plaintext
2023-11-30T17:20:19.818Z	INFO	📈 starting metrics server on '0.0.0.0:2112'
2023-11-30T17:20:19.818Z	INFO	🚀 starting openfga service...	{"version": "dev", "date": "unknown", "commit": "none", "go-version": "go1.21.4"}
2023-11-30T17:20:19.818Z	INFO	grpc server listening on '0.0.0.0:8081'...
2023-11-30T17:20:19.818Z	INFO	HTTP server listening on '0.0.0.0:8080'...
2023-11-30T17:20:19.818Z	INFO	🛝 starting openfga playground on http://localhost:3000/playground
^C2023-11-30T17:20:26.632Z	INFO	attempting to shutdown gracefully
2023-11-30T17:20:26.632Z	INFO	shutdown the openfga playground server
2023-11-30T17:20:26.633Z	INFO	server exited. goodbye 👋
```

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
