### PR TITLE
refactor: use t.Cleanup func to stop mock tracing server

### DIFF
--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -283,9 +283,7 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 	otlpServerPort, otlpServerPortReleaser := TCPRandomPort()
 	localOTLPServerURL := fmt.Sprintf("localhost:%d", otlpServerPort)
 	otlpServerPortReleaser()
-	otlpServer, serverStopFunc, err := mocks.NewMockTracingServer(otlpServerPort)
-	defer serverStopFunc()
-	require.NoError(t, err)
+	otlpServer := mocks.NewMockTracingServer(t, otlpServerPort)
 
 	// create OpenFGA server with tracing enabled
 	cfg := MustDefaultConfigWithRandomPorts()
@@ -307,7 +305,7 @@ func TestBuildServiceWithTracingEnabled(t *testing.T) {
 
 	// attempt a random request
 	client := retryablehttp.NewClient()
-	_, err = client.Get(fmt.Sprintf("http://%s/healthz", cfg.HTTP.Addr))
+	_, err := client.Get(fmt.Sprintf("http://%s/healthz", cfg.HTTP.Addr))
 	require.NoError(t, err)
 
 	// wait for trace exporting

--- a/internal/mocks/mock_tracing_server.go
+++ b/internal/mocks/mock_tracing_server.go
@@ -3,9 +3,11 @@ package mocks
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"log"
 	"net"
 	"sync"
+	"testing"
 
 	otlpcollector "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
@@ -27,13 +29,12 @@ func (s *mockTracingServer) Export(context.Context, *otlpcollector.ExportTraceSe
 	return &otlpcollector.ExportTraceServiceResponse{}, nil
 }
 
-func NewMockTracingServer(port int) (*mockTracingServer, func(), error) {
+func NewMockTracingServer(t testing.TB, port int) *mockTracingServer {
 	mockServer := &mockTracingServer{exportCount: 0, server: grpc.NewServer()}
 	otlpcollector.RegisterTraceServiceServer(mockServer.server, mockServer)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		log.Fatalf("failed to listen: %v", err)
-	}
+	require.NoError(t, err)
+	t.Cleanup(mockServer.server.Stop)
 
 	go func() {
 		if err := mockServer.server.Serve(listener); err != nil {
@@ -42,7 +43,7 @@ func NewMockTracingServer(port int) (*mockTracingServer, func(), error) {
 		log.Println("server closed")
 	}()
 
-	return mockServer, mockServer.server.Stop, nil
+	return mockServer
 }
 
 func (s *mockTracingServer) GetExportCount() int {

--- a/internal/mocks/mock_tracing_server.go
+++ b/internal/mocks/mock_tracing_server.go
@@ -3,11 +3,12 @@ package mocks
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"net"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	otlpcollector "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -52,9 +52,7 @@ func TestCheckLogs(t *testing.T) {
 	otlpServerPort, otlpServerPortReleaser := run.TCPRandomPort()
 	localOTLPServerURL := fmt.Sprintf("localhost:%d", otlpServerPort)
 	otlpServerPortReleaser()
-	_, serverStopFunc, err := mocks.NewMockTracingServer(otlpServerPort)
-	defer serverStopFunc()
-	require.NoError(t, err)
+	_ = mocks.NewMockTracingServer(t, otlpServerPort)
 
 	cfg := run.MustDefaultConfigWithRandomPorts()
 	cfg.Trace.Enabled = true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- Update mock tracing server helper to use `t.Cleanup` func, this function was introduced since Go 1.14 (https://go.dev/doc/go1.14)

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
