### PR TITLE
fix: `ListUsers` recursive depth limit protection

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -6949,8 +6949,7 @@ tests:
                 - user
               object: resource:abc
               relation: a1
-            temporarilySkipReason: "because depth protection not implemented yet"
-            errorCode: 2002 #ErrorCode_authorization_model_resolution_too_complex
+            errorCode: 2002
   - name: race_condition_same_user_same_object_diff_relation
     stages:
       - model: |

--- a/pkg/server/commands/listusers/list_users.go
+++ b/pkg/server/commands/listusers/list_users.go
@@ -13,20 +13,27 @@ type listUsersRequest interface {
 	GetRelation() string
 	GetUserFilters() []*openfgav1.ListUsersFilter
 	GetContextualTuples() *openfgav1.ContextualTupleKeys
+	GetDepth() uint32
 }
 
-type internalListUsersRequest struct {
+type ListUsersRequest struct {
 	*openfgav1.ListUsersRequest
 
 	// visitedUsersetsMap keeps track of the "path" we've made so far.
 	// It prevents stack overflows by preventing visiting the same userset twice.
 	visitedUsersetsMap map[string]struct{}
+
+	// Depth is the current depths of the traversal expressed as a positive, decrementing integer.
+	// When expansion of list users recursively traverses one level, we decrement by one. If this
+	// counter is 0, we throw ErrResolutionDepthExceeded. This protects against a potentially deep
+	// or endless cycle of recursion.
+	Depth uint32
 }
 
-var _ listUsersRequest = (*internalListUsersRequest)(nil)
+var _ listUsersRequest = (*ListUsersRequest)(nil)
 
 //nolint:stylecheck // it should be GetStoreID, but we want to satisfy the interface listUsersRequest
-func (r *internalListUsersRequest) GetStoreId() string {
+func (r *ListUsersRequest) GetStoreId() string {
 	if r == nil {
 		return ""
 	}
@@ -34,43 +41,50 @@ func (r *internalListUsersRequest) GetStoreId() string {
 }
 
 //nolint:stylecheck // it should be GetAuthorizationModelID, but we want to satisfy the interface listUsersRequest
-func (r *internalListUsersRequest) GetAuthorizationModelId() string {
+func (r *ListUsersRequest) GetAuthorizationModelId() string {
 	if r == nil {
 		return ""
 	}
 	return r.AuthorizationModelId
 }
 
-func (r *internalListUsersRequest) GetObject() *openfgav1.Object {
+func (r *ListUsersRequest) GetObject() *openfgav1.Object {
 	if r == nil {
 		return nil
 	}
 	return r.Object
 }
 
-func (r *internalListUsersRequest) GetRelation() string {
+func (r *ListUsersRequest) GetRelation() string {
 	if r == nil {
 		return ""
 	}
 	return r.Relation
 }
 
-func (r *internalListUsersRequest) GetUserFilters() []*openfgav1.ListUsersFilter {
+func (r *ListUsersRequest) GetUserFilters() []*openfgav1.ListUsersFilter {
 	if r == nil {
 		return nil
 	}
 	return r.UserFilters
 }
 
-func (r *internalListUsersRequest) GetContextualTuples() *openfgav1.ContextualTupleKeys {
+func (r *ListUsersRequest) GetContextualTuples() *openfgav1.ContextualTupleKeys {
 	if r == nil {
 		return nil
 	}
 	return r.ContextualTuples
 }
 
-func fromListUsersRequest(o listUsersRequest) *internalListUsersRequest {
-	return &internalListUsersRequest{
+func (r *ListUsersRequest) GetDepth() uint32 {
+	if r == nil {
+		return uint32(0)
+	}
+	return r.Depth
+}
+
+func fromListUsersRequest(o listUsersRequest) *ListUsersRequest {
+	return &ListUsersRequest{
 		ListUsersRequest: &openfgav1.ListUsersRequest{
 			StoreId:              o.GetStoreId(),
 			AuthorizationModelId: o.GetAuthorizationModelId(),
@@ -80,11 +94,12 @@ func fromListUsersRequest(o listUsersRequest) *internalListUsersRequest {
 			ContextualTuples:     o.GetContextualTuples(),
 		},
 		visitedUsersetsMap: make(map[string]struct{}),
+		Depth:              o.GetDepth(),
 	}
 }
 
 // clone creates a copy of the request. Note that some fields are not deep-cloned.
-func (r *internalListUsersRequest) clone() *internalListUsersRequest {
+func (r *ListUsersRequest) clone() *ListUsersRequest {
 	v := fromListUsersRequest(r)
 	v.visitedUsersetsMap = maps.Clone(r.visitedUsersetsMap)
 	return v

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -188,7 +188,7 @@ func (l *listUsersQuery) expand(
 	req *internalListUsersRequest,
 	foundUsersChan chan<- *openfgav1.User,
 ) error {
-	if req.depth == l.resolveNodeLimit {
+	if req.depth >= l.resolveNodeLimit {
 		return graph.ErrResolutionDepthExceeded
 	}
 	req.depth++

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -467,8 +467,7 @@ func TestListUsersUsersets(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria"},
 		},
 		{
-			name:                  "tuple_defines_itself",
-			TemporarilySkipReason: "because it wants to return `document:1`",
+			name: "tuple_defines_itself",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",
@@ -1130,8 +1129,7 @@ func TestListUsersUnion(t *testing.T) {
 			expectedUsers: []string{"user:will", "user:maria", "user:jon"},
 		},
 		{
-			name:                  "union_all_possible_rewrites",
-			TemporarilySkipReason: "because `user:maria` not being returned",
+			name: "union_all_possible_rewrites",
 			req: &openfgav1.ListUsersRequest{
 				Object:   &openfgav1.Object{Type: "document", Id: "1"},
 				Relation: "viewer",

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -2046,7 +2046,7 @@ func TestListUsersCycleDetection(t *testing.T) {
 		visitedUsersets[visitedUsersetKey] = struct{}{}
 
 		go func() {
-			err := l.expand(ctx, &internalListUsersRequest{
+			err := l.expand(ctx, &ListUsersRequest{
 				ListUsersRequest: &openfgav1.ListUsersRequest{
 					StoreId:              storeID,
 					AuthorizationModelId: modelID,
@@ -2060,6 +2060,7 @@ func TestListUsersCycleDetection(t *testing.T) {
 					}},
 				},
 				visitedUsersetsMap: visitedUsersets,
+				Depth:              25,
 			}, channelWithResults)
 			if err != nil {
 				channelWithError <- err
@@ -2077,6 +2078,87 @@ func TestListUsersCycleDetection(t *testing.T) {
 			break
 		}
 	})
+}
+
+func TestListUsersDepthExceeded(t *testing.T) {
+	model := `model
+	schema 1.1
+		type user
+
+	type folder
+		relations
+			define parent: [folder]
+			define viewer: [user] or viewer from parent`
+
+	depthNotExceededTuples := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("folder:26", "viewer", "user:maria"),
+		tuple.NewTupleKey("folder:25", "parent", "folder:26"),
+		tuple.NewTupleKey("folder:24", "parent", "folder:25"),
+		tuple.NewTupleKey("folder:23", "parent", "folder:24"),
+		tuple.NewTupleKey("folder:22", "parent", "folder:23"),
+		tuple.NewTupleKey("folder:21", "parent", "folder:22"),
+		tuple.NewTupleKey("folder:20", "parent", "folder:21"),
+		tuple.NewTupleKey("folder:19", "parent", "folder:20"),
+		tuple.NewTupleKey("folder:18", "parent", "folder:19"),
+		tuple.NewTupleKey("folder:17", "parent", "folder:18"),
+		tuple.NewTupleKey("folder:16", "parent", "folder:17"),
+		tuple.NewTupleKey("folder:15", "parent", "folder:16"),
+		tuple.NewTupleKey("folder:14", "parent", "folder:15"),
+		tuple.NewTupleKey("folder:13", "parent", "folder:14"),
+		tuple.NewTupleKey("folder:12", "parent", "folder:13"),
+		tuple.NewTupleKey("folder:11", "parent", "folder:12"),
+		tuple.NewTupleKey("folder:10", "parent", "folder:11"),
+		tuple.NewTupleKey("folder:9", "parent", "folder:10"),
+		tuple.NewTupleKey("folder:8", "parent", "folder:9"),
+		tuple.NewTupleKey("folder:7", "parent", "folder:8"),
+		tuple.NewTupleKey("folder:6", "parent", "folder:7"),
+		tuple.NewTupleKey("folder:5", "parent", "folder:6"),
+		tuple.NewTupleKey("folder:4", "parent", "folder:5"),
+		tuple.NewTupleKey("folder:3", "parent", "folder:4"),
+		tuple.NewTupleKey("folder:2", "parent", "folder:3"), // folder:2 will not exceed depth limit of 25
+		tuple.NewTupleKey("folder:1", "parent", "folder:2"), // folder:1 will exceed depth limit of 25
+	}
+
+	tests := ListUsersTests{
+		{
+			name: "depth_should_exceed_limit",
+			req: &openfgav1.ListUsersRequest{
+				Object: &openfgav1.Object{
+					Type: "folder",
+					Id:   "1", // Exceeded because we expand up until folder:1, beyond 25 allowable levels
+				},
+				Relation: "viewer",
+				UserFilters: []*openfgav1.ListUsersFilter{
+					{
+						Type: "user",
+					},
+				},
+			},
+			model:            model,
+			tuples:           depthNotExceededTuples,
+			expectedErrorMsg: "resolution depth exceeded",
+		},
+		{
+			name: "depth_should_not_exceed_limit",
+			req: &openfgav1.ListUsersRequest{
+				Object: &openfgav1.Object{
+					Type: "folder",
+					Id:   "2", // Does not exceed limit because we expand up until folder:2, up to the allowable 25 levels
+				},
+				Relation: "viewer",
+				UserFilters: []*openfgav1.ListUsersFilter{
+					{
+						Type: "user",
+					},
+				},
+			},
+			model:         model,
+			tuples:        depthNotExceededTuples,
+			expectedUsers: []string{"user:maria"},
+		},
+	}
+
+	tests.runListUsersTestCases(t)
 }
 
 func (testCases ListUsersTests) runListUsersTestCases(t *testing.T) {
@@ -2110,7 +2192,10 @@ func (testCases ListUsersTests) runListUsersTestCases(t *testing.T) {
 			test.req.AuthorizationModelId = model.GetId()
 			test.req.StoreId = storeID
 
-			resp, err := l.ListUsers(ctx, test.req)
+			resp, err := l.ListUsers(ctx, &ListUsersRequest{
+				ListUsersRequest: test.req,
+				Depth:            25,
+			})
 
 			actualErrorMsg := ""
 			if err != nil {

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -2089,7 +2089,7 @@ func TestListUsersDepthExceeded(t *testing.T) {
 			define parent: [folder]
 			define viewer: [user] or viewer from parent`
 
-	depthNotExceededTuples := []*openfgav1.TupleKey{
+	tuples := []*openfgav1.TupleKey{
 		tuple.NewTupleKey("folder:26", "viewer", "user:maria"),
 		tuple.NewTupleKey("folder:25", "parent", "folder:26"),
 		tuple.NewTupleKey("folder:24", "parent", "folder:25"),
@@ -2134,7 +2134,7 @@ func TestListUsersDepthExceeded(t *testing.T) {
 				},
 			},
 			model:            model,
-			tuples:           depthNotExceededTuples,
+			tuples:           tuples,
 			expectedErrorMsg: graph.ErrResolutionDepthExceeded.Error(),
 		},
 		{
@@ -2152,7 +2152,7 @@ func TestListUsersDepthExceeded(t *testing.T) {
 				},
 			},
 			model:         model,
-			tuples:        depthNotExceededTuples,
+			tuples:        tuples,
 			expectedUsers: []string{"user:maria"},
 		},
 	}

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/structpb"
 
+	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/mocks"
 
 	"github.com/openfga/openfga/pkg/storage/memory"
@@ -2137,7 +2138,7 @@ func TestListUsersDepthExceeded(t *testing.T) {
 			},
 			model:            model,
 			tuples:           depthNotExceededTuples,
-			expectedErrorMsg: "resolution depth exceeded",
+			expectedErrorMsg: graph.ErrResolutionDepthExceeded.Error(),
 		},
 		{
 			name: "depth_should_not_exceed_limit",

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -34,5 +34,9 @@ func (s *Server) ListUsers(
 	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 
 	listUsersQuery := listusers.NewListUsersQuery(s.datastore)
-	return listUsersQuery.ListUsers(ctx, req)
+
+	return listUsersQuery.ListUsers(ctx, &listusers.ListUsersRequest{
+		ListUsersRequest: req,
+		Depth:            s.resolveNodeLimit,
+	})
 }

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -36,12 +36,9 @@ func (s *Server) ListUsers(
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 
-	listUsersQuery := listusers.NewListUsersQuery(s.datastore)
+	listUsersQuery := listusers.NewListUsersQuery(s.datastore, listusers.WithResolveNodeLimit(s.resolveNodeLimit))
 
-	resp, err := listUsersQuery.ListUsers(ctx, &listusers.ListUsersRequest{
-		ListUsersRequest: req,
-		Depth:            s.resolveNodeLimit,
-	})
+	resp, err := listUsersQuery.ListUsers(ctx, req)
 	if err != nil {
 		if errors.Is(err, graph.ErrResolutionDepthExceeded) {
 			return nil, serverErrors.AuthorizationModelResolutionTooComplex

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -2,12 +2,9 @@ package server
 
 import (
 	"context"
-<<<<<<< HEAD
 	"errors"
-=======
 	"fmt"
 	"strings"
->>>>>>> fcc29a4b643a6035164be1290a2e7c9c9355b9a5
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel/attribute"
@@ -15,12 +12,9 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-<<<<<<< HEAD
 	"github.com/openfga/openfga/internal/graph"
-=======
 	"github.com/openfga/openfga/pkg/telemetry"
 
->>>>>>> fcc29a4b643a6035164be1290a2e7c9c9355b9a5
 	"github.com/openfga/openfga/pkg/server/commands/listusers"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/typesystem"

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -255,9 +255,6 @@ func TestListUsers_ErrorCases(t *testing.T) {
 	ctx := context.Background()
 	store := ulid.Make().String()
 
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-
 	t.Run("graph_resolution_errors", func(t *testing.T) {
 		s := MustNewServerWithOpts(
 			WithDatastore(memory.New()),

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	language "github.com/openfga/language/pkg/go/transformer"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	mockstorage "github.com/openfga/openfga/internal/mocks"
+	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/memory"
 	"github.com/openfga/openfga/pkg/testutils"
@@ -242,5 +244,72 @@ func TestExperimentalListUsers(t *testing.T) {
 
 		require.Error(t, err)
 		require.Equal(t, "rpc error: code = Code(2020) desc = No authorization models found for store ''", err.Error())
+	})
+}
+
+func TestListUsers_ErrorCases(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctx := context.Background()
+	store := ulid.Make().String()
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	t.Run("graph_resolution_errors", func(t *testing.T) {
+		s := MustNewServerWithOpts(
+			WithDatastore(memory.New()),
+			WithResolveNodeLimit(2),
+			WithExperimentals(ExperimentalEnableListUsers),
+		)
+		t.Cleanup(s.Close)
+
+		writeModelResp, err := s.WriteAuthorizationModel(ctx, &openfgav1.WriteAuthorizationModelRequest{
+			StoreId:       store,
+			SchemaVersion: typesystem.SchemaVersion1_1,
+			TypeDefinitions: language.MustTransformDSLToProto(`model
+  schema 1.1
+type user
+
+type group
+  relations
+	define member: [user, group#member]
+
+type document
+  relations
+	define viewer: [group#member]`).GetTypeDefinitions(),
+		})
+		require.NoError(t, err)
+
+		_, err = s.Write(ctx, &openfgav1.WriteRequest{
+			StoreId: store,
+			Writes: &openfgav1.WriteRequestWrites{
+				TupleKeys: []*openfgav1.TupleKey{
+					tuple.NewTupleKey("document:1", "viewer", "group:1#member"),
+					tuple.NewTupleKey("group:1", "member", "group:2#member"),
+					tuple.NewTupleKey("group:2", "member", "group:3#member"),
+					tuple.NewTupleKey("group:3", "member", "user:jon"),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		t.Run("resolution_depth_exceeded_error_unary", func(t *testing.T) {
+			res, err := s.ListUsers(ctx, &openfgav1.ListUsersRequest{
+				StoreId:              store,
+				AuthorizationModelId: writeModelResp.GetAuthorizationModelId(),
+				Relation:             "viewer",
+				Object: &openfgav1.Object{
+					Type: "document",
+					Id:   "1",
+				},
+				UserFilters: []*openfgav1.ListUsersFilter{{Type: "user"}},
+			})
+
+			require.Nil(t, res)
+			require.ErrorIs(t, err, serverErrors.AuthorizationModelResolutionTooComplex)
+		})
 	})
 }

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -163,8 +163,8 @@ func TestListUsersValidation(t *testing.T) {
 
 			s := MustNewServerWithOpts(
 				WithDatastore(ds),
+				WithExperimentals(ExperimentalEnableListUsers),
 			)
-			s.experimentals = []ExperimentalFeatureFlag{ExperimentalEnableListUsers}
 			t.Cleanup(s.Close)
 
 			ctx := typesystem.ContextWithTypesystem(context.Background(), typesys)
@@ -197,8 +197,8 @@ func TestModelIdNotFound(t *testing.T) {
 
 	server := MustNewServerWithOpts(
 		WithDatastore(mockDatastore),
+		WithExperimentals(ExperimentalEnableListUsers),
 	)
-	server.experimentals = []ExperimentalFeatureFlag{ExperimentalEnableListUsers}
 	t.Cleanup(server.Close)
 
 	resp, err := server.ListUsers(ctx, req)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -175,7 +175,7 @@ func WithTransport(t gateway.Transport) OpenFGAServiceV1Option {
 	}
 }
 
-// WithResolveNodeLimit sets a limit on the number of recursive calls that one Check or ListObjects call will allow.
+// WithResolveNodeLimit sets a limit on the number of recursive calls that one Check, ListObjects or ListUsers call will allow.
 // Thinking of a request as a tree of evaluations, this option controls
 // how many levels we will evaluate before throwing an error that the authorization model is too complex.
 func WithResolveNodeLimit(limit uint32) OpenFGAServiceV1Option {
@@ -185,7 +185,7 @@ func WithResolveNodeLimit(limit uint32) OpenFGAServiceV1Option {
 }
 
 // WithResolveNodeBreadthLimit sets a limit on the number of goroutines that can be created
-// when evaluating a subtree of a Check or ListObjects call.
+// when evaluating a subtree of a Check, ListObjects or ListUsers call.
 // Thinking of a Check request as a tree of evaluations, this option controls,
 // on a given level of the tree, the maximum number of nodes that can be evaluated concurrently (the breadth).
 // If your authorization models are very complex (e.g. one relation is a union of many relations, or one relation

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -70,6 +70,7 @@ func RunAllTests(t *testing.T, client ClientInterface) {
 			for _, test := range allTestCases {
 				test := test
 				runTest(t, test, client, false)
+				runTest(t, test, client, true)
 			}
 		})
 	})


### PR DESCRIPTION
## Description
This PR introduces depth limit protection that will prevent the recursive algorithm from exceeding a configured limit. This configuration is set on the server with the `resolveNodeLimit` property. This check uses a decrementing counter on the request object, as is in Check, and will emit the `ErrResolutionDepthExceeded` error. The main ListUsers method on the server will detect for that specific error and will response with the `AuthorizationModelResolutionTooComplex` error.

## References
Parent PR: #1428 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
