### PR TITLE
fix: race condition in ctx tag map set

### DIFF
--- a/internal/graph/dispatch_throttling_check_resolver.go
+++ b/internal/graph/dispatch_throttling_check_resolver.go
@@ -100,7 +100,9 @@ func (r *DispatchThrottlingCheckResolver) ResolveCheck(ctx context.Context,
 	currentNumDispatch := req.GetRequestMetadata().DispatchCounter.Load()
 
 	if currentNumDispatch > r.config.Threshold {
+		req.GetRequestMetadata().GrpcTagMutex.Lock()
 		grpc_ctxtags.Extract(ctx).Set(telemetry.Throttled, true)
+		req.GetRequestMetadata().GrpcTagMutex.Unlock()
 
 		start := time.Now()
 		<-r.throttlingQueue

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -56,6 +57,9 @@ type ResolveCheckRequestMetadata struct {
 	// The contents of this counter will be written by concurrent goroutines.
 	// After the root problem has been solved, this value can be read.
 	DispatchCounter *atomic.Uint32
+
+	// GrpcTagMutex protects grpc_ctxtags from being concurrently set by multiple threads
+	GrpcTagMutex sync.Mutex
 }
 
 func NewCheckRequestMetadata(maxDepth uint32) *ResolveCheckRequestMetadata {
@@ -63,6 +67,7 @@ func NewCheckRequestMetadata(maxDepth uint32) *ResolveCheckRequestMetadata {
 		Depth:               maxDepth,
 		DatastoreQueryCount: 0,
 		DispatchCounter:     new(atomic.Uint32),
+		GrpcTagMutex:        sync.Mutex{},
 	}
 }
 


### PR DESCRIPTION
## Description
Under high concurrent load and disptach throttling is enabled, server crash due to concurrent map write. 
Need to protect grpc_ctxtags.Extract(ctx).Set from concurrnet write race condition.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
