### PR TITLE
test: don't panic if ListStores fails

### DIFF
--- a/pkg/server/test/list_stores.go
+++ b/pkg/server/test/list_stores.go
@@ -21,15 +21,15 @@ func TestListStores(t *testing.T, datastore storage.OpenFGADatastore) {
 	deleteCmd := commands.NewDeleteStoreCommand(datastore)
 	deleteContinuationToken := ""
 	for ok := true; ok; ok = deleteContinuationToken != "" {
-		listStoresResponse, _ := getStoresQuery.Execute(ctx, &openfgav1.ListStoresRequest{
+		listStoresResponse, err := getStoresQuery.Execute(ctx, &openfgav1.ListStoresRequest{
 			ContinuationToken: deleteContinuationToken,
 		})
+		require.NoError(t, err)
 		for _, store := range listStoresResponse.Stores {
-			if _, err := deleteCmd.Execute(ctx, &openfgav1.DeleteStoreRequest{
+			_, err := deleteCmd.Execute(ctx, &openfgav1.DeleteStoreRequest{
 				StoreId: store.Id,
-			}); err != nil {
-				t.Fatalf("failed cleaning stores with %v", err)
-			}
+			})
+			require.NoError(t, err)
 		}
 		deleteContinuationToken = listStoresResponse.ContinuationToken
 	}


### PR DESCRIPTION
Fix potential panic in a test:

```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1a18987]

goroutine 147 [running]:
testing.tRunner.func1.2({0x1bcbc20, 0x3c65e20})
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1545 +0x3f7
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.21.5/x64/src/testing/testing.go:1548 +0x716
panic({0x1bcbc20?, 0x3c65e20?})
	/opt/hostedtoolcache/go/1.21.5/x64/src/runtime/panic.go:920 +0x270
github.com/openfga/openfga/pkg/server/test.TestListStores(0xc0008876c0, {0x30bb2b8?, 0xc0004d7400})
	/home/runner/go/pkg/mod/github.com/openfga/openfga@v1.4.4-0.20240201172210-29d9c34d421b/pkg/server/test/list_stores.go:27 +0x1a7
```