### PR TITLE
ci: fix uploading synk results to github

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -109,6 +109,13 @@ jobs:
           image: openfga/openfga
           args: --file=Dockerfile
 
+      # Replace any "undefined" security severity values with 0. The undefined value is used in the case
+      # of license-related findings, which do not do not indicate a security vulnerability.
+      # See https://github.com/github/codeql-action/issues/2187 for more context.
+      - name: Post-process snyk.sarif output
+        run: |
+          sed -i 's/"security-severity": "undefined"/"security-severity": "0"/g' snyk.sarif
+
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@9fdb3e49720b44c48891d036bb502feb25684276 # pin@v2
         with:


### PR DESCRIPTION
## Description

Fix issue during releases uploading snyk.sarif to Github Code Scanning.

Regarding "undefined" output in SARIF, from https://github.com/github/codeql-action/issues/2187#issuecomment-2043220400:
> This behavior is expected - licenses and vulnerabilities were originally designed with a common structure but license-related findings are now managed differently. That is, license-related findings do not indicate a security vulnerability and are labeled as 'undefined'. 


## References

https://github.com/github/codeql-action/issues/2187
https://github.com/openfga/openfga/actions/runs/9568501868/job/26379120370

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
