### PR TITLE
fix: close metrics and profiler properly, if enabled, on server shutdown

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -497,6 +497,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		s.Logger.Warn("grpc TLS is disabled, serving connections using insecure plaintext")
 	}
 
+	var profilerServer *http.Server
 	if config.Profiler.Enabled {
 		mux := http.NewServeMux()
 		mux.HandleFunc("/debug/pprof/", pprof.Index)
@@ -505,28 +506,35 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
+		profilerServer = &http.Server{Addr: config.Profiler.Addr, Handler: mux}
+
 		go func() {
 			s.Logger.Info(fmt.Sprintf("🔬 starting pprof profiler on '%s'", config.Profiler.Addr))
 
-			if err := http.ListenAndServe(config.Profiler.Addr, mux); err != nil {
+			if err := profilerServer.ListenAndServe(); err != nil {
 				if err != http.ErrServerClosed {
 					s.Logger.Fatal("failed to start pprof profiler", zap.Error(err))
 				}
 			}
+			s.Logger.Info("profiler shut down.")
 		}()
 	}
 
+	var metricsServer *http.Server
 	if config.Metrics.Enabled {
 		s.Logger.Info(fmt.Sprintf("📈 starting metrics server on '%s'", config.Metrics.Addr))
 
 		go func() {
 			mux := http.NewServeMux()
 			mux.Handle("/metrics", promhttp.Handler())
-			if err := http.ListenAndServe(config.Metrics.Addr, mux); err != nil {
+
+			metricsServer = &http.Server{Addr: config.Metrics.Addr, Handler: mux}
+			if err := metricsServer.ListenAndServe(); err != nil {
 				if err != http.ErrServerClosed {
 					s.Logger.Fatal("failed to start prometheus metrics server", zap.Error(err))
 				}
 			}
+			s.Logger.Info("metrics server shut down.")
 		}()
 	}
 
@@ -757,6 +765,18 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	if httpServer != nil {
 		if err := httpServer.Shutdown(ctx); err != nil {
 			s.Logger.Info("failed to shutdown the http server", zap.Error(err))
+		}
+	}
+
+	if profilerServer != nil {
+		if err := profilerServer.Shutdown(ctx); err != nil {
+			s.Logger.Info("failed to shutdown the profiler", zap.Error(err))
+		}
+	}
+
+	if metricsServer != nil {
+		if err := metricsServer.Shutdown(ctx); err != nil {
+			s.Logger.Info("failed to shutdown the prometheus metrics server", zap.Error(err))
 		}
 	}
 

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -25,9 +25,10 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
-	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/openfga/openfga/pkg/testutils"
 
 	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/storeid"

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -27,6 +27,7 @@ import (
 	parser "github.com/openfga/language/pkg/go/transformer"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/goleak"
 
 	"github.com/openfga/openfga/pkg/testutils"
 
@@ -746,6 +747,10 @@ func TestGRPCServingTLS(t *testing.T) {
 }
 
 func TestServerMetricsReporting(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	t.Run("mysql", func(t *testing.T) {
 		testServerMetricsReporting(t, "mysql")
 	})

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -25,11 +25,9 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
+	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
-	"go.uber.org/goleak"
-
-	"github.com/openfga/openfga/pkg/testutils"
 
 	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/storeid"
@@ -747,10 +745,6 @@ func TestGRPCServingTLS(t *testing.T) {
 }
 
 func TestServerMetricsReporting(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
 	t.Run("mysql", func(t *testing.T) {
 		testServerMetricsReporting(t, "mysql")
 	})


### PR DESCRIPTION
## Description
Noticed while working on https://github.com/openfga/openfga/pull/1609 that we're not closing properly the profiler and metrics servers on server shutdown. 
