### PR TITLE
Determine all terminal types and relations for typesystem

### DIFF
--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -1,0 +1,155 @@
+package typesystem
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+)
+
+// map[objectType]map[relation]map[subjectType]terminalRelation.
+type TypesystemConnectedTypes map[string]map[string]map[string][]string
+
+func (f TypesystemConnectedTypes) assign(objectType string, relation string, subjectType string, terminalRelation string) {
+	if f[objectType] == nil {
+		f[objectType] = make(map[string]map[string][]string)
+	}
+
+	if f[objectType][relation] == nil {
+		f[objectType][relation] = make(map[string][]string)
+	}
+
+	f[objectType][relation][subjectType] = append(f[objectType][relation][subjectType], terminalRelation)
+}
+
+func (t *TypeSystem) AreTypesConnectedViaRelations(objectType, relation, subjectType string) (bool, []string) {
+	terminalRelations, areConnected := t.connectedTypes[objectType][relation][subjectType]
+	if !areConnected {
+		return false, []string{}
+	}
+
+	return true, terminalRelations
+}
+
+func TMPPrettyPrint(data interface{}) {
+	// Marshal the map to a pretty-printed JSON string
+	jsonData, err := json.MarshalIndent(data, "", "    ")
+	if err != nil {
+		log.Fatalf("Error pretty-printing map: %v", err)
+	}
+	fmt.Println(string(jsonData))
+}
+
+// validateRelation applies all the validation rules to a relation definition in a model. A relation
+// must meet all the rewrite validation, type restriction validation, and entrypoint validation criteria
+// for it to be valid. Otherwise, an error is returned.
+func (t *TypeSystem) AssignTerminalTypes(typeName, relationName string, relationMap map[string]*openfgav1.Userset) {
+	rewrite := relationMap[relationName]
+	terminalTypesAndRelations := t.getTerminalSubjectTypesAndRelation(typeName, relationName, rewrite)
+
+	for _, terminalTypesAndRelation := range terminalTypesAndRelations {
+		for _, terminalType := range terminalTypesAndRelation.terminalTypes {
+			t.connectedTypes.assign(typeName, relationName, terminalType, terminalTypesAndRelation.terminalRelation)
+		}
+	}
+}
+
+type terminalTypesAndRelation struct {
+	terminalTypes    []string
+	terminalRelation string
+}
+
+func (t *TypeSystem) getTerminalSubjectTypesAndRelation(
+	typeName string,
+	relationName string,
+	rewrite *openfgav1.Userset,
+) []terminalTypesAndRelation {
+	cache, ok := t.connectedTypes[typeName][relationName]
+	if ok {
+		terminalTypesAndRelations := []terminalTypesAndRelation{}
+
+		for subjectType, terminalRelations := range cache {
+			for _, terminalRelation := range terminalRelations {
+				terminalTypesAndRelations = append(terminalTypesAndRelations, terminalTypesAndRelation{
+					terminalTypes:    []string{subjectType},
+					terminalRelation: terminalRelation,
+				})
+			}
+		}
+
+		return terminalTypesAndRelations
+	}
+
+	relation, ok := t.relations[typeName][relationName]
+	if !ok {
+		return []terminalTypesAndRelation{}
+	}
+
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgav1.Userset_This:
+		assignableTypes := []string{}
+		var terminalRelation string
+
+		for _, assignableType := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+			assignableTypes = append(assignableTypes, assignableType.GetType())
+			terminalRelation = relationName
+		}
+
+		return []terminalTypesAndRelation{
+			{
+				terminalTypes:    assignableTypes,
+				terminalRelation: terminalRelation,
+			},
+		}
+	case *openfgav1.Userset_ComputedUserset:
+		computedRelationName := rw.ComputedUserset.GetRelation()
+		computedRelation := t.relations[typeName][computedRelationName]
+		return t.getTerminalSubjectTypesAndRelation(typeName, computedRelationName, computedRelation.GetRewrite())
+	case *openfgav1.Userset_TupleToUserset:
+		tuplesetRelationName := rw.TupleToUserset.GetTupleset().GetRelation()
+		computedRelationName := rw.TupleToUserset.GetComputedUserset().GetRelation()
+
+		tuplesetRelation, ok := t.relations[typeName][tuplesetRelationName]
+		if !ok {
+			return []terminalTypesAndRelation{}
+		}
+
+		for _, assignableType := range tuplesetRelation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+			assignableTypeName := assignableType.GetType()
+
+			if assignableRelation, ok := t.relations[assignableTypeName][computedRelationName]; ok {
+				return t.getTerminalSubjectTypesAndRelation(assignableTypeName, computedRelationName, assignableRelation.GetRewrite())
+			}
+		}
+
+	case *openfgav1.Userset_Union:
+		assignableTypesForRelation := []terminalTypesAndRelation{}
+
+		for _, child := range rw.Union.GetChild() {
+			tt := t.getTerminalSubjectTypesAndRelation(typeName, relationName, child)
+			assignableTypesForRelation = append(assignableTypesForRelation, tt...)
+		}
+
+		return assignableTypesForRelation
+
+	case *openfgav1.Userset_Intersection:
+		intersectionAssignableTypesAndRelations := []terminalTypesAndRelation{}
+
+		for _, child := range rw.Intersection.GetChild() {
+			_ = t.getTerminalSubjectTypesAndRelation(typeName, relationName, child)
+		}
+
+		return intersectionAssignableTypesAndRelations
+	}
+
+	// case *openfgav1.Userset_Difference:
+	// 	// All the children must have an entrypoint.
+	// 	baseTypes, baseTerminalRelation := t.getTerminalSubjectTypesAndRelation(typeName, relationName, rw.Difference.GetBase())
+	// 	subTypes, subTerminalRelation := t.getTerminalSubjectTypesAndRelation(typeName, relationName, rw.Difference.GetSubtract())
+
+	// 	return
+	// }
+
+	panic("unexpected userset rewrite encountered")
+}

--- a/pkg/typesystem/connected_types_test.go
+++ b/pkg/typesystem/connected_types_test.go
@@ -1,0 +1,165 @@
+package typesystem
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openfga/openfga/pkg/testutils"
+)
+
+func TestTypesystemAreTypesConnectedViaRelation(t *testing.T) {
+	model := `
+		model
+			schema 1.1
+		type user
+		type employee
+
+		type document
+			relations
+				define computed: computed2
+				define computed2: direct_user
+				define direct_user: [user]
+				define direct_employee: [employee]
+				define direct_user_or_computed: [user] or direct_user
+				define direct_user_and_employee: [ user, employee ]
+				define union_user_or_employee: direct_employee or direct_user
+				define intersection_user_and_employee: direct_user and direct_employee
+				define intersection_direct_and_computed_user: [user] and direct_user
+	`
+
+	tests := []struct {
+		expectedAreConnected      bool
+		expectedTerminalRelations []string
+		objectType                string
+		relation                  string
+		subjectType               string
+	}{
+		// // Intersection
+		{
+			objectType:                "document",
+			relation:                  "intersection_user_and_employee",
+			subjectType:               "employee",
+			expectedAreConnected:      false,
+			expectedTerminalRelations: []string{},
+		},
+		{
+			objectType:                "document",
+			relation:                  "intersection_user_and_employee",
+			subjectType:               "user",
+			expectedAreConnected:      false,
+			expectedTerminalRelations: []string{},
+		},
+
+		// // Union
+		{
+			objectType:                "document",
+			relation:                  "union_user_or_employee",
+			subjectType:               "employee",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_employee"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "union_user_or_employee",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user_or_computed",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user_or_computed", "direct_user"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user_or_computed",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user", "direct_user_or_computed"},
+		},
+
+		// Impossible cases
+		{
+			objectType:                "document",
+			relation:                  "computed2",
+			subjectType:               "employee",
+			expectedAreConnected:      false,
+			expectedTerminalRelations: []string{},
+		},
+		{
+			objectType:                "document",
+			relation:                  "computed",
+			subjectType:               "employee",
+			expectedAreConnected:      false,
+			expectedTerminalRelations: []string{},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user",
+			subjectType:               "employee",
+			expectedAreConnected:      false,
+			expectedTerminalRelations: []string{},
+		},
+
+		// Direct relation
+		{
+			objectType:                "document",
+			relation:                  "direct_user",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user_and_employee",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user_and_employee"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "direct_user_and_employee",
+			subjectType:               "employee",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user_and_employee"},
+		},
+
+		// Computed relation case
+		{
+			objectType:                "document",
+			relation:                  "computed",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user"},
+		},
+		{
+			objectType:                "document",
+			relation:                  "computed2",
+			subjectType:               "user",
+			expectedAreConnected:      true,
+			expectedTerminalRelations: []string{"direct_user"},
+		},
+	}
+
+	ts, err := NewAndValidate(context.Background(), testutils.MustTransformDSLToProtoWithID(model))
+	require.NoError(t, err)
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("stage-%d", i), func(t *testing.T) {
+			actualAreConnected, actualTerminalRelations := ts.AreTypesConnectedViaRelations(test.objectType, test.relation, test.subjectType)
+			require.Equal(t, test.expectedAreConnected, actualAreConnected)
+			require.ElementsMatch(t, test.expectedTerminalRelations, actualTerminalRelations)
+		})
+	}
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -165,6 +165,8 @@ type TypeSystem struct {
 	// [objectType] => [relationName] => TTU relation.
 	ttuRelations map[string]map[string][]*openfgav1.TupleToUserset
 
+	connectedTypes TypesystemConnectedTypes
+
 	modelID       string
 	schemaVersion string
 }
@@ -216,7 +218,80 @@ func New(model *openfgav1.AuthorizationModel) *TypeSystem {
 		relations:       relations,
 		conditions:      uncompiledConditions,
 		ttuRelations:    ttuRelations,
+		connectedTypes:  make(TypesystemConnectedTypes),
 	}
+}
+
+// NewAndValidate is like New but also validates the model according to the following rules:
+//  1. Checks that the *TypeSystem have a valid schema version.
+//  2. For every rewrite the relations in the rewrite must:
+//     a) Be valid relations on the same type in the *TypeSystem (in cases of computedUserset)
+//     b) Be valid relations on another existing type (in cases of tupleToUserset)
+//  3. Do not allow duplicate types or duplicate relations (only need to check types as relations are
+//     in a map so cannot contain duplicates)
+//
+// If the *TypeSystem has a v1.1 schema version (with types on relations), then additionally
+// validate the *TypeSystem according to the following rules:
+//  3. Every type restriction on a relation must be a valid type:
+//     a) For a type (e.g. user) this means checking that this type is in the *TypeSystem
+//     b) For a type#relation this means checking that this type with this relation is in the *TypeSystem
+//  4. Check that a relation is assignable if and only if it has a non-zero list of types
+func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*TypeSystem, error) {
+	_, span := tracer.Start(ctx, "typesystem.NewAndValidate")
+	defer span.End()
+
+	t := New(model)
+	schemaVersion := t.GetSchemaVersion()
+
+	if !IsSchemaVersionSupported(schemaVersion) {
+		return nil, ErrInvalidSchemaVersion
+	}
+
+	if containsDuplicateType(model) {
+		return nil, ErrDuplicateTypes
+	}
+
+	if err := t.validateNames(); err != nil {
+		return nil, err
+	}
+
+	typedefsMap := t.typeDefinitions
+
+	typeNames := make([]string, 0, len(typedefsMap))
+	for typeName := range typedefsMap {
+		typeNames = append(typeNames, typeName)
+	}
+
+	// Range over the type definitions in sorted order to produce a deterministic outcome.
+	sort.Strings(typeNames)
+
+	for _, typeName := range typeNames {
+		typedef := typedefsMap[typeName]
+
+		relationMap := typedef.GetRelations()
+		relationNames := make([]string, 0, len(relationMap))
+		for relationName := range relationMap {
+			relationNames = append(relationNames, relationName)
+		}
+
+		// Range over the relations in sorted order to produce a deterministic outcome.
+		sort.Strings(relationNames)
+
+		for _, relationName := range relationNames {
+			err := t.validateRelation(typeName, relationName, relationMap)
+			if err != nil {
+				return nil, err
+			}
+
+			t.AssignTerminalTypes(typeName, relationName, relationMap)
+		}
+	}
+
+	if err := t.validateConditions(); err != nil {
+		return nil, err
+	}
+
+	return t, nil
 }
 
 // GetAuthorizationModelID returns the ID for the authorization
@@ -708,76 +783,6 @@ func hasEntrypoints(
 	}
 
 	panic("unexpected userset rewrite encountered")
-}
-
-// NewAndValidate is like New but also validates the model according to the following rules:
-//  1. Checks that the *TypeSystem have a valid schema version.
-//  2. For every rewrite the relations in the rewrite must:
-//     a) Be valid relations on the same type in the *TypeSystem (in cases of computedUserset)
-//     b) Be valid relations on another existing type (in cases of tupleToUserset)
-//  3. Do not allow duplicate types or duplicate relations (only need to check types as relations are
-//     in a map so cannot contain duplicates)
-//
-// If the *TypeSystem has a v1.1 schema version (with types on relations), then additionally
-// validate the *TypeSystem according to the following rules:
-//  3. Every type restriction on a relation must be a valid type:
-//     a) For a type (e.g. user) this means checking that this type is in the *TypeSystem
-//     b) For a type#relation this means checking that this type with this relation is in the *TypeSystem
-//  4. Check that a relation is assignable if and only if it has a non-zero list of types
-func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*TypeSystem, error) {
-	_, span := tracer.Start(ctx, "typesystem.NewAndValidate")
-	defer span.End()
-
-	t := New(model)
-	schemaVersion := t.GetSchemaVersion()
-
-	if !IsSchemaVersionSupported(schemaVersion) {
-		return nil, ErrInvalidSchemaVersion
-	}
-
-	if containsDuplicateType(model) {
-		return nil, ErrDuplicateTypes
-	}
-
-	if err := t.validateNames(); err != nil {
-		return nil, err
-	}
-
-	typedefsMap := t.typeDefinitions
-
-	typeNames := make([]string, 0, len(typedefsMap))
-	for typeName := range typedefsMap {
-		typeNames = append(typeNames, typeName)
-	}
-
-	// Range over the type definitions in sorted order to produce a deterministic outcome.
-	sort.Strings(typeNames)
-
-	for _, typeName := range typeNames {
-		typedef := typedefsMap[typeName]
-
-		relationMap := typedef.GetRelations()
-		relationNames := make([]string, 0, len(relationMap))
-		for relationName := range relationMap {
-			relationNames = append(relationNames, relationName)
-		}
-
-		// Range over the relations in sorted order to produce a deterministic outcome.
-		sort.Strings(relationNames)
-
-		for _, relationName := range relationNames {
-			err := t.validateRelation(typeName, relationName, relationMap)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	if err := t.validateConditions(); err != nil {
-		return nil, err
-	}
-
-	return t, nil
 }
 
 // validateRelation applies all the validation rules to a relation definition in a model. A relation


### PR DESCRIPTION
## Description
Determining the ultimate terminal types and terminal relations for a given object type and relation. This data is proposed to be calculated at the time of typesystem creation and validations (`t.NewAndValidate()`) and associated in a multi-key map on the typesystem struct.

This work enables two different optimizations. The first is an optimized TTU and userset lookup with much fewer DB queries. However, this requires knowledge of the terminal types and relations for a given userset to craft the appropriate query. Currently, this is limited to usersets that result in a direct relation and necessarily doesn't result in a computed relation, union, intersection, etc. This limitation can be observed in #1733. 

Secondly, this map of connected types can ultimately be used as an optimization in Check, ListObjects and ListUsers as a screen to determine if the request's relation and types are valid with respect to the model. If not, we can exit the process with a falsey outcome and prevent some DB requests. This work was previously visited in #1582 but this PR will reduce the computation to a O(1) lookup at runtime.

**DRAFT:** Work is still in progress. Needs more testing and support for intersection and difference rewrites.

## References
Supports: #1733, #1735, #1734
May help supercede: #1582 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
