### PR TITLE
chore: convert to panic on unexpected edge in reverse expand

### DIFF
--- a/internal/mocks/mock_error_iterator.go
+++ b/internal/mocks/mock_error_iterator.go
@@ -40,7 +40,7 @@ func (s *errorTupleIterator) Stop() {}
 var _ storage.TupleIterator = (*errorTupleIterator)(nil)
 
 // NewErrorTupleIterator mocks case where Next will return error after the first Next()
-// This TupleIterator is designed to be used in tests bre used in test
+// This TupleIterator is designed to be used in tests
 func NewErrorTupleIterator(tuples []*openfgav1.Tuple) storage.TupleIterator {
 	iter := &errorTupleIterator{
 		items:          tuples,

--- a/internal/mocks/mock_error_iterator.go
+++ b/internal/mocks/mock_error_iterator.go
@@ -9,26 +9,24 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 )
 
-// errorIterator is a mock iterator that returns error when calling next on the second Next call
-type errorIterator[T any] struct {
-	items          []T
+// errorTupleIterator is a mock iterator that returns error when calling next on the second Next call
+type errorTupleIterator struct {
+	items          []*openfgav1.Tuple
 	originalLength int
 }
 
-func (s *errorIterator[T]) Next(ctx context.Context) (T, error) {
-	var val T
-
+func (s *errorTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	if ctx.Err() != nil {
-		return val, ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	// we want to simulate returning error after the first read
 	if len(s.items) != s.originalLength {
-		return val, fmt.Errorf("simulated errors")
+		return nil, fmt.Errorf("simulated errors")
 	}
 
 	if len(s.items) == 0 {
-		return val, nil
+		return nil, nil
 	}
 
 	next, rest := s.items[0], s.items[1:]
@@ -37,11 +35,14 @@ func (s *errorIterator[T]) Next(ctx context.Context) (T, error) {
 	return next, nil
 }
 
-func (s *errorIterator[T]) Stop() {}
+func (s *errorTupleIterator) Stop() {}
 
-// NewErrorIterator mocks case where Next will return error after the first Next()
-func NewErrorIterator(tuples []*openfgav1.Tuple) storage.TupleIterator {
-	iter := &errorIterator[*openfgav1.Tuple]{
+var _ storage.TupleIterator = (*errorTupleIterator)(nil)
+
+// NewErrorTupleIterator mocks case where Next will return error after the first Next()
+// This TupleIterator is designed to be used in tests bre used in test
+func NewErrorTupleIterator(tuples []*openfgav1.Tuple) storage.TupleIterator {
+	iter := &errorTupleIterator{
 		items:          tuples,
 		originalLength: len(tuples),
 	}

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -322,8 +322,7 @@ LoopOnEdges:
 				return c.reverseExpandTupleToUserset(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
 			})
 		default:
-			errs = multierror.Append(errs, fmt.Errorf("unsupported edge type"))
-			break LoopOnEdges
+			panic("unsupported edge type")
 		}
 	}
 
@@ -442,7 +441,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 			panic("unexpected source for reverse expansion of tuple to userset")
 		}
 	default:
-		return fmt.Errorf("unsupported edge type")
+		panic("unsupported edge type")
 	}
 
 	combinedTupleReader := storagewrappers.NewCombinedTupleReader(c.datastore, req.ContextualTuples)
@@ -513,8 +512,7 @@ LoopOnIterator:
 		case graph.TupleToUsersetEdge:
 			newRelation = req.edge.TargetReference.GetRelation()
 		default:
-			errs = multierror.Append(errs, fmt.Errorf("unsupported edge type"))
-			break LoopOnIterator
+			panic("unsupported edge type")
 		}
 
 		pool.Go(func(ctx context.Context) error {

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestReverseExpandRespectsContextCancellation(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	store := ulid.Make().String()
 
 	model := testutils.MustTransformDSLToProtoWithID(`model
@@ -96,6 +98,8 @@ type document
 }
 
 func TestReverseExpandRespectsContextTimeout(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
 	store := ulid.Make().String()
 
 	model := testutils.MustTransformDSLToProtoWithID(`model
@@ -173,7 +177,7 @@ type document
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
-			iterator := mocks.NewErrorIterator(tuples)
+			iterator := mocks.NewErrorTupleIterator(tuples)
 			return iterator, nil
 		})
 	ctx, cancelFunc := context.WithCancel(context.Background())


### PR DESCRIPTION


## Description
Convert some of the unexpected edge path to panics and clean up mock tests infrastructure


## References
Implement feedback on https://github.com/openfga/openfga/pull/1297


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
