### PR TITLE
perf: don't create a span for EvaluateCondition if the tuple doesn't h…

### DIFF
--- a/internal/condition/eval/eval.go
+++ b/internal/condition/eval/eval.go
@@ -9,6 +9,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/openfga/openfga/internal/condition"
@@ -19,62 +20,64 @@ import (
 
 var tracer = otel.Tracer("openfga/internal/condition/eval")
 
-// EvaluateTupleCondition returns a bool indicating if the provided tupleKey's condition (if any) was met.
+// EvaluateTupleCondition looks at the given tuple's condition and returns an evaluation result for the given context.
+// If the tuple doesn't have a condition, it exits early and doesn't create a span.
+// If the tuple's condition isn't found in the model it returns an EvaluationError.
 func EvaluateTupleCondition(
 	ctx context.Context,
 	tupleKey *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
 	context *structpb.Struct,
 ) (*condition.EvaluationResult, error) {
-	ctx, span := tracer.Start(ctx, "EvaluateTupleCondition")
-	defer span.End()
-
-	span.SetAttributes(attribute.String("tuple_key", tupleKey.String()))
-
 	tupleCondition := tupleKey.GetCondition()
 	conditionName := tupleCondition.GetName()
-	if conditionName != "" {
-		start := time.Now()
-		span.SetAttributes(attribute.String("condition_name", conditionName))
-
-		evaluableCondition, ok := typesys.GetCondition(conditionName)
-		if !ok {
-			err := condition.NewEvaluationError(conditionName, fmt.Errorf("condition was not found"))
-			telemetry.TraceError(span, err)
-			return nil, err
-		}
-
-		span.SetAttributes(attribute.String("condition_expression", evaluableCondition.GetExpression()))
-
-		// merge both contexts
-		contextFields := []map[string]*structpb.Value{
-			{},
-		}
-		if context != nil {
-			contextFields = []map[string]*structpb.Value{context.GetFields()}
-		}
-
-		tupleContext := tupleCondition.GetContext()
-		if tupleContext != nil {
-			contextFields = append(contextFields, tupleContext.GetFields())
-		}
-
-		conditionResult, err := evaluableCondition.Evaluate(ctx, contextFields...)
-		if err != nil {
-			telemetry.TraceError(span, err)
-			return nil, err
-		}
-
-		metrics.Metrics.ObserveEvaluationDuration(time.Since(start))
-		metrics.Metrics.ObserveEvaluationCost(conditionResult.Cost)
-
-		span.SetAttributes(attribute.Bool("condition_met", conditionResult.ConditionMet))
-		span.SetAttributes(attribute.String("condition_cost", strconv.FormatUint(conditionResult.Cost, 10)))
-		span.SetAttributes(attribute.StringSlice("condition_missing_params", conditionResult.MissingParameters))
-		return &conditionResult, nil
+	if conditionName == "" {
+		return &condition.EvaluationResult{
+			ConditionMet: true,
+		}, nil
 	}
 
-	return &condition.EvaluationResult{
-		ConditionMet: true,
-	}, nil
+	ctx, span := tracer.Start(ctx, "EvaluateTupleCondition", trace.WithAttributes(
+		attribute.String("tuple_key", tupleKey.String()),
+		attribute.String("condition_name", conditionName)))
+	defer span.End()
+
+	start := time.Now()
+
+	evaluableCondition, ok := typesys.GetCondition(conditionName)
+	if !ok {
+		err := condition.NewEvaluationError(conditionName, fmt.Errorf("condition was not found"))
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+
+	span.SetAttributes(attribute.String("condition_expression", evaluableCondition.GetExpression()))
+
+	// merge both contexts
+	contextFields := []map[string]*structpb.Value{
+		{},
+	}
+	if context != nil {
+		contextFields = []map[string]*structpb.Value{context.GetFields()}
+	}
+
+	tupleContext := tupleCondition.GetContext()
+	if tupleContext != nil {
+		contextFields = append(contextFields, tupleContext.GetFields())
+	}
+
+	conditionResult, err := evaluableCondition.Evaluate(ctx, contextFields...)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+
+	metrics.Metrics.ObserveEvaluationDuration(time.Since(start))
+	metrics.Metrics.ObserveEvaluationCost(conditionResult.Cost)
+
+	span.SetAttributes(attribute.Bool("condition_met", conditionResult.ConditionMet),
+		attribute.String("condition_cost", strconv.FormatUint(conditionResult.Cost, 10)),
+		attribute.StringSlice("condition_missing_params", conditionResult.MissingParameters),
+	)
+	return &conditionResult, nil
 }


### PR DESCRIPTION
## Description
If the size of tuples is large, we will be creating lots of spans for `EvaluateTupleCondition` even if the model doesn't define any conditions. This is useless and inefficient.

In this PR I create a span only if the tuple has a condition defined.

## Testing

With this model:

```
model
  schema 1.1

type user

type group
  relations
    define member: [user]

type folder
  relations
    define viewer: [user]

type doc
  relations
    define viewer: viewer from parent
    define parent: [folder]
```

Before:
<img width="895" alt="image" src="https://github.com/openfga/openfga/assets/5374887/f2f85d4a-aa8e-4e98-9a2d-7fc210915e73">


After:
<img width="762" alt="image" src="https://github.com/openfga/openfga/assets/5374887/2ec49697-f3a9-4364-b73b-5240964046cc">

