### PR TITLE
fix: correctly set noop trace provider

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -291,8 +291,6 @@ func convertStringArrayToUintArray(stringArray []string) []uint {
 }
 
 func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
-	otel.SetTracerProvider(noop.NewTracerProvider())
-
 	var tracerProviderCloser func()
 
 	if config.Trace.Enabled {
@@ -318,6 +316,8 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 			_ = tp.ForceFlush(ctx)
 			_ = tp.Shutdown(ctx)
 		}
+	} else {
+		otel.SetTracerProvider(noop.NewTracerProvider())
 	}
 
 	s.Logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))


### PR DESCRIPTION
## Description

After changes introduced in https://github.com/openfga/openfga/pull/1139, children spans went missing.

See https://github.com/openfga/openfga/pull/1038#pullrequestreview-1756471345

I'll follow up this change with some improvements to our telemetry package and some tests.

## References

https://github.com/openfga/openfga/pull/1139

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
