### PR TITLE
chore: add test helpers to bootstrap FGA stores and tuple strings

### DIFF
--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/pkg/server/commands/reverseexpand"
 	"github.com/openfga/openfga/pkg/storage"
-	"github.com/openfga/openfga/pkg/testutils"
+	storagetest "github.com/openfga/openfga/pkg/storage/test"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
@@ -22,7 +22,7 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 	tests := []struct {
 		name                 string
 		model                string
-		tuples               []*openfgav1.TupleKey
+		tuples               []string
 		request              *reverseexpand.ReverseExpandRequest
 		resolveNodeLimit     uint32
 		expectedResult       []*reverseexpand.ReverseExpandResult
@@ -43,18 +43,20 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 				},
 				ContextualTuples: []*openfgav1.TupleKey{},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type document
-  relations
-	define allowed: [user]
-	define viewer: [user] and allowed`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "user:jon"),
-				tuple.NewTupleKey("document:2", "viewer", "user:jon"),
-				tuple.NewTupleKey("document:3", "allowed", "user:jon"),
+			type user
+
+			type document
+			  relations
+			    define allowed: [user]
+			    define viewer: [user] and allowed`,
+			tuples: []string{
+				"document:1#viewer@user:jon",
+				"document:2#viewer@user:jon",
+				"document:3#allowed@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -82,24 +84,26 @@ type document
 				},
 				ContextualTuples: []*openfgav1.TupleKey{},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type folder
-  relations
-	define writer: [user]
-	define editor: [user]
-	define viewer: writer and editor
+			type user
 
-type document
-  relations
-	define parent: [folder]
-	define viewer: viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "parent", "folder:X"),
-				tuple.NewTupleKey("folder:X", "writer", "user:jon"),
-				tuple.NewTupleKey("folder:X", "editor", "user:jon"),
+			type folder
+			  relations
+			    define writer: [user]
+			    define editor: [user]
+			    define viewer: writer and editor
+
+			type document
+			  relations
+			    define parent: [folder]
+			    define viewer: viewer from parent`,
+			tuples: []string{
+				"document:1#parent@folder:X",
+				"folder:X#writer@user:jon",
+				"folder:X#editor@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -127,15 +131,17 @@ type document
 					tuple.NewTupleKey("document:doc3", "viewer", "user:jon"),
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type document
-  relations
-	define viewer: [user]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+			type user
+
+			type document
+			  relations
+			    define viewer: [user]`,
+			tuples: []string{
+				"document:doc1#viewer@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -160,22 +166,24 @@ type document
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user]
+			type user
 
-type document
-  relations
-	define viewer: [user, group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
-				tuple.NewTupleKey("document:doc2", "viewer", "user:bob"),
-				tuple.NewTupleKey("document:doc3", "viewer", "group:openfga#member"),
-				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			type group
+		  	  relations
+			    define member: [user]
+
+			type document
+			  relations
+			    define viewer: [user, group#member]`,
+			tuples: []string{
+				"document:doc1#viewer@user:jon",
+				"document:doc2#viewer@user:bob",
+				"document:doc3#viewer@group:openfga#member",
+				"group:openfga#member@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -200,23 +208,25 @@ type document
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user]
+			type user
 
-type document
-  relations
-	define owner: [user, group#member]
-	define viewer: owner`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:doc1", "owner", "user:jon"),
-				tuple.NewTupleKey("document:doc2", "owner", "user:bob"),
-				tuple.NewTupleKey("document:doc3", "owner", "group:openfga#member"),
-				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			type group
+			  relations
+			    define member: [user]
+
+			type document
+			  relations
+			    define owner: [user, group#member]
+			    define viewer: owner`,
+			tuples: []string{
+				"document:doc1#owner@user:jon",
+				"document:doc2#owner@user:bob",
+				"document:doc3#owner@group:openfga#member",
+				"group:openfga#member@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -247,35 +257,35 @@ type document
 					tuple.NewTupleKey("folder:folder6", "viewer", "user:bob"),
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user, group#member]
+			type user
 
-type folder
-  relations
-	define parent: [folder]
-	define viewer: [user, group#member] or viewer from parent
+			type group
+			  relations
+			    define member: [user, group#member]
 
-type document
-  relations
-	define parent: [folder]
-	define viewer: viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
-				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
-				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
-				tuple.NewTupleKey("folder:folder4", "viewer", "group:eng#member"),
+			type folder
+			  relations
+			    define parent: [folder]
+			    define viewer: [user, group#member] or viewer from parent
 
-				tuple.NewTupleKey("document:doc1", "parent", "folder:folder3"),
-				tuple.NewTupleKey("document:doc2", "parent", "folder:folder5"),
-				tuple.NewTupleKey("document:doc3", "parent", "folder:folder6"),
-
-				tuple.NewTupleKey("group:eng", "member", "group:openfga#member"),
-				tuple.NewTupleKey("group:openfga", "member", "user:jon"),
+			type document
+			  relations
+			    define parent: [folder]
+			    define viewer: viewer from parent`,
+			tuples: []string{
+				"folder:folder1#viewer@user:jon",
+				"folder:folder2#parent@folder:folder1",
+				"folder:folder3#parent@folder:folder2",
+				"folder:folder4#viewer@group:eng#member",
+				"document:doc1#parent@folder:folder3",
+				"document:doc2#parent@folder:folder5",
+				"document:doc3#parent@folder:folder6",
+				"group:eng#member@group:openfga#member",
+				"group:openfga#member@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -302,18 +312,20 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type folder
-  relations
-	define parent: [folder]
-	define viewer: [user] or viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
-				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
-				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
+			type user
+
+			type folder
+			  relations
+			    define parent: [folder]
+			    define viewer: [user] or viewer from parent`,
+			tuples: []string{
+				"folder:folder1#viewer@user:jon",
+				"folder:folder2#parent@folder:folder1",
+				"folder:folder3#parent@folder:folder2",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -345,18 +357,20 @@ type folder
 				},
 			},
 			resolveNodeLimit: 2,
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type folder
-  relations
-	define parent: [folder]
-	define viewer: [user] or viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("folder:folder1", "viewer", "user:jon"),
-				tuple.NewTupleKey("folder:folder2", "parent", "folder:folder1"),
-				tuple.NewTupleKey("folder:folder3", "parent", "folder:folder2"),
+			type user
+
+			type folder
+			  relations
+			    define parent: [folder]
+			    define viewer: [user] or viewer from parent`,
+			tuples: []string{
+				"folder:folder1#viewer@user:jon",
+				"folder:folder2#parent@folder:folder1",
+				"folder:folder3#parent@folder:folder2",
 			},
 			expectedError:        graph.ErrResolutionDepthExceeded,
 			expectedDSQueryCount: 0,
@@ -374,17 +388,19 @@ type folder
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user, group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:opensource", "member", "group:eng#member"),
-				tuple.NewTupleKey("group:eng", "member", "group:iam#member"),
-				tuple.NewTupleKey("group:iam", "member", "user:jon"),
+			type user
+
+			type group
+			  relations
+			    define member: [user, group#member]`,
+			tuples: []string{
+				"group:opensource#member@group:eng#member",
+				"group:eng#member@group:iam#member",
+				"group:iam#member@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -415,13 +431,15 @@ type group
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type group
-  relations
-	define member: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:iam", "member", "group:iam#member"),
+			model: `
+			model
+			  schema 1.1
+
+			type group
+			  relations
+			    define member: [group#member]`,
+			tuples: []string{
+				"group:iam#member@group:iam#member",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -444,18 +462,20 @@ type group
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type document
-  relations
-	define owner: [user]
-	define editor: owner
-	define viewer: [document#editor]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "document:1#editor"),
-				tuple.NewTupleKey("document:1", "owner", "user:jon"),
+			type user
+
+			type document
+			  relations
+			    define owner: [user]
+			    define editor: owner
+			    define viewer: [document#editor]`,
+			tuples: []string{
+				"document:1#viewer@document:1#editor",
+				"document:1#owner@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -478,21 +498,23 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define manager: [user]
-	define member: manager
+			  type user
 
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("group:eng", "manager", "user:jon"),
+			type group
+			  relations
+			    define manager: [user]
+			    define member: manager
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"document:1#viewer@group:eng#member",
+				"group:eng#manager@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -515,22 +537,24 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type team
-  relations
-	define admin: [user]
-	define member: admin
+			type user
 
-type trial
-  relations
-	define editor: [team#member]
-	define viewer: editor`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("trial:1", "editor", "team:devs#member"),
-				tuple.NewTupleKey("team:devs", "admin", "user:fede"),
+			type team
+			  relations
+			    define admin: [user]
+			    define member: admin
+
+			type trial
+			  relations
+			    define editor: [team#member]
+			    define viewer: editor`,
+			tuples: []string{
+				"trial:1#editor@team:devs#member",
+				"team:devs#admin@user:fede",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -553,20 +577,22 @@ type trial
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type organization
-  relations
-	define viewer: [organization]
-	define can_view: viewer
+			model: `
+			model
+			  schema 1.1
 
-type document
-  relations
-	define parent: [organization]
-	define view: can_view from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "parent", "organization:1"),
-				tuple.NewTupleKey("organization:1", "viewer", "organization:2"),
+			type organization
+			  relations
+			    define viewer: [organization]
+			    define can_view: viewer
+
+			type document
+			  relations
+			    define parent: [organization]
+			    define view: can_view from parent`,
+			tuples: []string{
+				"document:1#parent@organization:1",
+				"organization:1#viewer@organization:2",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -584,17 +610,19 @@ type document
 				Relation:   "viewer",
 				User:       &reverseexpand.UserRefTypedWildcard{Type: "user"},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type document
-  relations
-	define viewer: [user, user:*]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "user:*"),
-				tuple.NewTupleKey("document:2", "viewer", "user:*"),
-				tuple.NewTupleKey("document:3", "viewer", "user:jon"),
+			type user
+
+			type document
+			  relations
+			    define viewer: [user, user:*]`,
+			tuples: []string{
+				"document:1#viewer@user:*",
+				"document:2#viewer@user:*",
+				"document:3#viewer@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -616,19 +644,23 @@ type document
 				Relation:   "viewer",
 				User:       &reverseexpand.UserRefTypedWildcard{Type: "user"},
 			},
-			model: `model
-	schema 1.1
-type user
-type group
-  relations
-	define member: [user:*]
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
-				tuple.NewTupleKey("group:eng", "member", "user:*"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type group
+			  relations
+			    define member: [user:*]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"document:1#viewer@group:eng#member",
+				"document:2#viewer@group:fga#member",
+				"group:eng#member@user:*",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -651,22 +683,27 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type team
-  relations
-	define member: [user]
-type group
-  relations
-	define member: [team#member]
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("team:tigers", "member", "user:jon"),
-				tuple.NewTupleKey("group:eng", "member", "team:tigers#member"),
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type team
+			  relations
+			    define member: [user]
+
+			type group
+			  relations
+			    define member: [team#member]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"team:tigers#member@user:jon",
+				"group:eng#member@team:tigers#member",
+				"document:1#viewer@group:eng#member",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -689,22 +726,27 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type group
-  relations
-	define member: [team#member]
-type team
-  relations
-	define member: [user:*]
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("team:tigers", "member", "user:*"),
-				tuple.NewTupleKey("group:eng", "member", "team:tigers#member"),
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type group
+			  relations
+			    define member: [team#member]
+
+			type team
+			  relations
+			    define member: [user:*]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"team:tigers#member@user:*",
+				"group:eng#member@team:tigers#member",
+				"document:1#viewer@group:eng#member",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -724,15 +766,18 @@ type document
 					Object: &openfgav1.Object{Type: "user", Id: "jon"},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type document
-  relations
-	define viewer: [user, user:*]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "user:*"),
-				tuple.NewTupleKey("document:2", "viewer", "user:jon"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type document
+			  relations
+			    define viewer: [user, user:*]`,
+			tuples: []string{
+				"document:1#viewer@user:*",
+				"document:2#viewer@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -759,20 +804,24 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type group
-  relations
-	define member: [user, user:*]
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:eng", "member", "user:*"),
-				tuple.NewTupleKey("group:fga", "member", "user:jon"),
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type group
+			  relations
+			    define member: [user, user:*]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"group:eng#member@user:*",
+				"group:fga#member@user:jon",
+				"document:1#viewer@group:eng#member",
+				"document:2#viewer@group:fga#member",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -799,21 +848,25 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type group
-  relations
-	define member: [user:*]
-type document
-  relations
-	define viewer: [group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("group:eng", "member", "user:*"),
-				tuple.NewTupleKey("group:other", "member", "employee:*"), // assume this comes from a prior model
-				tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("document:2", "viewer", "group:fga#member"),
-				tuple.NewTupleKey("document:3", "viewer", "group:other#member"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type group
+			  relations
+			    define member: [user:*]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
+			tuples: []string{
+				"group:eng#member@user:*",
+				"group:other#member@employee:*", // assume this comes from a prior model
+				"document:1#viewer@group:eng#member",
+				"document:2#viewer@group:fga#member",
+				"document:3#viewer@group:other#member",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -836,18 +889,22 @@ type document
 					},
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type group
-  relations
-	define member: [user]
-type resource
-  relations
-	define reader: [user, user:*, group#member] or writer
-	define writer: [user, user:*, group#member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("resource:x", "writer", "user:*"),
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type group
+			  relations
+			    define member: [user]
+
+			type resource
+			  relations
+			    define reader: [user, user:*, group#member] or writer
+			    define writer: [user, user:*, group#member]`,
+			tuples: []string{
+				"resource:x#writer@user:*",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -871,12 +928,14 @@ type resource
 					tuple.NewTupleKey("document:2", "viewer", "user:jon"),
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type document
-  relations
-	define viewer: [user, user:*]`,
+			model: `
+			model
+			  schema 1.1
+
+			type user
+			type document
+			  relations
+			    define viewer: [user, user:*]`,
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
 					Object:       "document:1",
@@ -901,13 +960,17 @@ type document
 					tuple.NewTupleKey("document:2", "viewer", "user:*"),
 				},
 			},
-			model: `model
-	schema 1.1
-type user
-type employee
-type document
-  relations
-	define viewer: [user:*]`,
+			model: `
+			model
+			  schema 1.1
+
+			type user
+
+			type employee
+
+			type document
+			  relations
+			    define viewer: [user:*]`,
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
 					Object:       "document:2",
@@ -932,17 +995,19 @@ type document
 					tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 				},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user]
+			type user
 
-type document
-  relations
-	define viewer: [group#member]`,
+			type group
+			  relations
+			    define member: [user]
+
+			type document
+			  relations
+			    define viewer: [group#member]`,
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
 					Object:       "document:1",
@@ -962,23 +1027,25 @@ type document
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type folder
-  relations
-	define viewer: [user, user:*]
+			type user
 
-type document
-  relations
-	define parent: [folder]
-	define viewer: viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "parent", "folder:1"),
-				tuple.NewTupleKey("document:2", "parent", "folder:2"),
-				tuple.NewTupleKey("folder:1", "viewer", "user:jon"),
-				tuple.NewTupleKey("folder:2", "viewer", "user:*"),
+			type folder
+			  relations
+			    define viewer: [user, user:*]
+
+			type document
+			  relations
+			    define parent: [folder]
+			    define viewer: viewer from parent`,
+			tuples: []string{
+				"document:1#parent@folder:1",
+				"document:2#parent@folder:2",
+				"folder:1#viewer@user:jon",
+				"folder:2#viewer@user:*",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1003,24 +1070,26 @@ type document
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
-type employee
+			model: `
+			model
+			  schema 1.1
 
-type folder
-  relations
-	define viewer: [user, employee:*]
+			type user
+			type employee
 
-type document
-  relations
-	define parent: [folder]
-	define viewer: viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "parent", "folder:1"),
-				tuple.NewTupleKey("document:2", "parent", "folder:2"),
-				tuple.NewTupleKey("folder:1", "viewer", "user:jon"),
-				tuple.NewTupleKey("folder:2", "viewer", "user:*"),
+			type folder
+			  relations
+			    define viewer: [user, employee:*]
+
+			type document
+			  relations
+			    define parent: [folder]
+			    define viewer: viewer from parent`,
+			tuples: []string{
+				"document:1#parent@folder:1",
+				"document:2#parent@folder:2",
+				"folder:1#viewer@user:jon",
+				"folder:2#viewer@user:*",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1041,25 +1110,28 @@ type document
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user:*]
-type folder
-  relations
-	define viewer: [group#member]
+			type user
 
-type document
-  relations
-	define parent: [folder]
-	define viewer: viewer from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "parent", "folder:1"),
-				tuple.NewTupleKey("folder:1", "viewer", "group:eng#member"),
-				tuple.NewTupleKey("group:eng", "member", "user:*"),
+			type group
+			  relations
+			    define member: [user:*]
+
+			type folder
+			  relations
+			    define viewer: [group#member]
+
+			type document
+			  relations
+			    define parent: [folder]
+			    define viewer: viewer from parent`,
+			tuples: []string{
+				"document:1#parent@folder:1",
+				"folder:1#viewer@group:eng#member",
+				"group:eng#member@user:*",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1080,26 +1152,28 @@ type document
 					Id:   "anne",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type org
-  relations
-	define dept: [group]
-	define dept_member: member from dept
+			type user
 
-type group
-  relations
-	define member: [user]
+			type org
+			  relations
+			    define dept: [group]
+			    define dept_member: member from dept
 
-type resource
-  relations
-	define writer: [org#dept_member]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("resource:eng_handbook", "writer", "org:eng#dept_member"),
-				tuple.NewTupleKey("org:eng", "dept", "group:fga"),
-				tuple.NewTupleKey("group:fga", "member", "user:anne"),
+			type group
+			  relations
+			    define member: [user]
+
+			type resource
+			  relations
+			    define writer: [org#dept_member]`,
+			tuples: []string{
+				"resource:eng_handbook#writer@org:eng#dept_member",
+				"org:eng#dept@group:fga",
+				"group:fga#member@user:anne",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1120,27 +1194,29 @@ type resource
 					Id:   "anne",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type org
-  relations
-	define dept: [group]
-	define dept_member: member from dept
+			type user
 
-type group
-  relations
-	define member: [user]
+			type org
+			  relations
+			    define dept: [group]
+			    define dept_member: member from dept
 
-type resource
-  relations
-	define writer: [org#dept_member]
-	define reader: [org#dept_member] or writer`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("resource:eng_handbook", "writer", "org:eng#dept_member"),
-				tuple.NewTupleKey("org:eng", "dept", "group:fga"),
-				tuple.NewTupleKey("group:fga", "member", "user:anne"),
+			type group
+			  relations
+			    define member: [user]
+
+			type resource
+			  relations
+			    define writer: [org#dept_member]
+			    define reader: [org#dept_member] or writer`,
+			tuples: []string{
+				"resource:eng_handbook#writer@org:eng#dept_member",
+				"org:eng#dept@group:fga",
+				"group:fga#member@user:anne",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1161,16 +1237,18 @@ type resource
 					Id:   "wonder",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type node
-  relations
-	define parent: [node]
-	define editor: [user] or editor from parent`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("node:abc", "editor", "user:wonder"),
+			type user
+
+			type node
+			  relations
+			    define parent: [node]
+			    define editor: [user] or editor from parent`,
+			tuples: []string{
+				"node:abc#editor@user:wonder",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1191,22 +1269,24 @@ type node
 					Id:   "jon",
 				}},
 			},
-			model: `model
-	schema 1.1
-type user
+			model: `
+			model
+			  schema 1.1
 
-type group
-  relations
-	define member: [user]
-	define maintainer: [user]
+			type user
 
-type document
-  relations
-	define viewer: [group#member,group#maintainer]`,
-			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:1", "viewer", "group:example1#maintainer"),
-				tuple.NewTupleKey("group:example1", "maintainer", "user:jon"),
-				tuple.NewTupleKey("group:example1", "member", "user:jon"),
+			type group
+			  relations
+			    define member: [user]
+			    define maintainer: [user]
+
+			type document
+			  relations
+			    define viewer: [group#member,group#maintainer]`,
+			tuples: []string{
+				"document:1#viewer@group:example1#maintainer",
+				"group:example1#maintainer@user:jon",
+				"group:example1#member@user:jon",
 			},
 			expectedResult: []*reverseexpand.ReverseExpandResult{
 				{
@@ -1220,16 +1300,8 @@ type document
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
-			store := ulid.Make().String()
-			test.request.StoreID = store
-
-			model := testutils.MustTransformDSLToProtoWithID(test.model)
-			err := ds.WriteAuthorizationModel(ctx, store, model)
-			require.NoError(t, err)
-
-			err = ds.Write(ctx, store, nil, test.tuples)
-			require.NoError(t, err)
+			storeID, model := storagetest.BootstrapFGAStore(t, ds, test.model, test.tuples)
+			test.request.StoreID = storeID
 
 			var opts []reverseexpand.ReverseExpandQueryOption
 

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -5,10 +5,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/protoadapt"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/openfga/openfga/pkg/tuple"
 
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
@@ -52,4 +55,32 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 
 	// Stores.
 	t.Run("TestStore", func(t *testing.T) { StoreTest(t, ds) })
+}
+
+// BootstrapFGAStore is a utility to write an FGA model and relationship tuples to a datastore.
+// It doesn't validate the model. It validates the format of the tuples, but not the types within them.
+// It returns the store_id and FGA AuthorizationModel, respectively.
+func BootstrapFGAStore(
+	t require.TestingT,
+	ds storage.OpenFGADatastore,
+	model string,
+	tupleStrs []string,
+) (string, *openfgav1.AuthorizationModel) {
+	storeID := ulid.Make().String()
+
+	fgaModel := testutils.MustTransformDSLToProtoWithID(model)
+	err := ds.WriteAuthorizationModel(context.Background(), storeID, fgaModel)
+	require.NoError(t, err)
+
+	tuples := tuple.MustParseTupleStrings(tupleStrs...)
+
+	batchSize := ds.MaxTuplesPerWrite()
+	for batch := 0; batch < len(tuples); batch += batchSize {
+		batchEnd := min(batch+batchSize, len(tuples))
+
+		err := ds.Write(context.Background(), storeID, nil, tuples[batch:batchEnd])
+		require.NoError(t, err)
+	}
+
+	return storeID, fgaModel
 }

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -366,3 +366,80 @@ func TestTypedPublicWildcard(t *testing.T) {
 	require.Equal(t, "group:*", TypedPublicWildcard("group"))
 	require.Equal(t, ":*", TypedPublicWildcard("")) // Does not panic
 }
+
+func TestParseTupleString(t *testing.T) {
+	tests := []struct {
+		name        string
+		str         string
+		tuple       *openfgav1.TupleKey
+		expectedErr bool
+	}{
+		{
+			name:  "well_formed_user_object",
+			str:   "document:1#viewer@user:jon",
+			tuple: NewTupleKey("document:1", "viewer", "user:jon"),
+		},
+		{
+			name:  "well_formed_user_userset",
+			str:   "document:1#viewer@group:eng#member",
+			tuple: NewTupleKey("document:1", "viewer", "group:eng#member"),
+		},
+		{
+			name:  "well_formed_user_wildcard",
+			str:   "document:1#viewer@user:*",
+			tuple: NewTupleKey("document:1", "viewer", "user:*"),
+		},
+		{
+			name:        "missing_user_field",
+			str:         "document:1#viewer",
+			expectedErr: true,
+		},
+		{
+			name:        "missing_relation_separator",
+			str:         "document:1viewer@user:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "missing_object_id",
+			str:         "document#viewer@user:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "malformed_object_type",
+			str:         "docu#ment:1#viewer@user:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "malformed_object_id",
+			str:         "document:#1#viewer@user:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "malformed_relation",
+			str:         "document:1#vie:wer@user:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "malformed_user_type",
+			str:         "document:1#viewer@use#r:jon",
+			expectedErr: true,
+		},
+		{
+			name:        "malformed_user_userset",
+			str:         "document:1#viewer@group:e:eng#member",
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tuple, err := ParseTupleString(test.str)
+			require.Equal(t, test.expectedErr, err != nil)
+
+			if !test.expectedErr {
+				require.NotNil(t, tuple)
+				require.Equal(t, test.tuple, tuple)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add some test helpers to bootstrap FGA store data (model and tuples) and encourage usage of tuple strings instead of having touse `tuple.NewTupleKey` everywhere.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
