### PR TITLE
test: wait for streaming endpoint to emit logs before asserting on them

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -264,6 +265,7 @@ func TestServerLogs(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			time.Sleep(1 * time.Second) // Wait for streaming endpoint to emit logs.
 			actualLogs := logs.All()
 			require.Len(t, actualLogs, 1)
 


### PR DESCRIPTION
## Description
Poor-woman's fix to

```
   tests.go:62: creating connection to address 0.0.0.0:39093
    --- FAIL: TestServerLogs/streamed_list_objects_success (0.01s)
        check_test.go:268: 
            	Error Trace:	/home/runner/work/openfga/openfga/tests/check/check_test.go:268
            	Error:      	"[]" should have 1 item(s), but has 0
            	Test:       	TestServerLogs/streamed_list_objects_success
```

because I don't know the root cause.