### PR TITLE
fix: reverse expand closes channel in all cases

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -221,6 +221,7 @@ func (q *ListObjectsQuery) evaluate(
 		reverseExpandQuery := reverseexpand.NewReverseExpandQuery(q.datastore, typesys,
 			reverseexpand.WithResolveNodeLimit(q.resolveNodeLimit),
 			reverseexpand.WithResolveNodeBreadthLimit(q.resolveNodeBreadthLimit),
+			reverseexpand.WithLogger(q.logger),
 		)
 
 		cancelCtx, cancel := context.WithCancel(ctx)

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -200,9 +200,9 @@ func (c *ReverseExpandQuery) Execute(
 	err := c.execute(ctx, req, reverseExpandResultsChan, false, resolutionMetadata)
 	if err != nil {
 		select {
-		case <-ctx.Done():
-			// this case is a safeguard for when the channel is full, we don't send the context error through the channel or we will block forever
 		case reverseExpandResultsChan <- &ReverseExpandResult{Err: err}:
+		default:
+			// this case is a safeguard for when the channel is full
 		}
 	}
 


### PR DESCRIPTION
## Description

Before this PR we had in `ReverseExpand`:

```go
if err != nil {
		select {
		case <-ctx.Done():
			return
		case resultChan <- &ReverseExpandResult{Err: err}:
			return
		}
	}
close(resultChan)
```

Notice how if we hit the first `return`s, we are not sending anything through the channel (which is reserved for when we saw no errors)

So I changed it to

```go
if err != nil {
		select {
		case <-ctx.Done():
			reverseExpandResultsChan <- &ReverseExpandResult{Err: ctx.Err()}
			return
		case reverseExpandResultsChan <- &ReverseExpandResult{Err: err}:
			return
		}
	}
close(resultChan)
```
so that if we see an error (any error) we send it through the channel.

 The remaining changes I can remove them from this PR depending on how reviewers feel, I added them because I used those to help me debug.

## References

Closes https://github.com/openfga/openfga/issues/1309.
