### PR TITLE
fix: leaking goroutines in tests if server didn't start properly

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -219,7 +219,8 @@ func TCPRandomPort() (int, func()) {
 	}
 }
 
-// MustDefaultConfigWithRandomPorts returns the DefaultConfig, but with random ports for the grpc and http addresses.
+// MustDefaultConfigWithRandomPorts is meant to be used for tests only (TODO move to test utils).
+// It returns default server config but with random ports for the grpc and http addresses and with the playground, tracing and metrics turned off.
 // This function may panic if somehow a random port cannot be chosen.
 func MustDefaultConfigWithRandomPorts() *serverconfig.Config {
 	config := serverconfig.DefaultConfig()

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -168,6 +168,7 @@ func EnsureServiceHealthy(t testing.TB, grpcAddr, httpAddr string, transportCred
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	t.Log("creating connection to address", grpcAddr)
 	conn, err := grpc.DialContext(
 		ctx,
 		grpcAddr,
@@ -188,10 +189,12 @@ func EnsureServiceHealthy(t testing.TB, grpcAddr, httpAddr string, transportCred
 			Service: openfgav1.OpenFGAService_ServiceDesc.ServiceName,
 		})
 		if err != nil {
+			t.Log(time.Now(), "not serving yet at address", grpcAddr, err)
 			return err
 		}
 
 		if resp.GetStatus() != healthv1pb.HealthCheckResponse_SERVING {
+			t.Log(time.Now(), resp.GetStatus())
 			return errors.New("not serving")
 		}
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -44,13 +44,12 @@ func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *r
 	go func() {
 		serverDone <- serverCtx.Run(ctx, cfg)
 	}()
-
-	testutils.EnsureServiceHealthy(t, cfg.GRPC.Addr, cfg.HTTP.Addr, nil, false)
-
 	t.Cleanup(func() {
-		// send cancellation signal to server and wait for it to stop
+		t.Log("waiting for server to stop")
 		cancel()
 		serverErr := <-serverDone
-		t.Log(serverErr)
+		t.Log("server stopped with error: ", serverErr)
 	})
+
+	testutils.EnsureServiceHealthy(t, cfg.GRPC.Addr, cfg.HTTP.Addr, nil, false)
 }


### PR DESCRIPTION
## Description
Fix false positive goroutine leak seen in https://github.com/openfga/openfga/actions/runs/7935612049/job/21669138931:

```shell
--- FAIL: TestListObjectsMySQL (34.92s)
    tests.go:48: 
        	Error Trace:	/home/runner/work/openfga/openfga/pkg/testutils/testutils.go:200
        	            				/home/runner/work/openfga/openfga/tests/tests.go:48
        	            				/home/runner/work/openfga/openfga/tests/tests.go:32
        	            				/home/runner/work/openfga/openfga/tests/listobjects/listobjects_test.go:34
        	            				/home/runner/work/openfga/openfga/tests/listobjects/listobjects_test.go:23
        	Error:      	Received unexpected error:
        	            	rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp 0.0.0.0:37117: connect: connection refused"
        	Test:       	TestListObjectsMySQL
        	Messages:   	server did not reach healthy status
    mysql.go:106: stopping container mysql-01HPSR9BFH6MGDTBWBY1X1HQ96
    mysql.go:113: stopped container mysql-01HPSR9BFH6MGDTBWBY1X1HQ96
    listobjects_test.go:28: found unexpected goroutines:
        [Goroutine 131507 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        internal/poll.runtime_pollWait(0x7f9db1c9a9f0, 0x72)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/runtime/netpoll.go:343 +0x85
        internal/poll.(*pollDesc).wait(0xc000ac0fa0, 0x4b0601?, 0x0)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_poll_runtime.go:84 +0xb1
        internal/poll.(*pollDesc).waitRead(...)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Accept(0xc000ac0f80)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_unix.go:611 +0x425
        net.(*netFD).accept(0xc000ac0f80)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/net/fd_unix.go:172 +0x3e
        net.(*TCPListener).accept(0xc000a44fe0)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/net/tcpsock_posix.go:152 +0x3e
        net.(*TCPListener).Accept(0xc000a44fe0)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/net/tcpsock.go:315 +0x65
        google.golang.org/grpc.(*Server).Serve(0xc0010b2800, {0x1fcc8e0, 0xc000a44fe0})
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/server.go:885 +0x611
        github.com/openfga/openfga/cmd/run.(*ServerContext).Run.func4()
        	/home/runner/work/openfga/openfga/cmd/run/run.go:536 +0x70
        created by github.com/openfga/openfga/cmd/run.(*ServerContext).Run in goroutine 131361
        	/home/runner/work/openfga/openfga/cmd/run/run.go:535 +0x61f8
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_server.go:322 +0x260b
         Goroutine 131470 in state select, with google.golang.org/grpc/internal/transport.(*http2Server).keepalive on top of the stack:
        google.golang.org/grpc/internal/transport.(*http2Server).keepalive(0xc0010d0000)
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_server.go:1138 +0x41b
        created by google.golang.org/grpc/internal/transport.NewServerTransport in goroutine 131484
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_server.go:328 +0x268b
         Goroutine 131471 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        internal/poll.runtime_pollWait(0x7f9e025c82b8, 0x72)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/runtime/netpoll.go:343 +0x85
        internal/poll.(*pollDesc).wait(0xc001292ca0, 0xc00068c000?, 0x0)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_poll_runtime.go:84 +0xb1
        internal/poll.(*pollDesc).waitRead(...)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0xc001292c80, {0xc00068c000, 0x8000, 0x8000})
        	/opt/hostedtoolcache/go/1.21.7/x64/src/internal/poll/fd_unix.go:164 +0x405
        net.(*netFD).Read(0xc001292c80, {0xc00068c000, 0x8000, 0x8000})
        	/opt/hostedtoolcache/go/1.21.7/x64/src/net/fd_posix.go:55 +0x4b
        net.(*conn).Read(0xc000520120, {0xc00068c000, 0x8000, 0x8000})
        	/opt/hostedtoolcache/go/1.21.7/x64/src/net/net.go:179 +0xad
        bufio.(*Reader).Read(0xc000[66](https://github.com/openfga/openfga/actions/runs/7935612049/job/21669138931#step:4:67)2ae0, {0xc000c1e900, 0x9, 0x9})
        	/opt/hostedtoolcache/go/1.21.7/x64/src/bufio/bufio.go:244 +0x4be
        io.ReadAtLeast({0x1fbbc20, 0xc000662ae0}, {0xc000c1e900, 0x9, 0x9}, 0x9)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/io/io.go:335 +0xd0
        io.ReadFull(...)
        	/opt/hostedtoolcache/go/1.21.7/x64/src/io/io.go:354
        golang.org/x/net/http2.readFrameHeader({0xc000c1e900, 0x9, 0x9}, {0x1fbbc20, 0xc000662ae0})
        	/home/runner/go/pkg/mod/golang.org/x/net@v0.20.0/http2/frame.go:237 +0x9b
        golang.org/x/net/http2.(*Framer).ReadFrame(0xc000c1e8c0)
        	/home/runner/go/pkg/mod/golang.org/x/net@v0.20.0/http2/frame.go:498 +0xf5
        google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams(0xc0010d0000, {0x1fcf918, 0xc000ce5b00}, 0x2b35ec0?)
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_server.go:617 +0x145
        google.golang.org/grpc.(*Server).serveStreams(0xc0010b2800, {0x1fcf8a8, 0x2b35ec0}, {0x1fd8520?, 0xc0010d0000}, {0x1fd7d78?, 0xc000520120})
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/server.go:1023 +0x6bc
        google.golang.org/grpc.(*Server).handleRawConn.func1()
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/server.go:959 +0x87
        created by google.golang.org/grpc.(*Server).handleRawConn in goroutine 131484
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/server.go:958 +0x2c7
         Goroutine 131522 in state select, with google.golang.org/grpc/internal/transport.(*controlBuffer).get on top of the stack:
        google.golang.org/grpc/internal/transport.(*controlBuffer).get(0xc000f503c0, 0x1)
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/controlbuf.go:418 +0x1af
        google.golang.org/grpc/internal/transport.(*loopyWriter).run(0xc00030a070)
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/controlbuf.go:552 +0x14f
        google.golang.org/grpc/internal/transport.newHTTP2Client.func6()
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_client.go:454 +0x1[68](https://github.com/openfga/openfga/actions/runs/7935612049/job/21669138931#step:4:69)
        created by google.golang.org/grpc/internal/transport.newHTTP2Client in goroutine 131511
        	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.61.0/internal/transport/http2_client.go:452 +0x3aeb
        ]
```
