### PR TITLE
fix: `ListUsers` reflexive usersets support

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -2735,6 +2735,62 @@ tests:
               relation: viewer
             expectation:
               - user:cheetah
+  - name: exclusion_between_userset_and_type
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type group
+            relations
+              define member: [user, group#member] but not blocked
+              define blocked: [user, group#member]
+        tuples:
+          - object: group:1
+            relation: blocked
+            user: group:1#member
+          - object: group:1
+            relation: member
+            user: user:will
+        checkAssertions:
+          - tuple:
+              object: group:1
+              relation: member
+              user: user:will
+            expectation: true
+          - tuple:
+              object: group:1
+              relation: blocked
+              user: group:1#member
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:will
+              type: group
+              relation: member
+            expectation:
+              - group:1
+          - request:
+              user: group:1#member
+              type: group
+              relation: blocked
+            expectation:
+             - group:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: group:1
+              relation: member
+            expectation:
+              - user:will
+          - request:
+              filters:
+                - user
+              object: group:1
+              relation: member
+            expectation:
+              - user:will
   - name: userset_as_user
     stages:
       - model: |

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -7248,6 +7248,14 @@ tests:
               type: document
               relation: viewer
             expectation: ["document:1"]
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#viewer
   - name: userset_defines_itself_2
     stages:
       - model: |
@@ -7293,6 +7301,28 @@ tests:
               type: document
               relation: viewer
             expectation: ["document:1"]
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#writer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#writer
+          - request:
+              filters:
+                - document#editor
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#editor
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#viewer
   - name: userset_defines_itself_3
     stages:
       - model: |
@@ -7337,6 +7367,27 @@ tests:
               type: document
               relation: writer
             expectation: []
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#writer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#writer
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#viewer
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: writer
+            expectation:
   - name: userset_defines_itself_4
     stages:
       - model: |
@@ -7379,6 +7430,21 @@ tests:
               type: document
               relation: viewer
             expectation: ["document:1"]
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+              - document:1#viewer
+          - request:
+              filters:
+                - folder#viewer
+              object: folder:x
+              relation: viewer
+            expectation:
+              - folder:x#viewer
   - name: userset_defines_itself_5
     stages:
       - model: |
@@ -7418,6 +7484,19 @@ tests:
               type: document
               relation: allowed
             expectation: []
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#allowed
+              object: document:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: allowed
+            expectation:
   - name: userset_defines_itself_6
     stages:
       - model: |
@@ -7462,6 +7541,26 @@ tests:
               type: document
               relation: restricted
             expectation: []
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: viewer
+            expectation:
+            - document:1#viewer
+          - request:
+              filters:
+                - document#viewer
+              object: document:1
+              relation: restricted
+            expectation:
+          - request:
+              filters:
+                - document#restricted
+              object: document:1
+              relation: viewer
+            expectation:
   - name: userset_defines_itself_7
     stages:
       - model: |
@@ -7493,6 +7592,14 @@ tests:
               type: group
               relation: member
             expectation: ["group:1"]
+        listUsersAssertions:
+          - request:
+              filters:
+                - group#member
+              object: group:1
+              relation: member
+            expectation:
+            - group:1#member
   - name: userset_defines_itself_8
     stages:
       - model: |
@@ -7517,6 +7624,14 @@ tests:
               type: document
               relation: viewer
             expectation: ["document:1"]
+        listUsersAssertions:
+          - request:
+              filters:
+                - document#writer
+              object: document:1
+              relation: viewer
+            expectation:
+            - document:1#writer
   - name: userset_defines_itself_9
     stages:
       - model: |
@@ -7550,6 +7665,14 @@ tests:
               type: document
               relation: viewer
             expectation: [document:1]
+        listUsersAssertions:
+          - request:
+              filters:
+                - group#member
+              object: document:1
+              relation: viewer
+            expectation:
+            - group:fga#member
   - name: userset_defines_itself_10
     stages:
       - model: |
@@ -7619,3 +7742,39 @@ tests:
               type: doc
               relation: a
             expectation: [doc:1]
+        listUsersAssertions:
+          - request:
+              filters:
+                - doc#d
+              object: doc:1
+              relation: b
+            expectation:
+            - doc:1#d
+          - request:
+              filters:
+                - doc#c
+              object: doc:1
+              relation: b
+            expectation:
+            - doc:1#c
+          - request:
+              filters:
+                - doc#c
+              object: doc:1
+              relation: a
+            expectation:
+            - doc:1#c
+          - request:
+              filters:
+                - doc#d
+              object: doc:1
+              relation: a
+            expectation:
+            - doc:1#d
+          - request:
+              filters:
+                - doc#b
+              object: doc:1
+              relation: a
+            expectation:
+            - doc:1#b

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -117,8 +117,18 @@ func doesHavePossibleEdges(typesys *typesystem.TypeSystem, req *openfgav1.ListUs
 	g := graph.New(typesys)
 
 	userFilters := req.GetUserFilters()
-	source := typesystem.DirectRelationReference(userFilters[0].GetType(), userFilters[0].GetRelation())
-	target := typesystem.DirectRelationReference(req.GetObject().GetType(), req.GetRelation())
+
+	userFilterType := userFilters[0].GetType()
+	userFilterRelation := userFilters[0].GetRelation()
+	targetType := req.GetObject().GetType()
+	targetRelation := req.GetRelation()
+
+	if userFilterType == targetType && userFilterRelation == targetRelation {
+		return true, nil // reflexive userset
+	}
+
+	source := typesystem.DirectRelationReference(userFilterType, userFilterRelation)
+	target := typesystem.DirectRelationReference(targetType, targetRelation)
 
 	edges, err := g.GetPrunedRelationshipEdges(target, source)
 	if err != nil {

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -70,15 +70,10 @@ func (l *listUsersQuery) ListUsers(
 		return nil, fmt.Errorf("typesystem missing in context")
 	}
 
-	hasReflexiveUserset := false
-	for _, userFilter := range req.GetUserFilters() {
-		hasReflexiveUserset = userFilter.GetType() == req.GetObject().GetType() && userFilter.GetRelation() == req.GetRelation()
-		if hasReflexiveUserset {
-			continue
-		}
-	}
+	userFilter := req.GetUserFilters()[0]
+	isReflexiveUserset := userFilter.GetType() == req.GetObject().GetType() && userFilter.GetRelation() == req.GetRelation()
 
-	if !hasReflexiveUserset {
+	if !isReflexiveUserset {
 		hasPossibleEdges, err := doesHavePossibleEdges(typesys, req)
 		if err != nil {
 			return nil, err

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -488,8 +488,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{},
 		},
 		{
-			name:                  "userset_defines_itself",
-			TemporarilySkipReason: "because reflexive relationships not supported yet",
+			name: "userset_defines_itself",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -1312,7 +1311,7 @@ func TestListUsersExclusion(t *testing.T) {
 		},
 		{
 			name:                  "exclusion_and_self_referential_tuples_1",
-			TemporarilySkipReason: "because reflexive relationships not supported yet",
+			TemporarilySkipReason: "because exclusion not working between users and underlying usersets",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "group", Id: "1"},
 				Relation: "member",

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -62,8 +62,7 @@ func TestListUsersDirectRelationship(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria"},
 		},
 		{
-			name:                  "direct_relationship_with_userset_subjects_and_userset_filter",
-			TemporarilySkipReason: "because reflexive relationships not supported yet",
+			name: "direct_relationship_with_userset_subjects_and_userset_filter",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "group", Id: "eng"},
 				Relation: "member",
@@ -1310,8 +1309,7 @@ func TestListUsersExclusion(t *testing.T) {
 			expectedUsers: []string{"user:will"},
 		},
 		{
-			name:                  "exclusion_and_self_referential_tuples_1",
-			TemporarilySkipReason: "because exclusion not working between users and underlying usersets",
+			name: "exclusion_and_self_referential_tuples_1",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "group", Id: "1"},
 				Relation: "member",
@@ -1328,14 +1326,14 @@ func TestListUsersExclusion(t *testing.T) {
 		  
 		  type group
 			relations
-			  define member: [user, group#member] but not other
-			  define other: [user, group#member]`,
+			  define member: [user, group#member] but not blocked
+			  define blocked: [user, group#member]`,
 
 			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:1", "other", "group:1#member"),
+				tuple.NewTupleKey("group:1", "blocked", "group:1#member"),
 				tuple.NewTupleKey("group:1", "member", "user:will"),
 			},
-			expectedUsers: []string{},
+			expectedUsers: []string{"user:will"},
 		},
 	}
 	tests.runListUsersTestCases(t)


### PR DESCRIPTION
## Description
Currently, the underlying algorithm for list users already mostly supports reflexive (self-defining) usersets. However, the `doesHavePossibleEdges` function validates the types in the request against the model and does not consider self-defining usersets as a valid edge. **Ex:** `ListUsers(object: "doc:1", relation: "viewer", user_filter: "doc#viewer")`. In this case, the endpoint exits early. So the solution here is to add another check for reflexive usersets specifically and prevent from exiting early.

**Reflexive Usersets**
The following demonstrates the behavior of reflexive usersets:
```
Check(user: "document:1#viewer", object: "document:1", relation: "viewer") // => true
ListUsers(object: "document:1", relation: "viewer", user_filter: "user") // => ["document:1#viewer",...]
ListObjects(user: "document:1#viewer", relation: "viewer") // => ["document:1",...]
```

## References
- #1066 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
