### PR TITLE
fix: slsa-verify stage during release by adding json file extension

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
           gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" \
-            -p "$PROVENANCE" -p "*.tar.gz" -p "*.tar.gz.sbom"
+            -p "$PROVENANCE" -p "*.tar.gz" -p "*.tar.gz.sbom.json"
 
       - name: Verify assets
         env:
@@ -169,7 +169,7 @@ jobs:
             --provenance-path "$PROVENANCE" \
             --source-uri "github.com/$GITHUB_REPOSITORY" \
             --source-tag "$GITHUB_REF_NAME" \
-            *.tar.gz *.tar.gz.sbom
+            *.tar.gz *.tar.gz.sbom.json
 
   verification-with-cosign:
     needs: [ goreleaser, image-provenance ]


### PR DESCRIPTION
## Description
The SLSA verification stage failed during [release of v1.5.4](https://github.com/openfga/openfga/actions/runs/9293326320/job/25607867536). The error message stated 

```
Verifying artifact *.tar.gz.sbom: FAILED: open *.tar.gz.sbom: no such file or directory

FAILED: SLSA verification failed: open *.tar.gz.sbom: no such file or directory
```

This happened because of a [recent goreleaser change](https://github.com/goreleaser/goreleaser/pull/4781) that added the `.json` fix extension to SBOM files by default. The solution here is to simply add the `.json` file extension to match the output of goreleaser.


**Testing:**
Not tested in CI but this was verified locally by running:
```sh
gh release download v1.5.4 \
--repo openfga/openfga \
-p "openfga.intoto.jsonl" -p "*.tar.gz" -p "*.tar.gz.sbom.json";

slsa-verifier verify-artifact \
--provenance-path "openfga.intoto.jsonl" \
--source-uri "github.com/openfga/openfga" \
--source-tag "v1.5.4" \
*.tar.gz *tar.gz.sbom.json

# ...
# PASSED: Verified SLSA provenance

```

## References
- [Related change in Goreleaser](https://github.com/goreleaser/goreleaser/pull/4781)
- [slsa-verification release failure in CI](https://github.com/openfga/openfga/actions/runs/9293326320/job/25607867536)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
