### PR TITLE
fix: Exclude mock_check_resolver from code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test: generate-mocks ## Run all tests. To run a specific test, pass the FILTER v
 			-count=1 \
 			-timeout=10m \
 			${GO_PACKAGES}
-	@cat coverageunit.tmp.out | grep -v "mocks" > coverageunit.out
+	@cat coverageunit.tmp.out | grep -v "mock" > coverageunit.out
 	@rm coverageunit.tmp.out
 
 test-docker: ## Run tests requiring Docker


### PR DESCRIPTION
<!-- Provide a brief summary of the changes -->
gomock is included in go coverage resulting in 71.43% coverage.
## Description

make test did not exclude all gomock packages, this change now excludes all gomock packages.

## References
[1398](https://github.com/openfga/openfga/issues/1398)

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
