### PR TITLE
test: Improving reliability of `TestEvaluateWithInterruptCheckFrequency`

### DIFF
--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -513,6 +513,11 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 		return items
 	}
 
+	// numLoops is the number of loops being evaluated by a CEL
+	// expression. This number needs to be large enough to not
+	// be resolved before the 1 microsecond context timeout.
+	numLoops := 500
+
 	var tests = []struct {
 		name           string
 		condition      *openfgav1.Condition
@@ -537,9 +542,12 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 					},
 				},
 			},
-			checkFrequency: 100,
+			checkFrequency: uint(numLoops),
 			context: map[string]interface{}{
-				"items": makeItems(100),
+				"items": makeItems(numLoops),
+			},
+			result: condition.EvaluationResult{
+				ConditionMet: false,
 			},
 			err: fmt.Errorf("failed to evaluate relationship condition: 'condition1' - failed to evaluate condition expression: operation interrupted"),
 		},
@@ -559,13 +567,14 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 					},
 				},
 			},
-			checkFrequency: 100,
+			checkFrequency: uint(numLoops),
 			context: map[string]interface{}{
-				"items": makeItems(99),
+				"items": makeItems(numLoops - 1),
 			},
 			result: condition.EvaluationResult{
 				ConditionMet: true,
 			},
+			err: nil,
 		},
 		{
 			name: "operation_interrupted_two_comprehensions",
@@ -583,9 +592,12 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 					},
 				},
 			},
-			checkFrequency: 100,
+			checkFrequency: uint(numLoops),
 			context: map[string]interface{}{
-				"items": makeItems(100),
+				"items": makeItems(numLoops),
+			},
+			result: condition.EvaluationResult{
+				ConditionMet: false,
 			},
 			err: fmt.Errorf("failed to evaluate relationship condition: 'condition1' - failed to evaluate condition expression: operation interrupted"),
 		},
@@ -605,9 +617,12 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 					},
 				},
 			},
-			checkFrequency: 100,
+			checkFrequency: uint(numLoops),
 			context: map[string]interface{}{
-				"items": makeItems(99),
+				"items": makeItems(numLoops - 1),
+			},
+			result: condition.EvaluationResult{
+				ConditionMet: false,
 			},
 			err: fmt.Errorf("failed to evaluate relationship condition: 'condition1' - failed to evaluate condition expression: operation interrupted"),
 		},


### PR DESCRIPTION
## Description
Intermittent failures have been observed with the `TestEvaluateWithInterruptCheckFrequency` test. These tests pertain to the CEL interpreter and the interaction between the interpreter's interrupt mechanism and context timeouts. Several of these tests will assert that the context will time-out before the CEL can be interpreted. However this creates a race condition and occasionally, the CEL will be interpreted before than the 1 microsecond timeout. The "fix" here is to add more loops to the CEL expression so that it takes longer than 1 microsecond to evaluate. This makes the test succeed much more reliably:

```
go test ./internal/condition/condition_test.go -race -run "TestEvaluateWithInterruptCheckFrequency" -count=10000


ok      command-line-arguments  115.756s
```

If this test continues to become an issue in the future, we will need to eliminated the race condition by mocking the timer or some other refactor.

## References
PR that introduced CEL interrupt functionality: https://github.com/openfga/openfga/pull/1237

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
