### PR TITLE
chore: add enable-consistency-params experimental flag

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -115,7 +115,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "enum": ["enable-list-users"]
+                "enum": ["enable-list-users","enable-consistency-params"]
             },
             "default": [],
             "x-env-variable": "OPENFGA_EXPERIMENTALS"

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -424,7 +424,6 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	var experimentals []server.ExperimentalFeatureFlag
 	for _, feature := range config.Experimentals {
 		experimentals = append(experimentals, server.ExperimentalFeatureFlag(feature))
-		s.Logger.Info(fmt.Sprintf("🧪 experimentals: %v", experimentals))
 	}
 
 	datastore, err := s.datastoreConfig(config)

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -86,7 +86,7 @@ func NewRunCommand() *cobra.Command {
 	defaultConfig := serverconfig.DefaultConfig()
 	flags := cmd.Flags()
 
-	flags.StringSlice("experimentals", defaultConfig.Experimentals, "a list of experimental features to enable. Allowed values: `enable-list-users`")
+	flags.StringSlice("experimentals", defaultConfig.Experimentals, "a list of experimental features to enable. Allowed values: `enable-list-users`, `enable-consistency-params`")
 
 	flags.String("grpc-addr", defaultConfig.GRPC.Addr, "the host:port address to serve the grpc server on")
 
@@ -424,6 +424,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 	var experimentals []server.ExperimentalFeatureFlag
 	for _, feature := range config.Experimentals {
 		experimentals = append(experimentals, server.ExperimentalFeatureFlag(feature))
+		s.Logger.Info(fmt.Sprintf("🧪 experimentals: %v", experimentals))
 	}
 
 	datastore, err := s.datastoreConfig(config)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,9 +49,10 @@ import (
 type ExperimentalFeatureFlag string
 
 const (
-	AuthorizationModelIDHeader                          = "Openfga-Authorization-Model-Id"
-	authorizationModelIDKey                             = "authorization_model_id"
-	ExperimentalEnableListUsers ExperimentalFeatureFlag = "enable-list-users"
+	AuthorizationModelIDHeader                                  = "Openfga-Authorization-Model-Id"
+	authorizationModelIDKey                                     = "authorization_model_id"
+	ExperimentalEnableListUsers         ExperimentalFeatureFlag = "enable-list-users"
+	ExperimentalEnableConsistencyParams ExperimentalFeatureFlag = "enable-consistency-params"
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Adds the experimental flag `enable-consistency-params`, which will be used to enable the configuration of read consistency behavior.

Note that this PR targets the `stronger-consistency-options` branch, which we will work on as we implement this feature.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
