### PR TITLE
test: amend #1316

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   go-bench:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30 # until we do https://github.com/openfga/openfga/issues/1172
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.5.2
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -103,7 +103,7 @@ jobs:
 
   go-bench:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30 # until we do https://github.com/openfga/openfga/issues/1172
     steps:
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.5.2

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -383,7 +383,6 @@ func benchmarkCheckWithoutTrace(b *testing.B, engine string) {
 
 		require.NoError(b, err)
 	}
-
 }
 
 func benchmarkCheckWithTrace(b *testing.B, engine string) {

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -33,7 +33,7 @@ func StartServer(t testing.TB, cfg *serverconfig.Config) context.CancelFunc {
 }
 
 // StartServerWithContext starts a server with a specific ServerContext, waits until it is healthy, and returns a cancel function
-// that callers must call when they want to stop the server.
+// that callers must call when they want to stop the server and the backing datastore.
 func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *run.ServerContext) context.CancelFunc {
 	container, stopFunc := storage.RunDatastoreTestContainer(t, cfg.Datastore.Engine)
 	cfg.Datastore.URI = container.GetConnectionURI(true)


### PR DESCRIPTION
We need to stop the benchmark timer when tear down is costly in terms of time, so that time spent tearing down is not added to the benchmark itself.