### PR TITLE
fix: ListUsers config related to deadline settings

### DIFF
--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -277,31 +277,25 @@ type Config struct {
 }
 
 func (cfg *Config) Verify() error {
-	if cfg.ListObjectsDeadline > cfg.HTTP.UpstreamTimeout {
+	configuredTimeout := DefaultContextTimeout(cfg)
+
+	if cfg.ListObjectsDeadline > configuredTimeout {
 		return fmt.Errorf(
-			"config 'http.upstreamTimeout' (%s) cannot be lower than 'listObjectsDeadline' config (%s)",
-			cfg.HTTP.UpstreamTimeout,
+			"configured request timeout (%s) cannot be lower than 'listObjectsDeadline' config (%s)",
+			configuredTimeout,
 			cfg.ListObjectsDeadline,
 		)
 	}
-	if cfg.ListUsersDeadline > cfg.HTTP.UpstreamTimeout {
+	if cfg.ListUsersDeadline > configuredTimeout {
 		return fmt.Errorf(
-			"config 'http.upstreamTimeout' (%s) cannot be lower than 'listUsersDeadline' config (%s)",
-			cfg.HTTP.UpstreamTimeout,
+			"configured request timeout (%s) cannot be lower than 'listUsersDeadline' config (%s)",
+			configuredTimeout,
 			cfg.ListUsersDeadline,
 		)
 	}
 
 	if cfg.MaxConcurrentReadsForListUsers == 0 {
 		return fmt.Errorf("config 'maxConcurrentReadsForListUsers' cannot be 0")
-	}
-
-	if cfg.RequestTimeout > 0 && cfg.ListObjectsDeadline > cfg.RequestTimeout {
-		return fmt.Errorf(
-			"config 'requestTimeout' (%s) cannot be lower than 'listObjectsDeadline' config (%s)",
-			cfg.RequestTimeout,
-			cfg.ListObjectsDeadline,
-		)
 	}
 
 	if cfg.Log.Format != "text" && cfg.Log.Format != "json" {

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -11,19 +11,21 @@ func TestVerifyConfig(t *testing.T) {
 	t.Run("UpstreamTimeout_cannot_be_less_than_ListObjectsDeadline", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.ListObjectsDeadline = 5 * time.Minute
+		cfg.RequestTimeout = 0
 		cfg.HTTP.UpstreamTimeout = 2 * time.Second
 
 		err := cfg.Verify()
-		require.EqualError(t, err, "config 'http.upstreamTimeout' (2s) cannot be lower than 'listObjectsDeadline' config (5m0s)")
+		require.EqualError(t, err, "configured request timeout (2s) cannot be lower than 'listObjectsDeadline' config (5m0s)")
 	})
 	t.Run("UpstreamTimeout_cannot_be_less_than_ListUsersDeadline", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.ListObjectsDeadline = 2 * time.Second
 		cfg.ListUsersDeadline = 5 * time.Minute
+		cfg.RequestTimeout = 0
 		cfg.HTTP.UpstreamTimeout = 2 * time.Second
 
 		err := cfg.Verify()
-		require.EqualError(t, err, "config 'http.upstreamTimeout' (2s) cannot be lower than 'listUsersDeadline' config (5m0s)")
+		require.EqualError(t, err, "configured request timeout (2s) cannot be lower than 'listUsersDeadline' config (5m0s)")
 	})
 
 	t.Run("maxConcurrentReadsForListUsers_not_zero", func(t *testing.T) {
@@ -218,7 +220,7 @@ func TestVerifyConfig(t *testing.T) {
 
 	t.Run("list_objects_deadline_request_timeout", func(t *testing.T) {
 		cfg := DefaultConfig()
-		cfg.RequestTimeout = 1 * time.Second
+		cfg.RequestTimeout = 500 * time.Millisecond
 		cfg.ListObjectsDeadline = 4 * time.Second
 
 		err := cfg.Verify()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR ensures that the ListUsers deadline is not lager than the configured request timeout.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
