### PR TITLE
test: fix data race in ReverseExpand test

### DIFF
--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1243,10 +1243,10 @@ type document
 
 			reverseExpandErrCh := make(chan error, 1)
 			go func() {
-				err := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
 				if err != nil {
-					reverseExpandErrCh <- err
-					t.Logf("sent err %s", err)
+					reverseExpandErrCh <- errReverseExpand
+					t.Logf("sent err %s", errReverseExpand)
 				}
 			}()
 

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1244,7 +1244,7 @@ type document
 			reverseExpandErrCh := make(chan error, 1)
 			go func() {
 				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
-				if err != nil {
+				if reverseExpandErrCh != nil {
 					reverseExpandErrCh <- errReverseExpand
 					t.Logf("sent err %s", errReverseExpand)
 				}
@@ -1257,6 +1257,8 @@ type document
 				case err := <-reverseExpandErrCh:
 					require.ErrorIs(t, err, test.expectedError)
 					return
+				case <-timeoutCtx.Done():
+					require.FailNow(t, "unexpected timeout")
 				case res, channelOpen := <-resultChan:
 					if !channelOpen {
 						t.Log("channel closed")

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1244,7 +1244,7 @@ type document
 			reverseExpandErrCh := make(chan error, 1)
 			go func() {
 				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
-				if reverseExpandErrCh != nil {
+				if errReverseExpand != nil {
 					reverseExpandErrCh <- errReverseExpand
 					t.Logf("sent err %s", errReverseExpand)
 				}


### PR DESCRIPTION
## Description

Fix data race in test

```
==================
WARNING: DATA RACE
Read at 0x00c000de66c3 by goroutine 1303:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1011 +0xcd
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1004 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1055 +0x6a
  github.com/openfga/openfga/pkg/server/test.TestReverseExpand.func1.1()
      /home/runner/go/pkg/mod/github.com/openfga/openfga@v1.4.4-0.20240201172210-29d9c34d421b/pkg/server/test/reverse_expand.go:1249 +0x1a6

Previous write at 0x00c000de66c3 by goroutine 1298:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1582 +0x8fa
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.21.5/x64/src/runtime/panic.go:477 +0x30
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44

Goroutine 1303 (running) created at:
  github.com/openfga/openfga/pkg/server/test.TestReverseExpand.func1()
      /home/runner/go/pkg/mod/github.com/openfga/openfga@v1.4.4-0.20240201172210-29d9c34d421b/pkg/server/test/reverse_expand.go:1245 +0x74a
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44

Goroutine 1298 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x845
  github.com/openfga/openfga/pkg/server/test.TestReverseExpand()
      /home/runner/go/pkg/mod/github.com/openfga/openfga@v1.4.4-0.20240201172210-29d9c34d421b/pkg/server/test/reverse_expand.go:1217 +0x12593
  github.com/openfga/openfga/pkg/server/test.RunQueryTests.func21()
      /home/runner/go/pkg/mod/github.com/openfga/openfga@v1.4.4-0.20240201172210-29d9c34d421b/pkg/server/test/server.go:52 +0x44
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x261
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x44
==================
```

Also fix dangling goroutines in case the tests abruptly end:

```
coverage: 44.3% of statements in ./...
panic: test timed out after 10m0s
running tests:
	TestServerWithPostgresDatastore (9m40s)
	TestServerWithPostgresDatastore/TestReverseExpand (9m34s)
	TestServerWithPostgresDatastore/TestReverseExpand/resolution_depth_exceeded_failure (9m34s)

goroutine 1108 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2259 +0x259
created by time.goFunc
	/opt/hostedtoolcache/go/1.21.5/x64/src/time/sleep.go:176 +0x45

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc00048e000, {0x1baf280, 0x1f}, 0x1c0c3b8)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1649 +0x871
testing.runTests.func1(0x0?)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2054 +0x85
testing.tRunner(0xc00048e000, 0xc000819ae8)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x262
testing.runTests(0xc00037d220?, {0x29160a0, 0x13, 0x13}, {0x1c?, 0x1e?, 0x2926160?})
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2052 +0x8ae
testing.(*M).Run(0xc00037d220)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1925 +0xcd8
main.main()
	_testmain.go:123 +0x2e5

goroutine 933 [chan receive, 9 minutes]:
testing.(*T).Run(0xc001cbdba0, {0x1bb2ea5, 0x21}, 0xc001daaa20)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1649 +0x871
github.com/openfga/openfga/pkg/server/test.TestReverseExpand(0xc001cbdba0?, {0x1ebdc[58](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:59)?, 0xc00007e500})
	/home/runner/work/openfga/openfga/pkg/server/test/reverse_expand.go:1217 +0x14[63](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:64)4
coverage: 44.3% of statements in ./...
panic: test timed out after 10m0s
running tests:
	TestServerWithPostgresDatastore (9m40s)
	TestServerWithPostgresDatastore/TestReverseExpand (9m34s)
	TestServerWithPostgresDatastore/TestReverseExpand/resolution_depth_exceeded_failure (9m34s)

goroutine 1108 [running]:
testing.(*M).startAlarm.func1()
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2259 +0x259
created by time.goFunc
	/opt/hostedtoolcache/go/1.21.5/x64/src/time/sleep.go:176 +0x45

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc00048e000, {0x1baf280, 0x1f}, 0x1c0c3b8)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1649 +0x871
testing.runTests.func1(0x0?)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2054 +0x85
testing.tRunner(0xc00048e000, 0xc000819ae8)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x262
testing.runTests(0xc00037d220?, {0x29160a0, 0x13, 0x13}, {0x1c?, 0x1e?, 0x2926160?})
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:2052 +0x8ae
testing.(*M).Run(0xc00037d220)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1925 +0xcd8
main.main()
	_testmain.go:123 +0x2e5

goroutine 933 [chan receive, 9 minutes]:
testing.(*T).Run(0xc001cbdba0, {0x1bb2ea5, 0x21}, 0xc001daaa20)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1649 +0x871
github.com/openfga/openfga/pkg/server/test.TestReverseExpand(0xc001cbdba0?, {0x1ebdc[58](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:59)?, 0xc00007e500})
	/home/runner/work/openfga/openfga/pkg/server/test/reverse_expand.go:1217 +0x14634
github.com/openfga/openfga/pkg/server/test.RunQueryTests.func21(0x0?)
	/home/runner/work/openfga/openfga/pkg/server/test/server.go:52 +0x[59](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:60)
testing.tRunner(0xc001cbdba0, 0xc00064c618)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 174
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x846

goroutine 189 [select, 9 minutes]:
database/sql.(*DB).connectionOpener(0xc0005af6c0, {0x1ea2670, 0xc00007e410})
	/opt/hostedtoolcache/go/1.21.5/x64/src/database/sql/sql.go:1218 +0xed
created by database/sql.OpenDB in goroutine 174
	/opt/hostedtoolcache/go/1.21.5/x64/src/database/sql/sql.go:791 +0x2f0

goroutine 174 [chan receive, 9 minutes]:
testing.(*T).Run(0xc0003f4820, {0x1b9d5a8, 0x11}, 0xc00064c618)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1649 +0x871
github.com/openfga/openfga/pkg/server/test.RunQueryTests(0xc00017e7a0?, {0x1ebdc58?, 0xc00007e500})
	/home/runner/work/openfga/openfga/pkg/server/test/server.go:52 +0xde5
github.com/openfga/openfga/pkg/server/test.RunAllTests(0x1ebd820?, {0x1ebdc58, 0xc00007e500})
	/home/runner/work/openfga/openfga/pkg/server/test/server.go:10 +0x85
github.com/openfga/openfga/pkg/server.TestServerWithPostgresDatastore(0xc0003f4820)
	/home/runner/work/openfga/openfga/pkg/server/server_test.go:174 +0x105
testing.tRunner(0xc0003f4820, 0x1c0c3b8)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x846

goroutine 183 [select, 9 minutes]:
net/http.(*persistConn).writeLoop(0xc0000c4000)
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/http/transport.go:2421 +0x1bc
created by net/http.(*Transport).dialConn in goroutine 175
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/http/transport.go:1777 +0x266b

goroutine 182 [IO wait, 9 minutes]:
internal/poll.runtime_pollWait(0x7f5a41e50e58, 0x72)
	/opt/hostedtoolcache/go/1.21.5/x64/src/runtime/netpoll.go:343 +0x85
internal/poll.(*pollDesc).wait(0xc000436220, 0xc000532000?, 0x0)
	/opt/hostedtoolcache/go/1.21.5/x64/src/internal/poll/fd_poll_runtime.go:84 +0xb1
internal/poll.(*pollDesc).waitRead(...)
	/opt/hostedtoolcache/go/1.21.5/x64/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc000436200, {0xc000532000, 0x1000, 0x1000})
	/opt/hostedtoolcache/go/1.21.5/x64/src/internal/poll/fd_unix.go:164 +0x405
net.(*netFD).Read(0xc000436200, {0xc000532000, 0x1000, 0x1000})
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/fd_posix.go:55 +0x4b
net.(*conn).Read(0xc0000cc240, {0xc000532000, 0x1000, 0x1000})
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/net.go:179 +0xad
net/http.(*persistConn).Read(0xc0000c4000, {0xc000532000, 0x1000, 0x1000})
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/http/transport.go:1954 +0x105
bufio.(*Reader).fill(0xc0004805a0)
	/opt/hostedtoolcache/go/1.21.5/x64/src/bufio/bufio.go:113 +0x29a
bufio.(*Reader).Peek(0xc0004805a0, 0x1)
	/opt/hostedtoolcache/go/1.21.5/x64/src/bufio/bufio.go:151 +0xc7
net/http.(*persistConn).readLoop(0xc0000c4000)
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/http/transport.go:2118 +0x354
created by net/http.(*Transport).dialConn in goroutine 175
	/opt/hostedtoolcache/go/1.21.5/x64/src/net/http/transport.go:1776 +0x25da

goroutine 1087 [select, 9 minutes]:
github.com/openfga/openfga/pkg/server/test.TestReverseExpand.func1(0xc0006d1040)
	/home/runner/work/openfga/openfga/pkg/server/test/reverse_expand.go:1256 +0x99c
testing.tRunner(0xc0006d1040, 0xc001daaa20)
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 933
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1648 +0x846
FAIL	github.com/openfga/openfga/pkg/server	[60](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:61)0.1[95](https://github.com/openfga/openfga/actions/runs/7822828727/job/21342664710#step:5:96)s
```