### PR TITLE
feat(list-users): ListUsers with Excluded Users

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -6517,7 +6517,9 @@ tests:
               object: document:1
               relation: can_view
             expectation:
-              - user:* # TODO but user:bob doesn't have access
+              - user:*
+            expectedExcludedUsers:
+              - user:bob
           - request:
               filters:
                 - user

--- a/internal/test/listusers/listusers.go
+++ b/internal/test/listusers/listusers.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Assertion struct {
-	Request          *TestListUsersRequest
-	ContextualTuples []*openfgav1.TupleKey `json:"contextualTuples"`
-	Context          *structpb.Struct
-	Expectation      []string
-	ErrorCode        int `json:"errorCode"` // If ErrorCode is non-zero then we expect that the ListUsers call failed.
+	Request               *TestListUsersRequest
+	ContextualTuples      []*openfgav1.TupleKey `json:"contextualTuples"`
+	Context               *structpb.Struct
+	Expectation           []string
+	ExpectedExcludedUsers []string
+	ErrorCode             int `json:"errorCode"` // If ErrorCode is non-zero then we expect that the ListUsers call failed.
 }
 
 type TestListUsersRequest struct {
@@ -28,10 +29,18 @@ func (t *TestListUsersRequest) ToString() string {
 	return fmt.Sprintf("object=%s, relation=%s, filters=%v", t.Object, t.Relation, strings.Join(t.Filters, ", "))
 }
 
-func FromProtoResponse(r *openfgav1.ListUsersResponse) []string {
+func FromUsersProto(r []*openfgav1.User) []string {
 	var users []string
-	for _, user := range r.GetUsers() {
+	for _, user := range r {
 		users = append(users, tuple.UserProtoToString(user))
+	}
+	return users
+}
+
+func FromObjectOrUsersetProto(r []*openfgav1.ObjectOrUserset) []string {
+	var users []string
+	for _, user := range r {
+		users = append(users, tuple.FromObjectOrUsersetProto(user))
 	}
 	return users
 }

--- a/pkg/server/commands/listusers/list_users.go
+++ b/pkg/server/commands/listusers/list_users.go
@@ -95,8 +95,9 @@ func (r *internalListUsersRequest) GetContext() *structpb.Struct {
 }
 
 type listUsersResponse struct {
-	Users    []*openfgav1.User
-	Metadata listUsersResponseMetadata
+	Users         []*openfgav1.User
+	ExcludedUsers []*openfgav1.ObjectOrUserset
+	Metadata      listUsersResponseMetadata
 }
 
 type listUsersResponseMetadata struct {
@@ -108,6 +109,13 @@ func (r *listUsersResponse) GetUsers() []*openfgav1.User {
 		return []*openfgav1.User{}
 	}
 	return r.Users
+}
+
+func (r *listUsersResponse) GetExcludedUsers() []*openfgav1.ObjectOrUserset {
+	if r == nil {
+		return []*openfgav1.ObjectOrUserset{}
+	}
+	return r.ExcludedUsers
 }
 
 func (r *listUsersResponse) GetMetadata() listUsersResponseMetadata {

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -157,7 +157,8 @@ func (l *listUsersQuery) ListUsers(
 		if !hasPossibleEdges {
 			span.SetAttributes(attribute.Bool("no_possible_edges", true))
 			return &listUsersResponse{
-				Users: []*openfgav1.User{},
+				Users:         []*openfgav1.User{},
+				ExcludedUsers: []*openfgav1.ObjectOrUserset{},
 				Metadata: listUsersResponseMetadata{
 					DatastoreQueryCount: 0,
 				},

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -92,7 +92,8 @@ func (s *Server) ListUsers(
 	).Observe(datastoreQueryCount)
 
 	return &openfgav1.ListUsersResponse{
-		Users: resp.GetUsers(),
+		Users:         resp.GetUsers(),
+		ExcludedUsers: resp.GetExcludedUsers(),
 	}, nil
 }
 

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -198,6 +198,43 @@ func StringToUserProto(userKey UserString) *openfgav1.User {
 	}}}
 }
 
+// FromObjectOrUsersetProto returns a string from a ObjectOrUserset proto. Ex: 'user:maria' or 'group:fga#member'. It is
+// the opposite from StringToObjectOrUserset function.
+func FromObjectOrUsersetProto(obj *openfgav1.ObjectOrUserset) UserString {
+	switch obj.GetUser().(type) {
+	case *openfgav1.ObjectOrUserset_Userset:
+		us := obj.GetUser().(*openfgav1.ObjectOrUserset_Userset)
+		return fmt.Sprintf("%s:%s#%s", us.Userset.GetType(), us.Userset.GetId(), us.Userset.GetRelation())
+	case *openfgav1.ObjectOrUserset_Object:
+		us := obj.GetUser().(*openfgav1.ObjectOrUserset_Object)
+		return fmt.Sprintf("%s:%s", us.Object.GetType(), us.Object.GetId())
+	default:
+		panic("unsupported type")
+	}
+}
+
+// StringToObjectOrUserset returns a ObjectOrUserset proto from a string. Ex: 'user:maria#member'.
+// It is the opposite from FromObjectOrUsersetProto function.
+func StringToObjectOrUserset(userKey UserString) *openfgav1.ObjectOrUserset {
+	userObj, userRel := SplitObjectRelation(userKey)
+	userObjType, userObjID := SplitObject(userObj)
+	if userRel == "" {
+		return &openfgav1.ObjectOrUserset{User: &openfgav1.ObjectOrUserset_Object{
+			Object: &openfgav1.Object{
+				Type: userObjType,
+				Id:   userObjID,
+			},
+		}}
+	}
+	return &openfgav1.ObjectOrUserset{User: &openfgav1.ObjectOrUserset_Userset{
+		Userset: &openfgav1.UsersetUser{
+			Type:     userObjType,
+			Id:       userObjID,
+			Relation: userRel,
+		},
+	}}
+}
+
 // SplitObject splits an object into an objectType and an objectID. If no type is present, it returns the empty string
 // and the original object.
 func SplitObject(object string) (string, string) {

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -213,7 +213,7 @@ func FromObjectOrUsersetProto(obj *openfgav1.ObjectOrUserset) UserString {
 	}
 }
 
-// StringToObjectOrUserset returns a ObjectOrUserset proto from a string. Ex: 'user:maria#member'.
+// StringToObjectOrUserset returns a ObjectOrUserset proto from a string. Ex: 'group:fga#member'.
 // It is the opposite from FromObjectOrUsersetProto function.
 func StringToObjectOrUserset(userKey UserString) *openfgav1.ObjectOrUserset {
 	userObj, userRel := SplitObjectRelation(userKey)

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -463,6 +463,86 @@ func TestToUserProto(t *testing.T) {
 	}
 }
 
+func TestFromObjectOrUsersetProto(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    *openfgav1.ObjectOrUserset
+		expected string
+	}{
+		{
+			name: "user_with_id",
+			input: &openfgav1.ObjectOrUserset{
+				User: &openfgav1.ObjectOrUserset_Object{
+					Object: &openfgav1.Object{
+						Type: "user",
+						Id:   "id-123",
+					},
+				},
+			},
+			expected: "user:id-123",
+		},
+		{
+			name: "user_with_id_and_relation",
+			input: &openfgav1.ObjectOrUserset{
+				User: &openfgav1.ObjectOrUserset_Userset{
+					Userset: &openfgav1.UsersetUser{
+						Type:     "user",
+						Id:       "id-123",
+						Relation: "member",
+					},
+				},
+			},
+			expected: "user:id-123#member",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual := FromObjectOrUsersetProto(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestToObjectOrUsersetProto(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected *openfgav1.ObjectOrUserset
+	}{
+		{
+			name:  "user_with_id",
+			input: "user:id-123",
+			expected: &openfgav1.ObjectOrUserset{
+				User: &openfgav1.ObjectOrUserset_Object{
+					Object: &openfgav1.Object{
+						Type: "user",
+						Id:   "id-123",
+					},
+				},
+			},
+		},
+		{
+			name:  "user_with_id_and_relation",
+			input: "user:id-123#member",
+			expected: &openfgav1.ObjectOrUserset{
+				User: &openfgav1.ObjectOrUserset_Userset{
+					Userset: &openfgav1.UsersetUser{
+						Type:     "user",
+						Id:       "id-123",
+						Relation: "member",
+					},
+				},
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual := StringToObjectOrUserset(tc.input)
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
 func TestTypedPublicWildcard(t *testing.T) {
 	require.Equal(t, "user:*", TypedPublicWildcard("user"))
 	require.Equal(t, "group:*", TypedPublicWildcard("group"))

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -170,7 +170,8 @@ func runTest(t *testing.T, test individualTest, client ClientInterface, contextT
 
 						if assertion.ErrorCode == 0 {
 							require.NoError(t, err, detailedInfo)
-							require.ElementsMatch(t, assertion.Expectation, listuserstest.FromProtoResponse(resp), detailedInfo)
+							require.ElementsMatch(t, assertion.Expectation, listuserstest.FromUsersProto(resp.GetUsers()), detailedInfo)
+							require.ElementsMatch(t, assertion.ExpectedExcludedUsers, listuserstest.FromObjectOrUsersetProto(resp.GetExcludedUsers()), detailedInfo)
 
 							// assert 2: each user in the response of ListUsers should return check -> true
 							for _, user := range resp.GetUsers() {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR introduces the concept of negation "differences" which represent the list of users that do not apply to a negation clause. This occurs in models that have chained negation where the intermediate negation includes a public typed wildcard. 

**Example:**
```
model
	schema 1.1
type user
type document
	relations
		define viewer: [user, user:*] but not blocked
		define blocked: [user, user:*] but not unblocked
		define unblocked: [user, user:*]
```
```
"document:1", "viewer", "user:jon"
"document:1", "blocked", "user:*"
"document:1", "unblocked", "user:jon"
```

In this example, the "unblocked" status of `user:jon` was being lost when evaluating the outer negation because the exclusion to the negation was not being communicated. This is considered an "**excluded user**". The solution here is to keep track of the excluded users so that the outer negation context can un-exclude the proper subjects. We also return the excluded users along with the response for the client to handle appropriately. See: https://github.com/openfga/api/pull/144/files#diff-d3a74ea9ecaac0a46611253dc0c4bc9c402e2ad9eb255cd41d07266453e258f0R864


## References
Related API PR: https://github.com/openfga/api/pull/144/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
