### PR TITLE
feat: update cached resolver cache when not reading from the cache

### DIFF
--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -92,7 +92,7 @@ func TestResolveCheckFromCache(t *testing.T) {
 			},
 		},
 		{
-			name:                     "result_not_cached_when_higher_consistency_requested",
+			name:                     "result_added_to_cache_when_higher_consistency_requested",
 			consistencyOptionEnabled: true,
 			initialReq: &ResolveCheckRequest{
 				StoreID:              "12",
@@ -106,13 +106,13 @@ func TestResolveCheckFromCache(t *testing.T) {
 				AuthorizationModelID: "33",
 				TupleKey:             tuple.NewTupleKey("document:abc", "reader", "user:XYZ"),
 				RequestMetadata:      NewCheckRequestMetadata(20),
-				Consistency:          openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+				Consistency:          openfgav1.ConsistencyPreference_MINIMIZE_LATENCY,
 			},
 			setInitialResult: func(mock *MockCheckResolver, request *ResolveCheckRequest) {
 				mock.EXPECT().ResolveCheck(gomock.Any(), request).Times(1).Return(result, nil)
 			},
 			setTestExpectations: func(mock *MockCheckResolver, request *ResolveCheckRequest) {
-				mock.EXPECT().ResolveCheck(gomock.Any(), request).Times(1).Return(result, nil)
+				mock.EXPECT().ResolveCheck(gomock.Any(), request).Times(0).Return(result, nil)
 			},
 		},
 		{

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -297,20 +297,8 @@ func TestDoesNotUseCacheWhenHigherConsistencyEnabled(t *testing.T) {
 		cachedChecker,
 	)
 
-	// First run a check with HIGHER_CONSISTENCY that will evaluate against the known tuples
+	// Run a check with MINIMIZE_LATENCY that will use the cache we added with 2 tuples
 	resp, err := q.Execute(ctx, &openfgav1.ListObjectsRequest{
-		StoreId:     storeID,
-		Type:        "folder",
-		Relation:    "viewer",
-		User:        "user:jon",
-		Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
-	})
-
-	require.NoError(t, err)
-	require.Len(t, resp.Objects, 3)
-
-	// Now run a check with MINIMIZE_LATENCY that will use the cache entry we added
-	resp, err = q.Execute(ctx, &openfgav1.ListObjectsRequest{
 		StoreId:     storeID,
 		Type:        "folder",
 		Relation:    "viewer",
@@ -321,13 +309,25 @@ func TestDoesNotUseCacheWhenHigherConsistencyEnabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, resp.Objects, 2)
 
-	// And finally run a check with HIGHER_CONSISTENCY that should still return 3 objects
+	// Now run a check with HIGHER_CONSISTENCY that will evaluate against the known tuples and return 3 tuples
 	resp, err = q.Execute(ctx, &openfgav1.ListObjectsRequest{
 		StoreId:     storeID,
 		Type:        "folder",
 		Relation:    "viewer",
 		User:        "user:jon",
 		Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resp.Objects, 3)
+
+	// Rerun check with MINIMIZE_LATENCY to ensure the cache was updated with the tuple we retrieved during the previous call
+	resp, err = q.Execute(ctx, &openfgav1.ListObjectsRequest{
+		StoreId:     storeID,
+		Type:        "folder",
+		Relation:    "viewer",
+		User:        "user:jon",
+		Consistency: openfgav1.ConsistencyPreference_MINIMIZE_LATENCY,
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR introduces writing to the cache in `CachedCheckResolver` even when we are not reading from it due to the consistency requested being `HIGHER_CONSISTENCY`. Previously when we implemented skipping the cache we chose to not update the cache, but as it is relatively simple to do so we are now choosing to enrich the cache.

It refactors the existing test for this behaviour to now require the cache to be updated, and updates the list objects test that relied on cache interaction to reflect the new reality.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
