### PR TITLE
fix: handle ReverseExpand channel closure correctly

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -148,6 +148,14 @@ type listObjectsRequest interface {
 	GetContext() *structpb.Struct
 }
 
+// evaluate fires of evaluation of the ListObjects query by delegating to
+// [[reverseexpand.ReverseExpand#Execute]] and resolving the results yielded
+// from it. If any results yielded by reverse expansion require further eval,
+// then these results get dispatched to Check to resolve the residual outcome.
+//
+// The resultsChan is **always** closed by evaluate when it is done with its work,
+// which is either when all results have been yielded, the deadline has been met,
+// or some other terminal error case has occurred.
 func (q *ListObjectsQuery) evaluate(
 	ctx context.Context,
 	req listObjectsRequest,

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -181,14 +181,18 @@ func WithLogger(logger logger.Logger) ReverseExpandQueryOption {
 	}
 }
 
-// Execute yields all the objects of the provided objectType that the given user has, possibly, a specific relation with
-// and sends those objects to resultChan. It MUST guarantee no duplicate objects sent.
+// Execute yields all the objects of the provided objectType that the
+// given user possibly has, a specific relation with and sends those
+// objects to resultChan. It MUST guarantee no duplicate objects sent.
 //
-// If an error is encountered before resolving all objects: the provided channel will NOT be closed and
-// - if the error is context cancellation or deadline: Execute may send the error through the channel
-// - otherwise: Execute will send the error through the channel
-// If no errors, Execute will yield all of the objects on the provided channel and then close the channel
-// to signal that it is done.
+// This function respects context timeouts and cancellations. If an
+// error is encountered (e.g. context timeout) before resolving all
+// objects, then the provided channel will NOT be closed, and it will
+// send the error through the channel.
+//
+// If no errors occur, then Execute will yield all of the objects on
+// the provided channel and then close the channel to signal that it
+// is done.
 func (c *ReverseExpandQuery) Execute(
 	ctx context.Context,
 	req *ReverseExpandRequest,

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -161,7 +161,6 @@ const (
 )
 
 type ReverseExpandResult struct {
-	Err          error
 	Object       string
 	ResultStatus ConditionalResultStatus
 }
@@ -195,18 +194,14 @@ func (c *ReverseExpandQuery) Execute(
 	req *ReverseExpandRequest,
 	resultChan chan<- *ReverseExpandResult,
 	resolutionMetadata *ResolutionMetadata,
-) {
+) error {
 	err := c.execute(ctx, req, resultChan, false, resolutionMetadata)
 	if err != nil {
-		select {
-		case <-ctx.Done():
-			return
-		case resultChan <- &ReverseExpandResult{Err: err}:
-			return
-		}
+		return err
 	}
 
 	close(resultChan)
+	return nil
 }
 
 func (c *ReverseExpandQuery) execute(

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -127,7 +128,7 @@ func TestServerWithMemoryDatastore(t *testing.T) {
 	ds, stopFunc := MustBootstrapDatastore(t, "memory")
 	defer func() {
 		stopFunc()
-		//goleak.VerifyNone(t)
+		goleak.VerifyNone(t)
 	}()
 
 	test.RunAllTests(t, ds)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -97,7 +97,7 @@ func TestServerWithPostgresDatastore(t *testing.T) {
 	ds, stopFunc := MustBootstrapDatastore(t, "postgres")
 	defer func() {
 		stopFunc()
-		//goleak.VerifyNone(t)
+		goleak.VerifyNone(t)
 	}()
 
 	test.RunAllTests(t, ds)
@@ -107,7 +107,7 @@ func TestServerWithPostgresDatastoreAndExplicitCredentials(t *testing.T) {
 	testDatastore, stopFunc := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 	defer func() {
 		stopFunc()
-		//goleak.VerifyNone(t)
+		goleak.VerifyNone(t)
 	}()
 
 	uri := testDatastore.GetConnectionURI(false)
@@ -138,7 +138,7 @@ func TestServerWithMySQLDatastore(t *testing.T) {
 	ds, stopFunc := MustBootstrapDatastore(t, "mysql")
 	defer func() {
 		stopFunc()
-		//goleak.VerifyNone(t)
+		goleak.VerifyNone(t)
 	}()
 
 	test.RunAllTests(t, ds)
@@ -148,7 +148,7 @@ func TestServerWithMySQLDatastoreAndExplicitCredentials(t *testing.T) {
 	testDatastore, stopFunc := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 	defer func() {
 		stopFunc()
-		//goleak.VerifyNone(t)
+		goleak.VerifyNone(t)
 	}()
 
 	uri := testDatastore.GetConnectionURI(false)

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -522,13 +522,13 @@ condition condition1(x: int) {
 				go func() {
 					for {
 						select {
-						case objectId, open := <-server.channel:
+						case objectID, open := <-server.channel:
 							if !open {
 								done <- struct{}{}
 								return
 							}
 
-							streamedObjectIds = append(streamedObjectIds, objectId)
+							streamedObjectIds = append(streamedObjectIds, objectID)
 
 						// for tests whose deadline is sooner than the latency of the storage layer
 						case <-time.After(test.readTuplesDelay + 1*time.Second):

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1215,18 +1215,16 @@ type document
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
-
 			ctx := context.Background()
 			store := ulid.Make().String()
 			test.request.StoreID = store
 
 			model := testutils.MustTransformDSLToProtoWithID(test.model)
 			err := ds.WriteAuthorizationModel(ctx, store, model)
-			require.NoError(err)
+			require.NoError(t, err)
 
 			err = ds.Write(ctx, store, nil, test.tuples)
-			require.NoError(err)
+			require.NoError(t, err)
 
 			var opts []reverseexpand.ReverseExpandQueryOption
 
@@ -1243,35 +1241,41 @@ type document
 
 			resolutionMetadata := reverseexpand.NewResolutionMetadata()
 
+			reverseExpandErrCh := make(chan error, 1)
 			go func() {
-				reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				err := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				if err != nil {
+					reverseExpandErrCh <- err
+					t.Logf("sent err %s", err)
+				}
 			}()
 
 			var results []*reverseexpand.ReverseExpandResult
-			reverseExpandErrCh := make(chan error)
-			go func() {
-				for result := range resultChan {
-					if result.Err != nil {
-						reverseExpandErrCh <- result.Err
+
+			for {
+				select {
+				case <-timeoutCtx.Done():
+					t.Logf("timed out")
+					require.FailNow(t, "timed out waiting for response")
+					return
+				case err := <-reverseExpandErrCh:
+					require.ErrorIs(t, err, test.expectedError)
+					return
+				case res, channelOpen := <-resultChan:
+					if !channelOpen {
+						t.Log("channel closed")
+						if test.expectedError == nil {
+							require.ElementsMatch(t, test.expectedResult, results)
+							require.Equal(t, test.expectedDSQueryCount, *resolutionMetadata.QueryCount)
+						} else {
+							require.FailNow(t, "expected an error, got none")
+						}
 						return
+					} else {
+						t.Logf("appending result %s", res.Object)
+						results = append(results, res)
 					}
-
-					results = append(results, result)
 				}
-
-				reverseExpandErrCh <- nil
-			}()
-
-			select {
-			case <-timeoutCtx.Done():
-				require.FailNow("timed out waiting for response")
-			case err := <-reverseExpandErrCh:
-				require.ErrorIs(err, test.expectedError)
-			}
-
-			if test.expectedError == nil {
-				require.ElementsMatch(test.expectedResult, results)
-				require.Equal(test.expectedDSQueryCount, *resolutionMetadata.QueryCount)
 			}
 		})
 	}

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1254,10 +1254,6 @@ type document
 
 			for {
 				select {
-				case <-timeoutCtx.Done():
-					t.Logf("timed out")
-					require.FailNow(t, "timed out waiting for response")
-					return
 				case err := <-reverseExpandErrCh:
 					require.ErrorIs(t, err, test.expectedError)
 					return

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"log"
@@ -100,13 +99,7 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) (DatastoreTestC
 	cont, err := dockerClient.ContainerCreate(context.Background(), &containerCfg, &hostCfg, nil, nil, name)
 	require.NoError(t, err, "failed to create mysql docker container")
 
-	var db *sql.DB
-
 	stopContainer := func() {
-		if db != nil {
-			db.Close()
-		}
-
 		t.Logf("stopping container %s", name)
 		timeoutSec := 5
 
@@ -146,7 +139,7 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) (DatastoreTestC
 
 	goose.SetLogger(goose.NopLogger())
 
-	db, err = goose.OpenDBWithDriver("mysql", uri)
+	db, err := goose.OpenDBWithDriver("mysql", uri)
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"io"
 	"strings"
@@ -99,13 +98,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) (Datastor
 	cont, err := dockerClient.ContainerCreate(context.Background(), &containerCfg, &hostCfg, nil, nil, name)
 	require.NoError(t, err, "failed to create postgres docker container")
 
-	var db *sql.DB
-
 	stopContainer := func() {
-		if db != nil {
-			db.Close()
-		}
-
 		t.Logf("stopping container %s", name)
 		timeoutSec := 5
 
@@ -142,7 +135,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) (Datastor
 
 	goose.SetLogger(goose.NopLogger())
 
-	db, err = goose.OpenDBWithDriver("pgx", uri)
+	db, err := goose.OpenDBWithDriver("pgx", uri)
 	require.NoError(t, err)
 	defer db.Close()
 

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -5,6 +5,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -25,8 +26,7 @@ func TestListObjectsMySQL(t *testing.T) {
 }
 
 func testRunAll(t *testing.T, engine string) {
-	// uncomment in https://github.com/openfga/openfga/pull/1315
-	// defer goleak.VerifyNone(t)
+	defer goleak.VerifyNone(t)
 	cfg := run.MustDefaultConfigWithRandomPorts()
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Avoid the forgotten consumer problem between ListObjects and ReverseExpand which, under some query outcomes, could lead to memory leaks. In particular, if we hit the `--listObjects-deadline` while actively reverse expanding, then the ListObjects consumer listening on the ReverseExpand results channel would be left dangling and thus not release the resources back to the Go garbage collector. The changes herein fix that issue particularly and thus avoid memory leaks.

## References
Closes https://github.com/openfga/openfga/issues/1309.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
