### PR TITLE
fix: listusers skip usersets for intersection and exclusion

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -939,7 +939,6 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
           - request:
               filters:
                 - folder
@@ -1032,7 +1031,6 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
   - name: union_and_tuple_to_userset
     stages:
       - model: |
@@ -1368,7 +1366,6 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because usersets not returned properly yet, returns `document:1` instead"
             expectation:
               - document:1#writer
           - request:
@@ -1376,7 +1373,6 @@ tests:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
@@ -1852,7 +1848,6 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
@@ -2011,7 +2006,6 @@ tests:
                 - folder#viewer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
@@ -2203,14 +2197,12 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
@@ -2756,7 +2748,6 @@ tests:
                 - group#member
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:x` instead"
             expectation:
               - group:x#member
   - name: wildcard_direct
@@ -3144,7 +3135,6 @@ tests:
                 - group#member
               object: document:public
               relation: viewer
-            temporarilySkipReason: "usersets not being returned properly"
             expectation:
               - group:fga#member
   - name: wildcard_obeys_the_types_in_stages
@@ -5457,7 +5447,6 @@ tests:
                 - group#member
               object: folder:a
               relation: can_view
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
           - request:
@@ -5562,7 +5551,6 @@ tests:
                 - group#member
               object: folder:a
               relation: can_view
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
   - name: contextual_tuple_ref_relation_disjoint
@@ -5634,7 +5622,6 @@ tests:
                 - group#member
               object: diagram:a
               relation: viewer
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
   - name: reverse_expand_relation_not_match
@@ -5692,7 +5679,6 @@ tests:
                 - group#member
               object: document:a
               relation: viewer
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
           - request:
@@ -5800,7 +5786,6 @@ tests:
                 - document#can_view
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because usersets not returned properly yet, returns `document:a` instead"
             expectation:
               - document:a#can_view
           - request:
@@ -5808,7 +5793,6 @@ tests:
                 - document#viewer
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
   - name: evaluate_userset_in_computed_relation_of_ttu
     stages:
@@ -5860,7 +5844,6 @@ tests:
                 - organization#member
               object: repo:openfga/openfga
               relation: reader
-            temporarilySkipReason: "because userset relations not being returned properly, `organization:openfga` returned"
             expectation:
               - organization:openfga#member
           - request:
@@ -6041,7 +6024,6 @@ tests:
                 - folder#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `folder:X` instead"
             expectation:
               - folder:X#viewer
           - request:
@@ -6049,7 +6031,6 @@ tests:
                 - organization#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `organization:openfga` instead"
             expectation:
               - organization:openfga#viewer
   - name: userset_with_intersection_in_computed_relation_of_ttu
@@ -6148,15 +6129,12 @@ tests:
                 - organization#member
               object: repo:openfga/openfga
               relation: reader
-            temporarilySkipReason: "because userset relations not being returned properly, `organization:openfga` returned"
             expectation:
-              - organization:openfga#member
           - request:
               filters:
                 - organization#member
               object: repo:openfga/openfga
               relation: can_read
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
             expectation:
           - request:
               filters:
@@ -6481,9 +6459,7 @@ tests:
                 - group#member
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:fga` instead"
             expectation:
-              - group:fga#member # TODO is this OK? not all users of group:fga#member have the can_view relation
   - name: list_objects_does_not_return_duplicates
     stages:
       - model: | #concurrent checks
@@ -7196,7 +7172,6 @@ tests:
                 - group#member
               object: group:eng
               relation: member
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:eng`,`group:fga` and `group:fga-backend` instead"
             expectation:
               - group:eng#member
               - group:fga#member

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -287,8 +287,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria"},
 		},
 		{
-			name:                  "userset_group_granularity",
-			TemporarilySkipReason: "because `group:eng` is being returned instead of `group:eng#member`",
+			name: "userset_group_granularity",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -330,8 +329,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{},
 		},
 		{
-			name:                  "userset_group_granularity_with_direct_user_relationships",
-			TemporarilySkipReason: "because `group:eng` is being returned instead of `group:eng#member`",
+			name: "userset_group_granularity_with_direct_user_relationships",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -392,8 +390,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{"user:jon", "user:hawker", "user:will"},
 		},
 		{
-			name:                  "userset_multiple_usersets_group_granularity",
-			TemporarilySkipReason: "because `group:eng`,`group:fga`,`group:other` is being returned instead of `group:eng#member`,`group:fga#member` and `group:other#member`",
+			name: "userset_multiple_usersets_group_granularity",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -470,8 +467,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria"},
 		},
 		{
-			name:                  "tuple_defines_itself",
-			TemporarilySkipReason: "because it wants to return `document:1`",
+			name: "tuple_defines_itself",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -778,7 +774,7 @@ func TestListUsersConditions(t *testing.T) {
 		},
 		{
 			name:                  "conditions_with_usersets",
-			TemporarilySkipReason: "because usersets don't return correct type and conditions that evaluate false don't get excluded from results",
+			TemporarilySkipReason: "because conditions that evaluate false don't get excluded from results",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -1069,8 +1065,7 @@ func TestListUsersUnion(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria", "user:jon"},
 		},
 		{
-			name:                  "union_all_possible_rewrites",
-			TemporarilySkipReason: "because `user:maria` not being returned",
+			name: "union_all_possible_rewrites",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -1522,8 +1517,7 @@ func TestListUsersWildcards(t *testing.T) {
 			expectedUsers: []string{"user:*"},
 		},
 		{
-			name:                  "wildcard_computed_ttu",
-			TemporarilySkipReason: "because results not deduplicated and data race occurring",
+			name: "wildcard_computed_ttu",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -2070,7 +2064,7 @@ func TestListUsersCycleDetection(t *testing.T) {
 					}},
 				},
 				visitedUsersetsMap: visitedUsersets,
-			}, channelWithResults)
+			}, channelWithResults, false)
 			if err != nil {
 				channelWithError <- err
 				return


### PR DESCRIPTION
## Description
Address two issues:
- ListUsers queries should return usersets as well as concrete users
- When the ListUsers query filter is a clause in an `and` or `but not`, it cannot be returned as result

TO DO: some Check responses are inconsistent with the ListUsers responses, e.g.

<img width="1732" alt="image" src="https://github.com/openfga/openfga/assets/5374887/14fba320-243c-4279-93ec-189fe0aaed67">


## References
https://github.com/openfga/openfga/pull/1433
