### PR TITLE
docs(v1.5.1): add v1.5.1 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 
-- We will throw 400 error when condition is invalid instead of "Internal Server Error" ([#1420](https://github.com/openfga/openfga/pull/1420))
+- Throw HTTP 400 when tuple condition is invalid instead of HTTP 500 ([#1420](https://github.com/openfga/openfga/pull/1420))
 - Fix model validation which threw error "no entrypoints defined" ([#1422](https://github.com/openfga/openfga/pull/1422))
 
 ### Deprecation :warning:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added
 
-- Added `dispatch_count` histogram support for `ListObjects` and `StreamedListObjects` methods ([#1469](https://github.com/openfga/openfga/pull/1469))
+- Include calls to ListObjects and StreamedListObjects methods in the `dispatch_count` histogram ([#1427](https://github.com/openfga/openfga/pull/1427))
 - Added `request_duration_ms` histogram which has `datastore_query_count` and `dispatch_count` as dimensions ([#1444](https://github.com/openfga/openfga/pull/1444))
 - Added new flag `OPENFGA_AUTHN_OIDC_ISSUER_ALIASES` to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
 - Added experimental support for modular models via `OPENFGA_EXPERIMENTALS=enable-modular-models` ([#1443](https://github.com/openfga/openfga/pull/1443)). This will enable writing models that are split across multiple files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -969,7 +969,8 @@ no tuple key instead.
 * Memory storage adapter implementation
 * Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/openfga/openfga/releases/tag/v1.5.1
 [1.5.0]: https://github.com/openfga/openfga/releases/tag/v1.5.0
 [1.4.3]: https://github.com/openfga/openfga/releases/tag/v1.4.3
 [1.4.2]: https://github.com/openfga/openfga/releases/tag/v1.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 
 - Added `request_duration_ms` histogram which has `datastore_query_count` and `dispatch_count` as dimensions ([#1444](https://github.com/openfga/openfga/pull/1444))
-- Added an option to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
-- Support schema version 1.2 for modular models ([#1443](https://github.com/openfga/openfga/pull/1443))
-- Support for throttling dispatches ([#1440](https://github.com/openfga/openfga/pull/1440))
+- Added new flag `OPENFGA_AUTHN_OIDC_ISSUER_ALIASES` to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
+- Added experimental support for modular models via `OPENFGA_EXPERIMENTALS=enable-modular-models` ([#1443](https://github.com/openfga/openfga/pull/1443)). This will enable writing models that are split across multiple files.
+- Added support for throttling dispatches ([#1440](https://github.com/openfga/openfga/pull/1440)). This will throttle Check requests that are overly complex. You can turn on this feature via OPENFGA_DISPATCH_THROTTLING_ENABLED and configured via OPENFGA_DISPATCH_THROTTLING_THRESHOLD and OPENFGA_DISPATCH_THROTTLING_FREQUENCY
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added
 
+- Added `dispatch_count` histogram support for `ListObjects` and `StreamedListObjects` methods ([#1469](https://github.com/openfga/openfga/pull/1469))
 - Added `request_duration_ms` histogram which has `datastore_query_count` and `dispatch_count` as dimensions ([#1444](https://github.com/openfga/openfga/pull/1444))
 - Added new flag `OPENFGA_AUTHN_OIDC_ISSUER_ALIASES` to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
 - Added experimental support for modular models via `OPENFGA_EXPERIMENTALS=enable-modular-models` ([#1443](https://github.com/openfga/openfga/pull/1443)). This will enable writing models that are split across multiple files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 - Added `request_duration_ms` which has `dispatch_count` as a dimension ([#1444](https://github.com/openfga/openfga/pull/1444))
 - Added an option to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
+- Support schema version 1.2 for modular models ([#1443](https://github.com/openfga/openfga/pull/1443))
+- Support for throttling dispatches ([#1440](https://github.com/openfga/openfga/pull/1440))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added
 
-- Added `request_duration_ms` which has `dispatch_count` as a dimension ([#1444](https://github.com/openfga/openfga/pull/1444))
+- Added `request_duration_ms` histogram which has `datastore_query_count` and `dispatch_count` as dimensions ([#1444](https://github.com/openfga/openfga/pull/1444))
 - Added an option to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
 - Support schema version 1.2 for modular models ([#1443](https://github.com/openfga/openfga/pull/1443))
 - Support for throttling dispatches ([#1440](https://github.com/openfga/openfga/pull/1440))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+## [1.5.1] - 2024-03-19
+
+[Full changelog](https://github.com/openfga/openfga/compare/v1.5.0...v1.5.1)
+
+### Added
+
+- Added `request_duration_ms` which has `dispatch_count` as a dimension ([#1444](https://github.com/openfga/openfga/pull/1444))
+- Added an option to specify oidc issuer aliases ([#1354](https://github.com/openfga/openfga/pull/1354)) - Thanks @le-yams!
+
+### Fixed
+
+- We will throw 400 error when condition is invalid instead of "Internal Server Error" ([#1420](https://github.com/openfga/openfga/pull/1420))
+- Fix model validation which threw error "no entrypoints defined" ([#1422](https://github.com/openfga/openfga/pull/1422))
+
+### Deprecation :warning:
+
+- `request_duration_by_query_count_ms` will be removed in favour of `request_duration_ms` ([#1450](https://github.com/openfga/openfga/pull/1450))
+
+### Contribution
+
+- Thanks @lekaf974 for enhancing NewLogger with builder pattern options ([#1413](https://github.com/openfga/openfga/pull/1413))
+
 ## [1.5.0] - 2024-03-01
 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.4.3...v1.5.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Deprecation :warning:
 
-- `request_duration_by_query_count_ms` will be removed in favour of `request_duration_ms` ([#1450](https://github.com/openfga/openfga/pull/1450))
+- Histogram `request_duration_by_query_count_ms` will be removed in the next release, in favour of `request_duration_ms` ([#1450](https://github.com/openfga/openfga/pull/1450))
 
 ### Contribution
 


### PR DESCRIPTION
## Description
Add v1.5.1 release details to the CHANGELOG.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
