### PR TITLE
fix: handle invalid condition tuple error

### DIFF
--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -143,6 +143,11 @@ func HandleTupleValidateError(err error) error {
 		return TypeNotFound(t.TypeName)
 	case *tuple.RelationNotFoundError:
 		return RelationNotFound(t.Relation, t.TypeName, t.TupleKey)
+	case *tuple.InvalidConditionalTupleError:
+		return status.Error(
+			codes.Code(openfgav1.ErrorCode_validation_error),
+			err.Error(),
+		)
 	}
 
 	return HandleError("", err)

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -2,7 +2,12 @@ package errors
 
 import (
 	"errors"
+	"fmt"
 	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/tuple"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -57,6 +62,65 @@ func TestHandleStorageErrors(t *testing.T) {
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
 			require.ErrorIs(t, HandleError("", test.storageErr), test.expectedTranslatedError)
+		})
+	}
+}
+
+func TestHandleTupleValidateError(t *testing.T) {
+	invalidConditionTupleError := tuple.InvalidConditionalTupleError{
+		Cause:    fmt.Errorf("foo"),
+		TupleKey: tuple.NewTupleKey("doc:x", "viewer", "user:z"),
+	}
+
+	tests := map[string]struct {
+		validateError           error
+		expectedTranslatedError error
+	}{
+		`invalid_tuple_error`: {
+			validateError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("invalid tuple error"),
+				TupleKey: tuple.NewCheckRequestTupleKey("object:x", "relation_y", "user:z"),
+			},
+			expectedTranslatedError: status.Error(
+				codes.Code(openfgav1.ErrorCode_invalid_tuple),
+				fmt.Sprintf("Invalid tuple '%s'. Reason: %s",
+					tuple.NewCheckRequestTupleKey("object:x", "relation_y", "user:z"),
+					fmt.Errorf("invalid tuple error")),
+			),
+		},
+		`type_not_found`: {
+			validateError: &tuple.TypeNotFoundError{
+				TypeName: "doc",
+			},
+			expectedTranslatedError: TypeNotFound("doc"),
+		},
+		"relationship_not_found": {
+			validateError: &tuple.RelationNotFoundError{
+				TypeName: "doc",
+				Relation: "viewer",
+				TupleKey: tuple.NewTupleKey("doc:x", "viewer", "user:z"),
+			},
+			expectedTranslatedError: RelationNotFound(
+				"viewer",
+				"doc",
+				tuple.NewTupleKey("doc:x", "viewer", "user:z"),
+			),
+		},
+		"invalid_tuple_condition": {
+			validateError: &invalidConditionTupleError,
+			expectedTranslatedError: status.Error(
+				codes.Code(openfgav1.ErrorCode_validation_error),
+				invalidConditionTupleError.Error(),
+			),
+		},
+		"undefined error": {
+			validateError:           fmt.Errorf("unknown"),
+			expectedTranslatedError: HandleError("", fmt.Errorf("unknown")),
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			require.ErrorIs(t, HandleTupleValidateError(test.validateError), test.expectedTranslatedError)
 		})
 	}
 }


### PR DESCRIPTION

## Description
Fix HandleTupleValidateError so that it handles invalid condition tuple error bugs.


## References
Close https://github.com/openfga/openfga/issues/1419

## Testing

1. Add with the following model
```
model
  schema 1.1

type user

type group
  relations
    define member: [user]
    define can_access: [user with less_than_hundred]
    
condition less_than_hundred(x: int) {
  x < 100
}
```

Send GET with 

```
{
    "tuple_key": {
        "user": "user:test",
        "relation": "can_access",
        "object": "group:8"
    },
    "contextual_tuples": {
        "tuple_keys": [
            {
                "user": "user:test",
                "relation": "can_access",
                "object": "group:8",
                "condition": {
                    "name": "less_than_hundred",
                    "context": {
                        "x": "b"
                    }
                }
            }
        ]
    }
}
```

and see 400 Bad Request error with body

```
{
    "code": "validation_error",
    "message": "Invalid tuple 'group:8#can_access@user:test (condition name:\"less_than_hundred\"  context:{fields:{key:\"x\"  value:{string_value:\"b\"}}})'. Reason: parameter type error on condition 'less_than_hundred' - failed to convert context parameter 'x': expected a int64 value, but found invalid string value 'b'"
}
```

2. With the following body

```
model
  schema 1.1

type user

type group
  relations
    define member: [user with restricted_to_ip]

type application
  relations
    define allowed: [group#member]

condition restricted_to_ip(allowed_ip_address: ipaddress, current_ip_address: ipaddress) {
  current_ip_address == allowed_ip_address
}
```

Check with body
```
{
    "tuple_key": {
        "user": "user:some_user",
        "relation": "allowed",
        "object": "application:test_application"
    },
    "contextual_tuples": {
        "tuple_keys": [
            {
                "user": "user:some_user",
                "relation": "member",
                "object": "group:premium"
            }
        ]
    }
}
```

produces 400 error with error message

```
{
    "code": "validation_error",
    "message": "Invalid tuple 'group:premium#member@user:some_user (condition <nil>)'. Reason: condition is missing"
}
```

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
