### PR TITLE
`TypedPublicWildcard` function for creating wildcard tuples from type strings

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -78,7 +78,7 @@ func (u *UserRefTypedWildcard) GetObjectType() string {
 }
 
 func (u *UserRefTypedWildcard) String() string {
-	return fmt.Sprintf("%s:*", u.Type)
+	return tuple.TypedPublicWildcard(u.Type)
 }
 
 type UserRefObjectRelation struct {
@@ -428,7 +428,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 		if publiclyAssignable {
 			// e.g. 'user:*'
 			userFilter = append(userFilter, &openfgav1.ObjectRelation{
-				Object: fmt.Sprintf("%s:*", targetUserObjectType),
+				Object: tuple.TypedPublicWildcard(targetUserObjectType),
 			})
 		}
 

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -151,7 +151,7 @@ func NewExpandRequestTupleKey(object, relation string) *openfgav1.ExpandRequestT
 // ObjectKey returns the canonical key for the provided Object. The ObjectKey of an object
 // is the string 'objectType:objectId'.
 func ObjectKey(obj *openfgav1.Object) string {
-	return fmt.Sprintf("%s:%s", obj.GetType(), obj.GetId())
+	return BuildObject(obj.GetType(), obj.GetId())
 }
 
 // SplitObject splits an object into an objectType and an objectID. If no type is present, it returns the empty string
@@ -275,4 +275,9 @@ func IsTypedWildcard(s string) bool {
 	}
 
 	return false
+}
+
+// TypedPublicWildcard returns the string tuple representation for a given object type (ex: "user:*")
+func TypedPublicWildcard(objectType string) string {
+	return BuildObject(objectType, Wildcard)
 }

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -252,7 +252,7 @@ func IsValidUser(user string) bool {
 	if strings.Count(user, ":") > 1 || strings.Count(user, "#") > 1 {
 		return false
 	}
-	if user == "*" || userIDRegex.MatchString(user) || objectRegex.MatchString(user) || userSetRegex.MatchString(user) {
+	if user == Wildcard || userIDRegex.MatchString(user) || objectRegex.MatchString(user) || userSetRegex.MatchString(user) {
 		return true
 	}
 

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -360,3 +360,9 @@ func TestGetObjectRelationAsString(t *testing.T) {
 		})
 	}
 }
+
+func TestTypedPublicWildcard(t *testing.T) {
+	require.Equal(t, "user:*", TypedPublicWildcard("user"))
+	require.Equal(t, "group:*", TypedPublicWildcard("group"))
+	require.Equal(t, ":*", TypedPublicWildcard("")) // Does not panic
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -299,7 +299,7 @@ func GetRelationReferenceAsString(rr *openfgav1.RelationReference) string {
 		return fmt.Sprintf("%s#%s", rr.GetType(), rr.GetRelation())
 	}
 	if _, ok := rr.GetRelationOrWildcard().(*openfgav1.RelationReference_Wildcard); ok {
-		return fmt.Sprintf("%s:*", rr.GetType())
+		return tuple.TypedPublicWildcard(rr.GetType())
 	}
 
 	panic("unexpected relation reference")


### PR DESCRIPTION
## Description
There are multiple instances in the code where a typed public wildcard tuple (ex: `user:*`) is generated manually. Instead, I'm proposing a `TypedPublicWildcard` function that creates the tuple when provided a type as a string.

This work is inspired by https://github.com/openfga/openfga/pull/1485#discussion_r1538232311: 

> This should be a helper in the pkg/tuple package.

Also done in this PR is implementing more consistent usage of the `Wildcard` string and `BuildObject` function.

## References
Related PR comment: https://github.com/openfga/openfga/pull/1485#discussion_r1538232311

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
