### PR TITLE
docs(v1.5.0): add v1.5.0 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,46 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added 
 
-- OpenTelemetry tracing and attributes to check algorithm [#1331](https://github.com/openfga/openfga/pull/1331),[#1388](https://github.com/openfga/openfga/pull/1388)
-- Dispatch count to check response metadata as a query complexity heuristic [#1343](https://github.com/openfga/openfga/pull/1343)
+- OpenTelemetry tracing and attributes to check algorithm ([#1331](https://github.com/openfga/openfga/pull/1331), [#1388](https://github.com/openfga/openfga/pull/1388))
+- Dispatch count to check response metadata as a query complexity heuristic ([#1343](https://github.com/openfga/openfga/pull/1343))
 
 ### Fixed
 
-- Fix incorrect path for grpc-health-probe in default healthcheck command [#1321](https://github.com/openfga/openfga/pull/1321)
+- Fix incorrect path for gPRC health check ([#1321](https://github.com/openfga/openfga/pull/1321))
 
-### [!WARNING] Breaking Changes
 
-- Data store interface function `FindLatestAuthorizationModelID` has changed to `FindLatestAuthorizationModel` for performance improvements. [#1387](https://github.com/openfga/openfga/pull/1387)
+### :warning: Breaking Change
+
+The `AuthorizationModelReadBackend` interface method `FindLatestAuthorizationModelID` has changed to `FindLatestAuthorizationModel` for performance improvements. [#1387](https://github.com/openfga/openfga/pull/1387)
+
+<table>
+<tr>
+<th>Before</th>
+<th>After</th>
+</tr>
+<tr>
+<td>
+
+```go
+func (c *cachedOpenFGADatastore) FindLatestAuthorizationModelID(ctx context.Context, storeID string) (string, error) {
+  //...get model ID
+  return modelID, nil
+}
+```
+
+</td>
+<td>
+
+```go
+func (c *cachedOpenFGADatastore) FindLatestAuthorizationModel(ctx context.Context, storeID string) (*openfgav1.AuthorizationModel, error) {
+  //...get model
+  return model.(*openfgav1.AuthorizationModel), nil
+}
+```
+
+</td>
+</tr>
+</table>
 
 ## [1.4.3] - 2024-01-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 - Fix incorrect path for gPRC health check ([#1321](https://github.com/openfga/openfga/pull/1321))
 
-
-### :warning: Breaking Change
+### Breaking Change :warning:
 
 The `AuthorizationModelReadBackend` interface method `FindLatestAuthorizationModelID` has changed to `FindLatestAuthorizationModel` for performance improvements. [#1387](https://github.com/openfga/openfga/pull/1387)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+## [1.5.0] - 2024-03-01
+
+[Full changelog](https://github.com/openfga/openfga/compare/v1.4.3...v1.5.0)
+
+### Added 
+
+- OpenTelemetry tracing and attributes to check algorithm [#1331](https://github.com/openfga/openfga/pull/1331),[#1388](https://github.com/openfga/openfga/pull/1388)
+- Dispatch count to check response metadata as a query complexity heuristic [#1343](https://github.com/openfga/openfga/pull/1343)
+
+### Fixed
+
+- Fix incorrect path for grpc-health-probe in default healthcheck command [#1321](https://github.com/openfga/openfga/pull/1321)
+
+### [!WARNING] Breaking Changes
+
+- Data store interface function `FindLatestAuthorizationModelID` has changed to `FindLatestAuthorizationModel` for performance improvements. [#1387](https://github.com/openfga/openfga/pull/1387)
+
 ## [1.4.3] - 2024-01-26
 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.4.2...v1.4.3)
@@ -897,7 +914,8 @@ no tuple key instead.
 * Memory storage adapter implementation
 * Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.4.3...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/openfga/openfga/releases/tag/v1.5.0
 [1.4.3]: https://github.com/openfga/openfga/releases/tag/v1.4.3
 [1.4.2]: https://github.com/openfga/openfga/releases/tag/v1.4.2
 [1.4.1]: https://github.com/openfga/openfga/releases/tag/v1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added 
 
+- Override option for timestamp in JSON logs ([#1330](https://github.com/openfga/openfga/pull/1330)) - thank you, @raj-saxena!
 - OpenTelemetry tracing and attributes to check algorithm ([#1331](https://github.com/openfga/openfga/pull/1331), [#1388](https://github.com/openfga/openfga/pull/1388))
 - Dispatch count to check response metadata as a query complexity heuristic ([#1343](https://github.com/openfga/openfga/pull/1343))
 
@@ -36,7 +37,7 @@ If you implement your own data store, you will need to make the following change
 <td>
 
 ```go
-func (c *cachedOpenFGADatastore) FindLatestAuthorizationModelID(ctx context.Context, storeID string) (string, error) {
+func (...) FindLatestAuthorizationModelID(ctx context.Context, storeID string) (string, error) {
   //...get model ID
   return modelID, nil
 }
@@ -46,7 +47,7 @@ func (c *cachedOpenFGADatastore) FindLatestAuthorizationModelID(ctx context.Cont
 <td>
 
 ```go
-func (c *cachedOpenFGADatastore) FindLatestAuthorizationModel(ctx context.Context, storeID string) (*openfgav1.AuthorizationModel, error) {
+func (...) FindLatestAuthorizationModel(ctx context.Context, storeID string) (*openfgav1.AuthorizationModel, error) {
   //...get model
   return model.(*openfgav1.AuthorizationModel), nil
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 The `AuthorizationModelReadBackend` interface method `FindLatestAuthorizationModelID` has changed to `FindLatestAuthorizationModel` for performance improvements. [#1387](https://github.com/openfga/openfga/pull/1387)
 
+If you implement your own data store, you will need to make the following change:
+
 <table>
 <tr>
 <th>Before</th>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 
+- Cycles detected during check now deterministically return with `{allowed:false}` ([#1371](https://github.com/openfga/openfga/pull/1371), [#1372](https://github.com/openfga/openfga/pull/1372))
 - Fix incorrect path for gPRC health check ([#1321](https://github.com/openfga/openfga/pull/1321))
 
 ### Breaking Change :warning:


### PR DESCRIPTION

<!-- Provide a brief summary of the changes -->

## Description
Updating changelog for upcoming v1.5.0 release. 

## References
<!-- Provide a list of any applicable references here (Github Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
