### PR TITLE
fix: `ListUsers` experimental flag

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -89,7 +89,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "enum": ["enable-modular-models"]
+                "enum": ["enable-modular-models","enable-list-users"]
             },
             "default": [],
             "x-env-variable": "OPENFGA_EXPERIMENTALS"

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -83,7 +83,7 @@ func NewRunCommand() *cobra.Command {
 	defaultConfig := serverconfig.DefaultConfig()
 	flags := cmd.Flags()
 
-	flags.StringSlice("experimentals", defaultConfig.Experimentals, "a list of experimental features to enable")
+	flags.StringSlice("experimentals", defaultConfig.Experimentals, "a list of experimental features to enable. Allowed values: `enable-list-users`")
 
 	flags.String("grpc-addr", defaultConfig.GRPC.Addr, "the host:port address to serve the grpc server on")
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -664,7 +664,7 @@ func (s *Server) ListUsers(
 	req *openfgav1.ListUsersRequest,
 ) (*openfgav1.ListUsersResponse, error) {
 	if !s.IsExperimentallyEnabled(ExperimentalEnableListUsers) {
-		return nil, fmt.Errorf("ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
+		return nil, status.Error(codes.Unimplemented, "ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
 	}
 
 	typesys, err := s.typesystemResolver(ctx, req.GetStoreId(), req.GetAuthorizationModelId())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -50,6 +50,7 @@ const (
 	AuthorizationModelIDHeader                              = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey                                 = "authorization_model_id"
 	ExperimentalEnableModularModels ExperimentalFeatureFlag = "enable-modular-models"
+	ExperimentalEnableListUsers     ExperimentalFeatureFlag = "enable-list-users"
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -336,6 +337,15 @@ func MustNewServerWithOpts(opts ...OpenFGAServiceV1Option) *Server {
 	}
 
 	return s
+}
+
+func (s *Server) IsExperimentallyEnabled(flag ExperimentalFeatureFlag) bool {
+	for _, e := range s.experimentals {
+		if e == flag {
+			return true
+		}
+	}
+	return false
 }
 
 // NewServerWithOpts returns a new server.
@@ -653,6 +663,10 @@ func (s *Server) ListUsers(
 	ctx context.Context,
 	req *openfgav1.ListUsersRequest,
 ) (*openfgav1.ListUsersResponse, error) {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableListUsers) {
+		return nil, fmt.Errorf("ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
+	}
+
 	typesys, err := s.typesystemResolver(ctx, req.GetStoreId(), req.GetAuthorizationModelId())
 	if err != nil {
 		return nil, err

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1645,7 +1645,7 @@ func TestExperimentalListUsers(t *testing.T) {
 	t.Run("list_users_errors_if_not_experimentally_enabled", func(t *testing.T) {
 		_, err := server.ListUsers(ctx, req)
 		require.Error(t, err)
-		require.Equal(t, "ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server", err.Error())
+		require.Equal(t, "rpc error: code = Unimplemented desc = ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server", err.Error())
 	})
 
 	t.Run("list_users_does_not_error_if_experimentally_enabled", func(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1646,6 +1646,10 @@ func TestExperimentalListUsers(t *testing.T) {
 		_, err := server.ListUsers(ctx, req)
 		require.Error(t, err)
 		require.Equal(t, "rpc error: code = Unimplemented desc = ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server", err.Error())
+
+		e, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Unimplemented, e.Code())
 	})
 
 	t.Run("list_users_does_not_error_if_experimentally_enabled", func(t *testing.T) {


### PR DESCRIPTION
## Description
Wiring-up ListUsers endpoint with the `--experimentals` flag. This allows it to be enabled by running `openfga run --experimentals enable-list-users`. This follows a similar pattern as modular models experimental enablement in #1443. 

## References
- Similar PR: #1443 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
