### PR TITLE
test: add tests for typesystem.hasEntrypoints

### DIFF
--- a/pkg/server/test/write_authzmodel.go
+++ b/pkg/server/test/write_authzmodel.go
@@ -299,7 +299,7 @@ type document
 		},
 		{
 			// TODO this test is invalid - "editor from parent" is invalid - "folder#editor" is not defined
-			// Replaced by computed_relation_has_no_entrypoints_because_cycle
+			// Replaced by computed_relation_has_no_entrypoints
 			name: "no_entrypoint_4",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,

--- a/pkg/server/test/write_authzmodel.go
+++ b/pkg/server/test/write_authzmodel.go
@@ -200,7 +200,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
-			// TODO remove - same as intersection_has_no_entrypoint_and_has_cycle
+			// TODO remove - same as intersection_has_no_entrypoint_and_has_cycle_2
 			name: "rewritten_relation_in_intersection_unresolvable",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -266,7 +266,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
-			// TODO remove - same as intersection_has_entrypoint_and_no_cycle
+			// TODO remove - same as intersection_has_no_entrypoint_and_no_cycle
 			name: "no_entrypoint_3a",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -282,7 +282,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
-			// TODO remove - same as intersection_has_no_entrypoint_and_no_cycle
+			// TODO remove - same as difference_has_no_entrypoint_and_no_cycle
 			name: "no_entrypoint_3b",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -430,7 +430,7 @@ type account
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
-			// TODO remove - same as intersection_and_union
+			// TODO remove - it's in TestHasCycle (intersection_and_union)
 			name: "circular_relations_involving_intersection",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -447,7 +447,7 @@ type other
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
-			// TODO remove - same as exclusion_and_union
+			// TODO remove - it's in TestHasCycle (exclusion_and_union)
 			name: "circular_relations_involving_exclusion",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,

--- a/pkg/server/test/write_authzmodel.go
+++ b/pkg/server/test/write_authzmodel.go
@@ -137,6 +137,7 @@ func WriteAuthorizationModelTest(t *testing.T, datastore storage.OpenFGADatastor
 			},
 		},
 		{
+			//TODO remove, same as union_has_entrypoint
 			name: "self_referencing_type_restriction_with_entrypoint",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -152,6 +153,7 @@ type document
 			},
 		},
 		{
+			//TODO remove, same as this_has_no_entrypoints
 			name: "self_referencing_type_restriction_without_entrypoint_1",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -166,6 +168,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			//TODO remove, same as intersection_has_no_entrypoint_and_no_cycle
 			name: "self_referencing_type_restriction_without_entrypoint_2",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -181,6 +184,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			//TODO remove - same as difference_has_no_entrypoint_and_no_cycle
 			name: "self_referencing_type_restriction_without_entrypoint_3",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -196,6 +200,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as intersection_has_no_entrypoint_and_has_cycle
 			name: "rewritten_relation_in_intersection_unresolvable",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -214,6 +219,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as this_has_entrypoints_through_user
 			name: "direct_relationship_with_entrypoint",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -227,6 +233,7 @@ type document
 			},
 		},
 		{
+			// TODO remove - same as computed_relation_has_entrypoint_through_user
 			name: "computed_relationship_with_entrypoint",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -241,6 +248,7 @@ type document
 			},
 		},
 		{
+			// TODO remove - same as difference_has_no_entrypoint_and_has_cycle
 			name: "rewritten_relation_in_exclusion_unresolvable",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -258,6 +266,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as intersection_has_entrypoint_and_no_cycle
 			name: "no_entrypoint_3a",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -273,6 +282,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as intersection_has_no_entrypoint_and_no_cycle
 			name: "no_entrypoint_3b",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -288,6 +298,8 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO this test is invalid - "editor from parent" is invalid - "folder#editor" is not defined
+			// Replaced by computed_relation_has_no_entrypoints_because_cycle
 			name: "no_entrypoint_4",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -309,6 +321,7 @@ type document
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as difference_has_entrypoints_and_no_cycle_2
 			name: "self_referencing_type_restriction_with_entrypoint_1",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -326,6 +339,7 @@ type document
 			},
 		},
 		{
+			// TODO remove - same as union_has_entrypoint_through_user
 			name: "self_referencing_type_restriction_with_entrypoint_2",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -391,6 +405,7 @@ type feature
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - it's in TestHasCycle
 			name: "many_circular_computed_relations",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -415,6 +430,7 @@ type account
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as intersection_and_union
 			name: "circular_relations_involving_intersection",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -431,6 +447,7 @@ type other
 			errCode: codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
 		},
 		{
+			// TODO remove - same as exclusion_and_union
 			name: "circular_relations_involving_exclusion",
 			request: &openfgav1.WriteAuthorizationModelRequest{
 				StoreId: storeID,
@@ -455,13 +472,7 @@ type other
 				),
 				TypeDefinitions: parser.MustTransformDSLToProto(`model
   schema 1.1
-type user
-
-type other
-  relations
-	define x: [user] but not y
-	define y: [user] but not z
-	define z: [user] or x`).TypeDefinitions,
+type user`).TypeDefinitions,
 			},
 			errCode: codes.Code(openfgav1.ErrorCode_exceeded_entity_limit),
 		},

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -672,6 +672,7 @@ func (t *TypeSystem) relationInvolvesExclusion(objectType, relation string, visi
 // could lead to at least one relationship with some object type, then false is returned along with an error indicating
 // no entrypoints were found. If at least one relationship with a specific object type is found while walking the rewrite,
 // then true is returned along with a nil error.
+// This function assumes that all other model validations have run.
 func hasEntrypoints(
 	typedefs map[string]map[string]*openfgav1.Relation,
 	typeName, relationName string,

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -226,6 +226,11 @@ func (t *TypeSystem) GetSchemaVersion() string {
 	return t.schemaVersion
 }
 
+// GetAllRelations returns a map [objectType] => [relationName] => relation.
+func (t *TypeSystem) GetAllRelations() map[string]map[string]*openfgav1.Relation {
+	return t.relations
+}
+
 // GetConditions retrieves a map of condition names to their corresponding
 // EvaluableCondition instances within the TypeSystem.
 func (t *TypeSystem) GetConditions() map[string]*condition.EvaluableCondition {
@@ -820,7 +825,7 @@ func hasEntrypoints(
 		return true, false, nil
 	}
 
-	return false, false, nil
+	panic("unexpected userset rewrite encountered")
 }
 
 // NewAndValidate is like New but also validates the model according to the following rules:

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -506,7 +506,7 @@ func TestHasEntrypoints(t *testing.T) {
 		//	inputRelation: "can_transition_with",
 		//	expectDetails: &relationDetails{true, false},
 		//},
-		`ttu_has_entrypoint`: {
+		`ttu_has_entrypoint_through_second_tupleset`: {
 			model: `
 			model
 				schema 1.1

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -91,22 +91,22 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation: "viewer",
 			expectError:   "undefined type definition for 'document#unknown'",
 		},
-		//`undefined_computed_relation_on_tupleset_target`: {
-		//	model: `
-		//	model
-		//		schema 1.1
-		//	type user
-		//	type folder
-		//		relations
-		//			define owner: [user]
-		//	type document
-		//		relations
-		//			define parent: [folder]
-		//			define viewer: viewer from parent`,
-		//	inputType:     "document",
-		//	inputRelation: "viewer",
-		//	expectDetails: &relationDetails{false, false}, //TODO this should be an error
-		//},
+		`undefined_computed_relation_on_tupleset_target`: {
+			model: `
+			model
+				schema 1.1
+			type user
+			type folder
+				relations
+					define owner: [user]
+			type document
+				relations
+					define parent: [folder]
+					define viewer: viewer from parent`,
+			inputType:     "document",
+			inputRelation: "viewer",
+			expectDetails: &relationDetails{false, false}, //TODO this should be an error
+		},
 		`this_has_entrypoints_to_same_type`: {
 			model: `
 			model

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -36,6 +36,39 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation: "unknown",
 			expectError:   "undefined type definition for 'document#unknown'",
 		},
+		`undefined_relation_in_assignable_type`: {
+			model: `
+			model
+				schema 1.1
+			type document
+				relations
+					define viewer: [document#unknown]`,
+			inputType:     "document",
+			inputRelation: "viewer",
+			expectError:   "undefined type definition for 'document#unknown'",
+		},
+		`undefined_computed_userset`: {
+			model: `
+			model
+				schema 1.1
+			type document
+				relations
+					define viewer: unknown`,
+			inputType:     "document",
+			inputRelation: "viewer",
+			expectError:   "undefined type definition for 'document#unknown'",
+		},
+		`undefined_tupleset`: {
+			model: `
+			model
+				schema 1.1
+			type document
+				relations
+					define viewer: viewer from unknown`,
+			inputType:     "document",
+			inputRelation: "viewer",
+			expectError:   "undefined type definition for 'document#unknown'",
+		},
 		`this_has_entrypoints_through_user`: {
 			model: `
 			model
@@ -407,6 +440,40 @@ func TestHasEntrypoints(t *testing.T) {
 		//	inputRelation: "can_transition_with",
 		//	expectDetails: &RelationDetails{true, false},
 		//},
+		`ttu_has_entrypoint`: {
+			model: `
+			model
+				schema 1.1
+			type user
+			type group
+				relations
+					define viewer: [user]
+			type folder
+				relations
+					define parent: [folder, group]
+					define viewer: viewer from parent`,
+			inputType:     "folder",
+			inputRelation: "viewer",
+			expectDetails: &RelationDetails{true, false},
+		},
+		`revisited_direct_has_entrypoints`: {
+			model: `
+			model
+				schema 1.1
+		
+			type user
+		
+			type document
+				relations
+					define a: [user]
+					define b: a
+					define c: a
+					define d: b and c
+			`,
+			inputType:     "document",
+			inputRelation: "d",
+			expectDetails: &RelationDetails{true, false},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -98,14 +98,14 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation: "parent",
 			expectDetails: &RelationDetails{true, false},
 		},
-		// TOOD fix
+		// TODO fix
 		//`this_has_no_entrypoints_because_type_unknown_is_not_defined`: {
 		//	model: `
 		//	model
-		//	  schema 1.1
+		//		schema 1.1
 		//	type folder
-		//	  relations
-		//		define parent: [unknown]`,
+		//		relations
+		//			define parent: [unknown]`,
 		//	inputType:     "folder",
 		//	inputRelation: "parent",
 		//	expectError:   "undefined type 'unknown'",
@@ -162,7 +162,7 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation: "a1",
 			expectDetails: &RelationDetails{false, true},
 		},
-		`computed_relation_has_no_entrypoints_because_cycle`: {
+		`computed_relation_has_no_entrypoints`: {
 			model: `
 			model
 				schema 1.1
@@ -180,7 +180,7 @@ func TestHasEntrypoints(t *testing.T) {
 					define viewer: viewer from parent`,
 			inputType:     "folder",
 			inputRelation: "viewer",
-			expectDetails: &RelationDetails{false, false}, // but it DOES have a cycle...
+			expectDetails: &RelationDetails{false, false},
 		},
 		`union_has_entrypoint_through_user`: {
 			model: `
@@ -208,7 +208,7 @@ func TestHasEntrypoints(t *testing.T) {
 					define viewer: [document#viewer] or editor`,
 			inputType:     "document",
 			inputRelation: "viewer",
-			expectDetails: &RelationDetails{false, false}, // but it DOES have a cycle...
+			expectDetails: &RelationDetails{false, false},
 		},
 		`ttu_has_entrypoint_through_user`: {
 			model: `
@@ -366,19 +366,19 @@ func TestHasEntrypoints(t *testing.T) {
 		//`issue_1385`: {
 		//	model: `
 		//	model
-		//	  schema 1.1
+		//		schema 1.1
 		//
 		//	type user
 		//
 		//	type entity
-		//	  relations
-		//		define member : [user]
-		//		define contextual_user: [user]
-		//		define contextual_member : member and contextual_user
-		//		define has_logging_product: [entity]
-		//		define block_logging : [user] and contextual_user
-		//		define has_access_to_logging : contextual_member from has_logging_product but not block_logging from has_logging_product
-		//		define can_enable_logging : has_access_to_logging
+		//		relations
+		//			define member : [user]
+		//			define contextual_user: [user]
+		//			define contextual_member : member and contextual_user
+		//			define has_logging_product: [entity]
+		//			define block_logging : [user] and contextual_user
+		//			define has_access_to_logging : contextual_member from has_logging_product but not block_logging from has_logging_product
+		//			define can_enable_logging : has_access_to_logging
 		//	`,
 		//	inputType:     "entity",
 		//	inputRelation: "can_enable_logging",
@@ -387,21 +387,21 @@ func TestHasEntrypoints(t *testing.T) {
 		//`issue_1260_parallel_edges_mean_entrypoints`: {
 		//	model: `
 		//	model
-		//	  schema 1.1
+		//		schema 1.1
 		//
 		//	type user
 		//
 		//	type state
-		//	  relations
-		//		define can_view: [user]
-		//		define associated_transition: [transition]
-		//		define can_transition_with: can_apply from associated_transition
+		//		relations
+		//			define can_view: [user]
+		//			define associated_transition: [transition]
+		//			define can_transition_with: can_apply from associated_transition
 		//
 		//	type transition
-		//	  relations
-		//		define start: [state]
-		//		define end: [state]
-		//		define can_apply: [user] and can_view from start and can_view from end
+		//		relations
+		//			define start: [state]
+		//			define end: [state]
+		//			define can_apply: [user] and can_view from start and can_view from end
 		//	`,
 		//	inputType:     "state",
 		//	inputRelation: "can_transition_with",
@@ -422,8 +422,8 @@ func TestHasEntrypoints(t *testing.T) {
 				require.ErrorContains(t, err, test.expectError)
 			} else {
 				require.NoError(t, err)
-				require.Equal(t, test.expectDetails.hasEntrypoints, hasEntrypoints)
-				require.Equal(t, test.expectDetails.hasCycle, hasCycle)
+				require.Equal(t, test.expectDetails.hasEntrypoints, hasEntrypoints, "unexpected value for hasEntrypoints")
+				require.Equal(t, test.expectDetails.hasCycle, hasCycle, "unexpected value for hasCycle")
 			}
 		})
 	}
@@ -711,7 +711,7 @@ type document
 		},
 		{
 			// TODO this test is invalid - "editor from parent" is invalid - "folder#editor" is not defined
-			// Replaced by computed_relation_has_no_entrypoints_because_cycle
+			// Replaced by computed_relation_has_no_entrypoints
 			name: "no_entrypoint_4",
 			model: `model
 	schema 1.1

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -91,21 +91,22 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation: "viewer",
 			expectError:   "undefined type definition for 'document#unknown'",
 		},
-		`undefined_computed_relation_on_tupleset_target`: {
-			model: `
-			model
-				schema 1.1
-			type folder
-				relations
-					define owner: [user]
-			type document
-				relations
-					define parent: [folder]
-					define viewer: viewer from parent`,
-			inputType:     "document",
-			inputRelation: "viewer",
-			expectDetails: &relationDetails{false, false},
-		},
+		//`undefined_computed_relation_on_tupleset_target`: {
+		//	model: `
+		//	model
+		//		schema 1.1
+		//	type user
+		//	type folder
+		//		relations
+		//			define owner: [user]
+		//	type document
+		//		relations
+		//			define parent: [folder]
+		//			define viewer: viewer from parent`,
+		//	inputType:     "document",
+		//	inputRelation: "viewer",
+		//	expectDetails: &relationDetails{false, false}, //TODO this should be an error
+		//},
 		`this_has_entrypoints_to_same_type`: {
 			model: `
 			model


### PR DESCRIPTION
## Description
In preparation for fixing https://github.com/openfga/openfga/issues/1385 and https://github.com/openfga/openfga/issues/1260, i am putting all the tests that exercise `typesystem.hasEntrypoints` in its own unit test `TestHasEntrypoints` so that (1) development cycle is shortened as I will only have to run `TestHasEntrypoints` to figure out if I broke something, and (2) I will be able to see which lines aren't covered more quickly.

I also updated `TestHasCycle` for similar reasons.

## References
- Issues listed above
- Follow-up to this PR with all tests passing is https://github.com/openfga/openfga/pull/1405
