### PR TITLE
fix: inverse experimental flag for conditions

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -80,6 +80,7 @@
                 "type": "string",
                 "enum": ["enable-conditions"]
             },
+            "default": [],
             "x-env-variable": "OPENFGA_EXPERIMENTALS"
         },
         "playground": {

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -78,9 +78,8 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "enum": ["reject-conditions"]
+                "enum": ["enable-conditions"]
             },
-            "default": ["reject-conditions"],
             "x-env-variable": "OPENFGA_EXPERIMENTALS"
         },
         "playground": {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -224,16 +224,9 @@ func MustDefaultConfigWithRandomPorts() *serverconfig.Config {
 	config.Playground.Enabled = false
 	config.Metrics.Enabled = false
 
-	var experimentals []string
-	for _, experimental := range config.Experimentals {
-		// Remove the `reject-conditions` default experimental flag to allow
-		// explicit control of tests around the behavior introduced when the flag
-		// is set or unset.
-		if experimental != "reject-conditions" {
-			experimentals = append(experimentals, experimental)
-		}
-	}
-	config.Experimentals = experimentals
+	// Add the `enable-conditions` experimental flag to allow explicit control
+	// of tests around the behavior introduced when the flag is set or unset.
+	config.Experimentals = []string{string(server.ExperimentalEnableConditions)}
 
 	httpPort, httpPortReleaser := TCPRandomPort()
 	defer httpPortReleaser()

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -299,7 +299,7 @@ func DefaultConfig() *Config {
 		ChangelogHorizonOffset:                    DefaultChangelogHorizonOffset,
 		ResolveNodeLimit:                          DefaultResolveNodeLimit,
 		ResolveNodeBreadthLimit:                   DefaultResolveNodeBreadthLimit,
-		Experimentals:                             []string{"reject-conditions"},
+		Experimentals:                             []string{},
 		ListObjectsDeadline:                       DefaultListObjectsDeadline,
 		ListObjectsMaxResults:                     DefaultListObjectsMaxResults,
 		RequestDurationDatastoreQueryCountBuckets: []string{"50", "200"},

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -57,7 +57,7 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 		tks := req.GetWrites()
 		for _, tk := range tks.TupleKeys {
 			if tk.Condition != nil {
-				return nil, status.Error(codes.Unimplemented, "conditions not supported")
+				return nil, status.Error(codes.InvalidArgument, "conditions not supported")
 			}
 		}
 	}

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -20,7 +20,7 @@ import (
 type WriteCommand struct {
 	logger           logger.Logger
 	datastore        storage.OpenFGADatastore
-	rejectConditions bool
+	enableConditions bool
 }
 
 type WriteCommandOption func(*WriteCommand)
@@ -31,9 +31,9 @@ func WithWriteCmdLogger(l logger.Logger) WriteCommandOption {
 	}
 }
 
-func WithWriteCmdRejectConditions(reject bool) WriteCommandOption {
+func WithWriteCmdEnableConditions(enable bool) WriteCommandOption {
 	return func(m *WriteCommand) {
-		m.rejectConditions = reject
+		m.enableConditions = enable
 	}
 }
 
@@ -42,7 +42,7 @@ func NewWriteCommand(datastore storage.OpenFGADatastore, opts ...WriteCommandOpt
 	cmd := &WriteCommand{
 		datastore:        datastore,
 		logger:           logger.NewNoopLogger(),
-		rejectConditions: false,
+		enableConditions: true,
 	}
 
 	for _, opt := range opts {
@@ -53,7 +53,7 @@ func NewWriteCommand(datastore storage.OpenFGADatastore, opts ...WriteCommandOpt
 
 // Execute deletes and writes the specified tuples. Deletes are applied first, then writes.
 func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest) (*openfgav1.WriteResponse, error) {
-	if c.rejectConditions {
+	if !c.enableConditions {
 		tks := req.GetWrites()
 		for _, tk := range tks.TupleKeys {
 			if tk.Condition != nil {

--- a/pkg/server/commands/write_authzmodel.go
+++ b/pkg/server/commands/write_authzmodel.go
@@ -80,7 +80,7 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 
 	if !w.enableConditions {
 		if conditions := model.GetConditions(); conditions != nil || len(conditions) > 0 {
-			return nil, status.Error(codes.Unimplemented, "conditions not supported")
+			return nil, status.Error(codes.InvalidArgument, "conditions not supported")
 		}
 	}
 
@@ -96,7 +96,7 @@ func (w *WriteAuthorizationModelCommand) Execute(ctx context.Context, req *openf
 	_, err := typesystem.NewAndValidate(ctx, model)
 	if err != nil {
 		if !w.enableConditions && errors.Is(err, typesystem.ErrNoConditionForRelation) {
-			return nil, status.Error(codes.Unimplemented, "conditions not supported")
+			return nil, status.Error(codes.InvalidArgument, "conditions not supported")
 		}
 
 		return nil, serverErrors.InvalidAuthorizationModelInput(err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,7 +48,7 @@ type ExperimentalFeatureFlag string
 const (
 	AuthorizationModelIDHeader                           = "openfga-authorization-model-id"
 	authorizationModelIDKey                              = "authorization_model_id"
-	ExperimentalRejectConditions ExperimentalFeatureFlag = "reject-conditions"
+	ExperimentalEnableConditions ExperimentalFeatureFlag = "enable-conditions"
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -517,12 +517,12 @@ func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openf
 		return nil, err
 	}
 
-	rejectConditions := slices.Contains(s.experimentals, ExperimentalRejectConditions)
+	enableConditions := slices.Contains(s.experimentals, ExperimentalEnableConditions)
 
 	cmd := commands.NewWriteCommand(
 		s.datastore,
 		commands.WithWriteCmdLogger(s.logger),
-		commands.WithWriteCmdRejectConditions(rejectConditions),
+		commands.WithWriteCmdEnableConditions(enableConditions),
 	)
 	return cmd.Execute(ctx, &openfgav1.WriteRequest{
 		StoreId:              storeID,
@@ -700,12 +700,12 @@ func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.Wri
 		Method:  "WriteAuthorizationModel",
 	})
 
-	rejectConditions := slices.Contains(s.experimentals, ExperimentalRejectConditions)
+	enableConditions := slices.Contains(s.experimentals, ExperimentalEnableConditions)
 
 	c := commands.NewWriteAuthorizationModelCommand(s.datastore,
 		commands.WithWriteAuthModelLogger(s.logger),
 		commands.WithWriteAuthModelMaxSizeInBytes(s.maxAuthorizationModelSizeInBytes),
-		commands.WithWriteAuthModelRejectConditions(rejectConditions),
+		commands.WithWriteAuthModelEnableConditions(enableConditions),
 	)
 	res, err := c.Execute(ctx, req)
 	if err != nil {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1069,7 +1069,7 @@ func TestWriteAuthorizationModelWithExperimentalEnableConditions(t *testing.T) {
 			},
 		})
 
-		require.ErrorIs(t, err, status.Error(codes.Unimplemented, "conditions not supported"))
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "conditions not supported"))
 	})
 
 	t.Run("rejects_request_with_relation_condition", func(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestWriteAuthorizationModelWithExperimentalEnableConditions(t *testing.T) {
 			},
 		})
 
-		require.ErrorIs(t, err, status.Error(codes.Unimplemented, "conditions not supported"))
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "conditions not supported"))
 	})
 }
 
@@ -1163,7 +1163,7 @@ func TestWriteWithExperimentalRejectConditions(t *testing.T) {
 			},
 		})
 
-		require.ErrorIs(t, err, status.Error(codes.Unimplemented, "conditions not supported"))
+		require.ErrorIs(t, err, status.Error(codes.InvalidArgument, "conditions not supported"))
 	})
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1031,7 +1031,7 @@ func TestDefaultMaxConcurrentReadSettings(t *testing.T) {
 	require.EqualValues(t, math.MaxUint32, s.maxConcurrentReadsForListObjects)
 }
 
-func TestWriteAuthorizationModelWithExperimentalRejectConditions(t *testing.T) {
+func TestWriteAuthorizationModelWithExperimentalEnableConditions(t *testing.T) {
 	ctx := context.Background()
 	storeID := ulid.Make().String()
 
@@ -1042,7 +1042,7 @@ func TestWriteAuthorizationModelWithExperimentalRejectConditions(t *testing.T) {
 
 	s := MustNewServerWithOpts(
 		WithDatastore(mockDatastore),
-		WithExperimentals(ExperimentalRejectConditions),
+		WithExperimentals(),
 	)
 
 	t.Run("rejects_request_with_condition", func(t *testing.T) {
@@ -1120,7 +1120,7 @@ func TestWriteWithExperimentalRejectConditions(t *testing.T) {
 
 	s := MustNewServerWithOpts(
 		WithDatastore(mockDatastore),
-		WithExperimentals(ExperimentalRejectConditions),
+		WithExperimentals(),
 	)
 
 	t.Run("rejects_request_with_condition", func(t *testing.T) {


### PR DESCRIPTION
## Description

In #1169, I introduced the default `reject-conditions` experimental flag. In order to run server and enable conditions you have to do something like `OPENFGA_EXPERIMENTALS="-"` which is clunky.

> Since we default reject-conditions and it’s the only experimental, it’s a negative negative, which means it can never be true.

This PR, changes that in favor of `enable-conditions` experimental flag which is not set by default.

## References

Follow up to https://github.com/openfga/openfga/pull/1169

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
