### PR TITLE
fix(test): test should not run with pageSize = 0

### DIFF
--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -98,10 +98,8 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 
 	for {
 		// fetch a page of stores
-		stores, tokenStores, err := db.ListStores(ctx, storage.PaginationOptions{
-			PageSize: 100,
-			From:     continuationTokenStores,
-		})
+		stores, tokenStores, err := db.ListStores(ctx,
+			storage.NewPaginationOptions(100, continuationTokenStores))
 		if err != nil {
 			return nil, fmt.Errorf("error reading stores: %w", err)
 		}
@@ -117,10 +115,8 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 
 			for {
 				// fetch a page of models for that store
-				models, tokenModels, err := db.ReadAuthorizationModels(ctx, store.GetId(), storage.PaginationOptions{
-					PageSize: 100,
-					From:     continuationTokenModels,
-				})
+				models, tokenModels, err := db.ReadAuthorizationModels(ctx, store.GetId(),
+					storage.NewPaginationOptions(100, continuationTokenModels))
 				if err != nil {
 					return nil, fmt.Errorf("error reading authorization models: %w", err)
 				}

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -175,7 +175,7 @@ func (s *MemoryBackend) Read(ctx context.Context, store string, key *openfgav1.T
 	ctx, span := tracer.Start(ctx, "memory.Read")
 	defer span.End()
 
-	return s.read(ctx, store, key, storage.PaginationOptions{})
+	return s.read(ctx, store, key, storage.NewPaginationOptions(storage.DefaultPageSize, ""))
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -190,9 +190,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.PaginationOptions{
-		PageSize: 2,
-	})
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
@@ -248,7 +246,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.PaginationOptions{}, 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(0, ""), 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -124,7 +124,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(0, ""))
+		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -246,7 +246,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(0, ""), 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -189,9 +189,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.PaginationOptions{
-		PageSize: 2,
-	})
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
@@ -247,7 +245,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.PaginationOptions{}, 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(0, ""), 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -123,7 +123,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(0, ""))
+		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -245,7 +245,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(0, ""), 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -53,9 +53,7 @@ func RelationshipTupleReaderFromContext(ctx context.Context) (RelationshipTupleR
 	return reader, ok
 }
 
-// PaginationOptions holds the settings for pagination in data retrieval operations. It defines
-// the number of items to be included on each page (PageSize) and a marker from where to start
-// the page (From).
+// PaginationOptions should not be instantiated directly. Use NewPaginationOptions.
 type PaginationOptions struct {
 	PageSize int
 	From     string
@@ -66,7 +64,7 @@ type PaginationOptions struct {
 // it uses DefaultPageSize.
 func NewPaginationOptions(ps int32, contToken string) PaginationOptions {
 	pageSize := DefaultPageSize
-	if ps != 0 {
+	if ps <= 0 {
 		pageSize = int(ps)
 	}
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -236,6 +236,8 @@ type ChangelogBackend interface {
 	// You can optionally provide a filter to filter out changes for objects of a specific type.
 	// The horizonOffset should be specified using a unit no more granular than a millisecond
 	// and should be interpreted as a millisecond duration.
+	// If no changes are found, it will return storage.ErrNotFound.  In this case,
+	// the API layer will return the original if it was provided.
 	ReadChanges(
 		ctx context.Context,
 		store,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -236,8 +236,7 @@ type ChangelogBackend interface {
 	// You can optionally provide a filter to filter out changes for objects of a specific type.
 	// The horizonOffset should be specified using a unit no more granular than a millisecond
 	// and should be interpreted as a millisecond duration.
-	// If no changes are found, it will return storage.ErrNotFound.  In this case,
-	// the API layer will return the original if it was provided.
+	// If no changes are found, it should return storage.ErrNotFound and an empty continuation token.
 	ReadChanges(
 		ctx context.Context,
 		store,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -64,7 +64,7 @@ type PaginationOptions struct {
 // it uses DefaultPageSize.
 func NewPaginationOptions(ps int32, contToken string) PaginationOptions {
 	pageSize := DefaultPageSize
-	if ps <= 0 {
+	if ps > 0 {
 		pageSize = int(ps)
 	}
 

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -86,9 +86,8 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 	err = datastore.WriteAuthorizationModel(ctx, store, model2)
 	require.NoError(t, err)
 
-	models, continuationToken, err := datastore.ReadAuthorizationModels(ctx, store, storage.PaginationOptions{
-		PageSize: 1,
-	})
+	models, continuationToken, err := datastore.ReadAuthorizationModels(ctx, store,
+		storage.NewPaginationOptions(1, ""))
 	require.NoError(t, err)
 	require.Len(t, models, 1)
 	require.NotEmpty(t, continuationToken)
@@ -97,10 +96,8 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
-	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store, storage.PaginationOptions{
-		PageSize: 2,
-		From:     string(continuationToken),
-	})
+	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store,
+		storage.NewPaginationOptions(2, string(continuationToken)))
 	require.NoError(t, err)
 	require.Len(t, models, 1)
 	require.Empty(t, continuationToken)

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -39,13 +39,13 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	})
 
 	t.Run("list_stores_succeeds", func(t *testing.T) {
-		gotStores, ct, err := datastore.ListStores(ctx, storage.PaginationOptions{PageSize: 1})
+		gotStores, ct, err := datastore.ListStores(ctx, storage.NewPaginationOptions(1, ""))
 		require.NoError(t, err)
 
 		require.Len(t, gotStores, 1)
 		require.NotEmpty(t, len(ct))
 
-		_, ct, err = datastore.ListStores(ctx, storage.PaginationOptions{PageSize: 100, From: string(ct)})
+		_, ct, err = datastore.ListStores(ctx, storage.NewPaginationOptions(100, string(ct)))
 		require.NoError(t, err)
 
 		// This will fail if there are actually over 101 stores in the DB at the time of running.
@@ -81,7 +81,7 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		require.NoError(t, err)
 
 		// Store id should not appear in the list of store ids.
-		gotStores, _, err := datastore.ListStores(ctx, storage.PaginationOptions{PageSize: storage.DefaultPageSize})
+		gotStores, _, err := datastore.ListStores(ctx, storage.NewPaginationOptions(storage.DefaultPageSize, ""))
 		require.NoError(t, err)
 
 		for _, s := range gotStores {

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -777,7 +777,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(0, ""), 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.Nil(t, changes[0].GetTupleKey().GetCondition())
@@ -860,7 +860,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(0, ""), 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.NotNil(t, changes[0].GetTupleKey().GetCondition().GetContext())

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -41,7 +41,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
 		require.NoError(t, err)
 
-		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: 1}, 0)
+		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(1, ""), 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, continuationToken)
 
@@ -56,10 +56,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
 
-		changes, continuationToken, err = datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{
-			PageSize: 2,
-			From:     string(continuationToken),
-		},
+		changes, continuationToken, err = datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(2, string(continuationToken)),
 			0,
 		)
 		require.NoError(t, err)
@@ -79,7 +76,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	t.Run("read_changes_with_no_changes_should_return_not_found", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		_, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 0)
+		_, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -100,7 +97,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
 		require.NoError(t, err)
 
-		_, _, err = datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 1*time.Minute)
+		_, _, err = datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 1*time.Minute)
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -121,7 +118,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
 		require.NoError(t, err)
 
-		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "folder", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 0)
+		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, continuationToken)
 
@@ -152,10 +149,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		var continuationToken []byte
 		var err error
 		for {
-			changes, continuationToken, err = datastore.ReadChanges(context.Background(), storeID, "", storage.PaginationOptions{
-				PageSize: 10,
-				From:     string(continuationToken),
-			}, 1*time.Millisecond)
+			changes, continuationToken, err = datastore.ReadChanges(context.Background(), storeID, "", storage.NewPaginationOptions(10, string(continuationToken)), 1*time.Millisecond)
 			if err != nil {
 				if errors.Is(err, storage.ErrNotFound) {
 					break
@@ -202,7 +196,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
 		require.NoError(t, err)
 
-		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 0)
+		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, continuationToken)
 
@@ -256,7 +250,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		err = datastore.Write(ctx, storeID, []*openfgav1.TupleKeyWithoutCondition{tk2}, nil)
 		require.NoError(t, err)
 
-		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{PageSize: storage.DefaultPageSize}, 0)
+		changes, continuationToken, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
 		require.NoError(t, err)
 		require.NotEmpty(t, continuationToken)
 
@@ -320,7 +314,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.EqualError(t, err, expectedError.Error())
 
 		// Since the write didn't succeed, we expect all tuples back
-		tuples, _, err := datastore.ReadPage(ctx, storeID, nil, storage.PaginationOptions{PageSize: 50})
+		tuples, _, err := datastore.ReadPage(ctx, storeID, nil, storage.NewPaginationOptions(50, ""))
 		require.NoError(t, err)
 		require.Equal(t, len(tks), len(tuples))
 	})
@@ -748,9 +742,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.PaginationOptions{
-			PageSize: 2,
-		})
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.Nil(t, tuples[0].GetKey().GetCondition())
@@ -833,9 +825,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 		require.Empty(t, tp.GetKey().GetCondition().GetContext())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.PaginationOptions{
-			PageSize: 2,
-		})
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.NotNil(t, tuples[0].GetKey().GetCondition().GetContext())
@@ -888,12 +878,13 @@ func ReadPageTestCorrectnessOfContinuationTokens(t *testing.T, datastore storage
 	require.NoError(t, err)
 
 	t.Run("readPage_pagination_works_properly_with_filter", func(t *testing.T) {
-		tuples0, contToken0, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.PaginationOptions{PageSize: 1})
+		tuples0, contToken0, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.NewPaginationOptions(1, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples0, 1)
 		require.NotEmpty(t, contToken0)
 
-		tuples1, contToken1, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.PaginationOptions{PageSize: 1, From: string(contToken0)})
+		tuples1, contToken1, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"},
+			storage.NewPaginationOptions(1, string(contToken0)))
 		require.NoError(t, err)
 		require.Len(t, tuples1, 1)
 		require.Empty(t, contToken1)
@@ -907,26 +898,26 @@ func ReadPageTestCorrectnessOfContinuationTokens(t *testing.T, datastore storage
 	})
 
 	t.Run("reading_a_page_completely_does_not_return_a_continuation_token", func(t *testing.T) {
-		tuples, contToken, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.PaginationOptions{PageSize: 2})
+		tuples, contToken, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.NewPaginationOptions(2, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.Empty(t, contToken)
 	})
 
 	t.Run("reading_a_page_partially_returns_a_continuation_token", func(t *testing.T) {
-		tuples, contToken, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.PaginationOptions{PageSize: 1})
+		tuples, contToken, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{Object: "doc:readme"}, storage.NewPaginationOptions(1, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 1)
 		require.NotEmpty(t, contToken)
 	})
 
 	t.Run("readPage_pagination_works_properly_without_filter", func(t *testing.T) {
-		tuple0, contToken0, err := datastore.ReadPage(ctx, storeID, nil, storage.PaginationOptions{PageSize: 1})
+		tuple0, contToken0, err := datastore.ReadPage(ctx, storeID, nil, storage.NewPaginationOptions(1, ""))
 		require.NoError(t, err)
 		require.Len(t, tuple0, 1)
 		require.NotEmpty(t, contToken0)
 
-		tuple1, contToken1, err := datastore.ReadPage(ctx, storeID, nil, storage.PaginationOptions{PageSize: 1, From: string(contToken0)})
+		tuple1, contToken1, err := datastore.ReadPage(ctx, storeID, nil, storage.NewPaginationOptions(1, string(contToken0)))
 		require.NoError(t, err)
 		require.Len(t, tuple1, 1)
 		require.Empty(t, contToken1)
@@ -940,14 +931,14 @@ func ReadPageTestCorrectnessOfContinuationTokens(t *testing.T, datastore storage
 	})
 
 	t.Run("reading_by_storeID_completely_does_not_return_a_continuation_token", func(t *testing.T) {
-		tuples, contToken, err := datastore.ReadPage(ctx, storeID, nil, storage.PaginationOptions{PageSize: 2})
+		tuples, contToken, err := datastore.ReadPage(ctx, storeID, nil, storage.NewPaginationOptions(2, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.Empty(t, contToken)
 	})
 
 	t.Run("reading_by_storeID_partially_returns_a_continuation_token", func(t *testing.T) {
-		tuples, contToken, err := datastore.ReadPage(ctx, storeID, nil, storage.PaginationOptions{PageSize: 1})
+		tuples, contToken, err := datastore.ReadPage(ctx, storeID, nil, storage.NewPaginationOptions(1, ""))
 		require.NoError(t, err)
 		require.Len(t, tuples, 1)
 		require.NotEmpty(t, contToken)
@@ -1260,9 +1251,7 @@ func ReadPageTestCorrectnessOfContinuationTokensV2(t *testing.T, datastore stora
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "", "user:anne"),
-			storage.PaginationOptions{
-				PageSize: 2,
-			},
+			storage.NewPaginationOptions(2, ""),
 		)
 		require.NoError(t, err)
 
@@ -1280,9 +1269,7 @@ func ReadPageTestCorrectnessOfContinuationTokensV2(t *testing.T, datastore stora
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "", "user:anne"),
-			storage.PaginationOptions{
-				PageSize: 1,
-			},
+			storage.NewPaginationOptions(1, ""),
 		)
 		require.NoError(t, err)
 
@@ -1297,10 +1284,7 @@ func ReadPageTestCorrectnessOfContinuationTokensV2(t *testing.T, datastore stora
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "", "user:anne"),
-			storage.PaginationOptions{
-				PageSize: 50, // fetch the remainder
-				From:     string(contToken),
-			},
+			storage.NewPaginationOptions(50, string(contToken)),
 		)
 		require.NoError(t, err)
 
@@ -1339,9 +1323,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("", "", ""),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1361,9 +1343,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "reader", "user:bob"),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1380,9 +1360,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:", "reader", "user:bob"),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1399,9 +1377,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:", "", "user:bob"),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1419,9 +1395,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "reader", ""),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1439,9 +1413,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "", ""),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 
@@ -1460,9 +1432,7 @@ func ReadPageTestCorrectnessOfTuples(t *testing.T, datastore storage.OpenFGAData
 			ctx,
 			storeID,
 			tuple.NewTupleKey("document:1", "", "user:bob"),
-			storage.PaginationOptions{
-				PageSize: 50,
-			},
+			storage.NewPaginationOptions(50, ""),
 		)
 		require.NoError(t, err)
 

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -785,7 +785,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{}, 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(0, ""), 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.Nil(t, changes[0].GetTupleKey().GetCondition())
@@ -870,7 +870,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.PaginationOptions{}, 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", storage.NewPaginationOptions(0, ""), 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.NotNil(t, changes[0].GetTupleKey().GetCondition().GetContext())


### PR DESCRIPTION
## Description
page size of 0 is not valid. Thus, tests should never run with this option.

## References
API validation - https://github.com/openfga/api/blob/394820dfc109972eb6366118718e212fc87412e3/openfga/v1/openfga_service.proto#L1381

Closes https://github.com/openfga/openfga/issues/1661

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
