### PR TITLE
fix: `ListUsers` race conditions

### DIFF
--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -342,7 +342,7 @@ func (l *listUsersQuery) expandDirect(
 
 	filteredIter := storage.NewFilteredTupleKeyIterator(
 		storage.NewTupleKeyIteratorFromTupleIterator(iter),
-		validation.FilterInvalidTuples(typesys), // ignore tuples that don't conform to the model
+		validation.FilterInvalidTuples(typesys),
 	)
 	defer filteredIter.Stop()
 
@@ -486,19 +486,19 @@ func (l *listUsersQuery) expandExclusion(
 	baseFoundUsersCh := make(chan *openfgav1.User, 1)
 	subtractFoundUsersCh := make(chan *openfgav1.User, 1)
 
-	var errsBase error
-	var errsSub error
+	var errBase error
+	var errSub error
 	go func() {
 		err := l.expandRewrite(ctx, req, rewrite.Difference.GetBase(), baseFoundUsersCh)
 		if err != nil {
-			errsBase = err
+			errBase = err
 		}
 		close(baseFoundUsersCh)
 	}()
 	go func() {
 		err := l.expandRewrite(ctx, req, rewrite.Difference.GetSubtract(), subtractFoundUsersCh)
 		if err != nil {
-			errsSub = err
+			errSub = err
 		}
 		close(subtractFoundUsersCh)
 	}()
@@ -526,9 +526,7 @@ func (l *listUsersQuery) expandExclusion(
 		}
 	}
 
-	var errs error
-	errs = errors.Join(errs, errsBase)
-	errs = errors.Join(errs, errsSub)
+	errs := errors.Join(errBase, errSub)
 	if errs != nil {
 		telemetry.TraceError(span, errs)
 		return errs

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -486,19 +486,18 @@ func (l *listUsersQuery) expandExclusion(
 	baseFoundUsersCh := make(chan *openfgav1.User, 1)
 	subtractFoundUsersCh := make(chan *openfgav1.User, 1)
 
-	var errBase error
-	var errSub error
+	var baseError, substractError error
 	go func() {
 		err := l.expandRewrite(ctx, req, rewrite.Difference.GetBase(), baseFoundUsersCh)
 		if err != nil {
-			errBase = err
+			baseError = err
 		}
 		close(baseFoundUsersCh)
 	}()
 	go func() {
 		err := l.expandRewrite(ctx, req, rewrite.Difference.GetSubtract(), subtractFoundUsersCh)
 		if err != nil {
-			errSub = err
+			substractError = err
 		}
 		close(subtractFoundUsersCh)
 	}()
@@ -526,7 +525,7 @@ func (l *listUsersQuery) expandExclusion(
 		}
 	}
 
-	errs := errors.Join(errBase, errSub)
+	errs := errors.Join(baseError, substractError)
 	if errs != nil {
 		telemetry.TraceError(span, errs)
 		return errs

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -1603,6 +1603,9 @@ func TestListUsersWildcards(t *testing.T) {
 }
 
 func TestListUsersEdgePruning(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	tests := ListUsersTests{
 		{
 			name: "valid_edges",
@@ -2080,6 +2083,9 @@ func TestListUsersCycleDetection(t *testing.T) {
 }
 
 func TestListUsersDepthExceeded(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 	model := `model
 	schema 1.1
 		type user
@@ -2158,6 +2164,71 @@ func TestListUsersDepthExceeded(t *testing.T) {
 	}
 
 	tests.runListUsersTestCases(t)
+}
+
+func TestListUsersStorageErrors(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+	testCases := map[string]struct {
+		req *openfgav1.ListUsersRequest
+	}{
+		`union`: {
+			req: &openfgav1.ListUsersRequest{
+				Object:      &openfgav1.Object{Type: "document", Id: "1"},
+				Relation:    "union",
+				UserFilters: []*openfgav1.ListUsersFilter{{Type: "user"}},
+			},
+		},
+		`exclusion`: {
+			req: &openfgav1.ListUsersRequest{
+				Object:      &openfgav1.Object{Type: "document", Id: "1"},
+				Relation:    "exclusion",
+				UserFilters: []*openfgav1.ListUsersFilter{{Type: "user"}},
+			},
+		},
+		`intersection`: {
+			req: &openfgav1.ListUsersRequest{
+				Object:      &openfgav1.Object{Type: "document", Id: "1"},
+				Relation:    "intersection",
+				UserFilters: []*openfgav1.ListUsersFilter{{Type: "user"}},
+			},
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mockController := gomock.NewController(t)
+			t.Cleanup(func() {
+				mockController.Finish()
+			})
+			mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+			mockDatastore.EXPECT().
+				Read(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, fmt.Errorf("storage err")).
+				Times(2) // each relation consists of two handlers
+
+			model := testutils.MustTransformDSLToProtoWithID(`
+			model
+				schema 1.1
+			type user
+			
+			type document
+				relations
+					define a: [user]
+					define b: [user]
+					define union: a or b
+					define exclusion: a but not b
+					define intersection: a and b`)
+			typesys := typesystem.New(model)
+
+			l := NewListUsersQuery(mockDatastore)
+
+			ctx := typesystem.ContextWithTypesystem(context.Background(), typesys)
+			resp, err := l.ListUsers(ctx, test.req)
+			require.Nil(t, resp)
+			require.ErrorContains(t, err, "storage err")
+		})
+	}
 }
 
 func (testCases ListUsersTests) runListUsersTestCases(t *testing.T) {


### PR DESCRIPTION
There is a race condition in ListUsers caused by two goroutines in `expandExclusion` trying to write to the same object. In this PR I fix it and add tests for the other cases (union and intersection) just in case.