### PR TITLE
feat: new server.Stop() to close all server resources

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -716,9 +716,9 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	grpcServer.GracefulStop()
 
-	authenticator.Close()
+	svr.Close()
 
-	datastore.Close()
+	authenticator.Close()
 
 	if tracerProviderCloser != nil {
 		tracerProviderCloser()

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -720,6 +720,8 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	authenticator.Close()
 
+	datastore.Close()
+
 	if tracerProviderCloser != nil {
 		tracerProviderCloser()
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -113,6 +113,8 @@ type Server struct {
 
 type OpenFGAServiceV1Option func(s *Server)
 
+// WithDatastore passes a datastore to the Server.
+// You must call [storage.OpenFGADatastore.Close] on it after you have stopped using it.
 func WithDatastore(ds storage.OpenFGADatastore) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.datastore = ds
@@ -244,6 +246,7 @@ func WithMaxAuthorizationModelSizeInBytes(size int) OpenFGAServiceV1Option {
 	}
 }
 
+// MustNewServerWithOpts see NewServerWithOpts
 func MustNewServerWithOpts(opts ...OpenFGAServiceV1Option) *Server {
 	s, err := NewServerWithOpts(opts...)
 	if err != nil {
@@ -253,6 +256,8 @@ func MustNewServerWithOpts(opts ...OpenFGAServiceV1Option) *Server {
 	return s
 }
 
+// NewServerWithOpts returns a new server.
+// You must call Close on it after you are done using it.
 func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 	s := &Server{
 		logger:                           logger.NewNoopLogger(),
@@ -312,11 +317,11 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 	return s, nil
 }
 
+// Close releases the server resources.
 func (s *Server) Close() {
 	if s.checkCache != nil {
 		s.checkCache.Stop()
 	}
-	s.datastore.Close()
 	s.typesystemResolverStop()
 }
 

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -28,7 +28,7 @@ type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (
 // the earlier constructed TypeSystem will be used.
 //
 // The memoized resolver function is designed for concurrent use.
-func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBackend) TypesystemResolverFunc {
+func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBackend) (TypesystemResolverFunc, func()) {
 	lookupGroup := singleflight.Group{}
 
 	cache := ccache.New(ccache.Configure[*TypeSystem]())
@@ -88,5 +88,5 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		cache.Set(key, typesys, typesystemCacheTTL)
 
 		return typesys, nil
-	}
+	}, cache.Stop
 }

--- a/pkg/typesystem/resolver_test.go
+++ b/pkg/typesystem/resolver_test.go
@@ -54,9 +54,10 @@ type document
 			}, nil),
 	)
 
-	resolver := MemoizedTypesystemResolverFunc(
+	resolver, resolverStop := MemoizedTypesystemResolverFunc(
 		mockDatastore,
 	)
+	defer resolverStop()
 
 	typesys, err := resolver(context.Background(), storeID, modelID1)
 	require.NoError(t, err)
@@ -104,9 +105,10 @@ func TestSingleFlightMemoizedTypesystemResolverFunc(t *testing.T) {
 			}, nil).MinTimes(1).MaxTimes(numGoroutines),
 	)
 
-	resolver := MemoizedTypesystemResolverFunc(
+	resolver, resolverStop := MemoizedTypesystemResolverFunc(
 		mockDatastore,
 	)
+	defer resolverStop()
 
 	var wg sync.WaitGroup
 	wg.Add(numGoroutines)

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -30,7 +30,10 @@ func testRunAll(t *testing.T, engine string) {
 	cfg.Datastore.Engine = engine
 
 	cancel := tests.StartServer(t, cfg)
-	defer cancel()
+	t.Cleanup(func() {
+		cancel()
+		//goleak.VerifyNone(t)
+	})
 
 	conn, err := grpc.Dial(cfg.GRPC.Addr,
 		grpc.WithBlock(),

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -25,15 +25,14 @@ func TestListObjectsMySQL(t *testing.T) {
 }
 
 func testRunAll(t *testing.T, engine string) {
+	// uncomment in https://github.com/openfga/openfga/pull/1315
+	// defer goleak.VerifyNone(t)
 	cfg := run.MustDefaultConfigWithRandomPorts()
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine
 
 	cancel := tests.StartServer(t, cfg)
-	t.Cleanup(func() {
-		cancel()
-		//goleak.VerifyNone(t)
-	})
+	defer cancel()
 
 	conn, err := grpc.Dial(cfg.GRPC.Addr,
 		grpc.WithBlock(),


### PR DESCRIPTION
This is a follow-up of https://github.com/openfga/openfga/pull/1317.

Whether we use OpenFGA as a library or as a server, we need to provide an API to clean up Server resources.