### PR TITLE
docs(v1.5.2): add v1.5.2 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+## [1.5.2] - 2024-04-03
+
+[Full changelog](https://github.com/openfga/openfga/compare/v1.5.1...v1.5.2)
+
+### Fixed
+
+* Fix the count of datastore reads in the Check API ([#1452](https://github.com/openfga/openfga/pull/1452))
+* Fix the correct default used for dispatch throttling ([#1479](https://github.com/openfga/openfga/pull/1479))
+
+### Security
+
+* Bumped up the `grpc-health-probe` dependency in the published Docker image to the latest release which fixes some vulnerabilities ([#1507](https://github.com/openfga/openfga/pull/1507))
+
+### Changed
+
+* Refactored Makefile commands ([#1454](https://github.com/openfga/openfga/pull/1454))
+
+### Contributions
+
+* release: add homebrew release job by @chenrui333 ([#780](https://github.com/openfga/openfga/pull/780))
+
 ## [1.5.1] - 2024-03-19
 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.5.0...v1.5.1)
@@ -37,7 +58,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.4.3...v1.5.0)
 
-### Added 
+### Added
 
 - Override option for timestamp in JSON logs ([#1330](https://github.com/openfga/openfga/pull/1330)) - thank you, @raj-saxena!
 - OpenTelemetry tracing and attributes to check algorithm ([#1331](https://github.com/openfga/openfga/pull/1331), [#1388](https://github.com/openfga/openfga/pull/1388))
@@ -972,7 +993,8 @@ no tuple key instead.
 * Memory storage adapter implementation
 * Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.5.1...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.5.2...HEAD
+[1.5.2]: https://github.com/openfga/openfga/releases/tag/v1.5.2
 [1.5.1]: https://github.com/openfga/openfga/releases/tag/v1.5.1
 [1.5.0]: https://github.com/openfga/openfga/releases/tag/v1.5.0
 [1.4.3]: https://github.com/openfga/openfga/releases/tag/v1.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 * Bumped up the `grpc-health-probe` dependency in the published Docker image to the latest release which fixes some vulnerabilities ([#1507](https://github.com/openfga/openfga/pull/1507))
 
-### Changed
-
-* Refactored Makefile commands ([#1454](https://github.com/openfga/openfga/pull/1454))
-
 ### Contributions
 
 * release: add homebrew release job by @chenrui333 ([#780](https://github.com/openfga/openfga/pull/780))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Contributions
 
-* release: add homebrew release job by @chenrui333 ([#780](https://github.com/openfga/openfga/pull/780))
+* Add homebrew release job by @chenrui333 ([#780](https://github.com/openfga/openfga/pull/780))
 
 ## [1.5.1] - 2024-03-19
 


### PR DESCRIPTION
## What's Changed
* test: fix data race in ReverseExpand test by @miparnisari in https://github.com/openfga/openfga/pull/1474
* docs: update security-self-assessment.md by @lj365 in https://github.com/openfga/openfga/pull/1456
* fix(check): count of datastore reads by @miparnisari in https://github.com/openfga/openfga/pull/1452
* bump: slsa actions to v1.10.0 by @jpadilla in https://github.com/openfga/openfga/pull/1478
* test: attempt at preventing 'bind: address already in use' by @miparnisari in https://github.com/openfga/openfga/pull/1468
* chore(deps): bump github.com/docker/docker from 25.0.4+incompatible to 25.0.5+incompatible by @dependabot in https://github.com/openfga/openfga/pull/1476
* release: add homebrew release job by @chenrui333 in https://github.com/openfga/openfga/pull/780
* CI: Add workflow to update NOTICE file by @Siddhant-K-code in https://github.com/openfga/openfga/pull/1458
* fix: correct default dispatch throttle enabled by @adriantam in https://github.com/openfga/openfga/pull/1479
* Revert "CI: Add workflow to update NOTICE file" by @willvedd in https://github.com/openfga/openfga/pull/1480
* chore: update SECURITY-INSIGHTS by @aaguiarz in https://github.com/openfga/openfga/pull/1483
* refactor: improve makefile commands by @sergiught in https://github.com/openfga/openfga/pull/1454
* docs: add CONTRIBUTING guide by @miparnisari in https://github.com/openfga/openfga/pull/1290
* `TypedPublicWildcard` function for creating wildcard tuples from type strings by @willvedd in https://github.com/openfga/openfga/pull/1490
* chore(deps): bump the dependencies group with 1 update by @dependabot in https://github.com/openfga/openfga/pull/1489
* chore(deps): bump the dependencies group with 6 updates by @dependabot in https://github.com/openfga/openfga/pull/1493
* fix: ensure usersets are self defining by @jon-whit in https://github.com/openfga/openfga/pull/1066
* chore(deps): bump the dependencies group with 1 update by @dependabot in https://github.com/openfga/openfga/pull/1499
* revert #1066 by @jon-whit in https://github.com/openfga/openfga/pull/1506
* chore(deps): bump grpc-health-probe in Goreleaser built image by @jon-whit in https://github.com/openfga/openfga/pull/1507

## New Contributors
* @lj365 made their first contribution in https://github.com/openfga/openfga/pull/1456

**Full Changelog**: https://github.com/openfga/openfga/compare/v1.5.1...v1.5.2