### PR TITLE
fix(list-users): initialization of response array

### DIFF
--- a/internal/test/listusers/listusers.go
+++ b/internal/test/listusers/listusers.go
@@ -31,7 +31,7 @@ func (t *TestListUsersRequest) ToString() string {
 func FromProtoResponse(r *openfgav1.ListUsersResponse) []string {
 	var users []string
 	for _, user := range r.GetUsers() {
-		users = append(users, tuple.ObjectKey(user.GetObject()))
+		users = append(users, tuple.UserProtoToString(user))
 	}
 	return users
 }

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -86,7 +86,7 @@ func (l *listUsersQuery) ListUsers(
 	case <-done:
 		break
 	}
-	foundUsers := make([]*openfgav1.User, len(foundUsersUnique))
+	foundUsers := make([]*openfgav1.User, 0, len(foundUsersUnique))
 	for foundUser := range foundUsersUnique {
 		foundUsers = append(foundUsers, tuple.StringToUserProto(foundUser))
 	}

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -169,9 +169,9 @@ func runTest(t *testing.T, test individualTest, client ClientInterface, contextT
 							require.NoError(t, err, detailedInfo)
 							require.ElementsMatch(t, assertion.Expectation, listuserstest.FromProtoResponse(resp), detailedInfo)
 
-							// assert 2: each object in the response of ListUsers should return check -> true
+							// assert 2: each user in the response of ListUsers should return check -> true
 							for _, user := range resp.GetUsers() {
-								checkRequestTupleKey := tuple.NewCheckRequestTupleKey(assertion.Request.Object, assertion.Request.Relation, tuple.ObjectKey(user.GetObject()))
+								checkRequestTupleKey := tuple.NewCheckRequestTupleKey(assertion.Request.Object, assertion.Request.Relation, tuple.UserProtoToString(user))
 								checkResp, err := client.Check(ctx, &openfgav1.CheckRequest{
 									StoreId:              storeID,
 									TupleKey:             checkRequestTupleKey,


### PR DESCRIPTION
## Description
`make(array, 1)` is not the same as `make(array, 0, 1)`

## References
https://github.com/openfga/openfga/issues/1428