### PR TITLE
test: add more tests for ReadPage correctness

### DIFF
--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -21,6 +21,9 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
+// TODO Read API delegates to [storage.ReadPage]. Tests here shouldn't assert on correctness of results because that's tested in pkg/storage/test.
+// We should pass a mock datastore and assert that mock.ReadPage was called
+
 func ReadQuerySuccessTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	// TODO: review which of these tests should be moved to validation/types in grpc rather than execution. e.g.: invalid relation in authorizationmodel is fine, but tuple without authorizationmodel is should be required before. see issue: https://github.com/openfga/sandcastle/issues/13
 	tests := []struct {

--- a/pkg/server/test/read.go
+++ b/pkg/server/test/read.go
@@ -21,7 +21,8 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-// TODO Read API delegates to [storage.ReadPage]. Tests here shouldn't assert on correctness of results because that's tested in pkg/storage/test.
+// Read Command delegates to [storage.ReadPage].
+// TODO Tests here shouldn't assert on correctness of results because that should be tested in pkg/storage/test.
 // We should pass a mock datastore and assert that mock.ReadPage was called
 
 func ReadQuerySuccessTest(t *testing.T, datastore storage.OpenFGADatastore) {

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -35,12 +35,12 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadStartingWithUser", func(t *testing.T) { ReadStartingWithUserTest(t, ds) })
 
 	// TODO I suspect there is overlap in test scenarios. Consolidate them into one
-	t.Run("TestReadPageTestPagination", func(t *testing.T) { ReadPageTestPagination(t, ds) })
-	t.Run("TestReadPageTestPaginationV2", func(t *testing.T) { ReadPageTestPaginationV2(t, ds) })
+	t.Run("ReadPageTestCorrectnessOfContinuationTokens", func(t *testing.T) { ReadPageTestCorrectnessOfContinuationTokens(t, ds) })
+	t.Run("ReadPageTestCorrectnessOfContinuationTokensV2", func(t *testing.T) { ReadPageTestCorrectnessOfContinuationTokensV2(t, ds) })
 
 	// TODO Consolidate them into one, since both Read and ReadPage should respect the same set of filters
-	t.Run("TestReadCorrectness", func(t *testing.T) { ReadTestCorrectness(t, ds) })
-	t.Run("TestReadPageCorrectness", func(t *testing.T) { ReadPageTestCorrectness(t, ds) })
+	t.Run("ReadTestCorrectnessOfTuples", func(t *testing.T) { ReadTestCorrectnessOfTuples(t, ds) })
+	t.Run("ReadPageTestCorrectnessOfTuples", func(t *testing.T) { ReadPageTestCorrectnessOfTuples(t, ds) })
 
 	// Authorization models.
 	t.Run("TestWriteAndReadAuthorizationModel", func(t *testing.T) { WriteAndReadAuthorizationModelTest(t, ds) })

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -34,11 +34,11 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadChanges", func(t *testing.T) { ReadChangesTest(t, ds) })
 	t.Run("TestReadStartingWithUser", func(t *testing.T) { ReadStartingWithUserTest(t, ds) })
 
-	// TODO Consolidate them into one
+	// TODO I suspect there is overlap in test scenarios. Consolidate them into one
 	t.Run("TestReadPageTestPagination", func(t *testing.T) { ReadPageTestPagination(t, ds) })
 	t.Run("TestReadPageTestPaginationV2", func(t *testing.T) { ReadPageTestPaginationV2(t, ds) })
 
-	// TODO Consolidate them into one
+	// TODO Consolidate them into one, since both Read and ReadPage should respect the same set of filters
 	t.Run("TestReadCorrectness", func(t *testing.T) { ReadTestCorrectness(t, ds) })
 	t.Run("TestReadPageCorrectness", func(t *testing.T) { ReadPageTestCorrectness(t, ds) })
 

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -31,11 +31,16 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 	})
 	// Tuples.
 	t.Run("TestTupleWriteAndRead", func(t *testing.T) { TupleWritingAndReadingTest(t, ds) })
-	t.Run("TestTuplePaginationOptions", func(t *testing.T) { TuplePaginationOptionsTest(t, ds) })
 	t.Run("TestReadChanges", func(t *testing.T) { ReadChangesTest(t, ds) })
 	t.Run("TestReadStartingWithUser", func(t *testing.T) { ReadStartingWithUserTest(t, ds) })
-	t.Run("TestRead", func(t *testing.T) { ReadTest(t, ds) })
-	t.Run("TestReadPage", func(t *testing.T) { ReadPageTest(t, ds) })
+
+	// TODO Consolidate them into one
+	t.Run("TestReadPageTestPagination", func(t *testing.T) { ReadPageTestPagination(t, ds) })
+	t.Run("TestReadPageTestPaginationV2", func(t *testing.T) { ReadPageTestPaginationV2(t, ds) })
+
+	// TODO Consolidate them into one
+	t.Run("TestReadCorrectness", func(t *testing.T) { ReadTestCorrectness(t, ds) })
+	t.Run("TestReadPageCorrectness", func(t *testing.T) { ReadPageTestCorrectness(t, ds) })
 
 	// Authorization models.
 	t.Run("TestWriteAndReadAuthorizationModel", func(t *testing.T) { WriteAndReadAuthorizationModelTest(t, ds) })

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -877,7 +877,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 	})
 }
 
-func ReadPageTestPagination(t *testing.T, datastore storage.OpenFGADatastore) {
+func ReadPageTestCorrectnessOfContinuationTokens(t *testing.T, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 	storeID := ulid.Make().String()
 	tk0 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
@@ -1083,7 +1083,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	})
 }
 
-func ReadTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
+func ReadTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 
 	tuples := []*openfgav1.TupleKey{
@@ -1234,7 +1234,7 @@ func ReadTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 	})
 }
 
-func ReadPageTestPaginationV2(t *testing.T, datastore storage.OpenFGADatastore) {
+func ReadPageTestCorrectnessOfContinuationTokensV2(t *testing.T, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 	storeID := ulid.Make().String()
 
@@ -1314,7 +1314,7 @@ func ReadPageTestPaginationV2(t *testing.T, datastore storage.OpenFGADatastore) 
 	})
 }
 
-func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
+func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGADatastore) {
 	ctx := context.Background()
 
 	tuples := []*openfgav1.TupleKey{

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1513,12 +1513,12 @@ func getTupleKeys(tupleIterator storage.TupleIterator, t *testing.T) []*openfgav
 	return tupleKeys
 }
 
-func requireEqualTuples(t *testing.T, expectedTuples []*openfgav1.Tuple, tuplesRead []*openfgav1.Tuple) {
+func requireEqualTuples(t *testing.T, expectedTuples []*openfgav1.Tuple, actualTuples []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{
 		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.Tuple{}), "timestamp"),
 		testutils.TupleCmpTransformer,
 		protocmp.Transform(),
 	}
-	diff := cmp.Diff(expectedTuples, tuplesRead, cmpOpts...)
+	diff := cmp.Diff(expectedTuples, actualTuples, cmpOpts...)
 	require.Empty(t, diff)
 }

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1164,7 +1164,7 @@ func ReadTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGADatastor
 		require.ElementsMatch(t, expectedTupleKeys, getTupleKeys(tupleIterator, t))
 	})
 
-	t.Run("filter_by_user_and_and_objectType", func(t *testing.T) {
+	t.Run("filter_by_user_and_objectType", func(t *testing.T) {
 		tupleIterator, err := datastore.Read(
 			ctx,
 			storeID,
@@ -1396,7 +1396,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 		require.Empty(t, contToken)
 	})
 
-	t.Run("filter_by_user_and_and_objectType", func(t *testing.T) {
+	t.Run("filter_by_user_and_objectType", func(t *testing.T) {
 		gotTuples, contToken, err := datastore.ReadPage(
 			ctx,
 			storeID,

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1273,7 +1273,7 @@ func ReadPageTestPaginationV2(t *testing.T, datastore storage.OpenFGADatastore) 
 			{Key: tuple.NewTupleKey("document:1", "reader", "user:anne")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, tuplesRead)
+		requireEqualTuples(t, expectedTuples, tuplesRead)
 		require.Empty(t, contToken)
 	})
 
@@ -1337,7 +1337,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 	require.NoError(t, err)
 
 	t.Run("empty_filter_returns_all_tuples", func(t *testing.T) {
-		gotTupleKeys, contToken, err := datastore.ReadPage(
+		gotTuples, contToken, err := datastore.ReadPage(
 			ctx,
 			storeID,
 			tuple.NewTupleKey("", "", ""),
@@ -1354,7 +1354,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKeyWithCondition("document:2", "viewer", "user:anne", "condition", nil)},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTupleKeys)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1373,7 +1373,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "reader", "user:bob")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1392,7 +1392,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "reader", "user:bob")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1412,7 +1412,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "writer", "user:bob")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1432,7 +1432,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "reader", "user:anne")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1453,7 +1453,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "writer", "user:bob")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 
@@ -1473,7 +1473,7 @@ func ReadPageTestCorrectness(t *testing.T, datastore storage.OpenFGADatastore) {
 			{Key: tuple.NewTupleKey("document:1", "writer", "user:bob")},
 		}
 
-		requireNoDiffTuples(t, expectedTuples, gotTuples)
+		requireEqualTuples(t, expectedTuples, gotTuples)
 		require.Empty(t, contToken)
 	})
 }
@@ -1513,7 +1513,7 @@ func getTupleKeys(tupleIterator storage.TupleIterator, t *testing.T) []*openfgav
 	return tupleKeys
 }
 
-func requireNoDiffTuples(t *testing.T, expectedTuples []*openfgav1.Tuple, tuplesRead []*openfgav1.Tuple) {
+func requireEqualTuples(t *testing.T, expectedTuples []*openfgav1.Tuple, tuplesRead []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{
 		protocmp.IgnoreFields(protoadapt.MessageV2Of(&openfgav1.Tuple{}), "timestamp"),
 		testutils.TupleCmpTransformer,

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1168,7 +1168,7 @@ func ReadTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGADatastor
 		tupleIterator, err := datastore.Read(
 			ctx,
 			storeID,
-			tuple.NewTupleKey("document:1", "", "user:bob"),
+			tuple.NewTupleKey("document:", "", "user:bob"),
 		)
 		require.NoError(t, err)
 		defer tupleIterator.Stop()


### PR DESCRIPTION
This is a follow-up of https://github.com/openfga/openfga/pull/1325 with more tests 😆 

Two tests were missing, filter by user and object type, for both `Read` and `ReadPage`.