### PR TITLE
fix: #935 (log request validation errors)

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -395,9 +395,11 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(
 		[]grpc.UnaryServerInterceptor{
-			requestid.NewUnaryInterceptor(),
+			grpc_ctxtags.UnaryServerInterceptor(),   // needed for logging
+			requestid.NewUnaryInterceptor(),         // add request_id to ctxtags
+			storeid.NewUnaryInterceptor(),           // if available, add store_id to ctxtags
+			logging.NewLoggingInterceptor(s.Logger), // needed to log invalid requests
 			validator.UnaryServerInterceptor(),
-			grpc_ctxtags.UnaryServerInterceptor(),
 		}...,
 	))
 
@@ -424,8 +426,6 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	serverOpts = append(serverOpts, grpc.ChainUnaryInterceptor(
 		[]grpc.UnaryServerInterceptor{
-			storeid.NewUnaryInterceptor(),
-			logging.NewLoggingInterceptor(s.Logger),
 			grpcauth.UnaryServerInterceptor(authnmw.AuthFunc(authenticator)),
 		}...,
 	))

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -144,7 +144,7 @@ type document
 			},
 		},
 		{
-			_name: "check_http_success",
+			_name: "http_check_success",
 			httpReqBody: bytes.NewBufferString(`{
   "tuple_key": {
     "user": "user:anne",
@@ -166,7 +166,7 @@ type document
 			},
 		},
 		{
-			_name: "check_grpc_error",
+			_name: "grpc_check_error",
 			grpcReq: &openfgav1.CheckRequest{
 				AuthorizationModelId: authorizationModelID,
 				StoreId:              storeID,
@@ -179,13 +179,13 @@ type document
 				"grpc_type":    "unary",
 				"grpc_code":    int32(2009),
 				"raw_request":  fmt.Sprintf(`{"store_id":"%s","tuple_key":{"object":"","relation":"viewer","user":"user:anne"},"contextual_tuples":null,"authorization_model_id":"%s","trace":false,"context":null}`, storeID, authorizationModelID),
-				"raw_response": `{"code":2009,"message":"Invalid input. Make sure you provide a user, object and relation"}`,
+				"raw_response": `{"code":"invalid_check_input","message":"Invalid input. Make sure you provide a user, object and relation"}`,
 				"store_id":     storeID,
 				"user_agent":   "test-user-agent" + " grpc-go/" + grpc.Version,
 			},
 		},
 		{
-			_name: "check_http_error",
+			_name: "http_check_error",
 			httpReqBody: bytes.NewBufferString(`{
   "tuple_key": {
     "user": "user:anne",
@@ -200,7 +200,7 @@ type document
 				"grpc_type":    "unary",
 				"grpc_code":    int32(2009),
 				"raw_request":  fmt.Sprintf(`{"store_id":"%s","tuple_key":{"object":"","relation":"viewer","user":"user:anne"},"contextual_tuples":null,"authorization_model_id":"%s","trace":false,"context":null}`, storeID, authorizationModelID),
-				"raw_response": `{"code":2009,"message":"Invalid input. Make sure you provide a user, object and relation"}`,
+				"raw_response": `{"code":"invalid_check_input","message":"Invalid input. Make sure you provide a user, object and relation"}`,
 				"store_id":     storeID,
 				"user_agent":   "test-user-agent",
 			},


### PR DESCRIPTION
## Description

Close https://github.com/openfga/openfga/issues/918 and https://github.com/openfga/openfga/issues/935

Now, all **unary** requests that are invalid (for example, a missing parameter) will be logged in the server.

## Testing

With the tests in this PR + manual tests:

Logs in Main vs this PR:

<img width="1291" alt="image" src="https://github.com/openfga/openfga/assets/5374887/9ca9d660-7e11-409c-95a0-3d0d719f50ba">

Traces in this PR:

<img width="1919" alt="image" src="https://github.com/openfga/openfga/assets/5374887/9eb3a8c1-fa29-49f8-811e-37917ab48b90">

Response headers in this PR 

<img width="1070" alt="image" src="https://github.com/openfga/openfga/assets/5374887/2ae5365c-71f6-4f33-ad28-598a45698721">

