### PR TITLE
test: add more integration tests for ListUsers API

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -44,7 +44,7 @@ tests:
         listUsersAssertions:
           - request:
               filters:
-              - user
+                - user
               object: document:1 # exists in store
               relation: viewer
             expectation:
@@ -224,6 +224,21 @@ tests:
               relation: viewer
             expectation:
               - document:2
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - user
+              object: document:2
+              relation: viewer
+            expectation:
+              - user:badger
 
   - name: this_and_intersection
     stages:
@@ -370,6 +385,14 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
 
   - name: computed_userset_and_union
     stages:
@@ -414,6 +437,21 @@ tests:
               relation: viewer
             expectation:
               - document:2
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - user
+              object: document:2
+              relation: viewer
+            expectation:
+              - user:badger
 
   - name: simple_computeduserset_indirect_ref
     stages:
@@ -452,6 +490,27 @@ tests:
             expectation:
               - folder:a
               - folder:b
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - folder
+              object: folder:a
+              relation: viewer
+              expectation:
 
   - name: computed_userset_and_intersection
     stages:
@@ -607,6 +666,20 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - folder
+              object: document:1
+              relation: viewer
+            expectation:
 
   - name: tuple_to_userset_and_tuple_to_userset
     stages:
@@ -651,6 +724,26 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - group
+              object: document:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - folder
+              object: document:1
+              relation: viewer
+            expectation:
 
   - name: tuple_to_userset_and_union
     stages:
@@ -703,6 +796,21 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+              - user:badger
+          - request:
+              filters:
+                - user
+              object: document:2
+              relation: viewer
+            expectation:
 
   - name: tuple_to_userset_and_intersection
     stages:
@@ -887,6 +995,21 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+              - user:badger
+          - request:
+              filters:
+                - user
+              object: document:2
+              relation: viewer
+            expectation:
 
   - name: union_and_union
     stages:
@@ -946,6 +1069,28 @@ tests:
               relation: viewer
             expectation:
               - document:3
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - user
+              object: document:2
+              relation: viewer
+            expectation:
+              - user:badger
+          - request:
+              filters:
+                - user
+              object: document:3
+              relation: viewer
+            expectation:
+              - user:cheetah
 
   - name: union_and_intersection
     stages:
@@ -2157,7 +2302,21 @@ tests:
               relation: viewer
             expectation:
               - document:1
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
+          - request:
+              filters:
+                - group#member
+              object: document:1
+              relation: viewer
+            expectation:
+              - group:x#member
   - name: wildcard_direct
     stages:
       - model: |
@@ -2196,7 +2355,14 @@ tests:
               relation: viewer
             expectation:
               - document:public
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:public
+              relation: viewer
+            expectation:
+              - user:*
   - name: prior_type_restrictions_ignored
     stages:
       - model: |
@@ -2224,6 +2390,14 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:jon
       - model: |
           model
             schema 1.1
@@ -2243,6 +2417,13 @@ tests:
           - request:
               user: user:jon
               type: document
+              relation: viewer
+            expectation:
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
               relation: viewer
             expectation:
   - name: prior_type_restrictions_ignored_with_wildcard
@@ -2271,6 +2452,14 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:*
       - model: |
           model
             schema 1.1
@@ -2288,6 +2477,13 @@ tests:
           - request:
               user: user:jon
               type: document
+              relation: viewer
+            expectation:
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
               relation: viewer
             expectation:
 
@@ -2318,7 +2514,27 @@ tests:
               relation: viewer
             expectation:
               - document:public
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:public
+              relation: viewer
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: document:public
+              relation: writer
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: document:notfound
+              relation: writer
+            expectation:
   - name: check_with_invalid_tuple_in_store
     stages:
       - model: |
@@ -2353,6 +2569,14 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
       - model: |
           model
             schema 1.1
@@ -2372,7 +2596,13 @@ tests:
               type: document
               relation: viewer
             expectation:
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
   - name: this_with_contextual_tuples
     stages:
       - model: |
@@ -2400,7 +2630,14 @@ tests:
               relation: viewer
             expectation:
               - document:1
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+              - user:aardvark
   - name: wildcard_and_userset_restriction
     stages:
       - model: |
@@ -2437,7 +2674,28 @@ tests:
               relation: viewer
             expectation:
               - document:public
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:public
+              relation: viewer
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user2
+              object: document:public
+              relation: viewer
+            expectation:
+              - user2:bob
+          - request:
+              filters:
+                - group#member
+              object: document:public
+              relation: viewer
+            expectation:
+              - group:fga#member
   - name: wildcard_obeys_the_types_in_stages
     stages:
       - model: |
@@ -2478,6 +2736,27 @@ tests:
               relation: viewer
             expectation:
               - document:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - employee
+              object: document:1
+              relation: viewer
+            expectation:
+              - employee:*
+          - request:
+              filters:
+                - employee
+              object: document:1
+              relation: writer
+            expectation:
+              - employee:*
       - model: |
           model
             schema 1.1
@@ -2510,7 +2789,25 @@ tests:
               type: document
               relation: viewer
             expectation:
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - employee
+              object: document:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - employee
+              object: document:1
+              relation: writer
+            expectation:
   - name: validation_relation_not_in_model
     stages:
       - model: |
@@ -2529,6 +2826,13 @@ tests:
               type: user
               relation: viewer
             errorCode: 2022
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: user:aardvark
+              relation: viewer #non-existent on type user
+            errorCode: 2000 # ErrorCode_validation_error
 
   - name: validation_type_not_in_model
     stages:
@@ -2545,6 +2849,13 @@ tests:
               type: group #non-existent
               relation: viewer
             errorCode: 2021
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: group:fga #non-existent type
+              relation: viewer
+            errorCode: 2000 # ErrorCode_validation_error
 
   - name: validation_user_type_not_in_model
     stages:
@@ -2567,6 +2878,13 @@ tests:
               type: document
               relation: viewer
             errorCode: 2000
+        listUsersAssertions:
+          - request:
+              filters:
+                - folder #non-existent type
+              object: document:1
+              relation: viewer
+            errorCode: 2000 # ErrorCode_validation_error
 
   - name: validation_userset_type_not_in_model
     stages:
@@ -2589,7 +2907,13 @@ tests:
               type: document
               relation: viewer
             errorCode: 2000
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - folder#writer #non-existent type & relation
+              object: document:1
+              relation: viewer
+            errorCode: 2000 # ErrorCode_validation_error
   - name: validation_userset_relation_not_in_model
     stages:
       - model: |
@@ -2611,7 +2935,13 @@ tests:
               type: document
               relation: viewer
             errorCode: 2000
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#writer #non-existent relation
+              object: document:1
+              relation: viewer
+            errorCode: 2000 # ErrorCode_validation_error
   - name: validation_user_invalid
     stages:
       - model: |
@@ -2663,6 +2993,17 @@ tests:
                 relation: viewer
                 user: user:aardvark
             errorCode: 2027
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: folder:x #invalid
+                relation: viewer
+                user: user:aardvark
+            errorCode: 2027 # ErrorCode_invalid_tuple
 
   - name: validation_invalid_relation_in_contextual_tuple
     stages:
@@ -2693,6 +3034,17 @@ tests:
                 relation: writer #invalid
                 user: user:aardvark
             errorCode: 2027
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: writer #invalid
+                user: user:aardvark
+            errorCode: 2027 # ErrorCode_invalid_tuple
 
   - name: validation_invalid_user_in_contextual_tuple
     stages:
@@ -2723,7 +3075,17 @@ tests:
                 relation: viewer
                 user: employee:aardvark #invalid
             errorCode: 2027
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: employee:aardvark #invalid
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: validation_invalid_wildcard_in_contextual_tuple
     stages:
       - model: |
@@ -2753,7 +3115,17 @@ tests:
                 relation: viewer
                 user: user:* #invalid
             errorCode: 2027
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: user:* #invalid
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: val_contextual_tuples_and_wildcard_in_ttu_evaluation
     stages:
       - model: |
@@ -2787,6 +3159,17 @@ tests:
                 relation: parent
                 user: user:* #invalid
             errorCode: 2027
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: parent
+                user: user:* #invalid
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: list_objects_considers_input_contextual_tuples
     stages:
       - model: | #concurrent checks
@@ -2840,6 +3223,19 @@ tests:
               - repo:1
               - repo:2
               - repo:3
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:1
+              relation: owner
+            contextualTuples:
+              - user: user:aardvark
+                relation: owner
+                object: repo:1
+            expectation:
+              - user:a
+              - user:aardvark
   - name: ignores_irrelevant_contextual_tuples_because_different_user
     stages:
       - model: | #concurrent checks
@@ -2886,6 +3282,7 @@ tests:
               relation: owner
             expectation:
               - repo:1
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: ignores_irrelevant_contextual_tuples_because_different_type
     stages:
       - model: | #concurrent checks
@@ -2936,6 +3333,18 @@ tests:
               relation: owner
             expectation:
               - repo:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:1
+              relation: owner
+            contextualTuples:
+              - user: user:a
+                relation: owner
+                object: organization:1 #different type than filter, should be ignored
+            expectation:
+              - user:a
   - name: list_objects_ignores_irrelevant_tuples_because_different_user
     stages:
       - model: | # concurrent checks
@@ -2974,6 +3383,14 @@ tests:
               relation: owner
             expectation:
               - repo:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:1
+              relation: owner
+            expectation:
+              - user:a
   - name: list_objects_ignores_duplicate_contextual_tuples
     stages:
       - model: | # concurrent checks
@@ -3025,6 +3442,21 @@ tests:
             expectation:
               - repo:1
               - repo:2
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:2
+              relation: owner
+            contextualTuples:
+              - user: user:a
+                relation: owner
+                object: repo:2
+              - user: user:a # same as above
+                relation: owner
+                object: repo:2
+            expectation:
+              - user:a
   - name: error_if_contextual_tuples_do_not_follow_type_restrictions
     stages:
       - model: | # concurrent checks
@@ -3073,6 +3505,17 @@ tests:
               type: repo
               relation: owner
             errorCode: 2027
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:1
+              relation: owner
+            contextualTuples:
+              - user: user:* #not allowed
+                relation: owner
+                object: organization:1
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: list_objects_error_if_unknown_type_in_request
     stages:
       - model: | # concurrent checks
@@ -3169,6 +3612,14 @@ tests:
               relation: can_read
             expectation:
               - document:c
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
 
   # https://github.com/openfga/openfga/issues/576
   - name: same_relation_name_different_type
@@ -3215,7 +3666,14 @@ tests:
             expectation:
               #document:d is not expected
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
   - name: computed_user_indirect_ref
     stages:
       - model: |
@@ -3280,7 +3738,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
   - name: computed_user_indirect_ref_extra_indirection
     stages:
       - model: |
@@ -3346,7 +3825,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
   - name: three_prong_relation
     stages:
       - model: |
@@ -3440,7 +3940,49 @@ tests:
             expectation:
               - module:a
               - module:b
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:a
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:b
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: module:a
+              relation: viewer
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: module:b
+              relation: viewer
+            expectation:
+              - user:anne
   - name: three_prong_relation_loop
     stages:
       - model: |
@@ -3537,7 +4079,49 @@ tests:
             expectation:
               - module:a
               - module:b
-
+  #        listUsersAssertions:
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: folder:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: folder:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: document:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: document:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: module:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: module:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
   - name: three_prong_relation_possible_exclusion
     stages:
       - model: |
@@ -3635,7 +4219,49 @@ tests:
             expectation:
               - module:a
               - module:b
-
+  #        listUsersAssertions:
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: folder:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: folder:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: document:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: document:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: module:a
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: module:b
+  #              relation: viewer
+  #            expectation:
+  #              - user:anne
   - name: computed_user_multi_route
     stages:
       - model: |
@@ -3702,7 +4328,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
   - name: computed_user_indirect_ref_same_rel_name
     stages:
       - model: |
@@ -3769,7 +4416,35 @@ tests:
             expectation:
               - document:c
               - document:d
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:d
+              relation: can_view
+            expectation:
+              - user:anne
   - name: computed_user_indirect_ref_wildcard
     stages:
       - model: |
@@ -3834,7 +4509,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:*
   - name: computed_user_indirect_ref_extra_indirection_wildcard
     stages:
       - model: |
@@ -3900,7 +4596,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:*
   - name: two_level_computed_user_indirect_ref
     stages:
       - model: |
@@ -3967,7 +4684,28 @@ tests:
               relation: can_read
             expectation:
               - document:c
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:c
+              relation: can_read
+            expectation:
+              - user:anne
   - name: ttu_and_computed_ttu
     stages:
       - model: |
@@ -4029,7 +4767,28 @@ tests:
               relation: viewer
             expectation:
               - document:b
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: document:b
+              relation: viewer
+            expectation:
+              - user:anne
   - name: ttu_and_computed_ttu_wildcard
     stages:
       - model: |
@@ -4091,7 +4850,35 @@ tests:
               relation: viewer
             expectation:
               - document:b
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - group#member
+              object: folder:a
+              relation: can_view
+            expectation:
+              - group:fga#member
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: document:b
+              relation: viewer
+            expectation:
+              - user:*
   - name: ttu_ttu_and_computed_ttu
     stages:
       - model: |
@@ -4160,7 +4947,28 @@ tests:
               relation: viewer
             expectation:
               - document:b
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:a
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - user
+              object: folder:b
+              relation: can_view
+            expectation:
+              - user:anne
+          - request:
+              filters:
+                - group#member
+              object: folder:a
+              relation: can_view
+            expectation:
+              - group:fga#member
   - name: contextual_tuple_ref_relation_disjoint
     stages:
       - model: |
@@ -4218,7 +5026,20 @@ tests:
               type: diagram
               relation: viewer
             expectation:
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: diagram:a
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - group#member
+              object: diagram:a
+              relation: viewer
+            expectation:
+              - group:fga#member
   - name: reverse_expand_relation_not_match
     stages:
       - model: |
@@ -4262,7 +5083,26 @@ tests:
               type: document
               relation: viewer
             expectation:
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:a
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - group#member
+              object: document:a
+              relation: viewer
+            expectation:
+              - group:fga#member
+          - request:
+              filters:
+                - group#member
+              object: document:b
+              relation: viewer
+            expectation:
   - name: exclusion_for_some_relations
     stages:
       - model: |
@@ -4366,7 +5206,27 @@ tests:
               relation: reader
             expectation:
               - repo:openfga/openfga
-
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:openfga/openfga
+              relation: reader
+            expectation:
+              - user:erik
+          - request:
+              filters:
+                - organization#member
+              object: repo:openfga/openfga
+              relation: reader
+            expectation:
+              - organization:openfga#member
+          - request:
+              filters:
+                - organization#member
+              object: repo:unknown
+              relation: reader
+            expectation:
   - name: nested_ttu_involving_intersection
     stages:
       - model: |
@@ -5173,6 +6033,13 @@ tests:
               relation: a1
               user: user:jon
             errorCode: 2002
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: resource:abc
+              relation: a1
+            errorCode: 2002 #ErrorCode_authorization_model_resolution_too_complex
   - name: race_condition_same_user_same_object_diff_relation
     stages:
       - model: |
@@ -5214,6 +6081,20 @@ tests:
               relation: list_relation
             expectation:
               - list_type:list_type1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: list_type:list_type1
+              relation: list_relation
+            expectation:
+              - user:test_user
+          - request:
+              filters:
+                - user
+              object: list_type:list_type2
+              relation: list_relation
+            expectation:
   - name: follows_correct_graph_edges
     stages:
       - model: |
@@ -5250,6 +6131,19 @@ tests:
               type: repo
               relation: admin
             expectation: []
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: repo:openfga/openfga
+              relation: admin
+            expectation:
+          - request:
+              filters:
+                - user
+              object: repo:acme/acme
+              relation: admin
+            expectation:
   - name: list_objects_with_subcheck_encounters_cycle
     stages:
       - model: |
@@ -5329,6 +6223,13 @@ tests:
               type: document
               relation: viewer
             errorCode: 2002
+  #        listUsersAssertions:
+  #          - request:
+  #              filters:
+  #                - user
+  #              object: document:1
+  #              relation: viewer
+  #            errorCode: 2002 #ErrorCode_authorization_model_resolution_too_complex
   - name: direct_relationships_with_intersection
     stages:
       - model: |

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -6305,3 +6305,30 @@ tests:
               relation: viewer
             expectation:
               - document:1
+  - name: nested_usersets_are_recursively_expanded
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+
+          type group
+            relations
+              define member: [user, group#member]
+        tuples:
+          - user: group:fga#member
+            relation: member
+            object: group:eng
+          - user: group:fga-backend#member
+            relation: member
+            object: group:fga
+        listUsersAssertions:
+          - request:
+              filters:
+                - group#member
+              object: group:eng
+              relation: member
+            expectation:
+              - group:eng#member
+              - group:fga#member
+              - group:fga-backend#member

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -495,21 +495,21 @@ tests:
               filters:
                 - user
               object: folder:a
-              relation: viewer
+              relation: can_view
             expectation:
               - user:anne
           - request:
               filters:
                 - user
               object: folder:b
-              relation: viewer
+              relation: can_view
             expectation:
               - user:anne
           - request:
               filters:
                 - folder
               object: folder:a
-              relation: viewer
+              relation: can_view
               expectation:
 
   - name: computed_userset_and_intersection
@@ -2326,11 +2326,14 @@ tests:
 
           type document
             relations
-              define viewer: [user:*]
+              define viewer: [user, user:*]
         tuples:
           - object: document:public
             relation: viewer
             user: user:*
+          - object: document:public
+            relation: viewer
+            user: user:jon
         checkAssertions:
           - tuple:
               object: document:public
@@ -2363,6 +2366,7 @@ tests:
               relation: viewer
             expectation:
               - user:*
+              - user:jon
   - name: prior_type_restrictions_ignored
     stages:
       - model: |
@@ -2501,6 +2505,9 @@ tests:
           - object: document:public
             relation: writer
             user: user:*
+          - object: document:public
+            relation: viewer
+            user: user:jon
         checkAssertions:
           - tuple:
               object: document:public
@@ -2522,6 +2529,7 @@ tests:
               relation: viewer
             expectation:
               - user:*
+              - user:jon
           - request:
               filters:
                 - user
@@ -3086,6 +3094,49 @@ tests:
                 relation: viewer
                 user: employee:aardvark #invalid
             errorCode: 2027 # ErrorCode_invalid_tuple
+  - name: validation_invalid_userset_in_contextual_tuple
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type group
+            relations
+              define member: [user]
+          type document
+            relations
+              define viewer: [user, group#member]
+        checkAssertions:
+          - tuple:
+              object: document:1
+              relation: viewer
+              user: user:aardvark
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: group:fga#undefined #invalid
+            errorCode: 2027
+        listObjectsAssertions:
+          - request:
+              user: user:aardvark
+              type: document
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: group:fga#undefined #invalid
+            errorCode: 2027
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: document:1
+              relation: viewer
+            contextualTuples:
+              - object: document:1
+                relation: viewer
+                user: group:fga#undefined #invalid
+            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: validation_invalid_wildcard_in_contextual_tuple
     stages:
       - model: |
@@ -3282,7 +3333,6 @@ tests:
               relation: owner
             expectation:
               - repo:1
-            errorCode: 2027 # ErrorCode_invalid_tuple
   - name: ignores_irrelevant_contextual_tuples_because_different_type
     stages:
       - model: | #concurrent checks

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -4129,6 +4129,7 @@ tests:
             expectation:
               - module:a
               - module:b
+  # TODO uncomment when introducing cycle detection
   #        listUsersAssertions:
   #          - request:
   #              filters:
@@ -4269,6 +4270,7 @@ tests:
             expectation:
               - module:a
               - module:b
+  # TODO uncomment when introducing support for exclusion
   #        listUsersAssertions:
   #          - request:
   #              filters:
@@ -6273,6 +6275,7 @@ tests:
               type: document
               relation: viewer
             errorCode: 2002
+  # TODO uncomment when introducing depth counters
   #        listUsersAssertions:
   #          - request:
   #              filters:

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -161,6 +161,9 @@ func runTest(t *testing.T, test individualTest, client ClientInterface, contextT
 								TupleKeys: ctxTuples,
 							},
 						})
+						if assertion.ErrorCode != 0 && len(assertion.Expectation) > 0 {
+							t.Errorf("cannot have a test with the expectation of both an error code and a result")
+						}
 
 						if assertion.ErrorCode == 0 {
 							require.NoError(t, err, detailedInfo)


### PR DESCRIPTION
## Description

Suggestion for reviewers: hit "hide whitespace" when reviewing file changes.

- Adding more assertions for ListUsers API. 
    - We have internal tickets tracking the extension of the tests to include coverage for ABAC (DXAZC-1916), contextual tuples (DXAZC-1915) and `and, but not` (DXAZC-1921)

Some reason for tests failures:
- contextual tuples need to be parsed
- duplicate results need to be cleaned
- if the filter is `type#relation`, we need to include `relation` in the response
- cycles need to be detected
- etc..

<img width="878" alt="image" src="https://github.com/openfga/openfga/assets/5374887/206e9c72-9b4b-4736-8786-c49707dd1f9b">


## References
https://github.com/openfga/openfga/issues/1428
