### PR TITLE
chore: add prometheus histogram metric for Condition evaluation cost

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -19,6 +19,7 @@ builds:
       - "-X github.com/openfga/openfga/internal/build.Version=nightly"
       - "-X github.com/openfga/openfga/internal/build.Commit={{.Commit}}"
       - "-X github.com/openfga/openfga/internal/build.Date={{.Date}}"
+      - "-X github.com/openfga/openfga/internal/build.ProjectName={{.ProjectName}}"
 
 # Do not make github release
 release:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,7 @@ builds:
       - "-X github.com/openfga/openfga/internal/build.Version=v{{ .Version }}"
       - "-X github.com/openfga/openfga/internal/build.Commit={{.Commit}}"
       - "-X github.com/openfga/openfga/internal/build.Date={{.Date}}"
+      - "-X github.com/openfga/openfga/internal/build.ProjectName={{.ProjectName}}"
 
 dockers:
   - goos: linux

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -870,6 +870,7 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 	require.Contains(t, stringBody, "list_objects_further_eval_required_count")
 	require.Contains(t, stringBody, "list_objects_no_further_eval_required_count")
 	require.Contains(t, stringBody, "go_sql_idle_connections")
+	require.Contains(t, stringBody, "condition_evaluation_cost")
 }
 
 func TestHTTPServerDisabled(t *testing.T) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -16,4 +16,6 @@ var (
 	// MinimumSupportedDatastoreSchemaRevision refers to the minimum schema version that is required to run
 	// this specific build of OpenFGA. Refer to the `assets/migrations` artifacts for more information.
 	MinimumSupportedDatastoreSchemaRevision int64 = 4
+
+	ProjectName = "openfga"
 )

--- a/internal/condition/eval/eval.go
+++ b/internal/condition/eval/eval.go
@@ -19,7 +19,7 @@ var conditionEvaluationCostHistogram = promauto.NewHistogram(prometheus.Histogra
 	Namespace:                       build.ProjectName,
 	Name:                            "condition_evaluation_cost",
 	Help:                            "A histogram of the CEL evaluation cost of a Condition in a Relationship Tuple",
-	Buckets:                         utils.LinearBuckets(1, config.DefaultMaxConditionEvaluationCost, 10),
+	Buckets:                         utils.LinearBuckets(0, config.DefaultMaxConditionEvaluationCost, 10),
 	NativeHistogramBucketFactor:     1.1,
 	NativeHistogramMaxBucketNumber:  config.DefaultMaxConditionEvaluationCost,
 	NativeHistogramMinResetDuration: time.Hour,

--- a/internal/condition/eval/eval.go
+++ b/internal/condition/eval/eval.go
@@ -2,12 +2,26 @@ package eval
 
 import (
 	"fmt"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/pkg/typesystem"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
+
+var conditionEvaluationCostHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
+	Namespace:                       build.ProjectName,
+	Name:                            "condition_evaluation_cost",
+	Help:                            "A histogram of the CEL evaluation cost of a Condition in a Relationship Tuple",
+	Buckets:                         []float64{1, 5, 15, 20, 35, 50, 75, 90, 100},
+	NativeHistogramBucketFactor:     1.1,
+	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMinResetDuration: time.Hour,
+})
 
 // EvaluateTupleCondition returns a bool indicating if the provided tupleKey's condition (if any) was met.
 func EvaluateTupleCondition(
@@ -40,6 +54,8 @@ func EvaluateTupleCondition(
 		if err != nil {
 			return nil, err
 		}
+
+		conditionEvaluationCostHistogram.Observe(float64(conditionResult.Cost))
 
 		return &conditionResult, nil
 	}

--- a/internal/condition/eval/eval.go
+++ b/internal/condition/eval/eval.go
@@ -7,6 +7,8 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/condition"
+	"github.com/openfga/openfga/internal/server/config"
+	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -17,9 +19,9 @@ var conditionEvaluationCostHistogram = promauto.NewHistogram(prometheus.Histogra
 	Namespace:                       build.ProjectName,
 	Name:                            "condition_evaluation_cost",
 	Help:                            "A histogram of the CEL evaluation cost of a Condition in a Relationship Tuple",
-	Buckets:                         []float64{1, 5, 15, 20, 35, 50, 75, 90, 100},
+	Buckets:                         utils.LinearBuckets(1, config.DefaultMaxConditionEvaluationCost, 10),
 	NativeHistogramBucketFactor:     1.1,
-	NativeHistogramMaxBucketNumber:  100,
+	NativeHistogramMaxBucketNumber:  config.DefaultMaxConditionEvaluationCost,
 	NativeHistogramMinResetDuration: time.Hour,
 })
 

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/karlseguin/ccache/v3"
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/keys"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/prometheus/client_golang/prometheus"
@@ -23,13 +24,15 @@ const (
 
 var (
 	checkCacheTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "check_cache_total_count",
-		Help: "The total number of calls to ResolveCheck.",
+		Namespace: build.ProjectName,
+		Name:      "check_cache_total_count",
+		Help:      "The total number of calls to ResolveCheck.",
 	})
 
 	checkCacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "check_cache_hit_count",
-		Help: "The total number of cache hits for ResolveCheck.",
+		Namespace: build.ProjectName,
+		Name:      "check_cache_hit_count",
+		Help:      "The total number of cache hits for ResolveCheck.",
 	})
 )
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -23,10 +23,11 @@ const (
 	DefaultMaxConcurrentReadsForCheck       = math.MaxUint32
 	DefaultMaxConcurrentReadsForListObjects = math.MaxUint32
 
-	DefaultWriteContextByteLimit = 32 * 1_024 // 32KB
-	DefaultCheckQueryCacheLimit  = 10000
-	DefaultCheckQueryCacheTTL    = 10 * time.Second
-	DefaultCheckQueryCacheEnable = false
+	DefaultWriteContextByteLimit      = 32 * 1_024 // 32KB
+	DefaultCheckQueryCacheLimit       = 10000
+	DefaultCheckQueryCacheTTL         = 10 * time.Second
+	DefaultCheckQueryCacheEnable      = false
+	DefaultMaxConditionEvaluationCost = 100 // care should be taken here - decreasing can cause API compatibility problems with Conditions
 )
 
 type DatastoreMetricsConfig struct {

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -101,3 +101,9 @@ func TestVerifyConfig(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestDefaultMaxConditionValuationCost(t *testing.T) {
+	// check to make sure DefaultMaxConditionEvaluationCost never drops below an explict 100, because
+	// API compatibility can be impacted otherwise
+	require.GreaterOrEqual(t, DefaultMaxConditionEvaluationCost, 100)
+}

--- a/internal/utils/bucket.go
+++ b/internal/utils/bucket.go
@@ -12,3 +12,18 @@ func Bucketize(value uint, buckets []uint) string {
 	}
 	return ">" + strconv.Itoa(int(buckets[len(buckets)-1]))
 }
+
+// LinearBuckets returns an evenly distributed range of buckets in the closed interval
+// [min...max]. The min and max count toward the bucket count since they are included
+// in the range.
+func LinearBuckets(min, max float64, count int) []float64 {
+	var buckets []float64
+
+	width := (max - min) / float64(count-1)
+
+	for i := min; i <= max; i += width {
+		buckets = append(buckets, i)
+	}
+
+	return buckets
+}

--- a/internal/utils/bucket_test.go
+++ b/internal/utils/bucket_test.go
@@ -69,3 +69,8 @@ func TestBucketize(t *testing.T) {
 		})
 	}
 }
+
+func TestLinearBuckets(t *testing.T) {
+	buckets := LinearBuckets(1.0, 100, 10)
+	require.Equal(t, []float64{1, 12, 23, 34, 45, 56, 67, 78, 89, 100}, buckets)
+}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/internal/graph"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
@@ -31,13 +32,15 @@ const streamedBufferSize = 100
 
 var (
 	furtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "list_objects_further_eval_required_count",
-		Help: "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
+		Namespace: build.ProjectName,
+		Name:      "list_objects_further_eval_required_count",
+		Help:      "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
 	})
 
 	noFurtherEvalRequiredCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "list_objects_no_further_eval_required_count",
-		Help: "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
+		Namespace: build.ProjectName,
+		Name:      "list_objects_no_further_eval_required_count",
+		Help:      "Number of objects in a ListObjects call that needed to issue a Check call to determine a final result",
 	})
 )
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -13,6 +13,7 @@ import (
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/karlseguin/ccache/v3"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/internal/gateway"
 	"github.com/openfga/openfga/internal/graph"
@@ -55,6 +56,7 @@ var (
 	datastoreQueryCountHistogramName = "datastore_query_count"
 
 	datastoreQueryCountHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       build.ProjectName,
 		Name:                            datastoreQueryCountHistogramName,
 		Help:                            "The number of database queries required to resolve a query (e.g. Check or ListObjects).",
 		Buckets:                         []float64{1, 5, 20, 50, 100, 150, 225, 400, 500, 750, 1000},
@@ -66,6 +68,7 @@ var (
 	requestDurationByQueryHistogramName = "request_duration_by_query_count_ms"
 
 	requestDurationByQueryHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       build.ProjectName,
 		Name:                            requestDurationByQueryHistogramName,
 		Help:                            "The request duration (in ms) labeled by method and buckets of datastore query counts. This allows for reporting percentiles based on the number of datastore queries required to resolve the request.",
 		Buckets:                         []float64{1, 5, 10, 25, 50, 80, 100, 150, 200, 300, 1000, 2000, 5000},

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,6 +20,7 @@ var _ storage.RelationshipTupleReader = (*boundedConcurrencyTupleReader)(nil)
 
 var (
 	boundedReadDelayMsHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       build.ProjectName,
 		Name:                            "datastore_bounded_read_delay_ms",
 		Help:                            "Time spent waiting for Read, ReadUserTuple and ReadUsersetTuples calls to the datastore",
 		Buckets:                         []float64{1, 3, 5, 10, 25, 50, 100, 1000, 5000}, // milliseconds. Upper bound is config.UpstreamTimeout

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -11,6 +11,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/openfga/internal/condition"
+	"github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/pkg/tuple"
 	"go.opentelemetry.io/otel"
 )
@@ -24,8 +25,6 @@ const (
 	SchemaVersion1_1 string = "1.1"
 
 	typesystemCtxKey ctxKey = "typesystem-context-key"
-
-	defaultMaxEvaluationCost = 100
 )
 
 func IsSchemaVersionSupported(version string) bool {
@@ -187,7 +186,7 @@ func New(model *openfgav1.AuthorizationModel) *TypeSystem {
 	uncompiledConditions := make(map[string]*condition.EvaluableCondition, len(model.GetConditions()))
 	for name, cond := range model.GetConditions() {
 		uncompiledConditions[name] = condition.NewUncompiled(cond).
-			WithMaxEvaluationCost(defaultMaxEvaluationCost). // care should be taken here - decreasing can cause API compatibility problems
+			WithMaxEvaluationCost(config.DefaultMaxConditionEvaluationCost). // care should be taken here - decreasing can cause API compatibility problems
 			WithTrackEvaluationCost()
 	}
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -2249,12 +2249,6 @@ func TestRewriteContainsExclusion(t *testing.T) {
 	}
 }
 
-func TestDefaultMaxCELEValuationCost(t *testing.T) {
-	// check to make sure defaultMaxEvaluationCost never drops below an explict 100, because
-	// API compatibility can be impacted otherwise
-	require.GreaterOrEqual(t, defaultMaxEvaluationCost, 100)
-}
-
 func TestRewriteContainsIntersection(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add a prometheus histogram metric to calculate the distribution of Condition evaluation costs. 

Additionally, I've wired up the `Namespace` field so it reports the project name `openfga`.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
