### PR TITLE
fix:`ListUsers` include correct relation when returning usersets

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -852,7 +852,33 @@ tests:
               object: document:2
               relation: viewer
             expectation:
-
+          - request:
+              filters:
+                - folder#editor
+              object: document:1
+              relation: viewer
+            expectation:
+             - folder:X#editor
+          - request:
+              filters:
+                - folder#writer
+              object: document:1
+              relation: viewer
+            expectation:
+              - folder:X#writer
+          - request:
+              filters:
+                - folder#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - folder:X#viewer
+          - request:
+              filters:
+                - folder
+              object: document:1
+              relation: viewer
+            expectation:
   - name: tuple_to_userset_and_intersection
     stages:
       - model: |
@@ -939,6 +965,13 @@ tests:
               object: document:1
               relation: viewer
             expectation:
+          - request:
+              filters:
+                - folder#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - folder:X#viewer
           - request:
               filters:
                 - folder

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -939,7 +939,6 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because reflexive relationships not supported yet"
           - request:
               filters:
                 - folder
@@ -1032,7 +1031,14 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because reflexive relationships not supported yet"
+             - folder:X#writer
+          - request:
+              filters:
+                - folder#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - folder:X#viewer
   - name: union_and_tuple_to_userset
     stages:
       - model: |
@@ -1368,7 +1374,6 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - document:1#writer
           - request:
@@ -1376,8 +1381,8 @@ tests:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
+             - document:1#editor
           - request:
               filters:
                 - user
@@ -1852,7 +1857,6 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -2011,8 +2015,8 @@ tests:
                 - folder#viewer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
+             - folder:X#viewer
           - request:
               filters:
                 - document#writer
@@ -2203,15 +2207,15 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
+             - document:1#writer
           - request:
               filters:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
+              - document:1#editor
           - request:
               filters:
                 - user
@@ -5687,7 +5691,6 @@ tests:
                 - group#member
               object: document:a
               relation: viewer
-            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - group:fga#member
           - request:
@@ -5795,7 +5798,6 @@ tests:
                 - document#can_view
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - document:a#can_view
           - request:
@@ -5803,8 +5805,8 @@ tests:
                 - document#viewer
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
+             - document:a#viewer
   - name: evaluate_userset_in_computed_relation_of_ttu
     stages:
       - model: |
@@ -6035,7 +6037,6 @@ tests:
                 - folder#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - folder:X#viewer
           - request:
@@ -6043,7 +6044,6 @@ tests:
                 - organization#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - organization:openfga#viewer
   - name: userset_with_intersection_in_computed_relation_of_ttu
@@ -6148,7 +6148,6 @@ tests:
                 - organization#member
               object: repo:openfga/openfga
               relation: can_read
-            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -7186,7 +7185,6 @@ tests:
                 - group#member
               object: group:eng
               relation: member
-            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - group:eng#member
               - group:fga#member

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -6506,7 +6506,7 @@ tests:
               object: document:1
               relation: can_view
             expectation:
-              - group:fga#member # TODO is this OK? not all users of group:fga#member have the can_view relation
+              - group:fga#member
   - name: list_objects_does_not_return_duplicates
     stages:
       - model: | #concurrent checks

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -939,7 +939,7 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
           - request:
               filters:
                 - folder
@@ -1032,7 +1032,7 @@ tests:
               object: document:1
               relation: viewer
             expectation:
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
   - name: union_and_tuple_to_userset
     stages:
       - model: |
@@ -1368,7 +1368,7 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because usersets not returned properly yet, returns `document:1` instead"
+            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - document:1#writer
           - request:
@@ -1376,7 +1376,7 @@ tests:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -1852,7 +1852,7 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -2011,7 +2011,7 @@ tests:
                 - folder#viewer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -2203,14 +2203,14 @@ tests:
                 - document#writer
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
                 - document#editor
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -2756,7 +2756,6 @@ tests:
                 - group#member
               object: document:1
               relation: viewer
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:x` instead"
             expectation:
               - group:x#member
   - name: wildcard_direct
@@ -3144,7 +3143,6 @@ tests:
                 - group#member
               object: document:public
               relation: viewer
-            temporarilySkipReason: "usersets not being returned properly"
             expectation:
               - group:fga#member
   - name: wildcard_obeys_the_types_in_stages
@@ -5457,7 +5455,6 @@ tests:
                 - group#member
               object: folder:a
               relation: can_view
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
           - request:
@@ -5562,7 +5559,6 @@ tests:
                 - group#member
               object: folder:a
               relation: can_view
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
   - name: contextual_tuple_ref_relation_disjoint
@@ -5634,7 +5630,6 @@ tests:
                 - group#member
               object: diagram:a
               relation: viewer
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
             expectation:
               - group:fga#member
   - name: reverse_expand_relation_not_match
@@ -5692,7 +5687,7 @@ tests:
                 - group#member
               object: document:a
               relation: viewer
-            temporarilySkipReason: "because userset relations not being returned properly, `group:fga` returned"
+            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - group:fga#member
           - request:
@@ -5800,7 +5795,7 @@ tests:
                 - document#can_view
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because usersets not returned properly yet, returns `document:a` instead"
+            temporarilySkipReason: "because returned results don't return true on check"
             expectation:
               - document:a#can_view
           - request:
@@ -5808,7 +5803,7 @@ tests:
                 - document#viewer
               object: document:a
               relation: can_see
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
   - name: evaluate_userset_in_computed_relation_of_ttu
     stages:
@@ -5860,7 +5855,6 @@ tests:
                 - organization#member
               object: repo:openfga/openfga
               relation: reader
-            temporarilySkipReason: "because userset relations not being returned properly, `organization:openfga` returned"
             expectation:
               - organization:openfga#member
           - request:
@@ -6041,7 +6035,7 @@ tests:
                 - folder#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `folder:X` instead"
+            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - folder:X#viewer
           - request:
@@ -6049,7 +6043,7 @@ tests:
                 - organization#viewer
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `organization:openfga` instead"
+            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - organization:openfga#viewer
   - name: userset_with_intersection_in_computed_relation_of_ttu
@@ -6148,15 +6142,13 @@ tests:
                 - organization#member
               object: repo:openfga/openfga
               relation: reader
-            temporarilySkipReason: "because userset relations not being returned properly, `organization:openfga` returned"
             expectation:
-              - organization:openfga#member
           - request:
               filters:
                 - organization#member
               object: repo:openfga/openfga
               relation: can_read
-            temporarilySkipReason: "because we need to remember if previous recursive calls had intersection or exclusion"
+            temporarilySkipReason: "because reflexive relationships not supported yet"
             expectation:
           - request:
               filters:
@@ -6481,7 +6473,6 @@ tests:
                 - group#member
               object: document:1
               relation: can_view
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:fga` instead"
             expectation:
               - group:fga#member # TODO is this OK? not all users of group:fga#member have the can_view relation
   - name: list_objects_does_not_return_duplicates
@@ -7195,7 +7186,7 @@ tests:
                 - group#member
               object: group:eng
               relation: member
-            temporarilySkipReason: "because usersets not returned properly yet, returns `group:eng`,`group:fga` and `group:fga-backend` instead"
+            temporarilySkipReason:  "because returned results don't return true on check"
             expectation:
               - group:eng#member
               - group:fga#member

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -179,14 +179,19 @@ func (l *listUsersQuery) expand(
 	if enteredCycle(req) {
 		return nil
 	}
+
+	reqObjectType := req.GetObject().GetType()
+	reqObjectID := req.GetObject().GetId()
+	reqRelation := req.GetRelation()
+
 	for _, userFilter := range req.GetUserFilters() {
-		if req.GetObject().GetType() == userFilter.GetType() && req.GetRelation() == userFilter.GetRelation() {
+		if reqObjectType == userFilter.GetType() && reqRelation == userFilter.GetRelation() {
 			foundUsersChan <- &openfgav1.User{
 				User: &openfgav1.User_Userset{
 					Userset: &openfgav1.UsersetUser{
-						Type:     req.GetObject().GetType(),
-						Id:       req.GetObject().GetId(),
-						Relation: req.GetRelation(),
+						Type:     reqObjectType,
+						Id:       reqObjectID,
+						Relation: reqRelation,
 					},
 				},
 			}

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -179,11 +179,15 @@ func (l *listUsersQuery) expand(
 	if enteredCycle(req) {
 		return nil
 	}
-	for _, f := range req.GetUserFilters() {
-		if req.GetObject().GetType() == f.GetType() {
+	for _, userFilter := range req.GetUserFilters() {
+		if req.GetObject().GetType() == userFilter.GetType() && req.GetRelation() == userFilter.GetRelation() {
 			foundUsersChan <- &openfgav1.User{
-				User: &openfgav1.User_Object{
-					Object: req.GetObject(),
+				User: &openfgav1.User_Userset{
+					Userset: &openfgav1.UsersetUser{
+						Type:     req.GetObject().GetType(),
+						Id:       req.GetObject().GetId(),
+						Relation: req.GetRelation(),
+					},
 				},
 			}
 		}


### PR DESCRIPTION
## Description
This PR fixes an issue in `ListUsers` where usersets weren't returning the relation in the response. Ex: (`group:fga` instead of `group:fga#member`). 

This bug occurred because we weren't checking the relation in the conditional when evaluating a userset _and_ because we weren't returning the correct object type. 

## References
Parent PR: #1428 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
