### PR TITLE
test: update listObjects benchmark

### DIFF
--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -696,13 +696,18 @@ func setupListObjectsBenchmark(b *testing.B, ds storage.OpenFGADatastore, storeI
 	model := &openfgav1.AuthorizationModel{
 		Id:            modelID,
 		SchemaVersion: typesystem.SchemaVersion1_1,
+		// this model exercises all possible execution paths: "direct" edge and "computed userset" edge and "TTU" edge
 		TypeDefinitions: parser.MustTransformDSLToProto(`model
 	schema 1.1
 type user
-
+type folder
+  relations
+    define viewer: [user]
 type document
   relations
-	define viewer: [user]`).TypeDefinitions,
+	define viewer: [user]
+	define parent: [folder]
+	define can_view: viewer or viewer from parent`).TypeDefinitions,
 	}
 	err := ds.WriteAuthorizationModel(context.Background(), storeID, model)
 	require.NoError(b, err)
@@ -737,7 +742,7 @@ func BenchmarkListObjects(b *testing.B, ds storage.OpenFGADatastore) {
 		StoreId:              store,
 		AuthorizationModelId: modelID,
 		Type:                 "document",
-		Relation:             "viewer",
+		Relation:             "can_view",
 		User:                 "user:maria",
 	}
 


### PR DESCRIPTION
Pre-requisite for: https://github.com/openfga/openfga/pull/1173

This PR updates the model used in ListObjects benchmarks so that it covers more code paths.

⚠️ this PR alerts of a performance regression. That is expected, since the model being benchmarked is more complex and requires more goroutines.


| Benchmark suite | Current: a7b23f6bb001836c82c09d657d3c12c1941e64d0 | Previous: 78422af76964abbfe524002a7dbf1f01e8ec8979 | Ratio |
|-|-|-|-|
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkListObjects/allResults - ns/op` | `379572501` ns/op | `182679092` ns/op | `2.08` |
