### PR TITLE
test: add a test for race conditions stemming from CachedCheckResolver

### DIFF
--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -416,7 +416,7 @@ func TestResolveCheckFromCache(t *testing.T) {
 	}
 }
 
-func TestResolveCheck_ConcurrentCachedReads(t *testing.T) {
+func TestResolveCheck_ConcurrentCachedReadsAndWrites(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
 	})

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -411,6 +413,66 @@ func TestResolveCheckFromCache(t *testing.T) {
 			require.Equal(t, result.Allowed, actualResult.Allowed)
 			require.NoError(t, err)
 		})
+	}
+}
+
+func TestResolveCheck_ConcurrentCachedReads(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockCheckResolver := NewMockCheckResolver(ctrl)
+
+	dut := NewCachedCheckResolver(WithCacheTTL(10 * time.Second))
+	t.Cleanup(dut.Close)
+
+	dut.SetDelegate(mockCheckResolver)
+
+	mockCheckResolver.EXPECT().
+		ResolveCheck(gomock.Any(), gomock.Any()).
+		Return(&ResolveCheckResponse{
+			Allowed: true,
+			ResolutionMetadata: &ResolveCheckResponseMetadata{
+				DatastoreQueryCount: 1,
+				CycleDetected:       false,
+			},
+		}, nil)
+
+	_, err := dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
+	require.NoError(t, err)
+
+	// run multiple times to increase probability of ensuring we detect the race
+	for i := 0; i < 100; i++ {
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		var resp1, resp2 *ResolveCheckResponse
+		var err1, err2 error
+		go func() {
+			defer wg.Done()
+			resp1, err1 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
+			resp1.GetResolutionMetadata().DatastoreQueryCount = 0
+		}()
+
+		var datastoreQueryCount uint32
+		go func() {
+			defer wg.Done()
+			resp2, err2 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
+			datastoreQueryCount = resp2.GetResolutionMetadata().DatastoreQueryCount
+		}()
+
+		wg.Wait()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.NotNil(t, resp1)
+		require.NotNil(t, resp2)
+		require.Equal(t, uint32(0), datastoreQueryCount)
+		require.False(t, resp1.GetCycleDetected())
+		require.False(t, resp2.GetCycleDetected())
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add a unit test to verify that the `CachedCheckResolver` returns an immutable / copy of the cached `ResolveCheckResponse` instead of returning the original reference/pointer of the originally cached response.

## References
Code under test: https://github.com/openfga/openfga/pull/1541

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
