### PR TITLE
chore(deps): bump grpc-health-probe in Goreleaser built image

### DIFF
--- a/.goreleaser-nightly.yaml
+++ b/.goreleaser-nightly.yaml
@@ -2,8 +2,7 @@ project_name: openfga-nightly
 
 before:
   hooks:
-    - make install-tools
-    - go generate ./...
+    - make generate-mocks
 
 builds:
   - main: ./cmd/openfga

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,8 +2,7 @@ project_name: openfga
 
 before:
   hooks:
-    - make install-tools
-    - go generate ./...
+    - make generate-mocks
 
 builds:
   -

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,11 @@
 FROM cgr.dev/chainguard/static@sha256:8665c8a9fcdab0f8afc09533ee23287c7870de26064d464a10e3baa52f337734
 COPY assets /assets
 COPY openfga /
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.24 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+
+# Goreleaser does not support multi-stage builds. See:
+# https://github.com/goreleaser/goreleaser/issues/609
+#
+# Dependabot is also not capable of updating inline image copies at this time, so
+# this needs to be updated manually until one of these issues is resolved.
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.25 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ $(GO_BIN)/CompileDaemon:
 
 $(GO_BIN)/openfga: install
 
+generate-mocks: $(GO_BIN)/mockgen ## Generate mock stubs
+	${call print, "Generating mock stubs"}
+	@go generate ./...
+
 #-----------------------------------------------------------------------------------------------------------------------
 # Building & Installing
 #-----------------------------------------------------------------------------------------------------------------------
@@ -78,9 +82,9 @@ lint: $(GO_BIN)/golangci-lint ## Lint Go source files
 #-----------------------------------------------------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------------------------------------------------
-.PHONY: test test-docker test-bench test-mocks
+.PHONY: test test-docker test-bench generate-mocks
 
-test: test-mocks ## Run all tests. To run a specific test, pass the FILTER var. Usage `make test FILTER="TestCheckLogs"`
+test: generate-mocks ## Run all tests. To run a specific test, pass the FILTER var. Usage `make test FILTER="TestCheckLogs"`
 	${call print, "Running tests"}
 	@go test -race \
 			-run "$(FILTER)" \
@@ -100,13 +104,9 @@ test-docker: ## Run tests requiring Docker
 	fi
 	@go test -v -count=1 -timeout=5m -tags=docker ./cmd/openfga/...
 
-test-bench: test-mocks ## Run benchmark tests. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
+test-bench: generate-mocks ## Run benchmark tests. See https://pkg.go.dev/cmd/go#hdr-Testing_flags
 	${call print, "Running benchmark tests"}
 	@go test ./... -bench . -benchtime 5s -timeout 0 -run=XXX -cpu 1 -benchmem
-
-test-mocks: $(GO_BIN)/mockgen ## Generate test mocks
-	${call print, "Generating test mocks"}
-	@go generate ./...
 
 #-----------------------------------------------------------------------------------------------------------------------
 # Development


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Resolve the differences between the `Dockerfile` and the one used in the Goreleaser build `Dockerfile.goreleaser`. See:

https://github.com/openfga/openfga/blob/8526d5208ff7003aa7b7cc8e30c530052fd37b80/Dockerfile#L1
vs
https://github.com/openfga/openfga/blob/8526d5208ff7003aa7b7cc8e30c530052fd37b80/Dockerfile.goreleaser#L4

## References
Closes #1504 (see https://github.com/orgs/openfga/discussions/290)
https://github.com/goreleaser/goreleaser/issues/4741

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
