### PR TITLE
chore: improve metrics test and update `v1.4.1` CHANGELOG details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 * Reduce goroutine overhead in ListObjects ([#1173](https://github.com/openfga/openfga/pull/1173))
 
+* Added `openfga` prefix to custom exported Prometheus metrics
+
+   > ⚠️ This change may impact existing deployments of OpenFGA if you're integrating with the metrics reported by OpenFGA.
+
+   Custom metrics reported by the OpenFGA server are now prefixed with `openfga_`. For example, `request_duration_by_query_count_ms `  is now exported as `openfga_request_duration_by_query_count_ms`.
+
 ### Added
 * Support for cancellation/timeouts when evaluating Conditions ([#1237](https://github.com/openfga/openfga/pull/1237))
 * Tracing span info for Condition evaluation ([#1251](https://github.com/openfga/openfga/pull/1251))

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/openfga/openfga/pkg/testutils"
 
@@ -766,11 +768,22 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 						},
 						"viewer": {
 							DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
-								{Type: "user"},
+								{Type: "user", Condition: "condx"},
 							},
 						},
 					},
 				},
+			},
+		},
+		Conditions: map[string]*openfgav1.Condition{
+			"condx": {
+				Name: "condx",
+				Parameters: map[string]*openfgav1.ConditionParamTypeRef{
+					"x": {
+						TypeName: openfgav1.ConditionParamTypeRef_TYPE_NAME_INT,
+					},
+				},
+				Expression: "x < 100",
 			},
 		},
 		SchemaVersion: typesystem.SchemaVersion1_1,
@@ -781,7 +794,7 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 		StoreId: storeID,
 		Writes: &openfgav1.WriteRequestWrites{
 			TupleKeys: []*openfgav1.TupleKey{
-				{Object: "document:1", Relation: "viewer", User: "user:jon"},
+				tuple.NewTupleKeyWithCondition("document:1", "viewer", "user:jon", "condx", nil),
 				{Object: "document:2", Relation: "editor", User: "user:jon"},
 				{Object: "document:2", Relation: "allowed", User: "user:jon"},
 			},
@@ -792,6 +805,9 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 	checkResp, err := client.Check(ctx, &openfgav1.CheckRequest{
 		StoreId:  storeID,
 		TupleKey: tuple.NewCheckRequestTupleKey("document:1", "viewer", "user:jon"),
+		Context: testutils.MustNewStruct(t, map[string]interface{}{
+			"x": 10,
+		}),
 	})
 	require.NoError(t, err)
 	require.True(t, checkResp.GetAllowed())
@@ -801,6 +817,9 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 		Type:     "document",
 		Relation: "viewer",
 		User:     "user:jon",
+		Context: testutils.MustNewStruct(t, map[string]interface{}{
+			"x": 10,
+		}),
 	})
 	require.NoError(t, err)
 	require.Len(t, listObjectsResp.GetObjects(), 2)
@@ -812,18 +831,24 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	defer resp.Body.Close()
 
-	resBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
+	expectedMetrics := []string{
+		"openfga_datastore_query_count",
+		"openfga_request_duration_by_query_count_ms",
+		"grpc_server_handling_seconds",
+		"openfga_datastore_bounded_read_delay_ms",
+		"openfga_list_objects_further_eval_required_count",
+		"openfga_list_objects_no_further_eval_required_count",
+		"go_sql_idle_connections",
+		"openfga_condition_evaluation_cost",
+		"openfga_condition_compilation_duration_ms",
+		"openfga_condition_evaluation_duration_ms",
+	}
 
-	stringBody := string(resBody)
-	require.Contains(t, stringBody, "datastore_query_count")
-	require.Contains(t, stringBody, "request_duration_by_query_count_ms")
-	require.Contains(t, stringBody, "grpc_server_handling_seconds")
-	require.Contains(t, stringBody, "datastore_bounded_read_delay_ms")
-	require.Contains(t, stringBody, "list_objects_further_eval_required_count")
-	require.Contains(t, stringBody, "list_objects_no_further_eval_required_count")
-	require.Contains(t, stringBody, "go_sql_idle_connections")
-	require.Contains(t, stringBody, "condition_evaluation_cost")
+	for _, metric := range expectedMetrics {
+		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, metric)
+		require.NoError(t, err)
+		require.GreaterOrEqualf(t, count, 1, "expected at least 1 reported value for '%s'", metric)
+	}
 }
 
 func TestHTTPServerDisabled(t *testing.T) {

--- a/internal/condition/metrics/metrics.go
+++ b/internal/condition/metrics/metrics.go
@@ -23,7 +23,6 @@ func init() {
 	m := &ConditionMetrics{
 		compilationTime: promauto.NewHistogram(prometheus.HistogramOpts{
 			Namespace: build.ProjectName,
-			Subsystem: subsystem,
 			Name:      "condition_compilation_duration_ms",
 			Help:      "A histogram measuring the compilation time (in milliseconds) of a Condition.",
 			Buckets:   []float64{1, 5, 15, 50, 100, 250, 500, 1000},
@@ -31,7 +30,6 @@ func init() {
 
 		evaluationTime: promauto.NewHistogram(prometheus.HistogramOpts{
 			Namespace: build.ProjectName,
-			Subsystem: subsystem,
 			Name:      "condition_evaluation_duration_ms",
 			Help:      "A histogram measuring the evaluation time (in milliseconds) of a Condition.",
 			Buckets:   []float64{0.1, 0.25, 0.5, 1, 5, 15, 50, 100, 250, 500},

--- a/internal/condition/metrics/metrics.go
+++ b/internal/condition/metrics/metrics.go
@@ -12,10 +12,6 @@ import (
 	"github.com/openfga/openfga/internal/utils"
 )
 
-const (
-	subsystem = "conditions"
-)
-
 // Metrics provides access to Condition metrics.
 var Metrics *ConditionMetrics
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
In the `v1.4.1` release we added the `Namespace` field to the custom Prometheus metrics we define. This leads to a FQN with the namespace prefixed to the metric (e.g. `openfga_`) which changed the name of the metric as reported by the server.

The purpose of this PR is to note that in the `v1.4.1` release details and to improve the test which verifies the metrics are reporting as expected in a way that is more protected from false positives.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
