### PR TITLE
Add Global Cache Hit Counter to CachedCheckResolver for Enhanced Metrics Tracking

### DIFF
--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -150,34 +150,34 @@ func (c *CachedCheckResolver) Close() {
 }
 
 func (c *CachedCheckResolver) ResolveCheck(
-    ctx context.Context,
-    req *ResolveCheckRequest,
+	ctx context.Context,
+	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
-    checkCacheTotalCounter.Inc()
+	checkCacheTotalCounter.Inc()
 
-    cacheKey, err := checkRequestCacheKey(req)
-    if err != nil {
-        c.logger.Error("cache key computation failed with error", zap.Error(err))
-        return nil, err
-    }
+	cacheKey, err := checkRequestCacheKey(req)
+	if err != nil {
+		c.logger.Error("cache key computation failed with error", zap.Error(err))
+		return nil, err
+	}
 
-    cachedResp := c.cache.Get(cacheKey)
-    if cachedResp != nil && !cachedResp.Expired() {
-        checkCacheHitCounter.Inc()
+	cachedResp := c.cache.Get(cacheKey)
+	if cachedResp != nil && !cachedResp.Expired() {
+		checkCacheHitCounter.Inc()
 
-        // Increment the global total cache hits counter
-        totalCacheHits++
+		// Increment the global total cache hits counter
+		totalCacheHits++
 
-        return cachedResp.Value().convertToResolveCheckResponse(), nil
-    }
+		return cachedResp.Value().convertToResolveCheckResponse(), nil
+	}
 
-    resp, err := c.delegate.ResolveCheck(ctx, req)
-    if err != nil {
-        return nil, err
-    }
+	resp, err := c.delegate.ResolveCheck(ctx, req)
+	if err != nil {
+		return nil, err
+	}
 
-    c.cache.Set(cacheKey, newCachedResolveCheckResponse(resp), c.cacheTTL)
-    return resp, nil
+	c.cache.Set(cacheKey, newCachedResolveCheckResponse(resp), c.cacheTTL)
+	return resp, nil
 }
 
 // checkRequestCacheKey converts the ResolveCheckRequest into a canonical cache key that can be

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -50,6 +50,9 @@ type ResolutionMetadata struct {
 	// evaluated and potentially discarded
 	// If the solution is "allowed=false", no paths were found. This is the sum of all the reads in all the paths that had to be evaluated
 	DatastoreQueryCount uint32
+
+	// field to track total cache hits
+	TotalCacheHits uint32
 }
 
 type RelationshipEdgeType int


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR introduces a new feature to the CachedCheckResolver in our codebase, aimed at improving the visibility and monitoring of cache performance. I have added a global counter to track the total number of cache hits. This enhancement is crucial for fine-tuning cache parameters and understanding the effectiveness of our caching strategy.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #1168

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
