### PR TITLE
style: enable misspell linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,6 +1,7 @@
 run:
   timeout: 3m
   modules-download-mode: readonly
+  allow-parallel-runners: true
   build-tags:
     - docker
 
@@ -16,6 +17,7 @@ linters:
     - govet
     - ineffassign
     - mirror
+    - misspell
     - staticcheck
     - tagalign
     - testifylint
@@ -26,11 +28,20 @@ linters:
     - wastedassign
     - whitespace
     - protogetter
-    # - gocritic
+    # TODO enable https://github.com/openfga/openfga/issues/598
+    # - bodyclose
+    # - contextcheck
     # - exhaustive
+    # - errorlint
+    # - gochecknoglobals
+    # - gocritic
+    # - godot
+    # - gosec
     # - noctx
-    # - promlinter
-
+    # - inamedparam
+    # - perfsprint
+    # - prealloc
+    # - tparallel
 linters-settings:
   govet:
     enable-all: true

--- a/internal/condition/eval/eval_test.go
+++ b/internal/condition/eval/eval_test.go
@@ -103,10 +103,10 @@ condition correct_ip(ip: string) {
 }
 
 // TestDefaultCELEvaluationCost is used to ensure we don't decreasee the default evaluation cost
-// of CEL expressions, which would break API compability.
+// of CEL expressions, which would break API compatibility.
 //
 // Critical paths involving ABAC Condition evaluations use the EvaluateTupleCondition function,
-// and so we test that directly to give us higher confidence we're not introducing a compability
+// and so we test that directly to give us higher confidence we're not introducing a compatibility
 // issue.
 func TestDefaultCELEvaluationCost(t *testing.T) {
 	tests := []struct {

--- a/internal/condition/metrics/metrics.go
+++ b/internal/condition/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Packge metrics provides various metric and telemetry definitions for OpenFGA Conditions.
+// Package metrics provides various metric and telemetry definitions for OpenFGA Conditions.
 package metrics
 
 import (

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -111,7 +111,7 @@ func TestVerifyConfig(t *testing.T) {
 }
 
 func TestDefaultMaxConditionValuationCost(t *testing.T) {
-	// check to make sure DefaultMaxConditionEvaluationCost never drops below an explict 100, because
+	// check to make sure DefaultMaxConditionEvaluationCost never drops below an explicit 100, because
 	// API compatibility can be impacted otherwise
 	require.GreaterOrEqual(t, DefaultMaxConditionEvaluationCost, 100)
 }


### PR DESCRIPTION
## Description

Enabling `misspell` linter to improve our Go report card:
<img width="749" alt="image" src="https://github.com/openfga/openfga/assets/5374887/28dde06e-d6ff-4a23-a0bd-6d942f9cdfb2">

## References 
https://github.com/openfga/openfga/issues/598