### PR TITLE
chore: further constrain RPC max message size

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -389,7 +389,9 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		return fmt.Errorf("failed to initialize authenticator: %w", err)
 	}
 
-	var serverOpts []grpc.ServerOption
+	serverOpts := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(serverconfig.DefaultMaxRPCMessageSizeInBytes),
+	}
 
 	serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(
 		[]grpc.UnaryServerInterceptor{

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	DefaultMaxRPCMessageSizeInBytes         = 512 * 1_204 // 512 KB
 	DefaultMaxTuplesPerWrite                = 100
 	DefaultMaxTypesPerAuthorizationModel    = 100
 	DefaultMaxAuthorizationModelSizeInBytes = 256 * 1_024


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This sets stricter RPC message size limits on the OpenFGA gRPC server. Existing API definitions have strict limits on resource inputs and so the default 4MB gRPC message size limit is overly generous. Additionally, request `context` added for ABAC support is ultimately constrained by the RPC message size limit, and so setting a stricter limit on it is important to constrain the arbitrary request context that can be provided.

## References
https://github.com/openfga/openfga/issues/1192


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
