### PR TITLE
feat: return HTTP code 422 if timeout due to throttling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240318145204-66b9e5cb403c
+	github.com/openfga/api/proto v0.0.0-20240418171136-0e805606b27a
 	github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d
 	github.com/pressly/goose/v3 v3.19.2
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf3phss=
 github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
-github.com/openfga/api/proto v0.0.0-20240318145204-66b9e5cb403c h1:2UmuAlvXoZGQRuZ4gzl0CQGLB+rSke2uo+OXlw9/1t8=
-github.com/openfga/api/proto v0.0.0-20240318145204-66b9e5cb403c/go.mod h1:5LtWOArDX4FlbcfDvBoJAzDEYJKLz/OEUoi+0S2tyM8=
+github.com/openfga/api/proto v0.0.0-20240418171136-0e805606b27a h1:Bo/q1RWR40WQ9ickZ7oGFYWbgc1qsgAHrPGrapcRr1k=
+github.com/openfga/api/proto v0.0.0-20240418171136-0e805606b27a/go.mod h1:5LtWOArDX4FlbcfDvBoJAzDEYJKLz/OEUoi+0S2tyM8=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d h1:n44DfITs+CLCYJIgsryJkG2ElwOZJ3huekPZKydPi7U=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d/go.mod h1:wkI4GcY3yNNuFMU2ncHPWqBaF7XylQTkJYfBi2pIpK8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -47,6 +47,7 @@ func clone(r *ResolveCheckRequest) *ResolveCheckRequest {
 			DispatchCounter:     r.GetRequestMetadata().DispatchCounter,
 			Depth:               r.GetRequestMetadata().Depth,
 			DatastoreQueryCount: r.GetRequestMetadata().DatastoreQueryCount,
+			HasThrottled:        r.GetRequestMetadata().HasThrottled,
 		},
 		VisitedPaths: maps.Clone(r.VisitedPaths),
 	}

--- a/internal/graph/dispatch_throttling_check_resolver_test.go
+++ b/internal/graph/dispatch_throttling_check_resolver_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
-
-	"github.com/openfga/openfga/pkg/telemetry"
 )
 
 func TestDispatchThrottlingCheckResolver(t *testing.T) {
@@ -53,7 +51,7 @@ func TestDispatchThrottlingCheckResolver(t *testing.T) {
 		_, err := dut.ResolveCheck(ctx, req)
 		require.NoError(t, err)
 		require.Equal(t, 1, resolveCheckDispatchedCounter)
-		require.False(t, grpc_ctxtags.Extract(ctx).Has(telemetry.Throttled))
+		require.False(t, req.GetRequestMetadata().HasThrottled.Load())
 	})
 
 	t.Run("above_threshold_should_be_throttled", func(t *testing.T) {
@@ -111,6 +109,6 @@ func TestDispatchThrottlingCheckResolver(t *testing.T) {
 		dut.nonBlockingSend(dut.throttlingQueue)
 		goFuncDone.Wait()
 		require.Equal(t, 1, resolveCheckDispatchedCounter)
-		require.True(t, grpc_ctxtags.Extract(ctx).Has(telemetry.Throttled))
+		require.False(t, req.GetRequestMetadata().HasThrottled.Load())
 	})
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -56,6 +56,9 @@ type ResolveCheckRequestMetadata struct {
 	// The contents of this counter will be written by concurrent goroutines.
 	// After the root problem has been solved, this value can be read.
 	DispatchCounter *atomic.Uint32
+
+	// HasThrottled indicates whether the request had been throttled
+	HasThrottled *atomic.Bool
 }
 
 func NewCheckRequestMetadata(maxDepth uint32) *ResolveCheckRequestMetadata {
@@ -63,6 +66,7 @@ func NewCheckRequestMetadata(maxDepth uint32) *ResolveCheckRequestMetadata {
 		Depth:               maxDepth,
 		DatastoreQueryCount: 0,
 		DispatchCounter:     new(atomic.Uint32),
+		HasThrottled:        new(atomic.Bool),
 	}
 }
 

--- a/pkg/middleware/timeout.go
+++ b/pkg/middleware/timeout.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	grpcvalidator "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/validator"
+	"google.golang.org/grpc"
+
+	"github.com/openfga/openfga/pkg/logger"
+)
+
+// TimeoutHandler sets the timeout in each request
+type TimeoutHandler struct {
+	timeout time.Duration
+	logger  logger.Logger
+}
+
+// NewTimeoutHandler returns new TimeoutHandler that timeouts request if it
+// exceeds the timeout value
+func NewTimeoutHandler(timeout time.Duration, logger logger.Logger) *TimeoutHandler {
+	return &TimeoutHandler{
+		timeout: timeout,
+		logger:  logger,
+	}
+}
+
+// NewUnaryTimeoutInterceptor configures the timeout expected in the http server side
+// We need to use this middleware instead of relying on runtime.DefaultContextTimeout to allow us
+// to return proper error code
+func (h *TimeoutHandler) NewUnaryTimeoutInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		ctx, cancel := context.WithTimeout(ctx, h.timeout)
+		defer cancel()
+		return handler(ctx, req)
+	}
+}
+
+// NewStreamTimeoutInterceptor configures the timeout expected in the http server side
+// We need to use this middleware instead of relying on runtime.DefaultContextTimeout to allow us
+// to return proper error code
+func (h *TimeoutHandler) NewStreamTimeoutInterceptor() grpc.StreamServerInterceptor {
+	validator := grpcvalidator.StreamServerInterceptor()
+	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {
+			ctx, cancel := context.WithTimeout(stream.Context(), h.timeout)
+			defer cancel()
+
+			return handler(srv, &recvWrapper{
+				ctx:          ctx,
+				ServerStream: ss,
+			})
+		})
+	}
+}
+
+type recvWrapper struct {
+	ctx context.Context
+	grpc.ServerStream
+}
+
+// Context returns the context associated with the recvWrapper.
+func (r *recvWrapper) Context() context.Context {
+	return r.ctx
+}

--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -13,6 +13,7 @@ import (
 const (
 	cFirstAuthenticationErrorCode  int32 = 1000
 	cFirstValidationErrorCode      int32 = 2000
+	cFirstThrottlingErrorCode      int32 = 3500
 	cFirstInternalErrorCode        int32 = 4000
 	cFirstUnknownEndpointErrorCode int32 = 5000
 )
@@ -97,10 +98,14 @@ func NewEncodedError(errorCode int32, message string) *EncodedError {
 		httpStatusCode = http.StatusUnauthorized
 		code = openfgav1.AuthErrorCode(errorCode).String()
 		grpcStatusCode = codes.Unauthenticated
-	} else if errorCode >= cFirstValidationErrorCode && errorCode < cFirstInternalErrorCode {
+	} else if errorCode >= cFirstValidationErrorCode && errorCode < cFirstThrottlingErrorCode {
 		httpStatusCode = http.StatusBadRequest
 		code = openfgav1.ErrorCode(errorCode).String()
 		grpcStatusCode = codes.InvalidArgument
+	} else if errorCode >= cFirstThrottlingErrorCode && errorCode < cFirstInternalErrorCode {
+		httpStatusCode = http.StatusUnprocessableEntity
+		code = openfgav1.ThrottledErrorCode(errorCode).String()
+		grpcStatusCode = codes.ResourceExhausted
 	} else if errorCode >= cFirstInternalErrorCode && errorCode < cFirstUnknownEndpointErrorCode {
 		httpStatusCode = http.StatusInternalServerError
 		code = openfgav1.InternalErrorCode(errorCode).String()

--- a/pkg/server/errors/encoded_errors_test.go
+++ b/pkg/server/errors/encoded_errors_test.go
@@ -101,6 +101,14 @@ func TestEncodedError(t *testing.T) {
 			expectedCodeString:     "validation_error",
 		},
 		{
+			_name:                  "throttle_error",
+			errorCode:              int32(openfgav1.ThrottledErrorCode_throttled_timeout_error),
+			message:                "error message",
+			expectedHTTPStatusCode: http.StatusUnprocessableEntity,
+			expectedCode:           3500,
+			expectedCodeString:     "throttled_timeout_error",
+		},
+		{
 			_name:                  "internal_error",
 			errorCode:              int32(openfgav1.InternalErrorCode_internal_error),
 			message:                "error message",

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -26,6 +26,7 @@ var (
 	MismatchObjectType                     = status.Error(codes.Code(openfgav1.ErrorCode_query_string_type_continuation_token_mismatch), "The type in the querystring and the continuation token don't match")
 	RequestCancelled                       = status.Error(codes.Code(openfgav1.InternalErrorCode_cancelled), "Request Cancelled")
 	RequestDeadlineExceeded                = status.Error(codes.Code(openfgav1.InternalErrorCode_deadline_exceeded), "Request Deadline Exceeded")
+	ThrottledTimeout                       = status.Error(codes.Code(openfgav1.ThrottledErrorCode_throttled_timeout_error), "Request Deadline Exceeded while throttled")
 )
 
 type InternalError struct {


### PR DESCRIPTION


## Description
Instead of return HTTP 500, return HTTP code 422 if check request timeouts due to throttling

## References
https://github.com/openfga/api/pull/151

## Note
DO NOT MERGE until https://github.com/openfga/api/pull/151 is merged (and go.sum/go.mod use the official reference)

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
