### PR TITLE
perf: reduce spans in check api

### DIFF
--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -139,13 +139,8 @@ func (c *CachedCheckResolver) ResolveCheck(
 	ctx context.Context,
 	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "ResolveCheck", trace.WithAttributes(
-		attribute.String("store_id", req.GetStoreID()),
-		attribute.String("resolver_type", "CachedCheckResolver"),
-		attribute.String("tuple_key", req.GetTupleKey().String()),
-		attribute.Bool("is_cached", false),
-	))
-	defer span.End()
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Bool("is_cached", false))
 
 	checkCacheTotalCounter.Inc()
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -878,8 +878,10 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		tk := req.GetTupleKey()
 		object := tk.GetObject()
 
-		span.SetAttributes(attribute.String("tupleset_relation", fmt.Sprintf("%s#%s", tuple.GetType(object), tuplesetRelation)))
-		span.SetAttributes(attribute.String("computed_relation", computedRelation))
+		span.SetAttributes(
+			attribute.String("tupleset_relation", fmt.Sprintf("%s#%s", tuple.GetType(object), tuplesetRelation)),
+			attribute.String("computed_relation", computedRelation),
+		)
 
 		iter, err := ds.Read(
 			ctx,

--- a/internal/graph/cycle_check_resolver.go
+++ b/internal/graph/cycle_check_resolver.go
@@ -31,7 +31,6 @@ func (c *CycleDetectionCheckResolver) ResolveCheck(
 	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.Bool("cycle_detected", false))
 
 	key := tuple.TupleKeyToString(req.GetTupleKey())
 
@@ -40,8 +39,8 @@ func (c *CycleDetectionCheckResolver) ResolveCheck(
 	}
 
 	_, cycleDetected := req.VisitedPaths[key]
+	span.SetAttributes(attribute.Bool("cycle_detected", cycleDetected))
 	if cycleDetected {
-		span.SetAttributes(attribute.Bool("cycle_detected", true))
 		return &ResolveCheckResponse{
 			Allowed: false,
 			ResolutionMetadata: &ResolveCheckResponseMetadata{

--- a/internal/graph/cycle_check_resolver.go
+++ b/internal/graph/cycle_check_resolver.go
@@ -30,13 +30,8 @@ func (c *CycleDetectionCheckResolver) ResolveCheck(
 	ctx context.Context,
 	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "ResolveCheck", trace.WithAttributes(
-		attribute.String("store_id", req.GetStoreID()),
-		attribute.String("resolver_type", "CycleDetectionCheckResolver"),
-		attribute.String("tuple_key", req.GetTupleKey().String()),
-		attribute.Bool("cycle_detected", false),
-	))
-	defer span.End()
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attribute.Bool("cycle_detected", false))
 
 	key := tuple.TupleKeyToString(req.GetTupleKey())
 

--- a/internal/graph/dispatch_throttling_check_resolver.go
+++ b/internal/graph/dispatch_throttling_check_resolver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/pkg/telemetry"
@@ -98,9 +99,7 @@ func (r *DispatchThrottlingCheckResolver) runTicker() {
 func (r *DispatchThrottlingCheckResolver) ResolveCheck(ctx context.Context,
 	req *ResolveCheckRequest,
 ) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "ResolveCheck")
-	defer span.End()
-	span.SetAttributes(attribute.String("resolver_type", "DispatchThrottlingCheckResolver"))
+	span := trace.SpanFromContext(ctx)
 
 	currentNumDispatch := req.GetRequestMetadata().DispatchCounter.Load()
 	span.SetAttributes(attribute.Int("dispatch_count", int(currentNumDispatch)))


### PR DESCRIPTION
## Description
Prefer trace attributes over spans to reduce number of spans created.

## Demo

<img width="1917" alt="image" src="https://github.com/openfga/openfga/assets/5374887/f250d895-cae1-4ea7-bf91-6eaa45005620">

