### PR TITLE
chore: remove extraneous param in slsa verification step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
           gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" \
-            -p "$PROVENANCE" -p "*.tar.gz" -p "*.tar.gz.sbom" -p
+            -p "$PROVENANCE" -p "*.tar.gz" -p "*.tar.gz.sbom"
 
       - name: Verify assets
         env:


### PR DESCRIPTION
## Description

```
Run set -euo pipefail
  set -euo pipefail
  gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" \
    -p "$PROVENANCE" -p "*.tar.gz" -p "*.tar.gz.sbom" -p
  shell: /usr/bin/bash -e {0}
  env:
    GH_TOKEN: ***
    PROVENANCE: openfga.intoto.jsonl
flag needs an argument: 'p' in -p

Usage:  gh release download [<tag>] [flags]

Flags:
  -A, --archive format        Download the source code archive in the specified format (zip or tar.gz)
      --clobber               Overwrite existing files of the same name
  -D, --dir directory         The directory to download files into (default ".")
  -O, --output file           The file to write a single asset to (use "-" to write to standard output)
  -p, --pattern stringArray   Download only assets that match a glob pattern
      --skip-existing         Skip downloading when files of the same name exist
  
Error: Process completed with exit code 1.
```

## References

https://github.com/openfga/openfga/actions/runs/7093212367/job/19306355812

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
