### PR TITLE
 feat(storage)!: update storage interface to account for consistency parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/openfga/openfga
 
 go 1.22.4
 
-// temporarily use api/proto on feat/stronger-consistency branch
-replace github.com/openfga/api/proto => github.com/openfga/api/proto v0.0.0-20240621160721-5ef60b7de76f
-
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/MicahParks/keyfunc v1.9.0
@@ -26,7 +23,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240620215129-f5a955a47ae4
+	github.com/openfga/api/proto v0.0.0-20240621160721-5ef60b7de76f
 	github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/prometheus/client_golang v1.19.0
@@ -101,6 +98,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
+	github.com/openfga/api v0.0.0-20240621160721-5ef60b7de76f // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/openfga/api v0.0.0-20240621160721-5ef60b7de76f h1:W1YB1zoZ/kaEeOgrl5U4UvC3GTBATzMWPLjeyEEtgYE=
+github.com/openfga/api v0.0.0-20240621160721-5ef60b7de76f/go.mod h1:DDiQkYdq1BOpBdGszDSQuaeMmpK0XsrppN1osfFeiSU=
 github.com/openfga/api/proto v0.0.0-20240621160721-5ef60b7de76f h1:rSOmBugBu8wPK6HYWhGIKh/eLSSGemdczRPe8TDfq9k=
 github.com/openfga/api/proto v0.0.0-20240621160721-5ef60b7de76f/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d h1:n44DfITs+CLCYJIgsryJkG2ElwOZJ3huekPZKydPi7U=

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -665,7 +665,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				},
 			}
 
-			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey)
+			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 			if err != nil {
 				if errors.Is(err, storage.ErrNotFound) {
 					return response, nil
@@ -724,7 +724,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				Object:                      reqTupleKey.GetObject(),
 				Relation:                    reqTupleKey.GetRelation(),
 				AllowedUserTypeRestrictions: directlyRelatedUsersetTypes,
-			})
+			}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 			if err != nil {
 				return nil, err
 			}
@@ -896,6 +896,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 			ctx,
 			req.GetStoreID(),
 			tuple.NewTupleKey(object, tuplesetRelation, ""),
+			storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())),
 		)
 		if err != nil {
 			return nil, err

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -665,7 +665,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				},
 			}
 
-			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, storage.QueryOptions{Consistency: req.GetConsistency()})
 			if err != nil {
 				if errors.Is(err, storage.ErrNotFound) {
 					return response, nil
@@ -724,7 +724,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				Object:                      reqTupleKey.GetObject(),
 				Relation:                    reqTupleKey.GetRelation(),
 				AllowedUserTypeRestrictions: directlyRelatedUsersetTypes,
-			}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+			}, storage.QueryOptions{Consistency: req.GetConsistency()})
 			if err != nil {
 				return nil, err
 			}
@@ -896,7 +896,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 			ctx,
 			req.GetStoreID(),
 			tuple.NewTupleKey(object, tuplesetRelation, ""),
-			storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())),
+			storage.QueryOptions{Consistency: req.GetConsistency()},
 		)
 		if err != nil {
 			return nil, err

--- a/internal/mocks/mock_slow_storage.go
+++ b/internal/mocks/mock_slow_storage.go
@@ -26,31 +26,32 @@ func NewMockSlowDataStorage(ds storage.OpenFGADatastore, readTuplesDelay time.Du
 
 func (m *slowDataStorage) Close() {}
 
-func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey, queryOpts storage.QueryOptions) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.Read(ctx, store, key)
+	return m.OpenFGADatastore.Read(ctx, store, key, queryOpts)
 }
 
-func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOpts storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadPage(ctx, store, key, paginationOptions)
+	return m.OpenFGADatastore.ReadPage(ctx, store, key, paginationOptions, queryOpts)
 }
 
-func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, queryOpts storage.QueryOptions) (*openfgav1.Tuple, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key)
+	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key, queryOpts)
 }
 
-func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOpts storage.QueryOptions) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter)
+	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter, queryOpts)
 }
 
 func (m *slowDataStorage) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	queryOpts storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter)
+	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter, queryOpts)
 }

--- a/internal/mocks/mock_slow_storage.go
+++ b/internal/mocks/mock_slow_storage.go
@@ -26,32 +26,32 @@ func NewMockSlowDataStorage(ds storage.OpenFGADatastore, readTuplesDelay time.Du
 
 func (m *slowDataStorage) Close() {}
 
-func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey, queryOpts storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.Read(ctx, store, key, queryOpts)
+	return m.OpenFGADatastore.Read(ctx, store, key, options...)
 }
 
-func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOpts storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, options ...storage.Option) ([]*openfgav1.Tuple, []byte, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadPage(ctx, store, key, paginationOptions, queryOpts)
+	return m.OpenFGADatastore.ReadPage(ctx, store, key, options...)
 }
 
-func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, queryOpts storage.QueryOptions) (*openfgav1.Tuple, error) {
+func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, options ...storage.Option) (*openfgav1.Tuple, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key, queryOpts)
+	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key, options...)
 }
 
-func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOpts storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter, queryOpts)
+	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter, options...)
 }
 
 func (m *slowDataStorage) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
-	queryOpts storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter, queryOpts)
+	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter, options...)
 }

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -19,6 +19,41 @@ import (
 	gomock "go.uber.org/mock/gomock"
 )
 
+// MockOption is a mock of Option interface.
+type MockOption struct {
+	ctrl     *gomock.Controller
+	recorder *MockOptionMockRecorder
+}
+
+// MockOptionMockRecorder is the mock recorder for MockOption.
+type MockOptionMockRecorder struct {
+	mock *MockOption
+}
+
+// NewMockOption creates a new mock instance.
+func NewMockOption(ctrl *gomock.Controller) *MockOption {
+	mock := &MockOption{ctrl: ctrl}
+	mock.recorder = &MockOptionMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockOption) EXPECT() *MockOptionMockRecorder {
+	return m.recorder
+}
+
+// Apply mocks base method.
+func (m *MockOption) Apply(arg0 *storage.Options) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Apply", arg0)
+}
+
+// Apply indicates an expected call of Apply.
+func (mr *MockOptionMockRecorder) Apply(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockOption)(nil).Apply), arg0)
+}
+
 // MockTupleBackend is a mock of TupleBackend interface.
 type MockTupleBackend struct {
 	ctrl     *gomock.Controller
@@ -57,24 +92,33 @@ func (mr *MockTupleBackendMockRecorder) MaxTuplesPerWrite() *gomock.Call {
 }
 
 // Read mocks base method.
-func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), varargs...)
 }
 
 // ReadPage mocks base method.
-func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadPage", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -82,54 +126,70 @@ func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey 
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), varargs...)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), varargs...)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
+func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUserTuple", varargs...)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), varargs...)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), varargs...)
 }
 
 // Write mocks base method.
@@ -170,24 +230,33 @@ func (m *MockRelationshipTupleReader) EXPECT() *MockRelationshipTupleReaderMockR
 }
 
 // Read mocks base method.
-func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), varargs...)
 }
 
 // ReadPage mocks base method.
-func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadPage", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -195,54 +264,70 @@ func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), varargs...)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), varargs...)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
+func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUserTuple", varargs...)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), varargs...)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), varargs...)
 }
 
 // MockRelationshipTupleWriter is a mock of RelationshipTupleWriter interface.
@@ -841,18 +926,23 @@ func (mr *MockOpenFGADatastoreMockRecorder) MaxTypesPerAuthorizationModel() *gom
 }
 
 // Read mocks base method.
-func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Read", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), varargs...)
 }
 
 // ReadAssertions mocks base method.
@@ -918,9 +1008,13 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, 
 }
 
 // ReadPage mocks base method.
-func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadPage", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -928,54 +1022,70 @@ func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tuple
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), varargs...)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), varargs...)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
+func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
+	varargs := []any{ctx, store, tupleKey}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUserTuple", varargs...)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
+	varargs := append([]any{ctx, store, tupleKey}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), varargs...)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
+	varargs := []any{ctx, store, filter}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", varargs...)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
+	varargs := append([]any{ctx, store, filter}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), varargs...)
 }
 
 // Write mocks base method.

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -435,9 +435,13 @@ func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModel(
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options ...storage.Option) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
+	varargs := []any{ctx, store}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadAuthorizationModels", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -445,9 +449,10 @@ func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.
 }
 
 // ReadAuthorizationModels indicates an expected call of ReadAuthorizationModels.
-func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModels(ctx, store, options any) *gomock.Call {
+func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModels(ctx, store any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockAuthorizationModelReadBackend)(nil).ReadAuthorizationModels), ctx, store, options)
+	varargs := append([]any{ctx, store}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockAuthorizationModelReadBackend)(nil).ReadAuthorizationModels), varargs...)
 }
 
 // MockTypeDefinitionWriteBackend is a mock of TypeDefinitionWriteBackend interface.
@@ -569,9 +574,13 @@ func (mr *MockAuthorizationModelBackendMockRecorder) ReadAuthorizationModel(ctx,
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options ...storage.Option) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
+	varargs := []any{ctx, store}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadAuthorizationModels", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -579,9 +588,10 @@ func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Cont
 }
 
 // ReadAuthorizationModels indicates an expected call of ReadAuthorizationModels.
-func (mr *MockAuthorizationModelBackendMockRecorder) ReadAuthorizationModels(ctx, store, options any) *gomock.Call {
+func (mr *MockAuthorizationModelBackendMockRecorder) ReadAuthorizationModels(ctx, store any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockAuthorizationModelBackend)(nil).ReadAuthorizationModels), ctx, store, options)
+	varargs := append([]any{ctx, store}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockAuthorizationModelBackend)(nil).ReadAuthorizationModels), varargs...)
 }
 
 // WriteAuthorizationModel mocks base method.
@@ -666,9 +676,13 @@ func (mr *MockStoresBackendMockRecorder) GetStore(ctx, id any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockStoresBackend) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockStoresBackend) ListStores(ctx context.Context, options ...storage.Option) ([]*openfgav1.Store, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStores", ctx, paginationOptions)
+	varargs := []any{ctx}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListStores", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.Store)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -676,9 +690,10 @@ func (m *MockStoresBackend) ListStores(ctx context.Context, paginationOptions st
 }
 
 // ListStores indicates an expected call of ListStores.
-func (mr *MockStoresBackendMockRecorder) ListStores(ctx, paginationOptions any) *gomock.Call {
+func (mr *MockStoresBackendMockRecorder) ListStores(ctx any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockStoresBackend)(nil).ListStores), ctx, paginationOptions)
+	varargs := append([]any{ctx}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockStoresBackend)(nil).ListStores), varargs...)
 }
 
 // MockAssertionsBackend is a mock of AssertionsBackend interface.
@@ -757,9 +772,13 @@ func (m *MockChangelogBackend) EXPECT() *MockChangelogBackendMockRecorder {
 }
 
 // ReadChanges mocks base method.
-func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectType string, horizonOffset time.Duration, options ...storage.Option) ([]*openfgav1.TupleChange, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, paginationOptions, horizonOffset)
+	varargs := []any{ctx, store, objectType, horizonOffset}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadChanges", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -767,9 +786,10 @@ func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectTyp
 }
 
 // ReadChanges indicates an expected call of ReadChanges.
-func (mr *MockChangelogBackendMockRecorder) ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset any) *gomock.Call {
+func (mr *MockChangelogBackendMockRecorder) ReadChanges(ctx, store, objectType, horizonOffset any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockChangelogBackend)(nil).ReadChanges), ctx, store, objectType, paginationOptions, horizonOffset)
+	varargs := append([]any{ctx, store, objectType, horizonOffset}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockChangelogBackend)(nil).ReadChanges), varargs...)
 }
 
 // MockOpenFGADatastore is a mock of OpenFGADatastore interface.
@@ -882,9 +902,13 @@ func (mr *MockOpenFGADatastoreMockRecorder) IsReady(ctx any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockOpenFGADatastore) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockOpenFGADatastore) ListStores(ctx context.Context, options ...storage.Option) ([]*openfgav1.Store, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStores", ctx, paginationOptions)
+	varargs := []any{ctx}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListStores", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.Store)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -892,9 +916,10 @@ func (m *MockOpenFGADatastore) ListStores(ctx context.Context, paginationOptions
 }
 
 // ListStores indicates an expected call of ListStores.
-func (mr *MockOpenFGADatastoreMockRecorder) ListStores(ctx, paginationOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ListStores(ctx any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockOpenFGADatastore)(nil).ListStores), ctx, paginationOptions)
+	varargs := append([]any{ctx}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockOpenFGADatastore)(nil).ListStores), varargs...)
 }
 
 // MaxTuplesPerWrite mocks base method.
@@ -976,9 +1001,13 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModel(ctx, store, i
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options ...storage.Option) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
+	varargs := []any{ctx, store}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadAuthorizationModels", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -986,15 +1015,20 @@ func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, stor
 }
 
 // ReadAuthorizationModels indicates an expected call of ReadAuthorizationModels.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModels(ctx, store, options any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModels(ctx, store any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadAuthorizationModels), ctx, store, options)
+	varargs := append([]any{ctx, store}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadAuthorizationModels", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadAuthorizationModels), varargs...)
 }
 
 // ReadChanges mocks base method.
-func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectType string, horizonOffset time.Duration, options ...storage.Option) ([]*openfgav1.TupleChange, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, paginationOptions, horizonOffset)
+	varargs := []any{ctx, store, objectType, horizonOffset}
+	for _, a := range options {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ReadChanges", varargs...)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -1002,9 +1036,10 @@ func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectTyp
 }
 
 // ReadChanges indicates an expected call of ReadChanges.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, horizonOffset any, options ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadChanges), ctx, store, objectType, paginationOptions, horizonOffset)
+	varargs := append([]any{ctx, store, objectType, horizonOffset}, options...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadChanges), varargs...)
 }
 
 // ReadPage mocks base method.

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -57,24 +57,24 @@ func (mr *MockTupleBackendMockRecorder) MaxTuplesPerWrite() *gomock.Call {
 }
 
 // Read mocks base method.
-func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadPage mocks base method.
-func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -82,54 +82,54 @@ func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey 
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
 }
 
 // Write mocks base method.
@@ -170,24 +170,24 @@ func (m *MockRelationshipTupleReader) EXPECT() *MockRelationshipTupleReaderMockR
 }
 
 // Read mocks base method.
-func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadPage mocks base method.
-func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -195,54 +195,54 @@ func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
 }
 
 // MockRelationshipTupleWriter is a mock of RelationshipTupleWriter interface.
@@ -841,18 +841,18 @@ func (mr *MockOpenFGADatastoreMockRecorder) MaxTypesPerAuthorizationModel() *gom
 }
 
 // Read mocks base method.
-func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadAssertions mocks base method.
@@ -918,9 +918,9 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, 
 }
 
 // ReadPage mocks base method.
-func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions, queryOptions)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -928,54 +928,54 @@ func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tuple
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), ctx, store, tupleKey, paginationOptions, queryOptions)
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), ctx, store, filter, queryOptions)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, queryOptions)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), ctx, store, tupleKey, queryOptions)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, queryOptions)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter, queryOptions any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), ctx, store, filter, queryOptions)
 }
 
 // Write mocks base method.

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -144,7 +144,7 @@ func (q *ExpandQuery) resolveThis(ctx context.Context, store string, tk *openfga
 	ctx, span := tracer.Start(ctx, "resolveThis")
 	defer span.End()
 
-	tupleIter, err := q.datastore.Read(ctx, store, tk, storage.NewQueryOptions(storage.WithConsistencyPreference(consistency)))
+	tupleIter, err := q.datastore.Read(ctx, store, tk, storage.QueryOptions{Consistency: consistency})
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}
@@ -255,7 +255,7 @@ func (q *ExpandQuery) resolveTupleToUserset(
 		tsKey.Relation = tk.GetRelation()
 	}
 
-	tupleIter, err := q.datastore.Read(ctx, store, tsKey, storage.NewQueryOptions(storage.WithConsistencyPreference(consistency)))
+	tupleIter, err := q.datastore.Read(ctx, store, tsKey, storage.QueryOptions{Consistency: consistency})
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -301,7 +301,7 @@ func (q *ListObjectsQuery) evaluate(
 				User:             sourceUserRef,
 				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
 				Context:          req.GetContext(),
-			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.QueryOptions{Consistency: req.GetConsistency()})
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -301,7 +301,7 @@ func (q *ListObjectsQuery) evaluate(
 				User:             sourceUserRef,
 				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
 				Context:          req.GetContext(),
-			}, reverseExpandResultsChan, reverseExpandResolutionMetadata)
+			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -402,7 +402,7 @@ func (l *listUsersQuery) expandDirect(
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: req.GetRelation(),
-	})
+	}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{
@@ -835,7 +835,7 @@ func (l *listUsersQuery) expandTTU(
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: tuplesetRelation,
-	})
+	}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -402,7 +402,7 @@ func (l *listUsersQuery) expandDirect(
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: req.GetRelation(),
-	}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+	}, storage.QueryOptions{Consistency: req.GetConsistency()})
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{
@@ -835,7 +835,7 @@ func (l *listUsersQuery) expandTTU(
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: tuplesetRelation,
-	}, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+	}, storage.QueryOptions{Consistency: req.GetConsistency()})
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -2545,7 +2545,7 @@ func TestListUsersCycleDetection(t *testing.T) {
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 
 	// Times(0) ensures that we exit quickly
-	mockDatastore.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockDatastore.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	l := NewListUsersQuery(mockDatastore, WithResolveNodeLimit(maximumRecursiveDepth))
 	channelDone := make(chan struct{})
@@ -2902,7 +2902,7 @@ func TestListUsersStorageErrors(t *testing.T) {
 			})
 			mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 			mockDatastore.EXPECT().
-				Read(gomock.Any(), gomock.Any(), gomock.Any()).
+				Read(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, fmt.Errorf("storage err")).
 				MinTimes(1).
 				MaxTimes(2) // Because DB errors will immediately halt the execution of the API function, it's possible that only one read is made
@@ -3001,14 +3001,14 @@ func TestListUsersReadFails_NoLeaks(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Relation: "viewer",
 			Object:   "document:1",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.QueryOptions) (storage.TupleIterator, error) {
 			return mocks.NewErrorTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "viewer", "group:fga#member")},
 				{Key: tuple.NewTupleKey("document:1", "viewer", "group:eng#member")},
 			}), nil
 		}),
-		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.QueryOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}),
 	)
@@ -3053,7 +3053,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Object:   "document:1",
 			Relation: "parent",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.QueryOptions) (storage.TupleIterator, error) {
 			return mocks.NewErrorTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "parent", "folder:1")},
 				{Key: tuple.NewTupleKey("document:1", "parent", "folder:2")},
@@ -3062,7 +3062,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Object:   "folder:1",
 			Relation: "viewer",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.QueryOptions) (storage.TupleIterator, error) {
 			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
 		}),
 	)

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -75,7 +75,7 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 
 	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
 
-	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), paginationOptions, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
+	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), paginationOptions, storage.QueryOptions{Consistency: req.GetConsistency()})
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -75,7 +75,7 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 
 	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
 
-	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), paginationOptions)
+	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), paginationOptions, storage.NewQueryOptions(storage.WithConsistencyPreference(req.GetConsistency())))
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read_changes.go
+++ b/pkg/server/commands/read_changes.go
@@ -63,9 +63,9 @@ func (q *ReadChangesQuery) Execute(ctx context.Context, req *openfgav1.ReadChang
 	if err != nil {
 		return nil, serverErrors.InvalidContinuationToken
 	}
-	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
+	paginationOptions := storage.PaginationOptions{PageSize: int(req.GetPageSize().GetValue()), From: string(decodedContToken)}
 
-	changes, contToken, err := q.backend.ReadChanges(ctx, req.GetStoreId(), req.GetType(), paginationOptions, q.horizonOffset)
+	changes, contToken, err := q.backend.ReadChanges(ctx, req.GetStoreId(), req.GetType(), q.horizonOffset, paginationOptions)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return &openfgav1.ReadChangesResponse{

--- a/pkg/server/commands/read_changes_test.go
+++ b/pkg/server/commands/read_changes_test.go
@@ -43,10 +43,10 @@ func TestReadChangesQuery(t *testing.T) {
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		// Assert on specific inputs passed in.
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, reqType, storage.PaginationOptions{
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, reqType, horizonOffset, storage.PaginationOptions{
 			PageSize: reqPageSize,
 			From:     reqToken,
-		}, horizonOffset).Times(1)
+		}).Times(1)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangeQueryHorizonOffset(int(horizonOffset.Minutes())))
 		_, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
@@ -72,10 +72,10 @@ func TestReadChangesQuery(t *testing.T) {
 		mockEncoder.EXPECT().Encode(gomock.Any()).Return(respToken, nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", storage.PaginationOptions{
-			PageSize: storage.DefaultPageSize,
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", 0*time.Minute, storage.PaginationOptions{
+			PageSize: 0,
 			From:     "",
-		}, 0*time.Minute).Times(1)
+		}).Times(1)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
@@ -118,10 +118,10 @@ func TestReadChangesQuery(t *testing.T) {
 		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", storage.PaginationOptions{
-			PageSize: storage.DefaultPageSize,
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", 0*time.Minute, storage.PaginationOptions{
+			PageSize: 0,
 			From:     "",
-		}, 0*time.Minute).Times(1).Return(nil, []byte{}, storage.ErrNotFound)
+		}).Times(1).Return(nil, []byte{}, storage.ErrNotFound)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{

--- a/pkg/server/commands/read_test.go
+++ b/pkg/server/commands/read_test.go
@@ -88,7 +88,7 @@ func TestReadCommand(t *testing.T) {
 		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, storage.PaginationOptions{
 			PageSize: storage.DefaultPageSize,
 			From:     "",
-		}).Times(1)
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED}).Times(1)
 
 		cmd := NewReadQuery(mockDatastore)
 		_, err := cmd.Execute(context.Background(), &openfgav1.ReadRequest{
@@ -116,7 +116,7 @@ func TestReadCommand(t *testing.T) {
 		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, storage.PaginationOptions{
 			PageSize: int(pageSize),
 			From:     "",
-		}).Times(1)
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED}).Times(1)
 
 		cmd := NewReadQuery(mockDatastore, WithReadQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadRequest{

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -465,7 +465,7 @@ func TestListUsers_Deadline(t *testing.T) {
 		mockDatastore.EXPECT().Close().Times(1)
 
 		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, gomock.Any()).
+			Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, context.DeadlineExceeded).
 			Times(1)
 
@@ -520,8 +520,8 @@ func TestListUsers_Deadline(t *testing.T) {
 			Times(1)
 
 		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, gomock.Any()).
-			DoAndReturn(func(ctx context.Context, storeID string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+			Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, storeID string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 				time.Sleep(10 * time.Millisecond)
 				return nil, context.Canceled
 			}).

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -748,15 +748,15 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 
 	// it could happen that one of the following two mocks won't be necessary because the goroutine will be short-circuited
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		Return(returnedTuple, nil)
 
 	mockDatastore.EXPECT().
-		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any()).
+		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.QueryOptions) (storage.TupleIterator, error) {
 				time.Sleep(50 * time.Millisecond)
 				return nil, errors.New("some error")
 			})
@@ -1040,10 +1040,10 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 
 	// it could happen that one of the following two mocks won't be necessary because the goroutine will be short-circuited
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(ctx context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+			func(ctx context.Context, _ string, _ *openfgav1.TupleKey, _ storage.QueryOptions) (storage.TupleIterator, error) {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
@@ -1053,10 +1053,10 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 			})
 
 	mockDatastore.EXPECT().
-		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any()).
+		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.QueryOptions) (storage.TupleIterator, error) {
 				time.Sleep(100 * time.Millisecond)
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}), nil
 			})
@@ -1120,7 +1120,7 @@ func TestCheckWithCachedResolution(t *testing.T) {
 		}, nil)
 
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(returnedTuple, nil)
 
@@ -1413,7 +1413,7 @@ func BenchmarkListObjectsNoRaceCondition(b *testing.B) {
 		SchemaVersion:   typesystem.SchemaVersion1_1,
 		TypeDefinitions: typedefs,
 	}, nil)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
 
 	s := MustNewServerWithOpts(
 		WithDatastore(mockDatastore),
@@ -1490,7 +1490,7 @@ func TestListObjects_ErrorCases(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: "user:*"},
 				{Object: "user:bob"},
-			}}).AnyTimes().Return(nil, errors.New("error reading from storage"))
+			}}, gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
 
 		t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
 			res, err := s.ListObjects(ctx, &openfgav1.ListObjectsRequest{

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1320,7 +1320,7 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 
 			reverseExpandErrCh := make(chan error, 1)
 			go func() {
-				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 				if errReverseExpand != nil {
 					reverseExpandErrCh <- errReverseExpand
 				}

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -174,11 +174,11 @@ func WithMaxTypesPerAuthorizationModel(n int) StorageOption {
 func (s *MemoryBackend) Close() {}
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (s *MemoryBackend) Read(ctx context.Context, store string, key *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (s *MemoryBackend) Read(ctx context.Context, store string, key *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "memory.Read")
 	defer span.End()
 
-	return s.read(ctx, store, key, nil)
+	return s.read(ctx, store, key, nil, queryOptions)
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -187,11 +187,12 @@ func (s *MemoryBackend) ReadPage(
 	store string,
 	key *openfgav1.TupleKey,
 	paginationOptions storage.PaginationOptions,
+	queryOptions storage.QueryOptions,
 ) ([]*openfgav1.Tuple, []byte, error) {
 	ctx, span := tracer.Start(ctx, "memory.ReadPage")
 	defer span.End()
 
-	it, err := s.read(ctx, store, key, &paginationOptions)
+	it, err := s.read(ctx, store, key, &paginationOptions, queryOptions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -271,7 +272,7 @@ func (s *MemoryBackend) ReadChanges(
 
 // read returns an iterator of a store's tuples with a given tuple as filter.
 // A nil paginationOptions input means the returned iterator will iterate through all values.
-func (s *MemoryBackend) read(ctx context.Context, store string, tk *openfgav1.TupleKey, paginationOptions *storage.PaginationOptions) (*staticIterator, error) {
+func (s *MemoryBackend) read(ctx context.Context, store string, tk *openfgav1.TupleKey, paginationOptions *storage.PaginationOptions, _ storage.QueryOptions) (*staticIterator, error) {
 	_, span := tracer.Start(ctx, "memory.read")
 	defer span.End()
 
@@ -426,7 +427,7 @@ func find(records []*storage.TupleRecord, tupleKey *openfgav1.TupleKey) bool {
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (s *MemoryBackend) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (s *MemoryBackend) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	_, span := tracer.Start(ctx, "memory.ReadUserTuple")
 	defer span.End()
 
@@ -448,6 +449,7 @@ func (s *MemoryBackend) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	_, span := tracer.Start(ctx, "memory.ReadUsersetTuples")
 	defer span.End()
@@ -486,6 +488,7 @@ func (s *MemoryBackend) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	_, span := tracer.Start(ctx, "memory.ReadStartingWithUser")
 	defer span.End()

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -129,11 +129,11 @@ func (m *MySQL) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (m *MySQL) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MySQL) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.Read")
 	defer span.End()
 
-	return m.read(ctx, store, tupleKey, nil)
+	return m.read(ctx, store, tupleKey, nil, queryOptions)
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -142,11 +142,12 @@ func (m *MySQL) ReadPage(
 	store string,
 	tupleKey *openfgav1.TupleKey,
 	opts storage.PaginationOptions,
+	queryOptions storage.QueryOptions,
 ) ([]*openfgav1.Tuple, []byte, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadPage")
 	defer span.End()
 
-	iter, err := m.read(ctx, store, tupleKey, &opts)
+	iter, err := m.read(ctx, store, tupleKey, &opts, queryOptions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,7 +156,7 @@ func (m *MySQL) ReadPage(
 	return iter.ToArray(opts)
 }
 
-func (m *MySQL) read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts *storage.PaginationOptions) (*sqlcommon.SQLTupleIterator, error) {
+func (m *MySQL) read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts *storage.PaginationOptions, _ storage.QueryOptions) (*sqlcommon.SQLTupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.read")
 	defer span.End()
 
@@ -216,7 +217,7 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (m *MySQL) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MySQL) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadUserTuple")
 	defer span.End()
 
@@ -273,6 +274,7 @@ func (m *MySQL) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadUsersetTuples")
 	defer span.End()
@@ -321,6 +323,7 @@ func (m *MySQL) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	opts storage.ReadStartingWithUserFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadStartingWithUser")
 	defer span.End()

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -247,7 +247,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", 0, storage.PaginationOptions{PageSize: storage.DefaultPageSize, From: ""})
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -74,7 +74,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 
 	iter, err := ds.Read(ctx,
 		store,
-		tuple.NewTupleKey("doc:", "relation", ""))
+		tuple.NewTupleKey("doc:", "relation", ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	defer iter.Stop()
 
 	require.NoError(t, err)
@@ -124,7 +124,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
+		storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+		storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -182,7 +183,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	tk := tuple.NewTupleKey("folder:2021-budget", "owner", "user:anne")
-	iter, err := ds.Read(ctx, "store", tk)
+	iter, err := ds.Read(ctx, "store", tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -190,12 +191,12 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
 
-	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
+	userTuple, err := ds.ReadUserTuple(ctx, "store", tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.GetKey())
 
@@ -206,7 +207,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"})
+	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -220,7 +221,7 @@ func TestAllowNullCondition(t *testing.T) {
 		UserFilter: []*openfgav1.ObjectRelation{
 			{Object: "user:anne"},
 		},
-	})
+	}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -142,19 +142,19 @@ func (p *Postgres) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (p *Postgres) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (p *Postgres) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.Read")
 	defer span.End()
 
-	return p.read(ctx, store, tupleKey, nil)
+	return p.read(ctx, store, tupleKey, nil, queryOptions)
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
-func (p *Postgres) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (p *Postgres) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadPage")
 	defer span.End()
 
-	iter, err := p.read(ctx, store, tupleKey, &opts)
+	iter, err := p.read(ctx, store, tupleKey, &opts, queryOptions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -163,7 +163,7 @@ func (p *Postgres) ReadPage(ctx context.Context, store string, tupleKey *openfga
 	return iter.ToArray(opts)
 }
 
-func (p *Postgres) read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts *storage.PaginationOptions) (*sqlcommon.SQLTupleIterator, error) {
+func (p *Postgres) read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts *storage.PaginationOptions, _ storage.QueryOptions) (*sqlcommon.SQLTupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.read")
 	defer span.End()
 
@@ -224,7 +224,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadUserTuple")
 	defer span.End()
 
@@ -278,7 +278,7 @@ func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *op
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
-func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadUsersetTuples")
 	defer span.End()
 
@@ -322,7 +322,7 @@ func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter s
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
-func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadStartingWithUser")
 	defer span.End()
 

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -247,7 +247,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", 0, storage.PaginationOptions{PageSize: storage.DefaultPageSize, From: ""})
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -74,7 +74,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 
 	iter, err := ds.Read(ctx,
 		store, tuple.
-			NewTupleKey("doc:", "relation", ""))
+			NewTupleKey("doc:", "relation", ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	defer iter.Stop()
 	require.NoError(t, err)
 
@@ -123,7 +123,9 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
+		storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+		storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED},
+	)
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -181,7 +183,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	tk := tuple.NewTupleKey("folder:2021-budget", "owner", "user:anne")
-	iter, err := ds.Read(ctx, "store", tk)
+	iter, err := ds.Read(ctx, "store", tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -189,12 +191,12 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
 
-	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
+	userTuple, err := ds.ReadUserTuple(ctx, "store", tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.GetKey())
 
@@ -205,7 +207,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"})
+	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -219,7 +221,7 @@ func TestAllowNullCondition(t *testing.T) {
 		UserFilter: []*openfgav1.ObjectRelation{
 			{Object: "user:anne"},
 		},
-	})
+	}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 	require.NoError(t, err)
 	defer iter.Stop()
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -232,10 +232,17 @@ func (t *SQLTupleIterator) next() (*storage.TupleRecord, error) {
 // ToArray converts the tupleIterator to an []*openfgav1.Tuple and a possibly empty continuation token.
 // If the continuation token exists it is the ulid of the last element of the returned array.
 func (t *SQLTupleIterator) ToArray(
-	opts storage.PaginationOptions,
+	options ...storage.Option,
 ) ([]*openfgav1.Tuple, []byte, error) {
+	opts := &storage.Options{}
+
+	// Apply each option to the opts struct
+	for _, option := range options {
+		option.Apply(opts)
+	}
+
 	var res []*openfgav1.Tuple
-	for i := 0; i < opts.PageSize; i++ {
+	for i := 0; i < opts.Pagination.PageSize; i++ {
 		tupleRecord, err := t.next()
 		if err != nil {
 			if err == storage.ErrIteratorDone {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -60,6 +60,9 @@ type PaginationOptions struct {
 }
 
 func (p PaginationOptions) Apply(opts *Options) {
+	if p.PageSize == 0 {
+		p.PageSize = DefaultPageSize
+	}
 	opts.Pagination = &p
 }
 
@@ -213,7 +216,7 @@ type AuthorizationModelReadBackend interface {
 	ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgav1.AuthorizationModel, error)
 
 	// ReadAuthorizationModels reads all models for the supplied store and returns them in descending order of ULID (from newest to oldest).
-	ReadAuthorizationModels(ctx context.Context, store string, options PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error)
+	ReadAuthorizationModels(ctx context.Context, store string, options ...Option) ([]*openfgav1.AuthorizationModel, []byte, error)
 
 	// FindLatestAuthorizationModel returns the last model for the store.
 	// If none were ever written, it must return ErrNotFound.
@@ -241,7 +244,7 @@ type StoresBackend interface {
 	CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error)
 	DeleteStore(ctx context.Context, id string) error
 	GetStore(ctx context.Context, id string) (*openfgav1.Store, error)
-	ListStores(ctx context.Context, paginationOptions PaginationOptions) ([]*openfgav1.Store, []byte, error)
+	ListStores(ctx context.Context, options ...Option) ([]*openfgav1.Store, []byte, error)
 }
 
 // AssertionsBackend is an interface that defines the set of methods for reading and writing assertions.
@@ -267,8 +270,8 @@ type ChangelogBackend interface {
 		ctx context.Context,
 		store,
 		objectType string,
-		paginationOptions PaginationOptions,
 		horizonOffset time.Duration,
+		options ...Option,
 	) ([]*openfgav1.TupleChange, []byte, error)
 }
 

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -51,6 +51,7 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tupleKey *openfgav1.TupleKey,
+	queryOptions storage.QueryOptions,
 ) (*openfgav1.Tuple, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -61,11 +62,11 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey)
+	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey, queryOptions)
 }
 
 // Read the set of tuples associated with `store` and `TupleKey`, which may be nil or partially filled.
-func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
 		return nil, err
@@ -75,7 +76,7 @@ func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, 
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.Read(ctx, store, tupleKey)
+	return b.RelationshipTupleReader.Read(ctx, store, tupleKey, queryOptions)
 }
 
 // ReadUsersetTuples returns all userset tuples for a specified object and relation.
@@ -83,6 +84,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -93,7 +95,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
+	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, queryOptions)
 }
 
 // ReadStartingWithUser performs a reverse read of relationship tuples starting at one or
@@ -102,6 +104,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -112,7 +115,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
+	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, queryOptions)
 }
 
 // waitForLimiter respects context errors and returns an error only if it couldn't send an item to the channel.

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -51,7 +51,7 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tupleKey *openfgav1.TupleKey,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (*openfgav1.Tuple, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -62,11 +62,11 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey, queryOptions)
+	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey, options...)
 }
 
 // Read the set of tuples associated with `store` and `TupleKey`, which may be nil or partially filled.
-func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, 
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.Read(ctx, store, tupleKey, queryOptions)
+	return b.RelationshipTupleReader.Read(ctx, store, tupleKey, options...)
 }
 
 // ReadUsersetTuples returns all userset tuples for a specified object and relation.
@@ -84,7 +84,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -95,7 +95,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, queryOptions)
+	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options...)
 }
 
 // ReadStartingWithUser performs a reverse read of relationship tuples starting at one or
@@ -104,7 +104,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -115,7 +115,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, queryOptions)
+	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options...)
 }
 
 // waitForLimiter respects context errors and returns an error only if it couldn't send an item to the channel.

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -41,7 +41,7 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 	start := time.Now()
 
 	wg.Go(func() error {
-		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"))
+		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		return err
 	})
 
@@ -49,12 +49,12 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 		_, err := limitedTupleReader.ReadUsersetTuples(context.Background(), store, storage.ReadUsersetTuplesFilter{
 			Object:   "obj:1",
 			Relation: "viewer",
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		return err
 	})
 
 	wg.Go(func() error {
-		_, err := limitedTupleReader.Read(context.Background(), store, nil)
+		_, err := limitedTupleReader.Read(context.Background(), store, nil, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		return err
 	})
 
@@ -68,7 +68,7 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 						Object:   "obj",
 						Relation: "viewer",
 					},
-				}})
+				}}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		return err
 	})
 
@@ -96,22 +96,22 @@ func TestBoundedConcurrencyWrapper_Exits_Early_If_Context_Error(t *testing.T) {
 	}{
 		`read`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.Read(ctx, ulid.Make().String(), &openfgav1.TupleKey{})
+				return dut.Read(ctx, ulid.Make().String(), &openfgav1.TupleKey{}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 			},
 		},
 		`read_user_tuple`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadUserTuple(ctx, ulid.Make().String(), &openfgav1.TupleKey{})
+				return dut.ReadUserTuple(ctx, ulid.Make().String(), &openfgav1.TupleKey{}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 			},
 		},
 		`read_userset_tuples`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadUsersetTuples(ctx, ulid.Make().String(), storage.ReadUsersetTuplesFilter{})
+				return dut.ReadUsersetTuples(ctx, ulid.Make().String(), storage.ReadUsersetTuplesFilter{}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 			},
 		},
 		`read_starting_with_user`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadStartingWithUser(ctx, ulid.Make().String(), storage.ReadStartingWithUserFilter{})
+				return dut.ReadStartingWithUser(ctx, ulid.Make().String(), storage.ReadStartingWithUserFilter{}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 			},
 		},
 	}

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -48,10 +48,11 @@ func (c *combinedTupleReader) Read(
 	ctx context.Context,
 	storeID string,
 	tk *openfgav1.TupleKey,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	iter1 := storage.NewStaticTupleIterator(filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation()))
 
-	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk)
+	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk, queryOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -65,9 +66,10 @@ func (c *combinedTupleReader) ReadPage(
 	store string,
 	tk *openfgav1.TupleKey,
 	opts storage.PaginationOptions,
+	queryOptions storage.QueryOptions,
 ) ([]*openfgav1.Tuple, []byte, error) {
 	// No reading from contextual tuples.
-	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, opts)
+	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, opts, queryOptions)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader.ReadUserTuple].
@@ -75,6 +77,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tk *openfgav1.TupleKey,
+	queryOptions storage.QueryOptions,
 ) (*openfgav1.Tuple, error) {
 	filteredContextualTuples := filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation())
 
@@ -84,7 +87,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 		}
 	}
 
-	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk)
+	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk, queryOptions)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
@@ -92,6 +95,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	var usersetTuples []*openfgav1.Tuple
 
@@ -103,7 +107,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 
 	iter1 := storage.NewStaticTupleIterator(usersetTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
+	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, queryOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -116,6 +120,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	queryOptions storage.QueryOptions,
 ) (storage.TupleIterator, error) {
 	var filteredTuples []*openfgav1.Tuple
 	for _, t := range c.contextualTuples {
@@ -143,7 +148,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 
 	iter1 := storage.NewStaticTupleIterator(filteredTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
+	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, queryOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -48,11 +48,11 @@ func (c *combinedTupleReader) Read(
 	ctx context.Context,
 	storeID string,
 	tk *openfgav1.TupleKey,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	iter1 := storage.NewStaticTupleIterator(filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation()))
 
-	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk, queryOptions)
+	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -65,11 +65,10 @@ func (c *combinedTupleReader) ReadPage(
 	ctx context.Context,
 	store string,
 	tk *openfgav1.TupleKey,
-	opts storage.PaginationOptions,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) ([]*openfgav1.Tuple, []byte, error) {
 	// No reading from contextual tuples.
-	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, opts, queryOptions)
+	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, options...)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader.ReadUserTuple].
@@ -77,7 +76,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tk *openfgav1.TupleKey,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (*openfgav1.Tuple, error) {
 	filteredContextualTuples := filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation())
 
@@ -87,7 +86,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 		}
 	}
 
-	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk, queryOptions)
+	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk, options...)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
@@ -95,7 +94,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	var usersetTuples []*openfgav1.Tuple
 
@@ -107,7 +106,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 
 	iter1 := storage.NewStaticTupleIterator(usersetTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, queryOptions)
+	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +119,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
-	queryOptions storage.QueryOptions,
+	options ...storage.Option,
 ) (storage.TupleIterator, error) {
 	var filteredTuples []*openfgav1.Tuple
 	for _, t := range c.contextualTuples {
@@ -148,7 +147,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 
 	iter1 := storage.NewStaticTupleIterator(filteredTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, queryOptions)
+	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -38,36 +38,36 @@ func (c *ContextTracerWrapper) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader.ReadUserTuple].
-func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey)
+	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey, queryOptions)
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, opts)
+	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, opts, queryOptions)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey)
+	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey, queryOptions)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
-func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter)
+	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter, queryOptions)
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
-func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts)
+	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts, queryOptions)
 }

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -38,36 +38,36 @@ func (c *ContextTracerWrapper) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader.ReadUserTuple].
-func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey, queryOptions)
+	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey, options...)
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions, queryOptions storage.QueryOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) ([]*openfgav1.Tuple, []byte, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, opts, queryOptions)
+	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, options...)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, queryOptions storage.QueryOptions) (*openfgav1.Tuple, error) {
+func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ...storage.Option) (*openfgav1.Tuple, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey, queryOptions)
+	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey, options...)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
-func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter, queryOptions)
+	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter, options...)
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
-func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, queryOptions storage.QueryOptions) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, options ...storage.Option) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts, queryOptions)
+	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts, options...)
 }

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -487,7 +487,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		}
 
 		t.Run("read_returns_everything", func(t *testing.T) {
-			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""))
+			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""), storage.NewQueryOptions())
 			require.NoError(t, err)
 			defer tupleIterator.Stop()
 
@@ -605,7 +605,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 
 		// Ensure it is not there.
-		_, err = datastore.ReadUserTuple(ctx, storeID, tk)
+		_, err = datastore.ReadUserTuple(ctx, storeID, tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -694,28 +694,28 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tuple1, tuple2, tuple3, tuple4})
 		require.NoError(t, err)
 
-		gotTuple, err := datastore.ReadUserTuple(ctx, storeID, tuple1)
+		gotTuple, err := datastore.ReadUserTuple(ctx, storeID, tuple1, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple1, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple2)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple2, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple2, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple3)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple3, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple3, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple4)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple4, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple4, gotTuple.GetKey(), cmpOpts...); diff != "" {
@@ -727,7 +727,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 		tk := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
 
-		_, err := datastore.ReadUserTuple(ctx, storeID, tk)
+		_, err := datastore.ReadUserTuple(ctx, storeID, tk, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -762,7 +762,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   "doc:readme",
 			Relation: "owner",
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -796,7 +796,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 	t.Run("reading_userset_tuples_that_don't_exist_should_return_an_empty_iterator", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"})
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer gotTuples.Stop()
 
@@ -822,7 +822,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.DirectRelationReference("group", "member"),
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -859,7 +859,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 				typesystem.DirectRelationReference("group", "member"),
 				typesystem.DirectRelationReference("grouping", "member"),
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -900,7 +900,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.WildcardRelationReference("user"),
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -937,7 +937,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 				typesystem.DirectRelationReference("group", "member"),
 				typesystem.WildcardRelationReference("user"),
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -985,7 +985,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, tks)
 		require.NoError(t, err)
 
-		iter, err := datastore.Read(ctx, storeID, tupleKey1)
+		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -993,20 +993,20 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.Nil(t, tuples[0].GetKey().GetCondition())
 		require.Nil(t, tuples[1].GetKey().GetCondition())
 
-		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
 			Relation: tupleKey2.GetRelation(),
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1020,7 +1020,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1066,7 +1066,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, tks)
 		require.NoError(t, err)
 
-		iter, err := datastore.Read(ctx, storeID, tupleKey1)
+		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1076,20 +1076,20 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 		require.Empty(t, tp.GetKey().GetCondition().GetContext())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""), storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.NotNil(t, tuples[0].GetKey().GetCondition().GetContext())
 		require.NotNil(t, tuples[1].GetKey().GetCondition().GetContext())
 
-		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
 			Relation: tupleKey2.GetRelation(),
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1103,7 +1103,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
 			},
-		})
+		}, storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1159,6 +1159,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 					},
 				},
 			},
+			storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED},
 		)
 		require.NoError(t, err)
 
@@ -1185,6 +1186,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 					},
 				},
 			},
+			storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED},
 		)
 		require.NoError(t, err)
 
@@ -1211,6 +1213,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 					},
 				},
 			},
+			storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED},
 		)
 		require.NoError(t, err)
 
@@ -1237,6 +1240,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 					},
 				},
 			},
+			storage.QueryOptions{Consistency: openfgav1.ConsistencyPreference_UNSPECIFIED},
 		)
 		require.NoError(t, err)
 
@@ -1305,7 +1309,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 				})
 
 				t.Run("Read", func(t *testing.T) {
-					tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
+					tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.NewQueryOptions())
 					require.NoError(t, err)
 					defer tupleIterator.Stop()
 
@@ -1401,7 +1405,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			})
 
 			t.Run("Read", func(t *testing.T) {
-				tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
+				tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.NewQueryOptions())
 				require.NoError(t, err)
 				defer tupleIterator.Stop()
 
@@ -1493,7 +1497,7 @@ func readWithPageSize(t *testing.T, ds storage.OpenFGADatastore, storeID string,
 		tuples, continuationToken, err = ds.ReadPage(context.Background(), storeID, filter, storage.PaginationOptions{
 			PageSize: pageSize,
 			From:     string(continuationToken),
-		})
+		}, storage.NewQueryOptions())
 		if err != nil {
 			require.ErrorIs(t, err, storage.ErrNotFound)
 			break

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -487,7 +487,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		}
 
 		t.Run("read_returns_everything", func(t *testing.T) {
-			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""), storage.NewQueryOptions())
+			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""))
 			require.NoError(t, err)
 			defer tupleIterator.Stop()
 
@@ -1309,7 +1309,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 				})
 
 				t.Run("Read", func(t *testing.T) {
-					tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.NewQueryOptions())
+					tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
 					require.NoError(t, err)
 					defer tupleIterator.Stop()
 
@@ -1405,7 +1405,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			})
 
 			t.Run("Read", func(t *testing.T) {
-				tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.NewQueryOptions())
+				tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
 				require.NoError(t, err)
 				defer tupleIterator.Stop()
 
@@ -1497,7 +1497,7 @@ func readWithPageSize(t *testing.T, ds storage.OpenFGADatastore, storeID string,
 		tuples, continuationToken, err = ds.ReadPage(context.Background(), storeID, filter, storage.PaginationOptions{
 			PageSize: pageSize,
 			From:     string(continuationToken),
-		}, storage.NewQueryOptions())
+		})
 		if err != nil {
 			require.ErrorIs(t, err, storage.ErrNotFound)
 			break


### PR DESCRIPTION
## Description

This PR updates the storage interface as required for the changes to begin accepting a consistency parameter that specifies the consistency type requested on `TupleBackend` read actions. A `QueryOptions` struct has been introduced that includes the consistency choice for a given request, defaulting `openfgav1.ConsistencyPreference_MINIMIZE_LATENCY`.

This results in a breaking change to the `storage` interface as follows:

* The functions that are part of `RelationshipTupleReader` interface accept a variadic argument of type `storage.Option`, which can currently be a `storage.QueryOption` or `storage.PaginationOption`. In order to construct the `Options` that should be used, the functional options pattern can be used like below to apply the various options onto the `Options` struct.

```
opts := &storage.Options{}

// Apply each option to the opts struct
for _, option := range options {
	option.Apply(opts)
}
``` 

When `queryOptions.Consistency == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY`, storage implementations should skip any cache that they may have and perform the read against the datasource directly to ensure that the tuples being read are of a higher consistency than if the cache was used. Internally, OpenFGA will also skip any use of the `CachedCheckResolver` when higher consistency is requested.

## References

https://github.com/openfga/roadmap/issues/54

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
