### PR TITLE
`ListUsers`: add tracing

### DIFF
--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -98,6 +98,7 @@ func (l *listUsersQuery) ListUsers(
 			return nil, err
 		}
 		if !hasPossibleEdges {
+			span.SetAttributes(attribute.Bool("no_possible_edges", true))
 			return &openfgav1.ListUsersResponse{
 				Users: []*openfgav1.User{},
 			}, nil
@@ -511,10 +512,9 @@ func (l *listUsersQuery) expandExclusion(
 		}
 	}
 
-	finalErr := errs
-	if finalErr != nil {
-		telemetry.TraceError(span, finalErr)
-		return finalErr
+	if errs != nil {
+		telemetry.TraceError(span, errs)
+		return errs
 	}
 	return nil
 }

--- a/pkg/server/commands/listusers/validate.go
+++ b/pkg/server/commands/listusers/validate.go
@@ -1,6 +1,7 @@
 package listusers
 
 import (
+	"context"
 	"errors"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -11,7 +12,9 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-func ValidateListUsersRequest(req *openfgav1.ListUsersRequest, typesys *typesystem.TypeSystem) error {
+func ValidateListUsersRequest(ctx context.Context, req *openfgav1.ListUsersRequest, typesys *typesystem.TypeSystem) error {
+	_, span := tracer.Start(ctx, "validateListUsersRequest")
+	defer span.End()
 	if err := validateContextualTuples(req, typesys); err != nil {
 		return err
 	}

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -2,10 +2,16 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/openfga/openfga/pkg/telemetry"
 
 	"github.com/openfga/openfga/pkg/server/commands/listusers"
 	"github.com/openfga/openfga/pkg/typesystem"
@@ -17,22 +23,47 @@ func (s *Server) ListUsers(
 	ctx context.Context,
 	req *openfgav1.ListUsersRequest,
 ) (*openfgav1.ListUsersResponse, error) {
+	ctx, span := tracer.Start(ctx, "ListUsers", trace.WithAttributes(
+		attribute.String("object", fmt.Sprintf("%s:%s", req.GetObject().GetType(), req.GetObject().GetId())),
+		attribute.String("relation", req.GetRelation()),
+		attribute.String("user_filters", UserFiltersToString(req.GetUserFilters())),
+	))
+	defer span.End()
 	if !s.IsExperimentallyEnabled(ExperimentalEnableListUsers) {
 		return nil, status.Error(codes.Unimplemented, "ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
 	}
 
 	typesys, err := s.resolveTypesystem(ctx, req.GetStoreId(), req.GetAuthorizationModelId())
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, err
 	}
 
-	err = listusers.ValidateListUsersRequest(req, typesys)
+	err = listusers.ValidateListUsersRequest(ctx, req, typesys)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, err
 	}
 
 	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 
-	listUsersQuery := listusers.NewListUsersQuery(s.datastore)
-	return listUsersQuery.ListUsers(ctx, req)
+	listUsersQuery := listusers.NewListUsersQuery(s.datastore,
+		listusers.WithListUsersQueryLogger(s.logger))
+	resp, err := listUsersQuery.ListUsers(ctx, req)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+	return resp, nil
+}
+
+func UserFiltersToString(filter []*openfgav1.ListUsersFilter) string {
+	var s strings.Builder
+	for _, f := range filter {
+		s.WriteString(f.GetType())
+		if f.GetRelation() != "" {
+			s.WriteString("#" + f.GetRelation())
+		}
+	}
+	return s.String()
 }

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -26,7 +26,7 @@ func (s *Server) ListUsers(
 	ctx, span := tracer.Start(ctx, "ListUsers", trace.WithAttributes(
 		attribute.String("object", fmt.Sprintf("%s:%s", req.GetObject().GetType(), req.GetObject().GetId())),
 		attribute.String("relation", req.GetRelation()),
-		attribute.String("user_filters", UserFiltersToString(req.GetUserFilters())),
+		attribute.String("user_filters", userFiltersToString(req.GetUserFilters())),
 	))
 	defer span.End()
 	if !s.IsExperimentallyEnabled(ExperimentalEnableListUsers) {
@@ -57,7 +57,7 @@ func (s *Server) ListUsers(
 	return resp, nil
 }
 
-func UserFiltersToString(filter []*openfgav1.ListUsersFilter) string {
+func userFiltersToString(filter []*openfgav1.ListUsersFilter) string {
 	var s strings.Builder
 	for _, f := range filter {
 		s.WriteString(f.GetType())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1156,6 +1156,7 @@ func (s *Server) resolveTypesystem(ctx context.Context, storeID, modelID string)
 
 	typesys, err := s.typesystemResolver(ctx, storeID, modelID)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		if errors.Is(err, typesystem.ErrModelNotFound) {
 			if modelID == "" {
 				return nil, serverErrors.LatestAuthorizationModelNotFound(storeID)


### PR DESCRIPTION
## Description
Add basic tracing around one ListUsers request. This will allow us to see where errors are coming from, and troubleshoot performance issues.

Note:

- This doesn't cover tracing around evaluation of conditions, we'll have to add this later.

## Testing

Happy path. See how relevant attributes are logged.

<img width="1919" alt="image" src="https://github.com/openfga/openfga/assets/5374887/16589f66-da0d-4b58-9043-6f429fe4e4cd">

Mocked error coming from DB propagates error up the call stack.

<img width="1919" alt="image" src="https://github.com/openfga/openfga/assets/5374887/095ac519-93a7-412b-bc9e-ec3122f69a5f">

