### PR TITLE
test: add case to cover recursion

### DIFF
--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -2946,7 +2946,21 @@ func TestResolvesExclusivelyToDirectlyAssignable(t *testing.T) {
 			expectDirectlyAssignable: true,
 			expectError:              false,
 		},
-
+		{
+			name: "userset_reference_itself",
+			model: `
+				model
+					schema 1.1
+				type user
+				type group
+					relations
+						define member: [user,group#member]`,
+			relationReferences: []*openfgav1.RelationReference{
+				DirectRelationReference("group", "member"),
+			},
+			expectDirectlyAssignable: false, // for now, we cannot shortcut this logic due to recursion
+			expectError:              false,
+		},
 		{
 			name: "complex_userset_member_is_userset",
 			model: `


### PR DESCRIPTION

## Description
Adding test to verify that we will not short circuit in the case of userset referencing itself

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
