### PR TITLE
Adding tracing + attributes to all resolvers

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -458,7 +458,7 @@ func (c *LocalChecker) ResolveCheck(
 
 	ctx, span := tracer.Start(ctx, "ResolveCheck")
 	defer span.End()
-
+	span.SetAttributes(attribute.String("resolver_type", "local"))
 	span.SetAttributes(attribute.String("tuple_key", req.GetTupleKey().String()))
 
 	if req.GetResolutionMetadata().Depth == 0 {


### PR DESCRIPTION
## Description
Improving observability of the check resolution process by adding tracing and an appropriate set of attributes for each resolver. Previously, only the local check resolver had tracing but now that we have three separate resolvers, it makes sense to observe those too. 

Admittedly, the `resolver_type` attribute is not a best practice and should have been accomplished by the built-in `package` attribute but that would have required a messy refactor.

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
