### PR TITLE
chore: Rename `QueryCount` to `DatastoreQueryCount`

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -59,7 +59,7 @@ type ListObjectsQuery struct {
 
 type ListObjectsResolutionMetadata struct {
 	// The total number of database reads from reverse_expand and Check (if any) to complete the ListObjects request
-	QueryCount *uint32
+	DatastoreQueryCount *uint32
 
 	// The total number of dispatches aggregated from reverse_expand and check resolutions (if any) to complete the ListObjects request
 	DispatchCount *uint32
@@ -67,8 +67,8 @@ type ListObjectsResolutionMetadata struct {
 
 func NewListObjectsResolutionMetadata() *ListObjectsResolutionMetadata {
 	return &ListObjectsResolutionMetadata{
-		QueryCount:    new(uint32),
-		DispatchCount: new(uint32),
+		DatastoreQueryCount: new(uint32),
+		DispatchCount:       new(uint32),
 	}
 }
 
@@ -283,7 +283,7 @@ func (q *ListObjectsQuery) evaluate(
 			if err != nil {
 				errChan <- err
 			}
-			atomic.AddUint32(resolutionMetadata.QueryCount, *reverseExpandResolutionMetadata.QueryCount)
+			atomic.AddUint32(resolutionMetadata.DatastoreQueryCount, *reverseExpandResolutionMetadata.DatastoreQueryCount)
 			atomic.AddUint32(resolutionMetadata.DispatchCount, *reverseExpandResolutionMetadata.DispatchCount)
 		}()
 
@@ -342,7 +342,7 @@ func (q *ListObjectsQuery) evaluate(
 						resultsChan <- ListObjectsResult{Err: err}
 						return
 					}
-					atomic.AddUint32(resolutionMetadata.QueryCount, resp.GetResolutionMetadata().DatastoreQueryCount)
+					atomic.AddUint32(resolutionMetadata.DatastoreQueryCount, resp.GetResolutionMetadata().DatastoreQueryCount)
 					atomic.AddUint32(resolutionMetadata.DispatchCount, resp.GetResolutionMetadata().DispatchCount)
 
 					if resp.Allowed {

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -166,7 +166,7 @@ type ReverseExpandResult struct {
 }
 
 type ResolutionMetadata struct {
-	QueryCount *uint32
+	DatastoreQueryCount *uint32
 
 	// The number of times we are expanding from each node to find set of objects
 	DispatchCount *uint32
@@ -174,8 +174,8 @@ type ResolutionMetadata struct {
 
 func NewResolutionMetadata() *ResolutionMetadata {
 	return &ResolutionMetadata{
-		QueryCount:    new(uint32),
-		DispatchCount: new(uint32),
+		DatastoreQueryCount: new(uint32),
+		DispatchCount:       new(uint32),
 	}
 }
 
@@ -466,7 +466,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 		Relation:   relationFilter,
 		UserFilter: userFilter,
 	})
-	atomic.AddUint32(resolutionMetadata.QueryCount, 1)
+	atomic.AddUint32(resolutionMetadata.DatastoreQueryCount, 1)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -442,14 +442,14 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 
 		return nil, err
 	}
-	queryCount := float64(*result.ResolutionMetadata.DatastoreQueryCount)
+	datastoreQueryCount := float64(*result.ResolutionMetadata.DatastoreQueryCount)
 
-	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
-	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
+	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, datastoreQueryCount)
+	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, datastoreQueryCount))
 	datastoreQueryCountHistogram.WithLabelValues(
 		s.serviceName,
 		methodName,
-	).Observe(queryCount)
+	).Observe(datastoreQueryCount)
 
 	dispatchCount := float64(*result.ResolutionMetadata.DispatchCount)
 
@@ -528,14 +528,14 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		telemetry.TraceError(span, err)
 		return err
 	}
-	queryCount := float64(*resolutionMetadata.DatastoreQueryCount)
+	datastoreQueryCount := float64(*resolutionMetadata.DatastoreQueryCount)
 
-	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
-	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
+	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, datastoreQueryCount)
+	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, datastoreQueryCount))
 	datastoreQueryCountHistogram.WithLabelValues(
 		s.serviceName,
 		methodName,
-	).Observe(queryCount)
+	).Observe(datastoreQueryCount)
 
 	dispatchCount := float64(*resolutionMetadata.DispatchCount)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -442,7 +442,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 
 		return nil, err
 	}
-	queryCount := float64(*result.ResolutionMetadata.QueryCount)
+	queryCount := float64(*result.ResolutionMetadata.DatastoreQueryCount)
 
 	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
 	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
@@ -463,7 +463,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	requestDurationByQueryAndDispatchHistogram.WithLabelValues(
 		s.serviceName,
 		methodName,
-		utils.Bucketize(uint(*result.ResolutionMetadata.QueryCount), s.requestDurationByQueryHistogramBuckets),
+		utils.Bucketize(uint(*result.ResolutionMetadata.DatastoreQueryCount), s.requestDurationByQueryHistogramBuckets),
 		utils.Bucketize(uint(*result.ResolutionMetadata.DispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
 	).Observe(float64(time.Since(start).Milliseconds()))
 
@@ -528,7 +528,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		telemetry.TraceError(span, err)
 		return err
 	}
-	queryCount := float64(*resolutionMetadata.QueryCount)
+	queryCount := float64(*resolutionMetadata.DatastoreQueryCount)
 
 	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
 	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
@@ -549,7 +549,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 	requestDurationByQueryAndDispatchHistogram.WithLabelValues(
 		s.serviceName,
 		methodName,
-		utils.Bucketize(uint(*resolutionMetadata.QueryCount), s.requestDurationByQueryHistogramBuckets),
+		utils.Bucketize(uint(*resolutionMetadata.DatastoreQueryCount), s.requestDurationByQueryHistogramBuckets),
 		utils.Bucketize(uint(*resolutionMetadata.DispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
 	).Observe(float64(time.Since(start).Milliseconds()))
 

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1264,7 +1264,7 @@ type document
 						t.Log("channel closed")
 						if test.expectedError == nil {
 							require.ElementsMatch(t, test.expectedResult, results)
-							require.Equal(t, test.expectedDSQueryCount, *resolutionMetadata.QueryCount)
+							require.Equal(t, test.expectedDSQueryCount, *resolutionMetadata.DatastoreQueryCount)
 						} else {
 							require.FailNow(t, "expected an error, got none")
 						}


### PR DESCRIPTION
We have renamed the `QueryCount` variable we use internally for `ResolutionMetaData` to `DatastoreQueryCount`

## Description
Rename internal variable used in ListObjects `QueryCount` to `DatastoreQueryCount` to be consistent

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [] The correct base branch is being used, if not `main`
- [] I have added tests to validate that the change in functionality is working as expected
