### PR TITLE
test: fix order of assertions

### DIFF
--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -369,9 +369,9 @@ func tryStreamingListObjects(t *testing.T, test authTest, httpAddr string, retry
 	req.Header.Set("content-type", "application/json")
 	req.Header.Set("authorization", test.authHeader)
 	res, err = retryClient.Do(req)
-	require.Equal(t, test.expectedStatusCode, res.StatusCode)
 	require.NoError(t, err, "Failed to execute streaming request")
 	defer res.Body.Close()
+	require.Equal(t, test.expectedStatusCode, res.StatusCode)
 	body, err = io.ReadAll(res.Body)
 	require.NoError(t, err, "Failed to read response")
 


### PR DESCRIPTION
## Description
Noticed after pulling https://github.com/openfga/openfga/pull/1417 locally and running tests that the order of the assertions is wrong. First we need to check that the call succeeded, then we check the status code in the response.


## Reference

<img width="894" alt="image" src="https://github.com/openfga/openfga/assets/5374887/b61459b9-45c3-477d-8532-24445f11cb9a">
