### PR TITLE
fix: prevent panic on server close if caching is enabled

### DIFF
--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -132,7 +132,6 @@ func (c *CachedCheckResolver) GetDelegate() CheckResolver {
 func (c *CachedCheckResolver) Close() {
 	if c.allocatedCache {
 		c.cache.Stop()
-		c.cache = nil
 	}
 }
 

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -656,6 +656,32 @@ type document
 	require.Equal(t, uint32(1), res.GetResolutionMetadata().DatastoreQueryCount)
 }
 
+func TestCachedCheckResolver_ResolveCheck_After_Stop_DoesNotPanic(t *testing.T) {
+	cachedCheckResolver := NewCachedCheckResolver(WithExistingCache(nil)) // create cache inside
+
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockCheckResolver := NewMockCheckResolver(mockCtrl)
+	cachedCheckResolver.SetDelegate(mockCheckResolver)
+
+	mockCheckResolver.EXPECT().
+		ResolveCheck(gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(&ResolveCheckResponse{
+			Allowed: false,
+			ResolutionMetadata: &ResolveCheckResponseMetadata{
+				DatastoreQueryCount: 1,
+				CycleDetected:       true,
+			},
+		}, nil)
+
+	cachedCheckResolver.Close()
+	resp, err := cachedCheckResolver.ResolveCheck(context.Background(), &ResolveCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), resp.GetResolutionMetadata().DatastoreQueryCount)
+}
+
 func TestCheckCacheKeyDoNotOverlap(t *testing.T) {
 	storeID := ulid.Make().String()
 	modelID := ulid.Make().String()


### PR DESCRIPTION
## Description

Detected this through local testing. Upon a server close, there may be in-flight Check requests still working.

```go
^C{"level":"info","ts":1713928093.823026,"msg":"Termination signal received! Gracefully shutting down","environment":"dev","region":"local","service_version":"latest"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x28 pc=0x105179a20]

goroutine 20624571 [running]:
github.com/karlseguin/ccache/v3.(*Cache[...]).bucket(0x15288d3b0b0, {0x152858ef698?, 0x12})
        /Users/maria.inesparnisari/go-mod-cache/github.com/karlseguin/ccache/v3@v3.0.5/cache.go:211 +0x80
github.com/karlseguin/ccache/v3.(*Cache[...]).Get(0x106f7dcc0, {0x152858ef698, 0x12})
        /Users/maria.inesparnisari/go-mod-cache/github.com/karlseguin/ccache/v3@v3.0.5/cache.go:107 +0x34
github.com/openfga/openfga/internal/graph.(*CachedCheckResolver).ResolveCheck(0x140004f2cc0, {0x106f39c38?, 0x15288d52ba0?}, 0x15288d49020)
        /Users/maria.inesparnisari/go-mod-cache/github.com/openfga/openfga@v1.5.3/internal/graph/cached_resolver.go:156 +0x518
github.com/openfga/openfga/internal/graph.(*CycleDetectionCheckResolver).ResolveCheck(0x140009e8170, {0x106f39c70?, 0x15288d3d3b0?}, 0x15288d48fc0)
        /Users/maria.inesparnisari/go-mod-cache/github.com/openfga/openfga@v1.5.3/internal/graph/cycle_check_resolver.go:56 +0x748
github.com/openfga/openfga/internal/graph.(*LocalChecker).dispatch.func1({0x106f39c70, 0x15288d3d3b0})
        /Users/maria.inesparnisari/go-mod-cache/github.com/openfga/openfga@v1.5.3/internal/graph/check.go:550 +0xfc
github.com/openfga/openfga/internal/graph.resolver.func1.2()
        /Users/maria.inesparnisari/go-mod-cache/github.com/openfga/openfga@v1.5.3/internal/graph/check.go:262 +0x38
created by github.com/openfga/openfga/internal/graph.resolver.func1 in goroutine 20624570
        /Users/maria.inesparnisari/go-mod-cache/github.com/openfga/openfga@v1.5.3/internal/graph/check.go:261 +0x118
make[1]: *** [run] Error 2
make: *** [run-no-auth] Interrupt: 2
```