### PR TITLE
fix: send error before results

### DIFF
--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -196,6 +196,7 @@ func (e *EvaluableCondition) CastContextToTypedParameters(contextMap map[string]
 // constructed from the condition's parameter type definitions and using the context maps provided.
 // If more than one source map of context is provided, and if the keys provided in those map
 // context(s) are overlapping, then the overlapping key for the last most context wins.
+// If there are parameters missing, ConditionMet will always be set as false.
 func (e *EvaluableCondition) Evaluate(
 	ctx context.Context,
 	contextMaps ...map[string]*structpb.Value,

--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -201,6 +201,28 @@ func TestEvaluate(t *testing.T) {
 			},
 		},
 		{
+			name: "mix_of_missing_params_and_strict_eval",
+			condition: &openfgav1.Condition{
+				Name:       "condition1",
+				Expression: "param1 == 'ok' && param2 == 'ok'",
+				Parameters: map[string]*openfgav1.ConditionParamTypeRef{
+					"param1": {
+						TypeName: openfgav1.ConditionParamTypeRef_TYPE_NAME_STRING,
+					},
+					"param2": {
+						TypeName: openfgav1.ConditionParamTypeRef_TYPE_NAME_STRING,
+					},
+				},
+			},
+			context: map[string]interface{}{
+				"param1": "ok",
+			},
+			result: condition.EvaluationResult{
+				ConditionMet:      false, // we apply strict evaluation
+				MissingParameters: []string{"param2"},
+			},
+		},
+		{
 			name: "fail_unexpected_type",
 			condition: &openfgav1.Condition{
 				Name:       "condition1",


### PR DESCRIPTION
## Description

Before:

```
go test ./pkg/server/commands/listusers -count=1000 -race -run "TestListUsersConditions/multiple_conditions_some_params_provided"

--- FAIL: TestListUsersConditions (0.01s)
    --- FAIL: TestListUsersConditions/multiple_conditions_some_params_provided (0.00s)
        list_users_rpc_test.go:2724: 
                Error Trace:    /Users/maria.inesparnisari/GitHub/openfga/pkg/server/commands/listusers/list_users_rpc_test.go:2724
                Error:          Not equal: 
                                expected: "failed to evaluate relationship condition: 'isEqualToTen' - context is missing parameters '[param2]'"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -failed to evaluate relationship condition: 'isEqualToTen' - context is missing parameters '[param2]'
                                + 
```

After:

```
[6/05/24 8:29:25] ~/GitHub/openfga (list-users-fix-error-before-results) $ go test ./pkg/server/commands/listusers -count=10000 -race -run "TestListUsersConditions/multiple_conditions_some_params_provided" 
ok      github.com/openfga/openfga/pkg/server/commands/listusers        114.928s
```