### PR TITLE
feat: throw error when higher consistency requested but flag not enabled

### DIFF
--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -36,8 +36,9 @@ func (s *Server) ListUsers(
 		return nil, status.Error(codes.Unimplemented, "ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
 	}
 
-	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
-		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	err := s.validateConsistencyRequest(req.GetConsistency())
+	if err != nil {
+		return nil, err
 	}
 
 	start := time.Now()

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -36,6 +36,10 @@ func (s *Server) ListUsers(
 		return nil, status.Error(codes.Unimplemented, "ListUsers is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-list-users` configuration option when running OpenFGA server")
 	}
 
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
+
 	start := time.Now()
 	ctx, span := tracer.Start(ctx, "ListUsers", trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -257,9 +257,20 @@ func TestExperimentalListUsers(t *testing.T) {
 
 	t.Run("list_users_errors_if_not_higher_consistency_param_sent_but_not_experimentally_enabled", func(t *testing.T) {
 		server.experimentals = []ExperimentalFeatureFlag{ExperimentalEnableListUsers}
-		req.Consistency = openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 
-		_, err := server.ListUsers(ctx, req)
+		_, err := server.ListUsers(ctx, &openfgav1.ListUsersRequest{
+			StoreId: storeID,
+			Object: &openfgav1.Object{
+				Type: "document",
+				Id:   "1",
+			},
+			Relation: "viewer",
+			UserFilters: []*openfgav1.UserTypeFilter{
+				{Type: "user"},
+			},
+			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+		})
+
 		require.Error(t, err)
 		require.Equal(t, "rpc error: code = InvalidArgument desc = Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server", err.Error())
 

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -255,6 +255,19 @@ func TestExperimentalListUsers(t *testing.T) {
 		require.Equal(t, codes.Unimplemented, e.Code())
 	})
 
+	t.Run("list_users_errors_if_not_higher_consistency_param_sent_but_not_experimentally_enabled", func(t *testing.T) {
+		server.experimentals = []ExperimentalFeatureFlag{ExperimentalEnableListUsers}
+		req.Consistency = openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
+
+		_, err := server.ListUsers(ctx, req)
+		require.Error(t, err)
+		require.Equal(t, "rpc error: code = InvalidArgument desc = Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server", err.Error())
+
+		e, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.InvalidArgument, e.Code())
+	})
+
 	t.Run("list_users_returns_error_if_latest_model_not_found", func(t *testing.T) {
 		mockDatastore.EXPECT().FindLatestAuthorizationModel(gomock.Any(), gomock.Any()).Return(nil, storage.ErrNotFound) // error demonstrates that main code path is reached
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -589,6 +589,9 @@ func (s *Server) Close() {
 }
 
 func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequest) (*openfgav1.ListObjectsResponse, error) {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
 	start := time.Now()
 
 	targetObjectType := req.GetType()
@@ -692,6 +695,9 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 }
 
 func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, srv openfgav1.OpenFGAService_StreamedListObjectsServer) error {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
 	start := time.Now()
 
 	ctx := srv.Context()
@@ -782,6 +788,9 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 }
 
 func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
 	tk := req.GetTupleKey()
 	ctx, span := tracer.Start(ctx, "Read", trace.WithAttributes(
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
@@ -849,6 +858,10 @@ func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openf
 }
 
 func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openfgav1.CheckResponse, error) {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
+
 	start := time.Now()
 
 	tk := req.GetTupleKey()
@@ -968,6 +981,9 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 }
 
 func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*openfgav1.ExpandResponse, error) {
+	if !s.IsExperimentallyEnabled(ExperimentalEnableConsistencyParams) && req.GetConsistency() == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		return nil, status.Error(codes.InvalidArgument, "Consistency parameters is not enabled. It can be enabled for experimental use by passing the `--experimentals enable-consistency-params` configuration option when running OpenFGA server")
+	}
 	tk := req.GetTupleKey()
 	ctx, span := tracer.Start(ctx, "Expand", trace.WithAttributes(
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Raises an error when the `consistency` parameter is `HIGHER_CONSISTENCY` but the `enable-consistency-params` experimental flag is not set.

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

If a request is made that requests higher consistency (`consistency: HIGHER_CONSISTENCY`), but the `enable-consistency-params` is not enabled, raise an `InvalidArgument` error.

Impacts the following endpoints:
* Check
* Read
* ListObjects
* StreamedListObjects
* Expand
* ListUsers

Note that because the API will always send the default value of the consistency enum (`UNSPECIFIED`), we are only raising an error if the caller has specifically requested `HIGHER_CONSISTENCY` without the flag enabled.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
