### PR TITLE
feat: support claims validation

### DIFF
--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -69,6 +69,20 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("authn.oidc.issuerAliases", flags.Lookup("authn-oidc-issuer-aliases"))
 		util.MustBindEnv("authn.oidc.issuerAliases", "OPENFGA_AUTHN_OIDC_ISSUER_ALIASES")
 
+		util.MustBindPFlag("authn.oidc.roles", flags.Lookup("authn-oidc-roles"))
+		util.MustBindEnv("authn.oidc.roles", "OPENFGA_AUTHN_OIDC_ROLES")
+
+		util.MustBindPFlag("authn.oidc.roles", flags.Lookup("authn-oidc-roles"))
+		util.MustBindEnv("authn.oidc.roles", "OPENFGA_AUTHN_OIDC_ROLES")
+
+		util.MustBindPFlag("authn.oidc.claimValues", flags.Lookup("authn-oidc-claim-values"))
+		util.MustBindEnv("authn.oidc.claimValues", "OPENFGA_AUTHN_OIDC_CLAIM_VALUES")
+
+		util.MustBindPFlag("authn.oidc.claimName", flags.Lookup("authn-oidc-claim-name"))
+		util.MustBindEnv("authn.oidc.claimName", "OPENFGA_AUTHN_OIDC_CLAIM_NAME")
+
+		command.MarkFlagsRequiredTogether("authn-oidc-claim-name", "authn-oidc-claim-values")
+
 		util.MustBindPFlag("datastore.engine", flags.Lookup("datastore-engine"))
 		util.MustBindEnv("datastore.engine", "OPENFGA_DATASTORE_ENGINE")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -126,6 +126,14 @@ func NewRunCommand() *cobra.Command {
 
 	flags.StringSlice("authn-oidc-issuer-aliases", defaultConfig.Authn.IssuerAliases, "the OIDC issuer DNS aliases that will be accepted as valid when verifying tokens")
 
+	flags.StringSlice("authn-oidc-roles", defaultConfig.Authn.Roles, "the OIDC roles that will be required when verifying tokens")
+
+	flags.String("authn-oidc-claim-name", defaultConfig.Authn.ClaimName, "an additonal OIDC token claim that will be required when verifying tokens")
+
+	flags.StringSlice("authn-oidc-claim-values", defaultConfig.Authn.ClaimValues, "the OIDC claim values that will be accepted when verifying tokens")
+
+	cmd.MarkFlagsRequiredTogether("authn-oidc-claim-name", "authn-oidc-claim-values")
+
 	flags.String("datastore-engine", defaultConfig.Datastore.Engine, "the datastore engine that will be used for persistence")
 
 	flags.String("datastore-uri", defaultConfig.Datastore.URI, "the connection uri to use to connect to the datastore (for any engine other than 'memory')")
@@ -371,7 +379,7 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 		authenticator, err = presharedkey.NewPresharedKeyAuthenticator(config.Authn.Keys)
 	case "oidc":
 		s.Logger.Info("using 'oidc' authentication")
-		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audience)
+		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audience, config.Authn.Roles, config.Authn.ClaimName, config.Authn.ClaimValues)
 	default:
 		return nil, fmt.Errorf("unsupported authentication method '%v'", config.Authn.Method)
 	}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -28,10 +28,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
+	"github.com/openfga/openfga/pkg/testutils"
+
 	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/storeid"
 	"github.com/openfga/openfga/pkg/server"
-	"github.com/openfga/openfga/pkg/testutils"
 
 	"github.com/openfga/openfga/cmd"
 	"github.com/openfga/openfga/cmd/util"
@@ -526,7 +527,6 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 
 	trustedIssuerServer, err := mocks.NewMockOidcServer(localOIDCServerURL)
 	require.NoError(t, err)
-	t.Cleanup(trustedIssuerServer.Stop)
 
 	trustedToken, err := trustedIssuerServer.GetToken("openfga.dev", "some-user")
 	require.NoError(t, err)
@@ -599,10 +599,8 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 
 	trustedIssuerServer1, err := mocks.NewMockOidcServer(oidcServerURL1)
 	require.NoError(t, err)
-	t.Cleanup(trustedIssuerServer1.Stop)
 
 	trustedIssuerServer2 := trustedIssuerServer1.NewAliasMockServer(oidcServerURL2)
-	t.Cleanup(trustedIssuerServer2.Stop)
 
 	trustedTokenFromAlias, err := trustedIssuerServer2.GetToken("openfga.dev", "some-user")
 	require.NoError(t, err)

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -117,6 +117,9 @@ type AuthnOIDCConfig struct {
 	Issuer        string
 	IssuerAliases []string
 	Audience      string
+	Roles         []string
+	ClaimName     string
+	ClaimValues   []string
 }
 
 // AuthnPresharedKeyConfig defines configurations for the 'preshared' method of authentication.


### PR DESCRIPTION
Added support for checking 'roles' claim, and for checking a custom claim during oidc validation.

## Description

Access tokens from Azure Entra can contain the [roles](https://learn.microsoft.com/en-us/entra/identity-platform/access-token-claims-reference#payload-claims) claim. This claim is normally used to give access to an application in machine-to-machine authorization. Added a new option to provide a list of accepted roles, hence if one of the roles are present in the roles claim the token is accepted.

In addition, two new options where added to add a custom claim and optional values of the claim. One can verify that the claim is present or that the claim contains one of the values given as an option. 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
