### PR TITLE
chore: add tracing to typesystem.NewAndValidate

### DIFF
--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -548,7 +548,7 @@ func TestHasEntrypoints(t *testing.T) {
 			inputRelation, _ := ts.GetRelation(test.inputType, test.inputRelation)
 
 			rewrite := inputRelation.GetRewrite()
-			hasEntrypoints, hasCycle, err := hasEntrypoints(ts.GetAllRelations(), test.inputType, test.inputRelation, rewrite, map[string]map[string]bool{})
+			hasEntrypoints, hasCycle, err := hasEntrypoints(context.Background(), ts.GetAllRelations(), test.inputType, test.inputRelation, rewrite, map[string]map[string]bool{})
 
 			if test.expectError != "" {
 				require.ErrorContains(t, err, test.expectError)
@@ -758,7 +758,7 @@ func TestHasCycle(t *testing.T) {
 
 			typesys := New(model)
 
-			hasCycle, err := typesys.HasCycle(test.objectType, test.relation)
+			hasCycle, err := typesys.HasCycle(context.Background(), test.objectType, test.relation)
 			require.Equal(t, test.expected, hasCycle)
 			require.NoError(t, err)
 		})


### PR DESCRIPTION
## Description
I'm seeing quite a few Check requests that have an unexpectedly large latency for `NewAndValidate`.

<img width="1491" alt="image" src="https://github.com/openfga/openfga/assets/5374887/dded98cd-494f-4078-8775-33ddced936cc">
