### PR TITLE
test: fix data race in ReverseExpand test

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -192,7 +192,7 @@ func WithLogger(logger logger.Logger) ReverseExpandQueryOption {
 // This function respects context timeouts and cancellations. If an
 // error is encountered (e.g. context timeout) before resolving all
 // objects, then the provided channel will NOT be closed, and it will
-// send the error through the channel.
+// return the error.
 //
 // If no errors occur, then Execute will yield all of the objects on
 // the provided channel and then close the channel to signal that it


### PR DESCRIPTION
## Description

While testing https://github.com/openfga/openfga/pull/1454 locally I managed to reproduce a data race in the ReverseExpand tests. The race happens because when we hit `case <-timeoutCtx.Done():` the test exits but there is still a goroutine calling `t.Log`