### PR TITLE
chore: fix testifylint errors on tests

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -291,6 +291,8 @@ func convertStringArrayToUintArray(stringArray []string) []uint {
 	return uintArray
 }
 
+// Run returns an error if the server was unable to start successfully.
+// If it started and terminated successfully, it returns a nil error.
 func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
 	var tracerProviderCloser func()
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -152,8 +152,7 @@ type document
 		res := <-resultChan
 		t.Logf("after receive one result")
 		cancelFunc()
-		t.Logf("after send cancellation")
-		require.NotNil(t, res.Object)
+		t.Logf("received object %s ", res.Object)
 	}()
 
 	select {

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -151,7 +151,11 @@ type document
 		t.Logf("before receive one result")
 		res := <-resultChan
 		t.Logf("after receive one result")
+
+		// send cancellation to the other goroutine
 		cancelFunc()
+
+		// this check it not the goal of this test, it's here just as sanity check
 		if res.Object == "" {
 			panic("expected object, got nil")
 		}
@@ -160,7 +164,7 @@ type document
 
 	select {
 	case err := <-errChan:
-		require.Error(t, err)
+		require.ErrorContains(t, err, "context canceled")
 	case <-time.After(30 * time.Millisecond):
 		require.FailNow(t, "unexpected timeout on channel receive, expected receive on error channel")
 	}

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -152,6 +152,9 @@ type document
 		res := <-resultChan
 		t.Logf("after receive one result")
 		cancelFunc()
+		if res.Object == "" {
+			panic("expected object, got nil")
+		}
 		t.Logf("received object %s ", res.Object)
 	}()
 

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -2,13 +2,13 @@ package storagewrappers
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/storage"
@@ -31,33 +31,29 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 	// Do reads from 4 goroutines - each should be run serially. Should be >4 seconds.
 	const numRoutine = 4
 
-	var wg sync.WaitGroup
-	wg.Add(numRoutine)
+	var wg errgroup.Group
 
 	start := time.Now()
 
-	go func() {
+	wg.Go(func() error {
 		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"))
-		require.NoError(t, err)
-		wg.Done()
-	}()
+		return err
+	})
 
-	go func() {
+	wg.Go(func() error {
 		_, err := limitedTupleReader.ReadUsersetTuples(context.Background(), store, storage.ReadUsersetTuplesFilter{
 			Object:   "obj:1",
 			Relation: "viewer",
 		})
-		require.NoError(t, err)
-		wg.Done()
-	}()
+		return err
+	})
 
-	go func() {
+	wg.Go(func() error {
 		_, err := limitedTupleReader.Read(context.Background(), store, nil)
-		require.NoError(t, err)
-		wg.Done()
-	}()
+		return err
+	})
 
-	go func() {
+	wg.Go(func() error {
 		_, err := limitedTupleReader.ReadStartingWithUser(
 			context.Background(),
 			store,
@@ -68,11 +64,11 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 						Relation: "viewer",
 					},
 				}})
-		require.NoError(t, err)
-		wg.Done()
-	}()
+		return err
+	})
 
-	wg.Wait()
+	err = wg.Wait()
+	require.NoError(t, err)
 
 	end := time.Now()
 


### PR DESCRIPTION
Fix

```
Run golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc
prepare environment
run golangci-lint
  Running [/home/runner/golangci-lint-1.56.0-linux-amd64/golangci-lint run --out-format=github-actions -v -c .golangci.yaml] in [] ...
  Error: File is not `goimports`-ed with -local github.com/openfga/openfga (goimports)
  Error: go-require: require must only be used in the goroutine running the test function (testifylint)
  Error: go-require: require must only be used in the goroutine running the test function (testifylint)
  Error: go-require: require must only be used in the goroutine running the test function (testifylint)
```

seen on https://github.com/openfga/openfga/actions/runs/7820454748/job/21335217274?pr=1345#step:4:29