### PR TITLE
fix: CachedCheckResolver data race issues

### DIFF
--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -158,7 +158,8 @@ func (c *CachedCheckResolver) ResolveCheck(
 		checkCacheHitCounter.Inc()
 		span.SetAttributes(attribute.Bool("is_cached", true))
 
-		return cachedResp.Value(), nil
+		// return a copy to avoid races across goroutines
+		return CloneResolveCheckResponse(cachedResp.Value()), nil
 	}
 	span.SetAttributes(attribute.Bool("is_cached", false))
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Avoid a race by creating a copy of the ResolveCheckResponse returned from the CachedCheckResolver. Since ResolveCheck is called concurrently across multiple goroutines, if two subproblems share the same cached Check subproblem then we'll see a race on the resolution metadata accesses to things like `DatastoreQueryCount` etc.. This fixes that by avoiding a shared referenced when we return the cached ResolveCheckResponse.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
