### PR TITLE
test(storage): add conformance test for normalized Condition behavior

### DIFF
--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -189,6 +189,13 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.Key)
 
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.PaginationOptions{
+		PageSize: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	require.Equal(t, tk, tuples[0].GetKey())
+
 	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.Key)

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -188,6 +188,13 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.Key)
 
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.PaginationOptions{
+		PageSize: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, tuples, 1)
+	require.Equal(t, tk, tuples[0].GetKey())
+
 	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.Key)

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -744,6 +744,14 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.PaginationOptions{
+			PageSize: 2,
+		})
+		require.NoError(t, err)
+		require.Len(t, tuples, 2)
+		require.Nil(t, tuples[0].GetKey().GetCondition())
+		require.Nil(t, tuples[1].GetKey().GetCondition())
+
 		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
@@ -820,6 +828,14 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.Equal(t, "somecondition", tp.GetKey().GetCondition().GetName())
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 		require.Empty(t, tp.GetKey().GetCondition().GetContext())
+
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.PaginationOptions{
+			PageSize: 2,
+		})
+		require.NoError(t, err)
+		require.Len(t, tuples, 2)
+		require.NotNil(t, tuples[0].GetKey().GetCondition().GetContext())
+		require.NotNil(t, tuples[1].GetKey().GetCondition().GetContext())
 
 		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
 		require.NoError(t, err)

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
-	tupleutils "github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -741,13 +740,13 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err := iter.Next(ctx)
+		tp, err := iter.Next(ctx)
 		require.NoError(t, err)
-		require.Nil(t, tuple.GetKey().GetCondition())
+		require.Nil(t, tp.GetKey().GetCondition())
 
-		tuple, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
 		require.NoError(t, err)
-		require.Nil(t, tuple.GetKey().GetCondition())
+		require.Nil(t, tp.GetKey().GetCondition())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
@@ -756,12 +755,12 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err = iter.Next(ctx)
+		tp, err = iter.Next(ctx)
 		require.NoError(t, err)
-		require.Nil(t, tuple.GetKey().GetCondition())
+		require.Nil(t, tp.GetKey().GetCondition())
 
 		iter, err = datastore.ReadStartingWithUser(ctx, storeID, storage.ReadStartingWithUserFilter{
-			ObjectType: tupleutils.GetType(tupleKey1.GetObject()),
+			ObjectType: tuple.GetType(tupleKey1.GetObject()),
 			Relation:   tupleKey1.GetRelation(),
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
@@ -770,9 +769,9 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err = iter.Next(ctx)
+		tp, err = iter.Next(ctx)
 		require.NoError(t, err)
-		require.Nil(t, tuple.GetKey().GetCondition())
+		require.Nil(t, tp.GetKey().GetCondition())
 
 		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{}, 0)
 		require.NoError(t, err)
@@ -816,15 +815,15 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err := iter.Next(ctx)
+		tp, err := iter.Next(ctx)
 		require.NoError(t, err)
-		require.Equal(t, "somecondition", tuple.GetKey().GetCondition().GetName())
-		require.NotNil(t, tuple.GetKey().GetCondition().GetContext())
-		require.Empty(t, tuple.GetKey().GetCondition().GetContext())
+		require.Equal(t, "somecondition", tp.GetKey().GetCondition().GetName())
+		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
+		require.Empty(t, tp.GetKey().GetCondition().GetContext())
 
-		tuple, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
 		require.NoError(t, err)
-		require.NotNil(t, tuple.GetKey().GetCondition().GetContext())
+		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
@@ -833,12 +832,12 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err = iter.Next(ctx)
+		tp, err = iter.Next(ctx)
 		require.NoError(t, err)
-		require.NotNil(t, tuple.GetKey().GetCondition().GetContext())
+		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
 		iter, err = datastore.ReadStartingWithUser(ctx, storeID, storage.ReadStartingWithUserFilter{
-			ObjectType: tupleutils.GetType(tupleKey1.GetObject()),
+			ObjectType: tuple.GetType(tupleKey1.GetObject()),
 			Relation:   tupleKey1.GetRelation(),
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
@@ -847,9 +846,9 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		defer iter.Stop()
 
-		tuple, err = iter.Next(ctx)
+		tp, err = iter.Next(ctx)
 		require.NoError(t, err)
-		require.NotNil(t, tuple.GetKey().GetCondition().GetContext())
+		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
 		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{}, 0)
 		require.NoError(t, err)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add storage conformance tests for normalization behavior around TupleKeys with conditions and condition context. Namely, if you write a tuple with a `nil` condition it should come back as a nil condition. Conditions are nullable. Likewise,  if you specify a non-empty condition in a tuple we normalize condition context to an empty context if the context is `nil`.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
