### PR TITLE
fix: filter out tuples with non-matching conditions from reverse expand

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -61,7 +61,7 @@ func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error
 			return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
 		}
 
-		if err := validateCondition(typesys, tk); err != nil {
+		if err := ValidateCondition(typesys, tk); err != nil {
 			return err
 		}
 	}
@@ -175,8 +175,8 @@ func validateTypeRestrictions(typesys *typesystem.TypeSystem, tk *openfgav1.Tupl
 	return fmt.Errorf("type '%s' is not an allowed type restriction for '%s#%s'", userType, objectType, tk.GetRelation())
 }
 
-// validateCondition enforces conditions on a relationship tuple
-func validateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
+// ValidateCondition enforces conditions on a relationship tuple
+func ValidateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
 	objectType := tuple.GetType(tk.Object)
 	userType := tuple.GetType(tk.User)
 	userRelation := tuple.GetRelation(tk.User)

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -426,7 +426,9 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 	// filter out invalid tuples yielded by the database iterator
 	filteredIter := storage.NewFilteredTupleKeyIterator(
 		storage.NewTupleKeyIteratorFromTupleIterator(iter),
-		validation.FilterInvalidTuples(c.typesystem),
+		func(tupleKey *openfgav1.TupleKey) bool {
+			return validation.ValidateCondition(c.typesystem, tupleKey) == nil
+		},
 	)
 	defer filteredIter.Stop()
 


### PR DESCRIPTION
## Description
Prior to ABAC Conditions we'd only reverse expand edges that were relevant to the model. Consequently, we had no need for similar tuple [filter iterator code](https://github.com/openfga/openfga/blob/main/internal/graph/check.go#L573-L577) like we have in check.

Now that we introduce conditions into the mix, between two models we can have the same relationship edges but with incompatible conditions defined for type restrctions. This means that we must also now filter the tuples yielded by `ReadStartingWithUser`.

These changes fixes this test:
https://github.com/openfga/openfga/blob/13a1dec951623513056a5c894f6ed650d4d1c449/assets/tests/abac_tests.yaml#L589

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
