### PR TITLE
chore: copy grpc-health-probe from a build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.24@sha256:ba223f05f047e15d169bb87e0b312646668e874c8207066d964bdfb6757c10f6 as grpc_health_probe
 FROM cgr.dev/chainguard/go:1.21@sha256:40fb38b3f61d1ecdecd2bfe3d14fa621ab5e9ecb4c9ebba590276c2992f3e282 AS builder
 
 WORKDIR /app
@@ -20,7 +21,7 @@ EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
 
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.24 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=grpc_health_probe /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=builder /bin/openfga /openfga
 
 # Healthcheck configuration for the container using grpc_health_probe


### PR DESCRIPTION
## Description

This is a workaround to have Dependabot correctly propose updates for grpc-health-probe where we use a noop build stage to copy the dependency over to the final build stage artifact.

We should see updates for it like these https://github.com/openfga/openfga/pull/1380

## References

https://github.com/dependabot/dependabot-core/issues/5103

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
