### PR TITLE
feat(storage): add consistency parameter

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -665,7 +665,12 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				},
 			}
 
-			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey)
+			opts := storage.ReadUserTupleOptions{
+				Consistency: storage.ConsistencyOptions{
+					Consistency: req.GetConsistency(),
+				},
+			}
+			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, opts)
 			if err != nil {
 				if errors.Is(err, storage.ErrNotFound) {
 					return response, nil
@@ -720,11 +725,16 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				},
 			}
 
+			opts := storage.ReadUsersetTuplesOptions{
+				Consistency: storage.ConsistencyOptions{
+					Consistency: req.GetConsistency(),
+				},
+			}
 			iter, err := ds.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 				Object:                      reqTupleKey.GetObject(),
 				Relation:                    reqTupleKey.GetRelation(),
 				AllowedUserTypeRestrictions: directlyRelatedUsersetTypes,
-			})
+			}, opts)
 			if err != nil {
 				return nil, err
 			}
@@ -892,11 +902,12 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 			attribute.String("computed_relation", computedRelation),
 		)
 
-		iter, err := ds.Read(
-			ctx,
-			req.GetStoreID(),
-			tuple.NewTupleKey(object, tuplesetRelation, ""),
-		)
+		opts := storage.ReadOptions{
+			Consistency: storage.ConsistencyOptions{
+				Consistency: req.GetConsistency(),
+			},
+		}
+		iter, err := ds.Read(ctx, req.GetStoreID(), tuple.NewTupleKey(object, tuplesetRelation, ""), opts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -667,7 +667,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 			opts := storage.ReadUserTupleOptions{
 				Consistency: storage.ConsistencyOptions{
-					Consistency: req.GetConsistency(),
+					Preference: req.GetConsistency(),
 				},
 			}
 			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, opts)
@@ -727,7 +727,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 			opts := storage.ReadUsersetTuplesOptions{
 				Consistency: storage.ConsistencyOptions{
-					Consistency: req.GetConsistency(),
+					Preference: req.GetConsistency(),
 				},
 			}
 			iter, err := ds.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -904,7 +904,7 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 
 		opts := storage.ReadOptions{
 			Consistency: storage.ConsistencyOptions{
-				Consistency: req.GetConsistency(),
+				Preference: req.GetConsistency(),
 			},
 		}
 		iter, err := ds.Read(ctx, req.GetStoreID(), tuple.NewTupleKey(object, tuplesetRelation, ""), opts)

--- a/internal/mocks/mock_slow_storage.go
+++ b/internal/mocks/mock_slow_storage.go
@@ -26,9 +26,9 @@ func NewMockSlowDataStorage(ds storage.OpenFGADatastore, readTuplesDelay time.Du
 
 func (m *slowDataStorage) Close() {}
 
-func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.Read(ctx, store, key)
+	return m.OpenFGADatastore.Read(ctx, store, key, options)
 }
 
 func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
@@ -36,21 +36,22 @@ func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openf
 	return m.OpenFGADatastore.ReadPage(ctx, store, key, options)
 }
 
-func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *slowDataStorage) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key)
+	return m.OpenFGADatastore.ReadUserTuple(ctx, store, key, options)
 }
 
-func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *slowDataStorage) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter)
+	return m.OpenFGADatastore.ReadUsersetTuples(ctx, store, filter, options)
 }
 
 func (m *slowDataStorage) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	time.Sleep(m.readTuplesDelay)
-	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter)
+	return m.OpenFGADatastore.ReadStartingWithUser(ctx, store, filter, options)
 }

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -57,18 +57,18 @@ func (mr *MockTupleBackendMockRecorder) MaxTuplesPerWrite() *gomock.Call {
 }
 
 // Read mocks base method.
-func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockTupleBackend)(nil).Read), ctx, store, tupleKey, options)
 }
 
 // ReadPage mocks base method.
@@ -88,48 +88,48 @@ func (mr *MockTupleBackendMockRecorder) ReadPage(ctx, store, tupleKey, options a
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadStartingWithUser(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockTupleBackend)(nil).ReadStartingWithUser), ctx, store, filter, options)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockTupleBackend) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUserTuple(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockTupleBackend)(nil).ReadUserTuple), ctx, store, tupleKey, options)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockTupleBackend) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockTupleBackend)(nil).ReadUsersetTuples), ctx, store, filter, options)
 }
 
 // Write mocks base method.
@@ -170,18 +170,18 @@ func (m *MockRelationshipTupleReader) EXPECT() *MockRelationshipTupleReaderMockR
 }
 
 // Read mocks base method.
-func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRelationshipTupleReader)(nil).Read), ctx, store, tupleKey, options)
 }
 
 // ReadPage mocks base method.
@@ -201,48 +201,48 @@ func (mr *MockRelationshipTupleReaderMockRecorder) ReadPage(ctx, store, tupleKey
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadStartingWithUser(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadStartingWithUser), ctx, store, filter, options)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockRelationshipTupleReader) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUserTuple(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUserTuple), ctx, store, tupleKey, options)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockRelationshipTupleReader) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockRelationshipTupleReader)(nil).ReadUsersetTuples), ctx, store, filter, options)
 }
 
 // MockRelationshipTupleWriter is a mock of RelationshipTupleWriter interface.
@@ -841,18 +841,18 @@ func (mr *MockOpenFGADatastoreMockRecorder) MaxTypesPerAuthorizationModel() *gom
 }
 
 // Read mocks base method.
-func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "Read", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) Read(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOpenFGADatastore)(nil).Read), ctx, store, tupleKey, options)
 }
 
 // ReadAssertions mocks base method.
@@ -934,48 +934,48 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadPage(ctx, store, tupleKey, optio
 }
 
 // ReadStartingWithUser mocks base method.
-func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadStartingWithUser(ctx context.Context, store string, filter storage.ReadStartingWithUserFilter, options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadStartingWithUser", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadStartingWithUser indicates an expected call of ReadStartingWithUser.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadStartingWithUser(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadStartingWithUser", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadStartingWithUser), ctx, store, filter, options)
 }
 
 // ReadUserTuple mocks base method.
-func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MockOpenFGADatastore) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey)
+	ret := m.ctrl.Call(m, "ReadUserTuple", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].(*openfgav1.Tuple)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUserTuple indicates an expected call of ReadUserTuple.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUserTuple(ctx, store, tupleKey, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), ctx, store, tupleKey)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUserTuple", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUserTuple), ctx, store, tupleKey, options)
 }
 
 // ReadUsersetTuples mocks base method.
-func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (m *MockOpenFGADatastore) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter)
+	ret := m.ctrl.Call(m, "ReadUsersetTuples", ctx, store, filter, options)
 	ret0, _ := ret[0].(storage.TupleIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadUsersetTuples indicates an expected call of ReadUsersetTuples.
-func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), ctx, store, filter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadUsersetTuples", reflect.TypeOf((*MockOpenFGADatastore)(nil).ReadUsersetTuples), ctx, store, filter, options)
 }
 
 // Write mocks base method.

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -98,7 +98,7 @@ func (q *ExpandQuery) Execute(ctx context.Context, req *openfgav1.ExpandRequest)
 
 	userset := rel.GetRewrite()
 
-	root, err := q.resolveUserset(ctx, store, userset, tk, typesys)
+	root, err := q.resolveUserset(ctx, store, userset, tk, typesys, req.GetConsistency())
 	if err != nil {
 		return nil, err
 	}
@@ -116,34 +116,40 @@ func (q *ExpandQuery) resolveUserset(
 	userset *openfgav1.Userset,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveUserset")
 	defer span.End()
 
 	switch us := userset.GetUserset().(type) {
 	case nil, *openfgav1.Userset_This:
-		return q.resolveThis(ctx, store, tk, typesys)
+		return q.resolveThis(ctx, store, tk, typesys, consistency)
 	case *openfgav1.Userset_ComputedUserset:
 		return q.resolveComputedUserset(ctx, us.ComputedUserset, tk)
 	case *openfgav1.Userset_TupleToUserset:
-		return q.resolveTupleToUserset(ctx, store, us.TupleToUserset, tk, typesys)
+		return q.resolveTupleToUserset(ctx, store, us.TupleToUserset, tk, typesys, consistency)
 	case *openfgav1.Userset_Union:
-		return q.resolveUnionUserset(ctx, store, us.Union, tk, typesys)
+		return q.resolveUnionUserset(ctx, store, us.Union, tk, typesys, consistency)
 	case *openfgav1.Userset_Difference:
-		return q.resolveDifferenceUserset(ctx, store, us.Difference, tk, typesys)
+		return q.resolveDifferenceUserset(ctx, store, us.Difference, tk, typesys, consistency)
 	case *openfgav1.Userset_Intersection:
-		return q.resolveIntersectionUserset(ctx, store, us.Intersection, tk, typesys)
+		return q.resolveIntersectionUserset(ctx, store, us.Intersection, tk, typesys, consistency)
 	default:
 		return nil, serverErrors.UnsupportedUserSet
 	}
 }
 
 // resolveThis resolves a DirectUserset into a leaf node containing a distinct set of users with that relation.
-func (q *ExpandQuery) resolveThis(ctx context.Context, store string, tk *openfgav1.TupleKey, typesys *typesystem.TypeSystem) (*openfgav1.UsersetTree_Node, error) {
+func (q *ExpandQuery) resolveThis(ctx context.Context, store string, tk *openfgav1.TupleKey, typesys *typesystem.TypeSystem, consistency openfgav1.ConsistencyPreference) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveThis")
 	defer span.End()
 
-	tupleIter, err := q.datastore.Read(ctx, store, tk)
+	opts := storage.ReadOptions{
+		Consistency: storage.ConsistencyOptions{
+			Consistency: consistency,
+		},
+	}
+	tupleIter, err := q.datastore.Read(ctx, store, tk, opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}
@@ -224,6 +230,7 @@ func (q *ExpandQuery) resolveTupleToUserset(
 	userset *openfgav1.TupleToUserset,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveTupleToUserset")
 	defer span.End()
@@ -253,7 +260,12 @@ func (q *ExpandQuery) resolveTupleToUserset(
 		tsKey.Relation = tk.GetRelation()
 	}
 
-	tupleIter, err := q.datastore.Read(ctx, store, tsKey)
+	opts := storage.ReadOptions{
+		Consistency: storage.ConsistencyOptions{
+			Consistency: consistency,
+		},
+	}
+	tupleIter, err := q.datastore.Read(ctx, store, tsKey, opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}
@@ -317,11 +329,12 @@ func (q *ExpandQuery) resolveUnionUserset(
 	usersets *openfgav1.Usersets,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveUnionUserset")
 	defer span.End()
 
-	nodes, err := q.resolveUsersets(ctx, store, usersets.GetChild(), tk, typesys)
+	nodes, err := q.resolveUsersets(ctx, store, usersets.GetChild(), tk, typesys, consistency)
 	if err != nil {
 		return nil, err
 	}
@@ -342,11 +355,12 @@ func (q *ExpandQuery) resolveIntersectionUserset(
 	usersets *openfgav1.Usersets,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveIntersectionUserset")
 	defer span.End()
 
-	nodes, err := q.resolveUsersets(ctx, store, usersets.GetChild(), tk, typesys)
+	nodes, err := q.resolveUsersets(ctx, store, usersets.GetChild(), tk, typesys, consistency)
 	if err != nil {
 		return nil, err
 	}
@@ -367,11 +381,12 @@ func (q *ExpandQuery) resolveDifferenceUserset(
 	userset *openfgav1.Difference,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) (*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveDifferenceUserset")
 	defer span.End()
 
-	nodes, err := q.resolveUsersets(ctx, store, []*openfgav1.Userset{userset.GetBase(), userset.GetSubtract()}, tk, typesys)
+	nodes, err := q.resolveUsersets(ctx, store, []*openfgav1.Userset{userset.GetBase(), userset.GetSubtract()}, tk, typesys, consistency)
 	if err != nil {
 		return nil, err
 	}
@@ -395,6 +410,7 @@ func (q *ExpandQuery) resolveUsersets(
 	usersets []*openfgav1.Userset,
 	tk *openfgav1.TupleKey,
 	typesys *typesystem.TypeSystem,
+	consistency openfgav1.ConsistencyPreference,
 ) ([]*openfgav1.UsersetTree_Node, error) {
 	ctx, span := tracer.Start(ctx, "resolveUsersets")
 	defer span.End()
@@ -405,7 +421,7 @@ func (q *ExpandQuery) resolveUsersets(
 		// https://golang.org/doc/faq#closures_and_goroutines
 		i, us := i, us
 		grp.Go(func() error {
-			node, err := q.resolveUserset(ctx, store, us, tk, typesys)
+			node, err := q.resolveUserset(ctx, store, us, tk, typesys, consistency)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -146,7 +146,7 @@ func (q *ExpandQuery) resolveThis(ctx context.Context, store string, tk *openfga
 
 	opts := storage.ReadOptions{
 		Consistency: storage.ConsistencyOptions{
-			Consistency: consistency,
+			Preference: consistency,
 		},
 	}
 	tupleIter, err := q.datastore.Read(ctx, store, tk, opts)
@@ -262,7 +262,7 @@ func (q *ExpandQuery) resolveTupleToUserset(
 
 	opts := storage.ReadOptions{
 		Consistency: storage.ConsistencyOptions{
-			Consistency: consistency,
+			Preference: consistency,
 		},
 	}
 	tupleIter, err := q.datastore.Read(ctx, store, tsKey, opts)

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -301,7 +301,7 @@ func (q *ListObjectsQuery) evaluate(
 				User:             sourceUserRef,
 				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
 				Context:          req.GetContext(),
-			}, reverseExpandResultsChan, reverseExpandResolutionMetadata)
+			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.ConsistencyOptions{Consistency: req.GetConsistency()})
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -301,7 +301,7 @@ func (q *ListObjectsQuery) evaluate(
 				User:             sourceUserRef,
 				ContextualTuples: req.GetContextualTuples().GetTupleKeys(),
 				Context:          req.GetContext(),
-			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.ConsistencyOptions{Consistency: req.GetConsistency()})
+			}, reverseExpandResultsChan, reverseExpandResolutionMetadata, storage.ConsistencyOptions{Preference: req.GetConsistency()})
 			if err != nil {
 				errChan <- err
 			}

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -401,7 +401,7 @@ func (l *listUsersQuery) expandDirect(
 
 	opts := storage.ReadOptions{
 		Consistency: storage.ConsistencyOptions{
-			Consistency: req.GetConsistency(),
+			Preference: req.GetConsistency(),
 		},
 	}
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
@@ -839,7 +839,7 @@ func (l *listUsersQuery) expandTTU(
 
 	opts := storage.ReadOptions{
 		Consistency: storage.ConsistencyOptions{
-			Consistency: req.GetConsistency(),
+			Preference: req.GetConsistency(),
 		},
 	}
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -399,10 +399,15 @@ func (l *listUsersQuery) expandDirect(
 		}
 	}
 
+	opts := storage.ReadOptions{
+		Consistency: storage.ConsistencyOptions{
+			Consistency: req.GetConsistency(),
+		},
+	}
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: req.GetRelation(),
-	})
+	}, opts)
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{
@@ -832,10 +837,15 @@ func (l *listUsersQuery) expandTTU(
 		}
 	}
 
+	opts := storage.ReadOptions{
+		Consistency: storage.ConsistencyOptions{
+			Consistency: req.GetConsistency(),
+		},
+	}
 	iter, err := l.ds.Read(ctx, req.GetStoreId(), &openfgav1.TupleKey{
 		Object:   tuple.ObjectKey(req.GetObject()),
 		Relation: tuplesetRelation,
-	})
+	}, opts)
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return expandResponse{

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -2545,7 +2545,7 @@ func TestListUsersCycleDetection(t *testing.T) {
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 
 	// Times(0) ensures that we exit quickly
-	mockDatastore.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	mockDatastore.EXPECT().Read(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
 	l := NewListUsersQuery(mockDatastore, WithResolveNodeLimit(maximumRecursiveDepth))
 	channelDone := make(chan struct{})
@@ -2902,7 +2902,7 @@ func TestListUsersStorageErrors(t *testing.T) {
 			})
 			mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 			mockDatastore.EXPECT().
-				Read(gomock.Any(), gomock.Any(), gomock.Any()).
+				Read(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(nil, fmt.Errorf("storage err")).
 				MinTimes(1).
 				MaxTimes(2) // Because DB errors will immediately halt the execution of the API function, it's possible that only one read is made
@@ -3001,14 +3001,14 @@ func TestListUsersReadFails_NoLeaks(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Relation: "viewer",
 			Object:   "document:1",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 			return mocks.NewErrorTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "viewer", "group:fga#member")},
 				{Key: tuple.NewTupleKey("document:1", "viewer", "group:eng#member")},
 			}), nil
 		}),
-		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any()).
-			DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}),
 	)
@@ -3053,7 +3053,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Object:   "document:1",
 			Relation: "parent",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 			return mocks.NewErrorTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "parent", "folder:1")},
 				{Key: tuple.NewTupleKey("document:1", "parent", "folder:2")},
@@ -3062,7 +3062,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), store, &openfgav1.TupleKey{
 			Object:   "folder:1",
 			Relation: "viewer",
-		}).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
 		}),
 	)

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -220,8 +220,9 @@ func (c *ReverseExpandQuery) Execute(
 	req *ReverseExpandRequest,
 	resultChan chan<- *ReverseExpandResult,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
-	err := c.execute(ctx, req, resultChan, false, resolutionMetadata)
+	err := c.execute(ctx, req, resultChan, false, resolutionMetadata, consistencyOptions)
 	if err != nil {
 		return err
 	}
@@ -236,12 +237,13 @@ func (c *ReverseExpandQuery) dispatch(
 	resultChan chan<- *ReverseExpandResult,
 	intersectionOrExclusionInPreviousEdges bool,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
 	newcount := resolutionMetadata.DispatchCounter.Add(1)
 	if c.dispatchThrottlerConfig.Enabled {
 		c.throttle(ctx, newcount, resolutionMetadata)
 	}
-	return c.execute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+	return c.execute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 }
 
 func (c *ReverseExpandQuery) execute(
@@ -250,6 +252,7 @@ func (c *ReverseExpandQuery) execute(
 	resultChan chan<- *ReverseExpandResult,
 	intersectionOrExclusionInPreviousEdges bool,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -349,7 +352,7 @@ LoopOnEdges:
 		switch innerLoopEdge.Type {
 		case graph.DirectEdge:
 			pool.Go(func(ctx context.Context) error {
-				return c.reverseExpandDirect(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+				return c.reverseExpandDirect(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 			})
 		case graph.ComputedUsersetEdge:
 			// follow the computed_userset edge, no new goroutine needed since it's not I/O intensive
@@ -359,14 +362,14 @@ LoopOnEdges:
 					Relation: innerLoopEdge.TargetReference.GetRelation(),
 				},
 			}
-			err = c.dispatch(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+			err = c.dispatch(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 			if err != nil {
 				errs = errors.Join(errs, err)
 				break LoopOnEdges
 			}
 		case graph.TupleToUsersetEdge:
 			pool.Go(func(ctx context.Context) error {
-				return c.reverseExpandTupleToUserset(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+				return c.reverseExpandTupleToUserset(ctx, r, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 			})
 		default:
 			panic("unsupported edge type")
@@ -388,6 +391,7 @@ func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 	resultChan chan<- *ReverseExpandResult,
 	intersectionOrExclusionInPreviousEdges bool,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandTupleToUserset", trace.WithAttributes(
 		attribute.String("edge", req.edge.String()),
@@ -401,7 +405,7 @@ func (c *ReverseExpandQuery) reverseExpandTupleToUserset(
 		span.End()
 	}()
 
-	err = c.readTuplesAndExecute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+	err = c.readTuplesAndExecute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 	return err
 }
 
@@ -411,6 +415,7 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 	resultChan chan<- *ReverseExpandResult,
 	intersectionOrExclusionInPreviousEdges bool,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
 	ctx, span := tracer.Start(ctx, "reverseExpandDirect", trace.WithAttributes(
 		attribute.String("edge", req.edge.String()),
@@ -424,7 +429,7 @@ func (c *ReverseExpandQuery) reverseExpandDirect(
 		span.End()
 	}()
 
-	err = c.readTuplesAndExecute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+	err = c.readTuplesAndExecute(ctx, req, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 	return err
 }
 
@@ -434,6 +439,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 	resultChan chan<- *ReverseExpandResult,
 	intersectionOrExclusionInPreviousEdges bool,
 	resolutionMetadata *ResolutionMetadata,
+	consistencyOptions storage.ConsistencyOptions,
 ) error {
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -495,7 +501,7 @@ func (c *ReverseExpandQuery) readTuplesAndExecute(
 		ObjectType: req.edge.TargetReference.GetType(),
 		Relation:   relationFilter,
 		UserFilter: userFilter,
-	})
+	}, storage.ReadStartingWithUserOptions{Consistency: consistencyOptions})
 	atomic.AddUint32(resolutionMetadata.DatastoreQueryCount, 1)
 	if err != nil {
 		return err
@@ -572,7 +578,7 @@ LoopOnIterator:
 				ContextualTuples: req.ContextualTuples,
 				Context:          req.Context,
 				edge:             req.edge,
-			}, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
+			}, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata, consistencyOptions)
 		})
 	}
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -49,9 +49,9 @@ func TestReverseExpandResultChannelClosed(t *testing.T) {
 	var tuples []*openfgav1.Tuple
 
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 			iterator := storage.NewStaticTupleIterator(tuples)
 			return iterator, nil
 		})
@@ -76,7 +76,7 @@ func TestReverseExpandResultChannelClosed(t *testing.T) {
 				},
 			},
 			ContextualTuples: []*openfgav1.TupleKey{},
-		}, resultChan, NewResolutionMetadata())
+		}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 		t.Logf("after execute reverse expand")
 
 		if err != nil {
@@ -121,9 +121,9 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 	}
 
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 			// simulate many goroutines trying to write to the results channel
 			iterator := storage.NewStaticTupleIterator(tuples)
 			t.Logf("returning tuple iterator")
@@ -149,7 +149,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 				},
 			},
 			ContextualTuples: []*openfgav1.TupleKey{},
-		}, resultChan, NewResolutionMetadata())
+		}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 		t.Logf("after execute reverse expand")
 
 		if err != nil {
@@ -200,7 +200,7 @@ func TestReverseExpandRespectsContextTimeout(t *testing.T) {
 	defer mockController.Finish()
 
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
 		MaxTimes(2) // we expect it to be 0 most of the time
 
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
@@ -221,7 +221,7 @@ func TestReverseExpandRespectsContextTimeout(t *testing.T) {
 				},
 			},
 			ContextualTuples: []*openfgav1.TupleKey{},
-		}, resultChan, NewResolutionMetadata())
+		}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 
 		if err != nil {
 			errChan <- err
@@ -264,8 +264,8 @@ func TestReverseExpandErrorInTuples(t *testing.T) {
 	}
 
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 			iterator := mocks.NewErrorTupleIterator(tuples)
 			return iterator, nil
 		})
@@ -290,7 +290,7 @@ func TestReverseExpandErrorInTuples(t *testing.T) {
 				},
 			},
 			ContextualTuples: []*openfgav1.TupleKey{},
-		}, resultChan, NewResolutionMetadata())
+		}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 		if err != nil {
 			errChan <- err
 		}
@@ -352,7 +352,7 @@ func TestReverseExpandSendsAllErrorsThroughChannel(t *testing.T) {
 					},
 				},
 				ContextualTuples: []*openfgav1.TupleKey{},
-			}, resultChan, NewResolutionMetadata())
+			}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 			t.Logf("after produce")
 
 			if err != nil {
@@ -400,9 +400,9 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 			ObjectType: "group",
 			Relation:   "member",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:anne"}},
-		}).
+		}, gomock.Any()).
 			Times(1).
-			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					{Key: tuple.NewTupleKey("group:fga", "member", "user:anne")},
 				}), nil
@@ -412,9 +412,9 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 			ObjectType: "group",
 			Relation:   "member",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "group:fga", Relation: "member"}},
-		}).
+		}, gomock.Any()).
 			Times(1).
-			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					// NOTE this tuple is invalid
 					{Key: tuple.NewTupleKey("group:eng#member", "member", "group:fga#member")},
@@ -436,7 +436,7 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 			Relation:         "member",
 			User:             &UserRefObject{Object: &openfgav1.Object{Type: "user", Id: "anne"}},
 			ContextualTuples: []*openfgav1.TupleKey{},
-		}, resultChan, NewResolutionMetadata())
+		}, resultChan, NewResolutionMetadata(), storage.ConsistencyOptions{})
 
 		if err != nil {
 			errChan <- err
@@ -716,7 +716,7 @@ func TestReverseExpandDispatchCount(t *testing.T) {
 					ObjectType: test.objectType,
 					Relation:   test.relation,
 					User:       test.user,
-				}, resultChan, resolutionMetadata)
+				}, resultChan, resolutionMetadata, storage.ConsistencyOptions{})
 
 				if err != nil {
 					errChan <- err

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -465,7 +465,7 @@ func TestListUsers_Deadline(t *testing.T) {
 		mockDatastore.EXPECT().Close().Times(1)
 
 		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, gomock.Any()).
+			Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, context.DeadlineExceeded).
 			Times(1)
 
@@ -520,8 +520,8 @@ func TestListUsers_Deadline(t *testing.T) {
 			Times(1)
 
 		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, gomock.Any()).
-			DoAndReturn(func(ctx context.Context, storeID string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+			Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, storeID string, tupleKey *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 				time.Sleep(10 * time.Millisecond)
 				return nil, context.Canceled
 			}).

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -748,15 +748,15 @@ func TestCheckDoesNotThrowBecauseDirectTupleWasFound(t *testing.T) {
 
 	// it could happen that one of the following two mocks won't be necessary because the goroutine will be short-circuited
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		Return(returnedTuple, nil)
 
 	mockDatastore.EXPECT().
-		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any()).
+		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				time.Sleep(50 * time.Millisecond)
 				return nil, errors.New("some error")
 			})
@@ -1040,10 +1040,10 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 
 	// it could happen that one of the following two mocks won't be necessary because the goroutine will be short-circuited
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(ctx context.Context, _ string, _ *openfgav1.TupleKey) (storage.TupleIterator, error) {
+			func(ctx context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadUserTupleOptions) (storage.TupleIterator, error) {
 				select {
 				case <-ctx.Done():
 					return nil, ctx.Err()
@@ -1053,10 +1053,10 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 			})
 
 	mockDatastore.EXPECT().
-		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any()).
+		ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		AnyTimes().
 		DoAndReturn(
-			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				time.Sleep(100 * time.Millisecond)
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}), nil
 			})
@@ -1120,7 +1120,7 @@ func TestCheckWithCachedResolution(t *testing.T) {
 		}, nil)
 
 	mockDatastore.EXPECT().
-		ReadUserTuple(gomock.Any(), storeID, gomock.Any()).
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		Times(1).
 		Return(returnedTuple, nil)
 
@@ -1413,7 +1413,7 @@ func BenchmarkListObjectsNoRaceCondition(b *testing.B) {
 		SchemaVersion:   typesystem.SchemaVersion1_1,
 		TypeDefinitions: typedefs,
 	}, nil)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
 
 	s := MustNewServerWithOpts(
 		WithDatastore(mockDatastore),
@@ -1490,7 +1490,7 @@ func TestListObjects_ErrorCases(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: "user:*"},
 				{Object: "user:bob"},
-			}}).AnyTimes().Return(nil, errors.New("error reading from storage"))
+			}}, gomock.Any()).AnyTimes().Return(nil, errors.New("error reading from storage"))
 
 		t.Run("error_listing_objects_from_storage_in_non-streaming_version", func(t *testing.T) {
 			res, err := s.ListObjects(ctx, &openfgav1.ListObjectsRequest{

--- a/pkg/server/test/reverse_expand.go
+++ b/pkg/server/test/reverse_expand.go
@@ -1320,7 +1320,7 @@ func TestReverseExpand(t *testing.T, ds storage.OpenFGADatastore) {
 
 			reverseExpandErrCh := make(chan error, 1)
 			go func() {
-				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata)
+				errReverseExpand := reverseExpandQuery.Execute(timeoutCtx, test.request, resultChan, resolutionMetadata, storage.ConsistencyOptions{})
 				if errReverseExpand != nil {
 					reverseExpandErrCh <- errReverseExpand
 				}

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -174,7 +174,7 @@ func WithMaxTypesPerAuthorizationModel(n int) StorageOption {
 func (s *MemoryBackend) Close() {}
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (s *MemoryBackend) Read(ctx context.Context, store string, key *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (s *MemoryBackend) Read(ctx context.Context, store string, key *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "memory.Read")
 	defer span.End()
 
@@ -415,7 +415,7 @@ func find(records []*storage.TupleRecord, tupleKey *openfgav1.TupleKey) bool {
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (s *MemoryBackend) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (s *MemoryBackend) ReadUserTuple(ctx context.Context, store string, key *openfgav1.TupleKey, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	_, span := tracer.Start(ctx, "memory.ReadUserTuple")
 	defer span.End()
 
@@ -437,6 +437,7 @@ func (s *MemoryBackend) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	_ storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	_, span := tracer.Start(ctx, "memory.ReadUsersetTuples")
 	defer span.End()
@@ -475,6 +476,7 @@ func (s *MemoryBackend) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	_, span := tracer.Start(ctx, "memory.ReadStartingWithUser")
 	defer span.End()

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -129,7 +129,7 @@ func (m *MySQL) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (m *MySQL) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (m *MySQL) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.Read")
 	defer span.End()
 
@@ -211,7 +211,7 @@ func (m *MySQL) Write(ctx context.Context, store string, deletes storage.Deletes
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (m *MySQL) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (m *MySQL) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadUserTuple")
 	defer span.End()
 
@@ -268,6 +268,7 @@ func (m *MySQL) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	_ storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadUsersetTuples")
 	defer span.End()
@@ -316,6 +317,7 @@ func (m *MySQL) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	opts storage.ReadStartingWithUserFilter,
+	_ storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "mysql.ReadStartingWithUser")
 	defer span.End()

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -72,9 +72,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 
-	iter, err := ds.Read(ctx,
-		store,
-		tuple.NewTupleKey("doc:", "relation", ""))
+	iter, err := ds.Read(ctx, store, tuple.NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
 	defer iter.Stop()
 
 	require.NoError(t, err)
@@ -185,7 +183,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	tk := tuple.NewTupleKey("folder:2021-budget", "owner", "user:anne")
-	iter, err := ds.Read(ctx, "store", tk)
+	iter, err := ds.Read(ctx, "store", tk, storage.ReadOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -201,7 +199,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
 
-	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
+	userTuple, err := ds.ReadUserTuple(ctx, "store", tk, storage.ReadUserTupleOptions{})
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.GetKey())
 
@@ -212,7 +210,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"})
+	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"}, storage.ReadUsersetTuplesOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -226,7 +224,7 @@ func TestAllowNullCondition(t *testing.T) {
 		UserFilter: []*openfgav1.ObjectRelation{
 			{Object: "user:anne"},
 		},
-	})
+	}, storage.ReadStartingWithUserOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -142,7 +142,7 @@ func (p *Postgres) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (p *Postgres) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (p *Postgres) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.Read")
 	defer span.End()
 
@@ -224,7 +224,7 @@ func (p *Postgres) Write(ctx context.Context, store string, deletes storage.Dele
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadUserTuple")
 	defer span.End()
 
@@ -278,7 +278,7 @@ func (p *Postgres) ReadUserTuple(ctx context.Context, store string, tupleKey *op
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
-func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadUsersetTuples")
 	defer span.End()
 
@@ -322,7 +322,7 @@ func (p *Postgres) ReadUsersetTuples(ctx context.Context, store string, filter s
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
-func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "postgres.ReadStartingWithUser")
 	defer span.End()
 

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -72,9 +72,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 
-	iter, err := ds.Read(ctx,
-		store, tuple.
-			NewTupleKey("doc:", "relation", ""))
+	iter, err := ds.Read(ctx, store, tuple.
+		NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
 	defer iter.Stop()
 	require.NoError(t, err)
 
@@ -184,7 +183,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.NoError(t, err)
 
 	tk := tuple.NewTupleKey("folder:2021-budget", "owner", "user:anne")
-	iter, err := ds.Read(ctx, "store", tk)
+	iter, err := ds.Read(ctx, "store", tk, storage.ReadOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -200,7 +199,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.Len(t, tuples, 1)
 	require.Equal(t, tk, tuples[0].GetKey())
 
-	userTuple, err := ds.ReadUserTuple(ctx, "store", tk)
+	userTuple, err := ds.ReadUserTuple(ctx, "store", tk, storage.ReadUserTupleOptions{})
 	require.NoError(t, err)
 	require.Equal(t, tk, userTuple.GetKey())
 
@@ -211,7 +210,7 @@ func TestAllowNullCondition(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"})
+	iter, err = ds.ReadUsersetTuples(ctx, "store", storage.ReadUsersetTuplesFilter{Object: "folder:2022-budget"}, storage.ReadUsersetTuplesOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 
@@ -225,7 +224,7 @@ func TestAllowNullCondition(t *testing.T) {
 		UserFilter: []*openfgav1.ObjectRelation{
 			{Object: "user:anne"},
 		},
-	})
+	}, storage.ReadStartingWithUserOptions{})
 	require.NoError(t, err)
 	defer iter.Stop()
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -95,7 +95,38 @@ type ReadChangesOptions struct {
 // ReadPageOptions represents the options that can
 // be used with the ReadPage method.
 type ReadPageOptions struct {
-	Pagination PaginationOptions
+	Pagination  PaginationOptions
+	Consistency ConsistencyOptions
+}
+
+// ConsistencyOptions represents the options that can
+// be used for methods that accept a consistency preference.
+type ConsistencyOptions struct {
+	Consistency openfgav1.ConsistencyPreference
+}
+
+// ReadOptions represents the options that can
+// be used with the Read method.
+type ReadOptions struct {
+	Consistency ConsistencyOptions
+}
+
+// ReadUserTupleOptions represents the options that can
+// be used with the ReadUserTuple method.
+type ReadUserTupleOptions struct {
+	Consistency ConsistencyOptions
+}
+
+// ReadUsersetTuplesOptions represents the options that can
+// be used with the ReadUsersetTuples method.
+type ReadUsersetTuplesOptions struct {
+	Consistency ConsistencyOptions
+}
+
+// ReadStartingWithUserOptions represents the options that can
+// be used with the ReadStartingWithUser method.
+type ReadStartingWithUserOptions struct {
+	Consistency ConsistencyOptions
 }
 
 // Writes is a typesafe alias for Write arguments.
@@ -120,7 +151,7 @@ type RelationshipTupleReader interface {
 	//
 	// The caller must be careful to close the [TupleIterator], either by consuming the entire iterator or by closing it.
 	// There is NO guarantee on the order of the tuples returned on the iterator.
-	Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (TupleIterator, error)
+	Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ReadOptions) (TupleIterator, error)
 
 	// ReadPage functions similarly to Read but includes support for pagination. It takes
 	// mandatory pagination options. PageSize will always be greater than zero.
@@ -139,6 +170,7 @@ type RelationshipTupleReader interface {
 		ctx context.Context,
 		store string,
 		tupleKey *openfgav1.TupleKey,
+		options ReadUserTupleOptions,
 	) (*openfgav1.Tuple, error)
 
 	// ReadUsersetTuples returns all userset tuples for a specified object and relation.
@@ -154,6 +186,7 @@ type RelationshipTupleReader interface {
 		ctx context.Context,
 		store string,
 		filter ReadUsersetTuplesFilter,
+		options ReadUsersetTuplesOptions,
 	) (TupleIterator, error)
 
 	// ReadStartingWithUser performs a reverse read of relationship tuples starting at one or
@@ -171,6 +204,7 @@ type RelationshipTupleReader interface {
 		ctx context.Context,
 		store string,
 		filter ReadStartingWithUserFilter,
+		options ReadStartingWithUserOptions,
 	) (TupleIterator, error)
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -102,7 +102,7 @@ type ReadPageOptions struct {
 // ConsistencyOptions represents the options that can
 // be used for methods that accept a consistency preference.
 type ConsistencyOptions struct {
-	Consistency openfgav1.ConsistencyPreference
+	Preference openfgav1.ConsistencyPreference
 }
 
 // ReadOptions represents the options that can

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -154,7 +154,7 @@ type RelationshipTupleReader interface {
 	Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ReadOptions) (TupleIterator, error)
 
 	// ReadPage functions similarly to Read but includes support for pagination. It takes
-	// mandatory pagination options. PageSize will always be greater than zero.
+	// mandatory ReadPageOptions options. PageSize will always be greater than zero.
 	// It returns a slice of tuples along with a continuation token. This token can be used for retrieving subsequent pages of data.
 	// There is NO guarantee on the order of the tuples in one page.
 	ReadPage(

--- a/pkg/storage/storagewrappers/boundedconcurrency.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency.go
@@ -51,6 +51,7 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tupleKey *openfgav1.TupleKey,
+	options storage.ReadUserTupleOptions,
 ) (*openfgav1.Tuple, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -61,11 +62,11 @@ func (b *boundedConcurrencyTupleReader) ReadUserTuple(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey)
+	return b.RelationshipTupleReader.ReadUserTuple(ctx, store, tupleKey, options)
 }
 
 // Read the set of tuples associated with `store` and `TupleKey`, which may be nil or partially filled.
-func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
 		return nil, err
@@ -75,7 +76,7 @@ func (b *boundedConcurrencyTupleReader) Read(ctx context.Context, store string, 
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.Read(ctx, store, tupleKey)
+	return b.RelationshipTupleReader.Read(ctx, store, tupleKey, options)
 }
 
 // ReadUsersetTuples returns all userset tuples for a specified object and relation.
@@ -83,6 +84,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -93,7 +95,7 @@ func (b *boundedConcurrencyTupleReader) ReadUsersetTuples(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
+	return b.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 }
 
 // ReadStartingWithUser performs a reverse read of relationship tuples starting at one or
@@ -102,6 +104,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	err := b.waitForLimiter(ctx)
 	if err != nil {
@@ -112,7 +115,7 @@ func (b *boundedConcurrencyTupleReader) ReadStartingWithUser(
 		<-b.limiter
 	}()
 
-	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
+	return b.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 }
 
 // waitForLimiter respects context errors and returns an error only if it couldn't send an item to the channel.

--- a/pkg/storage/storagewrappers/boundedconcurrency_test.go
+++ b/pkg/storage/storagewrappers/boundedconcurrency_test.go
@@ -41,7 +41,7 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 	start := time.Now()
 
 	wg.Go(func() error {
-		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"))
+		_, err := limitedTupleReader.ReadUserTuple(context.Background(), store, tuple.NewTupleKey("obj:1", "viewer", "user:anne"), storage.ReadUserTupleOptions{})
 		return err
 	})
 
@@ -49,12 +49,12 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 		_, err := limitedTupleReader.ReadUsersetTuples(context.Background(), store, storage.ReadUsersetTuplesFilter{
 			Object:   "obj:1",
 			Relation: "viewer",
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		return err
 	})
 
 	wg.Go(func() error {
-		_, err := limitedTupleReader.Read(context.Background(), store, nil)
+		_, err := limitedTupleReader.Read(context.Background(), store, nil, storage.ReadOptions{})
 		return err
 	})
 
@@ -68,7 +68,7 @@ func TestBoundedConcurrencyWrapper(t *testing.T) {
 						Object:   "obj",
 						Relation: "viewer",
 					},
-				}})
+				}}, storage.ReadStartingWithUserOptions{})
 		return err
 	})
 
@@ -96,22 +96,22 @@ func TestBoundedConcurrencyWrapper_Exits_Early_If_Context_Error(t *testing.T) {
 	}{
 		`read`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.Read(ctx, ulid.Make().String(), &openfgav1.TupleKey{})
+				return dut.Read(ctx, ulid.Make().String(), &openfgav1.TupleKey{}, storage.ReadOptions{})
 			},
 		},
 		`read_user_tuple`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadUserTuple(ctx, ulid.Make().String(), &openfgav1.TupleKey{})
+				return dut.ReadUserTuple(ctx, ulid.Make().String(), &openfgav1.TupleKey{}, storage.ReadUserTupleOptions{})
 			},
 		},
 		`read_userset_tuples`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadUsersetTuples(ctx, ulid.Make().String(), storage.ReadUsersetTuplesFilter{})
+				return dut.ReadUsersetTuples(ctx, ulid.Make().String(), storage.ReadUsersetTuplesFilter{}, storage.ReadUsersetTuplesOptions{})
 			},
 		},
 		`read_starting_with_user`: {
 			requestFunc: func(ctx context.Context) (any, error) {
-				return dut.ReadStartingWithUser(ctx, ulid.Make().String(), storage.ReadStartingWithUserFilter{})
+				return dut.ReadStartingWithUser(ctx, ulid.Make().String(), storage.ReadStartingWithUserFilter{}, storage.ReadStartingWithUserOptions{})
 			},
 		},
 	}

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -48,10 +48,11 @@ func (c *combinedTupleReader) Read(
 	ctx context.Context,
 	storeID string,
 	tk *openfgav1.TupleKey,
+	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
 	iter1 := storage.NewStaticTupleIterator(filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation()))
 
-	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk)
+	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, tk, options)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +71,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 	ctx context.Context,
 	store string,
 	tk *openfgav1.TupleKey,
+	options storage.ReadUserTupleOptions,
 ) (*openfgav1.Tuple, error) {
 	filteredContextualTuples := filterTuples(c.contextualTuples, tk.GetObject(), tk.GetRelation())
 
@@ -79,7 +81,7 @@ func (c *combinedTupleReader) ReadUserTuple(
 		}
 	}
 
-	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk)
+	return c.RelationshipTupleReader.ReadUserTuple(ctx, store, tk, options)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
@@ -87,6 +89,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
+	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	var usersetTuples []*openfgav1.Tuple
 
@@ -98,7 +101,7 @@ func (c *combinedTupleReader) ReadUsersetTuples(
 
 	iter1 := storage.NewStaticTupleIterator(usersetTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter)
+	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	if err != nil {
 		return nil, err
 	}
@@ -111,6 +114,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	var filteredTuples []*openfgav1.Tuple
 	for _, t := range c.contextualTuples {
@@ -138,7 +142,7 @@ func (c *combinedTupleReader) ReadStartingWithUser(
 
 	iter1 := storage.NewStaticTupleIterator(filteredTuples)
 
-	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter)
+	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -38,10 +38,10 @@ func (c *ContextTracerWrapper) Close() {
 }
 
 // Read see [storage.RelationshipTupleReader.ReadUserTuple].
-func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey)
+	return c.OpenFGADatastore.Read(queryCtx, store, tupleKey, options)
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
@@ -52,22 +52,22 @@ func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tuple
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
-func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey) (*openfgav1.Tuple, error) {
+func (c *ContextTracerWrapper) ReadUserTuple(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey)
+	return c.OpenFGADatastore.ReadUserTuple(queryCtx, store, tupleKey, options)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
-func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadUsersetTuples(ctx context.Context, store string, filter storage.ReadUsersetTuplesFilter, options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter)
+	return c.OpenFGADatastore.ReadUsersetTuples(queryCtx, store, filter, options)
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
-func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter) (storage.TupleIterator, error) {
+func (c *ContextTracerWrapper) ReadStartingWithUser(ctx context.Context, store string, opts storage.ReadStartingWithUserFilter, options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 	queryCtx := queryContext(ctx)
 
-	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts)
+	return c.OpenFGADatastore.ReadStartingWithUser(queryCtx, store, opts, options)
 }

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -505,7 +505,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		}
 
 		t.Run("read_returns_everything", func(t *testing.T) {
-			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""))
+			tupleIterator, err := datastore.Read(ctx, storeID, tuple.NewTupleKey("", "", ""), storage.ReadOptions{})
 			require.NoError(t, err)
 			defer tupleIterator.Stop()
 
@@ -623,7 +623,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NoError(t, err)
 
 		// Ensure it is not there.
-		_, err = datastore.ReadUserTuple(ctx, storeID, tk)
+		_, err = datastore.ReadUserTuple(ctx, storeID, tk, storage.ReadUserTupleOptions{})
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -712,28 +712,28 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tuple1, tuple2, tuple3, tuple4})
 		require.NoError(t, err)
 
-		gotTuple, err := datastore.ReadUserTuple(ctx, storeID, tuple1)
+		gotTuple, err := datastore.ReadUserTuple(ctx, storeID, tuple1, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple1, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple2)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple2, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple2, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple3)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple3, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple3, gotTuple.GetKey(), cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
 		}
 
-		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple4)
+		gotTuple, err = datastore.ReadUserTuple(ctx, storeID, tuple4, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 
 		if diff := cmp.Diff(tuple4, gotTuple.GetKey(), cmpOpts...); diff != "" {
@@ -745,7 +745,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 		tk := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
 
-		_, err := datastore.ReadUserTuple(ctx, storeID, tk)
+		_, err := datastore.ReadUserTuple(ctx, storeID, tk, storage.ReadUserTupleOptions{})
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
@@ -780,7 +780,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   "doc:readme",
 			Relation: "owner",
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -814,7 +814,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 	t.Run("reading_userset_tuples_that_don't_exist_should_return_an_empty_iterator", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"})
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 		defer gotTuples.Stop()
 
@@ -840,7 +840,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.DirectRelationReference("group", "member"),
 			},
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -877,7 +877,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 				typesystem.DirectRelationReference("group", "member"),
 				typesystem.DirectRelationReference("grouping", "member"),
 			},
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -918,7 +918,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.WildcardRelationReference("user"),
 			},
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -955,7 +955,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 				typesystem.DirectRelationReference("group", "member"),
 				typesystem.WildcardRelationReference("user"),
 			},
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 
 		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
@@ -1003,7 +1003,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, tks)
 		require.NoError(t, err)
 
-		iter, err := datastore.Read(ctx, storeID, tupleKey1)
+		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.ReadOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1020,14 +1020,14 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.Nil(t, tuples[0].GetKey().GetCondition())
 		require.Nil(t, tuples[1].GetKey().GetCondition())
 
-		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 		require.Nil(t, tp.GetKey().GetCondition())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
 			Relation: tupleKey2.GetRelation(),
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1041,7 +1041,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
 			},
-		})
+		}, storage.ReadStartingWithUserOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1090,7 +1090,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, tks)
 		require.NoError(t, err)
 
-		iter, err := datastore.Read(ctx, storeID, tupleKey1)
+		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.ReadOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1109,14 +1109,14 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.NotNil(t, tuples[0].GetKey().GetCondition().GetContext())
 		require.NotNil(t, tuples[1].GetKey().GetCondition().GetContext())
 
-		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1)
+		tp, err = datastore.ReadUserTuple(ctx, storeID, tupleKey1, storage.ReadUserTupleOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, tp.GetKey().GetCondition().GetContext())
 
 		iter, err = datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
 			Object:   tupleKey2.GetObject(),
 			Relation: tupleKey2.GetRelation(),
-		})
+		}, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1130,7 +1130,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			UserFilter: []*openfgav1.ObjectRelation{
 				{Object: tupleKey1.GetUser()},
 			},
-		})
+		}, storage.ReadStartingWithUserOptions{})
 		require.NoError(t, err)
 		defer iter.Stop()
 
@@ -1188,7 +1188,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 						Relation: "member",
 					},
 				},
-			},
+			}, storage.ReadStartingWithUserOptions{},
 		)
 		require.NoError(t, err)
 
@@ -1214,7 +1214,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 						Object: "user:maria",
 					},
 				},
-			},
+			}, storage.ReadStartingWithUserOptions{},
 		)
 		require.NoError(t, err)
 
@@ -1240,7 +1240,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 						Object: "user:jon",
 					},
 				},
-			},
+			}, storage.ReadStartingWithUserOptions{},
 		)
 		require.NoError(t, err)
 
@@ -1266,7 +1266,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 						Object: "user:jon",
 					},
 				},
-			},
+			}, storage.ReadStartingWithUserOptions{},
 		)
 		require.NoError(t, err)
 
@@ -1335,7 +1335,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 				})
 
 				t.Run("Read", func(t *testing.T) {
-					tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
+					tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.ReadOptions{})
 					require.NoError(t, err)
 					defer tupleIterator.Stop()
 
@@ -1431,7 +1431,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			})
 
 			t.Run("Read", func(t *testing.T) {
-				tupleIterator, err := datastore.Read(ctx, storeID, test.filter)
+				tupleIterator, err := datastore.Read(ctx, storeID, test.filter, storage.ReadOptions{})
 				require.NoError(t, err)
 				defer tupleIterator.Stop()
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Adds the consistency parameter to storage methods.

## Description
<!-- Provide a detailed description of the changes -->

Adds a new `ConsistencyOptions` type:

```go
type ConsistencyOptions struct {
	Preference openfgav1.ConsistencyPreference
}
```

The following methods have been updated to take new options to support consistency:
- `Read`
- `ReadPage`
- `ReadUsersetTuples`
- `ReadStartingWithUser`

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
