### PR TITLE
chore: reduce complexity of storage.memory.findAuthorizationModelByID

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -480,29 +480,25 @@ func (s *MemoryBackend) ReadStartingWithUser(
 	return &staticIterator{records: matches}, nil
 }
 
-func findAuthorizationModelByID(id string, configurations map[string]*AuthorizationModelEntry) (*openfgav1.AuthorizationModel, bool) {
-	var nsc *openfgav1.AuthorizationModel
-
-	if id == "" {
-		// find latest
-		for _, entry := range configurations {
-			if entry.latest {
-				nsc = entry.model
-				break
-			}
+func findAuthorizationModelByID(
+	id string,
+	configurations map[string]*AuthorizationModelEntry,
+) (*openfgav1.AuthorizationModel, bool) {
+	if id != "" {
+		if entry, ok := configurations[id]; ok {
+			return entry.model, true
 		}
 
-		if nsc == nil {
-			return nil, false
-		}
-	} else {
-		if entry, ok := configurations[id]; !ok {
-			return nil, false
-		} else {
-			nsc = entry.model
+		return nil, false
+	}
+
+	for _, entry := range configurations {
+		if entry.latest {
+			return entry.model, true
 		}
 	}
-	return nsc, true
+
+	return nil, false
 }
 
 // ReadAuthorizationModel See storage.AuthorizationModelBackend.ReadAuthorizationModel


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

This PR refactors how we find the authorization model by ID within the memory storage in order to reduce the cyclomatic complexity from 5 to 4 and make the code easier and negligently faster to navigate.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
