### PR TITLE
feat(storage)!: use method-specific options

### DIFF
--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -116,7 +116,7 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 			for {
 				// fetch a page of models for that store
 				opts := storage.ReadAuthorizationModelsOptions{
-					storage.NewPaginationOptions(100, continuationTokenModels),
+					Pagination: storage.NewPaginationOptions(100, continuationTokenModels),
 				}
 				models, tokenModels, err := db.ReadAuthorizationModels(ctx, store.GetId(), opts)
 				if err != nil {

--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -115,8 +115,10 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 
 			for {
 				// fetch a page of models for that store
-				models, tokenModels, err := db.ReadAuthorizationModels(ctx, store.GetId(),
-					storage.NewPaginationOptions(100, continuationTokenModels))
+				opts := storage.ReadAuthorizationModelsOptions{
+					storage.NewPaginationOptions(100, continuationTokenModels),
+				}
+				models, tokenModels, err := db.ReadAuthorizationModels(ctx, store.GetId(), opts)
 				if err != nil {
 					return nil, fmt.Errorf("error reading authorization models: %w", err)
 				}

--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -98,8 +98,10 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 
 	for {
 		// fetch a page of stores
-		stores, tokenStores, err := db.ListStores(ctx,
-			storage.NewPaginationOptions(100, continuationTokenStores))
+		opts := storage.ListStoresOptions{
+			Pagination: storage.NewPaginationOptions(100, continuationTokenStores),
+		}
+		stores, tokenStores, err := db.ListStores(ctx, opts)
 		if err != nil {
 			return nil, fmt.Errorf("error reading stores: %w", err)
 		}

--- a/internal/mocks/mock_slow_storage.go
+++ b/internal/mocks/mock_slow_storage.go
@@ -31,9 +31,9 @@ func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1
 	return m.OpenFGADatastore.Read(ctx, store, key)
 }
 
-func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadPage(ctx, store, key, paginationOptions)
+	return m.OpenFGADatastore.ReadPage(ctx, store, key, options)
 }
 
 func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey) (*openfgav1.Tuple, error) {

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -581,9 +581,9 @@ func (mr *MockStoresBackendMockRecorder) GetStore(ctx, id any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockStoresBackend) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockStoresBackend) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStores", ctx, paginationOptions)
+	ret := m.ctrl.Call(m, "ListStores", ctx, options)
 	ret0, _ := ret[0].([]*openfgav1.Store)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -591,9 +591,9 @@ func (m *MockStoresBackend) ListStores(ctx context.Context, paginationOptions st
 }
 
 // ListStores indicates an expected call of ListStores.
-func (mr *MockStoresBackendMockRecorder) ListStores(ctx, paginationOptions any) *gomock.Call {
+func (mr *MockStoresBackendMockRecorder) ListStores(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockStoresBackend)(nil).ListStores), ctx, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockStoresBackend)(nil).ListStores), ctx, options)
 }
 
 // MockAssertionsBackend is a mock of AssertionsBackend interface.
@@ -797,9 +797,9 @@ func (mr *MockOpenFGADatastoreMockRecorder) IsReady(ctx any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockOpenFGADatastore) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockOpenFGADatastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListStores", ctx, paginationOptions)
+	ret := m.ctrl.Call(m, "ListStores", ctx, options)
 	ret0, _ := ret[0].([]*openfgav1.Store)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -807,9 +807,9 @@ func (m *MockOpenFGADatastore) ListStores(ctx context.Context, paginationOptions
 }
 
 // ListStores indicates an expected call of ListStores.
-func (mr *MockOpenFGADatastoreMockRecorder) ListStores(ctx, paginationOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ListStores(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockOpenFGADatastore)(nil).ListStores), ctx, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStores", reflect.TypeOf((*MockOpenFGADatastore)(nil).ListStores), ctx, options)
 }
 
 // MaxTuplesPerWrite mocks base method.

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -350,7 +350,7 @@ func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModel(
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
@@ -484,7 +484,7 @@ func (mr *MockAuthorizationModelBackendMockRecorder) ReadAuthorizationModel(ctx,
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
@@ -886,7 +886,7 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModel(ctx, store, i
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -72,9 +72,9 @@ func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey any) *gomock.C
 }
 
 // ReadPage mocks base method.
-func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -82,9 +82,9 @@ func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey 
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockTupleBackend)(nil).ReadPage), ctx, store, tupleKey, options)
 }
 
 // ReadStartingWithUser mocks base method.
@@ -185,9 +185,9 @@ func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey any
 }
 
 // ReadPage mocks base method.
-func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -195,9 +195,9 @@ func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadPage), ctx, store, tupleKey, options)
 }
 
 // ReadStartingWithUser mocks base method.
@@ -918,9 +918,9 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, 
 }
 
 // ReadPage mocks base method.
-func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, paginationOptions storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, paginationOptions)
+	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -928,9 +928,9 @@ func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tuple
 }
 
 // ReadPage indicates an expected call of ReadPage.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, paginationOptions any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), ctx, store, tupleKey, paginationOptions)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadPage", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadPage), ctx, store, tupleKey, options)
 }
 
 // ReadStartingWithUser mocks base method.

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -672,9 +672,9 @@ func (m *MockChangelogBackend) EXPECT() *MockChangelogBackendMockRecorder {
 }
 
 // ReadChanges mocks base method.
-func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectType string, options storage.ReadChangesOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, paginationOptions, horizonOffset)
+	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, options, horizonOffset)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -682,9 +682,9 @@ func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store, objectTyp
 }
 
 // ReadChanges indicates an expected call of ReadChanges.
-func (mr *MockChangelogBackendMockRecorder) ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset any) *gomock.Call {
+func (mr *MockChangelogBackendMockRecorder) ReadChanges(ctx, store, objectType, options, horizonOffset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockChangelogBackend)(nil).ReadChanges), ctx, store, objectType, paginationOptions, horizonOffset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockChangelogBackend)(nil).ReadChanges), ctx, store, objectType, options, horizonOffset)
 }
 
 // MockOpenFGADatastore is a mock of OpenFGADatastore interface.
@@ -902,9 +902,9 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModels(ctx, store, 
 }
 
 // ReadChanges mocks base method.
-func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectType string, paginationOptions storage.PaginationOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectType string, options storage.ReadChangesOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, paginationOptions, horizonOffset)
+	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, objectType, options, horizonOffset)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -912,9 +912,9 @@ func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store, objectTyp
 }
 
 // ReadChanges indicates an expected call of ReadChanges.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, paginationOptions, horizonOffset any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, objectType, options, horizonOffset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadChanges), ctx, store, objectType, paginationOptions, horizonOffset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadChanges", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadChanges), ctx, store, objectType, options, horizonOffset)
 }
 
 // ReadPage mocks base method.

--- a/pkg/server/commands/list_stores.go
+++ b/pkg/server/commands/list_stores.go
@@ -50,9 +50,10 @@ func (q *ListStoresQuery) Execute(ctx context.Context, req *openfgav1.ListStores
 		return nil, serverErrors.InvalidContinuationToken
 	}
 
-	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
-
-	stores, continuationToken, err := q.storesBackend.ListStores(ctx, paginationOptions)
+	opts := storage.ListStoresOptions{
+		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+	}
+	stores, continuationToken, err := q.storesBackend.ListStores(ctx, opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -73,9 +73,10 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 		return nil, serverErrors.InvalidContinuationToken
 	}
 
-	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
-
-	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), paginationOptions)
+	opts := storage.ReadPageOptions{
+		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+	}
+	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read_authzmodels.go
+++ b/pkg/server/commands/read_authzmodels.go
@@ -50,9 +50,10 @@ func (q *ReadAuthorizationModelsQuery) Execute(ctx context.Context, req *openfga
 		return nil, serverErrors.InvalidContinuationToken
 	}
 
-	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
-
-	models, contToken, err := q.backend.ReadAuthorizationModels(ctx, req.GetStoreId(), paginationOptions)
+	opts := storage.ReadAuthorizationModelsOptions{
+		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+	}
+	models, contToken, err := q.backend.ReadAuthorizationModels(ctx, req.GetStoreId(), opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read_changes.go
+++ b/pkg/server/commands/read_changes.go
@@ -63,9 +63,10 @@ func (q *ReadChangesQuery) Execute(ctx context.Context, req *openfgav1.ReadChang
 	if err != nil {
 		return nil, serverErrors.InvalidContinuationToken
 	}
-	paginationOptions := storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken))
-
-	changes, contToken, err := q.backend.ReadChanges(ctx, req.GetStoreId(), req.GetType(), paginationOptions, q.horizonOffset)
+	opts := storage.ReadChangesOptions{
+		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+	}
+	changes, contToken, err := q.backend.ReadChanges(ctx, req.GetStoreId(), req.GetType(), opts, q.horizonOffset)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return &openfgav1.ReadChangesResponse{

--- a/pkg/server/commands/read_changes_test.go
+++ b/pkg/server/commands/read_changes_test.go
@@ -43,10 +43,13 @@ func TestReadChangesQuery(t *testing.T) {
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		// Assert on specific inputs passed in.
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, reqType, storage.PaginationOptions{
-			PageSize: reqPageSize,
-			From:     reqToken,
-		}, horizonOffset).Times(1)
+		opts := storage.ReadChangesOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: reqPageSize,
+				From:     reqToken,
+			},
+		}
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, reqType, opts, horizonOffset).Times(1)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangeQueryHorizonOffset(int(horizonOffset.Minutes())))
 		_, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
@@ -72,10 +75,13 @@ func TestReadChangesQuery(t *testing.T) {
 		mockEncoder.EXPECT().Encode(gomock.Any()).Return(respToken, nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", storage.PaginationOptions{
-			PageSize: storage.DefaultPageSize,
-			From:     "",
-		}, 0*time.Minute).Times(1)
+		opts := storage.ReadChangesOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: storage.DefaultPageSize,
+				From:     "",
+			},
+		}
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", opts, 0*time.Minute).Times(1)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
@@ -118,10 +124,13 @@ func TestReadChangesQuery(t *testing.T) {
 		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", storage.PaginationOptions{
-			PageSize: storage.DefaultPageSize,
-			From:     "",
-		}, 0*time.Minute).Times(1).Return(nil, []byte{}, storage.ErrNotFound)
+		opts := storage.ReadChangesOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: storage.DefaultPageSize,
+				From:     "",
+			},
+		}
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, "", opts, 0*time.Minute).Times(1).Return(nil, []byte{}, storage.ErrNotFound)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{

--- a/pkg/server/commands/read_test.go
+++ b/pkg/server/commands/read_test.go
@@ -85,10 +85,13 @@ func TestReadCommand(t *testing.T) {
 		storeID := ulid.Make().String()
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, storage.PaginationOptions{
-			PageSize: storage.DefaultPageSize,
-			From:     "",
-		}).Times(1)
+		opts := storage.ReadPageOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: storage.DefaultPageSize,
+				From:     "",
+			},
+		}
+		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, opts).Times(1)
 
 		cmd := NewReadQuery(mockDatastore)
 		_, err := cmd.Execute(context.Background(), &openfgav1.ReadRequest{
@@ -113,10 +116,13 @@ func TestReadCommand(t *testing.T) {
 		mockEncoder.EXPECT().Encode(gomock.Any()).Return("encodedtoken", nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, storage.PaginationOptions{
-			PageSize: int(pageSize),
-			From:     "",
-		}).Times(1)
+		opts := storage.ReadPageOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: int(pageSize),
+				From:     "",
+			},
+		}
+		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, opts).Times(1)
 
 		cmd := NewReadQuery(mockDatastore, WithReadQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadRequest{

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -200,13 +200,7 @@ func (s *MemoryBackend) ReadPage(
 }
 
 // ReadChanges see [storage.ChangelogBackend].ReadChanges.
-func (s *MemoryBackend) ReadChanges(
-	ctx context.Context,
-	store,
-	objectType string,
-	paginationOptions storage.PaginationOptions,
-	horizonOffset time.Duration,
-) ([]*openfgav1.TupleChange, []byte, error) {
+func (s *MemoryBackend) ReadChanges(ctx context.Context, store, objectType string, options storage.ReadChangesOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error) {
 	_, span := tracer.Start(ctx, "memory.ReadChanges")
 	defer span.End()
 
@@ -217,8 +211,8 @@ func (s *MemoryBackend) ReadChanges(
 	var from int64
 	var typeInToken string
 	var continuationToken string
-	if paginationOptions.From != "" {
-		tokens := strings.Split(paginationOptions.From, "|")
+	if options.Pagination.From != "" {
+		tokens := strings.Split(options.Pagination.From, "|")
 		if len(tokens) == 2 {
 			concreteToken := tokens[0]
 			typeInToken = tokens[1]
@@ -248,8 +242,8 @@ func (s *MemoryBackend) ReadChanges(
 	}
 
 	pageSize := storage.DefaultPageSize
-	if paginationOptions.PageSize > 0 {
-		pageSize = paginationOptions.PageSize
+	if options.Pagination.PageSize > 0 {
+		pageSize = options.Pagination.PageSize
 	}
 	to := int(from) + pageSize
 	if len(allChanges) < to {

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -752,7 +752,7 @@ func (s *MemoryBackend) GetStore(ctx context.Context, storeID string) (*openfgav
 }
 
 // ListStores provides a paginated list of all stores present in the MemoryBackend.
-func (s *MemoryBackend) ListStores(ctx context.Context, paginationOptions storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (s *MemoryBackend) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
 	_, span := tracer.Start(ctx, "memory.ListStores")
 	defer span.End()
 
@@ -771,15 +771,15 @@ func (s *MemoryBackend) ListStores(ctx context.Context, paginationOptions storag
 
 	var err error
 	var from int64
-	if paginationOptions.From != "" {
-		from, err = strconv.ParseInt(paginationOptions.From, 10, 32)
+	if options.Pagination.From != "" {
+		from, err = strconv.ParseInt(options.Pagination.From, 10, 32)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
 	pageSize := storage.DefaultPageSize
-	if paginationOptions.PageSize > 0 {
-		pageSize = paginationOptions.PageSize
+	if options.Pagination.PageSize > 0 {
+		pageSize = options.Pagination.PageSize
 	}
 	to := int(from) + pageSize
 	if len(stores) < to {

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -568,11 +568,7 @@ func (s *MemoryBackend) ReadAuthorizationModel(
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
-func (s *MemoryBackend) ReadAuthorizationModels(
-	ctx context.Context,
-	store string,
-	options storage.PaginationOptions,
-) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (s *MemoryBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	_, span := tracer.Start(ctx, "memory.ReadAuthorizationModels")
 	defer span.End()
 
@@ -594,12 +590,12 @@ func (s *MemoryBackend) ReadAuthorizationModels(
 	var err error
 
 	pageSize := storage.DefaultPageSize
-	if options.PageSize > 0 {
-		pageSize = options.PageSize
+	if options.Pagination.PageSize > 0 {
+		pageSize = options.Pagination.PageSize
 	}
 
-	if options.From != "" {
-		from, err = strconv.ParseInt(options.From, 10, 32)
+	if options.Pagination.From != "" {
+		from, err = strconv.ParseInt(options.Pagination.From, 10, 32)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -544,7 +544,7 @@ func (m *MySQL) GetStore(ctx context.Context, id string) (*openfgav1.Store, erro
 }
 
 // ListStores provides a paginated list of all stores present in the MySQL storage.
-func (m *MySQL) ListStores(ctx context.Context, opts storage.PaginationOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MySQL) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ListStores")
 	defer span.End()
 
@@ -554,15 +554,15 @@ func (m *MySQL) ListStores(ctx context.Context, opts storage.PaginationOptions) 
 		Where(sq.Eq{"deleted_at": nil}).
 		OrderBy("id")
 
-	if opts.From != "" {
-		token, err := sqlcommon.UnmarshallContToken(opts.From)
+	if options.Pagination.From != "" {
+		token, err := sqlcommon.UnmarshallContToken(options.Pagination.From)
 		if err != nil {
 			return nil, nil, err
 		}
 		sb = sb.Where(sq.GtOrEq{"id": token.Ulid})
 	}
-	if opts.PageSize > 0 {
-		sb = sb.Limit(uint64(opts.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
+	if options.Pagination.PageSize > 0 {
+		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
 	}
 
 	rows, err := sb.QueryContext(ctx)
@@ -593,12 +593,12 @@ func (m *MySQL) ListStores(ctx context.Context, opts storage.PaginationOptions) 
 		return nil, nil, sqlcommon.HandleSQLError(err)
 	}
 
-	if len(stores) > opts.PageSize {
+	if len(stores) > options.Pagination.PageSize {
 		contToken, err := json.Marshal(sqlcommon.NewContToken(id, ""))
 		if err != nil {
 			return nil, nil, err
 		}
-		return stores[:opts.PageSize], contToken, nil
+		return stores[:options.Pagination.PageSize], contToken, nil
 	}
 
 	return stores, nil, nil

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -246,7 +246,10 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
+	opts := storage.ReadChangesOptions{
+		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+	}
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", opts, 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -121,10 +121,13 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 
+	opts := storage.ReadPageOptions{
+		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+	}
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
+		opts)
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -190,7 +193,10 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+	opts := storage.ReadPageOptions{
+		Pagination: storage.NewPaginationOptions(2, ""),
+	}
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, opts)
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
@@ -246,10 +252,10 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	opts := storage.ReadChangesOptions{
+	readChangesOpts := storage.ReadChangesOptions{
 		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
 	}
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", opts, 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", readChangesOpts, 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -368,7 +368,7 @@ func (p *Postgres) ReadAuthorizationModel(ctx context.Context, store string, mod
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
-func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, opts storage.PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadAuthorizationModels")
 	defer span.End()
 
@@ -379,15 +379,15 @@ func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, op
 		Where(sq.Eq{"store": store}).
 		OrderBy("authorization_model_id desc")
 
-	if opts.From != "" {
-		token, err := sqlcommon.UnmarshallContToken(opts.From)
+	if options.Pagination.From != "" {
+		token, err := sqlcommon.UnmarshallContToken(options.Pagination.From)
 		if err != nil {
 			return nil, nil, err
 		}
 		sb = sb.Where(sq.LtOrEq{"authorization_model_id": token.Ulid})
 	}
-	if opts.PageSize > 0 {
-		sb = sb.Limit(uint64(opts.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
+	if options.Pagination.PageSize > 0 {
+		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
 	}
 
 	rows, err := sb.QueryContext(ctx)
@@ -414,8 +414,8 @@ func (p *Postgres) ReadAuthorizationModels(ctx context.Context, store string, op
 
 	var token []byte
 	numModelIDs := len(modelIDs)
-	if len(modelIDs) > opts.PageSize {
-		numModelIDs = opts.PageSize
+	if len(modelIDs) > options.Pagination.PageSize {
+		numModelIDs = options.Pagination.PageSize
 		token, err = json.Marshal(sqlcommon.NewContToken(modelID, ""))
 		if err != nil {
 			return nil, nil, err

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -120,10 +120,13 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 
+	opts := storage.ReadPageOptions{
+		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+	}
 	tuples, _, err := ds.ReadPage(ctx,
 		store,
 		tuple.NewTupleKey("doc:", "relation", ""),
-		storage.NewPaginationOptions(storage.DefaultPageSize, ""))
+		opts)
 	require.NoError(t, err)
 
 	require.Len(t, tuples, 2)
@@ -189,7 +192,10 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tk, curTuple.GetKey())
 
-	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+	opts := storage.ReadPageOptions{
+		Pagination: storage.NewPaginationOptions(2, ""),
+	}
+	tuples, _, err := ds.ReadPage(ctx, "store", &openfgav1.TupleKey{}, opts)
 	require.NoError(t, err)
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
@@ -245,10 +251,10 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	opts := storage.ReadChangesOptions{
+	readChangesOpts := storage.ReadChangesOptions{
 		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
 	}
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", opts, 0)
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", readChangesOpts, 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -245,7 +245,10 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	changes, _, err := ds.ReadChanges(ctx, "store", "folder", storage.NewPaginationOptions(storage.DefaultPageSize, ""), 0)
+	opts := storage.ReadChangesOptions{
+		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+	}
+	changes, _, err := ds.ReadChanges(ctx, "store", "folder", opts, 0)
 	require.NoError(t, err)
 	require.Len(t, changes, 2)
 	require.Equal(t, tk, changes[0].GetTupleKey())

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -75,7 +75,7 @@ func NewPaginationOptions(ps int32, contToken string) PaginationOptions {
 }
 
 // ReadAuthorizationModelOptions represents the options that can
-// be used with the ReadAuthorizationModels method
+// be used with the ReadAuthorizationModels method.
 type ReadAuthorizationModelsOptions struct {
 	Pagination PaginationOptions
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -74,6 +74,12 @@ func NewPaginationOptions(ps int32, contToken string) PaginationOptions {
 	}
 }
 
+// ReadAuthorizationModelOptions represents the options that can
+// be used with the ReadAuthorizationModels method
+type ReadAuthorizationModelsOptions struct {
+	Pagination PaginationOptions
+}
+
 // Writes is a typesafe alias for Write arguments.
 type Writes = []*openfgav1.TupleKey
 
@@ -188,7 +194,7 @@ type AuthorizationModelReadBackend interface {
 	ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgav1.AuthorizationModel, error)
 
 	// ReadAuthorizationModels reads all models for the supplied store and returns them in descending order of ULID (from newest to oldest).
-	ReadAuthorizationModels(ctx context.Context, store string, options PaginationOptions) ([]*openfgav1.AuthorizationModel, []byte, error)
+	ReadAuthorizationModels(ctx context.Context, store string, options ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error)
 
 	// FindLatestAuthorizationModel returns the last model for the store.
 	// If none were ever written, it must return ErrNotFound.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -80,6 +80,12 @@ type ReadAuthorizationModelsOptions struct {
 	Pagination PaginationOptions
 }
 
+// ListStoresOptions represents the options that can
+// be used with the ListStores method.
+type ListStoresOptions struct {
+	Pagination PaginationOptions
+}
+
 // Writes is a typesafe alias for Write arguments.
 type Writes = []*openfgav1.TupleKey
 
@@ -222,7 +228,7 @@ type StoresBackend interface {
 	CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error)
 	DeleteStore(ctx context.Context, id string) error
 	GetStore(ctx context.Context, id string) (*openfgav1.Store, error)
-	ListStores(ctx context.Context, paginationOptions PaginationOptions) ([]*openfgav1.Store, []byte, error)
+	ListStores(ctx context.Context, options ListStoresOptions) ([]*openfgav1.Store, []byte, error)
 }
 
 // AssertionsBackend is an interface that defines the set of methods for reading and writing assertions.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -86,6 +86,12 @@ type ListStoresOptions struct {
 	Pagination PaginationOptions
 }
 
+// ReadChangesOptions represents the options that can
+// be used with the ReadChanges method.
+type ReadChangesOptions struct {
+	Pagination PaginationOptions
+}
+
 // Writes is a typesafe alias for Write arguments.
 type Writes = []*openfgav1.TupleKey
 
@@ -250,13 +256,7 @@ type ChangelogBackend interface {
 	// It should always return a non-empty continuation token so readers can continue reading later, except the case where
 	// if no changes are found, it should return storage.ErrNotFound and an empty continuation token.
 	// It the objectType and the type in the continuation token don't match, it should return ErrMismatchObjectType.
-	ReadChanges(
-		ctx context.Context,
-		store,
-		objectType string,
-		paginationOptions PaginationOptions,
-		horizonOffset time.Duration,
-	) ([]*openfgav1.TupleChange, []byte, error)
+	ReadChanges(ctx context.Context, store, objectType string, options ReadChangesOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error)
 }
 
 // OpenFGADatastore is an interface that defines a set of methods for interacting

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -92,6 +92,12 @@ type ReadChangesOptions struct {
 	Pagination PaginationOptions
 }
 
+// ReadPageOptions represents the options that can
+// be used with the ReadPage method.
+type ReadPageOptions struct {
+	Pagination PaginationOptions
+}
+
 // Writes is a typesafe alias for Write arguments.
 type Writes = []*openfgav1.TupleKey
 
@@ -124,7 +130,7 @@ type RelationshipTupleReader interface {
 		ctx context.Context,
 		store string,
 		tupleKey *openfgav1.TupleKey,
-		paginationOptions PaginationOptions,
+		options ReadPageOptions,
 	) ([]*openfgav1.Tuple, []byte, error)
 
 	// ReadUserTuple tries to return one tuple that matches the provided key exactly.

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -60,14 +60,9 @@ func (c *combinedTupleReader) Read(
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *combinedTupleReader) ReadPage(
-	ctx context.Context,
-	store string,
-	tk *openfgav1.TupleKey,
-	opts storage.PaginationOptions,
-) ([]*openfgav1.Tuple, []byte, error) {
+func (c *combinedTupleReader) ReadPage(ctx context.Context, store string, tk *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	// No reading from contextual tuples.
-	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, opts)
+	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, options)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader.ReadUserTuple].

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -45,10 +45,10 @@ func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey 
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, opts storage.PaginationOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, opts)
+	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, options)
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -86,8 +86,10 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 	err = datastore.WriteAuthorizationModel(ctx, store, model2)
 	require.NoError(t, err)
 
-	models, continuationToken, err := datastore.ReadAuthorizationModels(ctx, store,
-		storage.NewPaginationOptions(1, ""))
+	opts := storage.ReadAuthorizationModelsOptions{
+		Pagination: storage.NewPaginationOptions(1, ""),
+	}
+	models, continuationToken, err := datastore.ReadAuthorizationModels(ctx, store, opts)
 	require.NoError(t, err)
 	require.Len(t, models, 1)
 	require.NotEmpty(t, continuationToken)
@@ -96,8 +98,10 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 		t.Fatalf("mismatch (-want +got):\n%s", diff)
 	}
 
-	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store,
-		storage.NewPaginationOptions(2, string(continuationToken)))
+	opts = storage.ReadAuthorizationModelsOptions{
+		Pagination: storage.NewPaginationOptions(2, string(continuationToken)),
+	}
+	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store, opts)
 	require.NoError(t, err)
 	require.Len(t, models, 1)
 	require.Empty(t, continuationToken)

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -39,13 +39,19 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	})
 
 	t.Run("list_stores_succeeds", func(t *testing.T) {
-		gotStores, ct, err := datastore.ListStores(ctx, storage.NewPaginationOptions(1, ""))
+		opts := storage.ListStoresOptions{
+			Pagination: storage.NewPaginationOptions(1, ""),
+		}
+		gotStores, ct, err := datastore.ListStores(ctx, opts)
 		require.NoError(t, err)
 
 		require.Len(t, gotStores, 1)
 		require.NotEmpty(t, len(ct))
 
-		_, ct, err = datastore.ListStores(ctx, storage.NewPaginationOptions(100, string(ct)))
+		opts = storage.ListStoresOptions{
+			Pagination: storage.NewPaginationOptions(100, string(ct)),
+		}
+		_, ct, err = datastore.ListStores(ctx, opts)
 		require.NoError(t, err)
 
 		// This will fail if there are actually over 101 stores in the DB at the time of running.
@@ -81,7 +87,10 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		require.NoError(t, err)
 
 		// Store id should not appear in the list of store ids.
-		gotStores, _, err := datastore.ListStores(ctx, storage.NewPaginationOptions(storage.DefaultPageSize, ""))
+		opts := storage.ListStoresOptions{
+			Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
+		}
+		gotStores, _, err := datastore.ListStores(ctx, opts)
 		require.NoError(t, err)
 
 		for _, s := range gotStores {

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1011,7 +1011,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+		opts := storage.ReadPageOptions{
+			Pagination: storage.NewPaginationOptions(2, ""),
+		}
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, opts)
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.Nil(t, tuples[0].GetKey().GetCondition())
@@ -1046,10 +1049,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
-		opts := storage.ReadChangesOptions{
+		readChangesOpts := storage.ReadChangesOptions{
 			Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
 		}
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", opts, 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", readChangesOpts, 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.Nil(t, changes[0].GetTupleKey().GetCondition())
@@ -1097,7 +1100,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 		require.Empty(t, tp.GetKey().GetCondition().GetContext())
 
-		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, storage.NewPaginationOptions(2, ""))
+		opts := storage.ReadPageOptions{
+			Pagination: storage.NewPaginationOptions(2, ""),
+		}
+		tuples, _, err := datastore.ReadPage(ctx, storeID, &openfgav1.TupleKey{}, opts)
 		require.NoError(t, err)
 		require.Len(t, tuples, 2)
 		require.NotNil(t, tuples[0].GetKey().GetCondition().GetContext())
@@ -1132,10 +1138,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
-		opts := storage.ReadChangesOptions{
+		readChangesOpts := storage.ReadChangesOptions{
 			Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
 		}
-		changes, _, err := datastore.ReadChanges(ctx, storeID, "", opts, 0)
+		changes, _, err := datastore.ReadChanges(ctx, storeID, "", readChangesOpts, 0)
 		require.NoError(t, err)
 		require.Len(t, changes, 2)
 		require.NotNil(t, changes[0].GetTupleKey().GetCondition().GetContext())
@@ -1517,10 +1523,13 @@ func readWithPageSize(t *testing.T, ds storage.OpenFGADatastore, storeID string,
 		err               error
 	)
 	for {
-		tuples, continuationToken, err = ds.ReadPage(context.Background(), storeID, filter, storage.PaginationOptions{
-			PageSize: pageSize,
-			From:     string(continuationToken),
-		})
+		opts := storage.ReadPageOptions{
+			Pagination: storage.PaginationOptions{
+				PageSize: pageSize,
+				From:     string(continuationToken),
+			},
+		}
+		tuples, continuationToken, err = ds.ReadPage(context.Background(), storeID, filter, opts)
 		if err != nil {
 			require.ErrorIs(t, err, storage.ErrNotFound)
 			break


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

For every storage method that takes a `PaginationOptions`, replace with method-specific options.

## Description
<!-- Provide a detailed description of the changes -->

As discussed in #1716, as we add the ability to specify a consistency preference, we want to avoid adding another parameter to the methods that will require it. To make the storage API more resilient to additional future changes, we should instead specify an options type.

This PR adds the method-specific options, but **does not** introduce any consistency-related changes. The intent is that this PR maintain current functional behavior, while enabling us to add the consistency changes in a later PR.

The following options types have been added in this PR:
* `ReadAuthorizationModelsOptions`
* `ListStoresOptions`
* `ReadChangesOptions`
* `ReadPageOptions`

The related methods have been updated to accept these options (which currently only hold `PaginationOptions`), instead of the `PaginationOptions` directly:

* `ReadAuthorizationModels(ctx context.Context, store string, options ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error)`
* `ListStores(ctx context.Context, options ListStoresOptions) ([]*openfgav1.Store, []byte, error)`
* `ReadChanges(ctx context.Context, store, objectType string, options ReadChangesOptions, horizonOffset time.Duration) ([]*openfgav1.TupleChange, []byte, error)`
* `ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ReadPageOptions ([]*openfgav1.Tuple, []byte, error)`

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

#1716 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
