### PR TITLE
refactor: replace hashicorp/go-multierror with errors.Join

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jon-whit/go-grpc-prometheus v1.4.0
@@ -77,6 +76,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hashicorp/go-multierror"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -729,7 +728,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			)
 			defer filteredIter.Stop()
 
-			var errs *multierror.Error
+			var errs error
 			var handlers []CheckHandlerFunc
 			for {
 				t, err := filteredIter.Next(ctx)
@@ -743,12 +742,12 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 				condEvalResult, err := eval.EvaluateTupleCondition(ctx, t, typesys, req.GetContext())
 				if err != nil {
-					errs = multierror.Append(errs, err)
+					errs = errors.Join(errs, err)
 					continue
 				}
 
 				if len(condEvalResult.MissingParameters) > 0 {
-					errs = multierror.Append(errs, condition.NewEvaluationError(
+					errs = errors.Join(errs, condition.NewEvaluationError(
 						t.GetCondition().GetName(),
 						fmt.Errorf("tuple '%s' is missing context parameters '%v'",
 							tuple.TupleKeyToString(t),
@@ -784,7 +783,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				}
 			}
 
-			if len(handlers) == 0 && errs.ErrorOrNil() != nil {
+			if len(handlers) == 0 && errs != nil {
 				telemetry.TraceError(span, errs)
 				return nil, errs
 			}
@@ -792,7 +791,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			resp, err := union(ctx, c.concurrencyLimit, handlers...)
 			if err != nil {
 				telemetry.TraceError(span, err)
-				return nil, multierror.Append(errs, err)
+				return nil, errors.Join(errs, err)
 			}
 
 			return resp, nil
@@ -899,7 +898,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		)
 		defer filteredIter.Stop()
 
-		var errs *multierror.Error
+		var errs error
 		var handlers []CheckHandlerFunc
 		for {
 			t, err := filteredIter.Next(ctx)
@@ -913,13 +912,13 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 
 			condEvalResult, err := eval.EvaluateTupleCondition(ctx, t, typesys, req.GetContext())
 			if err != nil {
-				errs = multierror.Append(errs, err)
+				errs = errors.Join(errs, err)
 
 				continue
 			}
 
 			if len(condEvalResult.MissingParameters) > 0 {
-				errs = multierror.Append(errs, condition.NewEvaluationError(
+				errs = errors.Join(errs, condition.NewEvaluationError(
 					t.GetCondition().GetName(),
 					fmt.Errorf("tuple '%s' is missing context parameters '%v'",
 						tuple.TupleKeyToString(t),
@@ -951,7 +950,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 			handlers = append(handlers, c.dispatch(ctx, req, tupleKey))
 		}
 
-		if len(handlers) == 0 && errs.ErrorOrNil() != nil {
+		if len(handlers) == 0 && errs != nil {
 			telemetry.TraceError(span, errs)
 			return nil, errs
 		}
@@ -959,7 +958,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		unionResponse, err := union(ctx, c.concurrencyLimit, handlers...)
 		if err != nil {
 			telemetry.TraceError(span, err)
-			return nil, multierror.Append(errs, err)
+			return nil, errors.Join(errs, err)
 		}
 
 		// if we had 3 dispatched requests, and the final result is "allowed = false",

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -340,10 +340,7 @@ LoopOnEdges:
 		}
 	}
 
-	err = pool.Wait()
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
+	errs = errors.Join(errs, pool.Wait())
 	if errs != nil {
 		telemetry.TraceError(span, errs)
 		return errs


### PR DESCRIPTION
## Description
in the latest versions of Go, specifically from Go 1.19 onwards, we can use the errors.Join function, which was added to the standard library. This function can replace all of the functionality of the 3rd party [hashicorp/go-multierror](https://github.com/openfga/openfga/issues/github.com/hashicorp/go-multierror) package.

## References
Closes https://github.com/openfga/openfga/issues/1556

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
