### PR TITLE
fix: stricter validation during ListObjects read of tuples

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -62,7 +62,7 @@ func ValidateTuple(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error
 			return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}
 		}
 
-		if err := ValidateCondition(typesys, tk); err != nil {
+		if err := validateCondition(typesys, tk); err != nil {
 			return err
 		}
 	}
@@ -176,8 +176,9 @@ func validateTypeRestrictions(typesys *typesystem.TypeSystem, tk *openfgav1.Tupl
 	return fmt.Errorf("type '%s' is not an allowed type restriction for '%s#%s'", userType, objectType, tk.GetRelation())
 }
 
-// ValidateCondition enforces conditions on a relationship tuple
-func ValidateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
+// validateCondition returns an error if the condition of the tuple is required but not present,
+// or if the tuple provides a condition but it is invalid according to the model.
+func validateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
 	objectType := tuple.GetType(tk.GetObject())
 	userType := tuple.GetType(tk.GetUser())
 	userRelation := tuple.GetRelation(tk.GetUser())
@@ -259,10 +260,7 @@ func ValidateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) e
 	return nil
 }
 
-// FilterInvalidTuples implements the TupleFilterFunc signature and can be used to provide
-// a generic filtering mechanism when reading tuples. It is particularly useful to filter
-// out tuples that aren't valid according to the provided model, which can help filter
-// tuples that were introduced due to another authorization model.
+// FilterInvalidTuples filters out tuples that aren't valid according to the provided model.
 func FilterInvalidTuples(typesys *typesystem.TypeSystem) storage.TupleKeyFilterFunc {
 	return func(tupleKey *openfgav1.TupleKey) bool {
 		err := ValidateTuple(typesys, tupleKey)

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -140,7 +140,7 @@ func TestListObjectsDispatchCount(t *testing.T) {
 				define member: [user, group#member]
 			`,
 			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:eng#member", "member", "group:fga#member"),
+				tuple.NewTupleKey("group:eng", "member", "group:fga#member"),
 				tuple.NewTupleKey("group:fga", "member", "user:jon"),
 			},
 			objectType:            "group",

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -474,9 +474,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 	// filter out invalid tuples yielded by the database iterator
 	filteredIter := storage.NewFilteredTupleKeyIterator(
 		storage.NewTupleKeyIteratorFromTupleIterator(iter),
-		func(tupleKey *openfgav1.TupleKey) bool {
-			return validation.ValidateCondition(c.typesystem, tupleKey) == nil
-		},
+		validation.FilterInvalidTuples(c.typesystem),
 	)
 	defer filteredIter.Stop()
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -356,3 +356,90 @@ type document
 		}
 	}
 }
+
+func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	store := ulid.Make().String()
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+		type user
+		type group
+			relations
+				define member: [user, group#member]`)
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+	gomock.InAnyOrder([]*gomock.Call{
+		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, storage.ReadStartingWithUserFilter{
+			ObjectType: "group",
+			Relation:   "member",
+			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:anne"}},
+		}).
+			Times(1).
+			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					{Key: tuple.NewTupleKey("group:fga", "member", "user:anne")},
+				}), nil
+			}),
+
+		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, storage.ReadStartingWithUserFilter{
+			ObjectType: "group",
+			Relation:   "member",
+			UserFilter: []*openfgav1.ObjectRelation{{Object: "group:fga", Relation: "member"}},
+		}).
+			Times(1).
+			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					// NOTE this tuple is invalid
+					{Key: tuple.NewTupleKey("group:eng#member", "member", "group:fga#member")},
+				}), nil
+			}),
+	},
+	)
+
+	ctx := context.Background()
+
+	resultChan := make(chan *ReverseExpandResult, 2)
+	errChan := make(chan error, 1)
+
+	go func() {
+		reverseExpandQuery := NewReverseExpandQuery(mockDatastore, typesystem.New(model))
+		err := reverseExpandQuery.Execute(ctx, &ReverseExpandRequest{
+			StoreID:          store,
+			ObjectType:       "group",
+			Relation:         "member",
+			User:             &UserRefObject{Object: &openfgav1.Object{Type: "user", Id: "anne"}},
+			ContextualTuples: []*openfgav1.TupleKey{},
+		}, resultChan, NewResolutionMetadata())
+
+		if err != nil {
+			errChan <- err
+		}
+	}()
+
+	var results []string
+
+	for {
+		select {
+		case res, open := <-resultChan:
+			if open {
+				results = append(results, res.Object)
+			} else {
+				require.ElementsMatch(t, []string{"group:fga"}, results)
+				return
+			}
+		case err := <-errChan:
+			require.FailNow(t, "unexpected error received on error channel :%v", err)
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Description
In ListObjects, when reading tuples, we should skip over all the invalid ones, and the definition of "invalid" can't just be "invalid condition".

## Testing

With this model

```
model
  schema 1.1

  type user

  type group
    relations
    define member: [user, group#member]
```

and these tuples

```
group:fga#member@user:maria
group:eng#member#member@group:fga#member // invalid
```

|                                                            | Before                              | After          |
|------------------------------------------------------------|-------------------------------------|----------------|
| ListObjects(type:group, relation:member, user: user:maria) | [ "group:fga", "group:eng#member" ] | ["group:fga" ] |