### PR TITLE
docs: update flag docs

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -158,7 +158,7 @@
                     "x-env-variable": "OPENFGA_DATASTORE_PASSWORD"
                 },
                 "maxCacheSize": {
-                    "description": "The maximum number of cache keys that the storage cache can store before evicting old keys.",
+                    "description": "The maximum number of authorization models that will be cached in memory",
                     "type": "integer",
                     "default": 100000,
                     "x-env-variable": "OPENFGA_DATASTORE_MAX_CACHE_SIZE"

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -134,7 +134,7 @@ func NewRunCommand() *cobra.Command {
 
 	flags.String("datastore-password", "", "the connection password to use to connect to the datastore (overwrites any password provided in the connection uri)")
 
-	flags.Int("datastore-max-cache-size", defaultConfig.Datastore.MaxCacheSize, "the maximum number of cache keys that the storage cache can store before evicting old keys")
+	flags.Int("datastore-max-cache-size", defaultConfig.Datastore.MaxCacheSize, "the maximum number of authorization models that will be cached in memory")
 
 	flags.Int("datastore-max-open-conns", defaultConfig.Datastore.MaxOpenConns, "the maximum number of open connections to the datastore")
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -55,10 +55,7 @@ type DatastoreConfig struct {
 	Username string
 	Password string
 
-	// MaxCacheSize is the maximum number of cache keys that the storage cache can store before
-	// evicting
-	// old keys. The storage cache is used to cache query results for various static resources
-	// such as type definitions.
+	// MaxCacheSize is the maximum number of authorization models that will be cached in memory.
 	MaxCacheSize int
 
 	// MaxOpenConns is the maximum number of open connections to the database.


### PR DESCRIPTION
## Description

Noticed while writing https://github.com/openfga/openfga.dev/pull/735.

Before:

```
[6/05/24 10:58:14] ~/GitHub/openfga-main (main) $ ./dist/openfga run --help | grep datastore-max-cache
      --datastore-max-cache-size int                             the maximum number of cache keys that the storage cache can store before evicting old keys (default 100000)
```

After:

```
[6/05/24 10:59:03] ~/GitHub/openfga (doc-model-cache) $ ./dist/openfga run --help | grep datastore-max-cache
      --datastore-max-cache-size int                             the maximum number of authorization models that will be cached in memory (default 100000)
[6/05/24 10:59:07] ~/GitHub/openfga (doc-model-cache) $ 
```