### PR TITLE
feat: log all server settings (except sensitive) on start up

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -519,14 +519,14 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	}
 
 	if config.Metrics.Enabled {
-		s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics endpoint on '%s'", config.Metrics.Addr))
+		s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics server on '%s'", config.Metrics.Addr))
 
 		go func() {
 			mux := http.NewServeMux()
 			mux.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(config.Metrics.Addr, mux); err != nil {
 				if err != http.ErrServerClosed {
-					s.Logger.Fatal("failed to start prometheus metrics endpoint", zap.Error(err))
+					s.Logger.Fatal("failed to start prometheus metrics server", zap.Error(err))
 				}
 			}
 		}()

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -392,7 +392,9 @@ func PrintJSON(obj interface{}) string {
 func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
 	tracerProviderCloser := s.telemetryConfig(config)
 
-	s.Logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
+	if len(config.Experimentals) > 0 {
+		s.Logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
+	}
 
 	var experimentals []server.ExperimentalFeatureFlag
 	for _, feature := range config.Experimentals {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -499,7 +499,6 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		s.Logger.Warn("gRPC TLS is disabled, serving connections using insecure plaintext")
 	}
 
-	var profilerServer *http.Server
 	if config.Profiler.Enabled {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/debug/pprof/", pprof.Index)
@@ -508,35 +507,28 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
-		profilerServer = &http.Server{Addr: config.Profiler.Addr, Handler: mux}
-
 		go func() {
 			s.Logger.Info(fmt.Sprintf("🔬 starting pprof profiler on '%s'", config.Profiler.Addr))
 
-			if err := profilerServer.ListenAndServe(); err != nil {
+			if err := http.ListenAndServe(config.Profiler.Addr, mux); err != nil {
 				if err != http.ErrServerClosed {
 					s.Logger.Fatal("failed to start pprof profiler", zap.Error(err))
 				}
 			}
-			s.Logger.Info("profiler shut down.")
 		}()
 	}
 
-	var metricsServer *http.Server
 	if config.Metrics.Enabled {
 		s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics server on '%s'", config.Metrics.Addr))
 
 		go func() {
 			mux := http.NewServeMux()
 			mux.Handle("/metrics", promhttp.Handler())
-
-			metricsServer = &http.Server{Addr: config.Metrics.Addr, Handler: mux}
-			if err := metricsServer.ListenAndServe(); err != nil {
+			if err := http.ListenAndServe(config.Metrics.Addr, mux); err != nil {
 				if err != http.ErrServerClosed {
 					s.Logger.Fatal("failed to start prometheus metrics server", zap.Error(err))
 				}
 			}
-			s.Logger.Info("metrics server shut down.")
 		}()
 	}
 
@@ -769,18 +761,6 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	if httpServer != nil {
 		if err := httpServer.Shutdown(ctx); err != nil {
 			s.Logger.Info("failed to shutdown the http server", zap.Error(err))
-		}
-	}
-
-	if profilerServer != nil {
-		if err := profilerServer.Shutdown(ctx); err != nil {
-			s.Logger.Info("failed to shutdown the profiler", zap.Error(err))
-		}
-	}
-
-	if metricsServer != nil {
-		if err := metricsServer.Shutdown(ctx); err != nil {
-			s.Logger.Info("failed to shutdown the prometheus metrics server", zap.Error(err))
 		}
 	}
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -3,6 +3,7 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -381,6 +382,11 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 	return authenticator, nil
 }
 
+func PrintJSON(obj interface{}) string {
+	bytes, _ := json.Marshal(obj)
+	return string(bytes)
+}
+
 // Run returns an error if the server was unable to start successfully.
 // If it started and terminated successfully, it returns a nil error.
 func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) error {
@@ -492,9 +498,9 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 		serverOpts = append(serverOpts, grpc.Creds(creds))
 
-		s.Logger.Info("grpc TLS is enabled, serving connections using the provided certificate")
+		s.Logger.Info("gRPC TLS is enabled, serving connections using the provided certificate")
 	} else {
-		s.Logger.Warn("grpc TLS is disabled, serving connections using insecure plaintext")
+		s.Logger.Warn("gRPC TLS is disabled, serving connections using insecure plaintext")
 	}
 
 	if config.Profiler.Enabled {
@@ -517,14 +523,14 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	}
 
 	if config.Metrics.Enabled {
-		s.Logger.Info(fmt.Sprintf("📈 starting metrics server on '%s'", config.Metrics.Addr))
+		s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics endpoint on '%s'", config.Metrics.Addr))
 
 		go func() {
 			mux := http.NewServeMux()
 			mux.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(config.Metrics.Addr, mux); err != nil {
 				if err != http.ErrServerClosed {
-					s.Logger.Fatal("failed to start prometheus metrics server", zap.Error(err))
+					s.Logger.Fatal("failed to start prometheus metrics endpoint", zap.Error(err))
 				}
 			}
 		}()
@@ -555,11 +561,12 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	)
 
 	s.Logger.Info(
-		"🚀 starting openfga service...",
+		"starting openfga service...",
 		zap.String("version", build.Version),
 		zap.String("date", build.Date),
 		zap.String("commit", build.Commit),
 		zap.String("go-version", goruntime.Version()),
+		zap.Any("config", config),
 	)
 
 	// nosemgrep: grpc-server-insecure-connection
@@ -575,15 +582,14 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	}
 
 	go func() {
+		s.Logger.Info(fmt.Sprintf("🚀 starting gRPC server on '%s'...", config.GRPC.Addr))
 		if err := grpcServer.Serve(lis); err != nil {
 			if !errors.Is(err, grpc.ErrServerStopped) {
-				s.Logger.Fatal("failed to start grpc server", zap.Error(err))
+				s.Logger.Fatal("failed to start gRPC server", zap.Error(err))
 			}
-
-			s.Logger.Info("grpc server shut down..")
 		}
+		s.Logger.Info("gRPC server shut down.")
 	}()
-	s.Logger.Info(fmt.Sprintf("grpc server listening on '%s'...", config.GRPC.Addr))
 
 	var httpServer *http.Server
 	if config.HTTP.Enabled {
@@ -642,6 +648,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		}
 
 		go func() {
+			s.Logger.Info(fmt.Sprintf("🚀 starting HTTP server on '%s'...", httpServer.Addr))
 			var err error
 			if config.HTTP.TLS.Enabled {
 				if config.HTTP.TLS.CertPath == "" || config.HTTP.TLS.KeyPath == "" {
@@ -649,13 +656,14 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 				}
 				err = httpServer.ListenAndServeTLS(config.HTTP.TLS.CertPath, config.HTTP.TLS.KeyPath)
 			} else {
+				s.Logger.Warn("HTTP TLS is disabled, serving connections using insecure plaintext")
 				err = httpServer.ListenAndServe()
 			}
 			if err != http.ErrServerClosed {
 				s.Logger.Fatal("HTTP server closed with unexpected error", zap.Error(err))
 			}
+			s.Logger.Info("HTTP server shut down.")
 		}()
-		s.Logger.Info(fmt.Sprintf("HTTP server listening on '%s'...", httpServer.Addr))
 	}
 
 	var playground *http.Server
@@ -732,7 +740,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 			if err != http.ErrServerClosed {
 				s.Logger.Fatal("failed to start the openfga playground server", zap.Error(err))
 			}
-			s.Logger.Info("shutdown the openfga playground server")
+			s.Logger.Info("playground shut down.")
 		}()
 	}
 
@@ -743,14 +751,14 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	case <-done:
 	case <-ctx.Done():
 	}
-	s.Logger.Info("attempting to shutdown gracefully")
+	s.Logger.Info("attempting to shutdown gracefully...")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	if playground != nil {
 		if err := playground.Shutdown(ctx); err != nil {
-			s.Logger.Info("failed to gracefully shutdown playground server", zap.Error(err))
+			s.Logger.Info("failed to shutdown the playground", zap.Error(err))
 		}
 	}
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -3,7 +3,6 @@ package run
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
@@ -380,11 +379,6 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 		return nil, fmt.Errorf("failed to initialize authenticator: %w", err)
 	}
 	return authenticator, nil
-}
-
-func PrintJSON(obj interface{}) string {
-	bytes, _ := json.Marshal(obj)
-	return string(bytes)
 }
 
 // Run returns an error if the server was unable to start successfully.

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -51,7 +51,7 @@ type DatastoreMetricsConfig struct {
 type DatastoreConfig struct {
 	// Engine is the datastore engine to use (e.g. 'memory', 'postgres', 'mysql')
 	Engine   string
-	URI      string
+	URI      string `json:"-"` // private field, won't be logged
 	Username string
 	Password string `json:"-"` // private field, won't be logged
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -53,7 +53,7 @@ type DatastoreConfig struct {
 	Engine   string
 	URI      string
 	Username string
-	Password string
+	Password string `json:"-"` // private field, won't be logged
 
 	// MaxCacheSize is the maximum number of authorization models that will be cached in memory.
 	MaxCacheSize int

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -122,7 +122,7 @@ type AuthnOIDCConfig struct {
 // AuthnPresharedKeyConfig defines configurations for the 'preshared' method of authentication.
 type AuthnPresharedKeyConfig struct {
 	// Keys define the preshared keys to verify authn tokens against.
-	Keys []string
+	Keys []string `json:"-"` // private field, won't be logged
 }
 
 // LogConfig defines OpenFGA server configurations for log specific settings. For production we


### PR DESCRIPTION
## Description
- log all server settings (except sensitive) on start up
- a few minor changes in wording

## References
Closes https://github.com/openfga/openfga/issues/1501

## Testing
Before:

<img width="1683" alt="image" src="https://github.com/openfga/openfga/assets/5374887/a7b0a7f2-5bc2-4964-9bec-039f1dc9bc9e">

After:
<img width="1679" alt="image" src="https://github.com/openfga/openfga/assets/5374887/883a4e81-2094-48c6-a437-9cea681ca17b">

