### PR TITLE
chore: pass through consistency params

### DIFF
--- a/pkg/server/commands/listusers/list_users.go
+++ b/pkg/server/commands/listusers/list_users.go
@@ -16,6 +16,7 @@ type listUsersRequest interface {
 	GetUserFilters() []*openfgav1.UserTypeFilter
 	GetContextualTuples() []*openfgav1.TupleKey
 	GetContext() *structpb.Struct
+	GetConsistency() openfgav1.ConsistencyPreference
 }
 
 type internalListUsersRequest struct {
@@ -146,6 +147,7 @@ func fromListUsersRequest(o listUsersRequest, datastoreQueryCount *atomic.Uint32
 			UserFilters:          o.GetUserFilters(),
 			ContextualTuples:     o.GetContextualTuples(),
 			Context:              o.GetContext(),
+			Consistency:          o.GetConsistency(),
 		},
 		visitedUsersetsMap:  make(map[string]struct{}),
 		depth:               0,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -810,6 +810,7 @@ func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfga
 		TupleKey:          tk,
 		PageSize:          req.GetPageSize(),
 		ContinuationToken: req.GetContinuationToken(),
+		Consistency:       req.GetConsistency(),
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -997,6 +997,7 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 		StoreId:              storeID,
 		AuthorizationModelId: typesys.GetAuthorizationModelID(), // the resolved model id
 		TupleKey:             tk,
+		Consistency:          req.GetConsistency(),
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Passes the consistency parameter for Read, List Users, and Expand

## Description
<!-- Provide a detailed description of the changes -->
Even though no cache is used in OpenFGA for Read, List Users, or Expand, we should pass through the request parameters.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
