### PR TITLE
perf: check improvement in case userset and TTU wildcard

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -5478,6 +5478,157 @@ tests:
               relation: viewer
             expectation:
               - user:anne
+  - name: simple_userset_child_wildcard
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type group
+            relations
+              define member: [user, user:*]
+          type folder
+            relations
+              define viewer: [group#member]
+        tuples:
+          - user: user:*
+            relation: member
+            object: group:fga
+          - user: user:maria
+            relation: member
+            object: group:engineering
+          - user: group:fga#member
+            relation: viewer
+            object: folder:1
+          - user: group:engineering#member
+            relation: viewer
+            object: folder:2
+        checkAssertions:
+          - tuple:
+              user: user:anne
+              relation: viewer
+              object: folder:1
+            expectation: true
+          - tuple:
+              user: user:anne
+              relation: viewer
+              object: folder:2
+            expectation: false
+          - tuple:
+              user: user:maria
+              relation: viewer
+              object: folder:1
+            expectation: true
+          - tuple:
+              user: user:maria
+              relation: viewer
+              object: folder:2
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:anne
+              type: folder
+              relation: viewer
+            expectation:
+              - folder:1
+          - request:
+              user: user:maria
+              type: folder
+              relation: viewer
+            expectation:
+              - folder:1
+              - folder:2
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:1
+              relation: viewer
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: folder:2
+              relation: viewer
+            expectation:
+              - user:maria
+  - name: simple_ttu_child_wildcard
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type group
+            relations
+              define member: [user, user:*]
+          type folder
+            relations
+              define viewer: member from owner
+              define owner: [group]
+        tuples:
+          - user: user:*
+            relation: member
+            object: group:fga
+          - user: user:maria
+            relation: member
+            object: group:engineering
+          - user: group:fga
+            relation: owner
+            object: folder:1
+          - user: group:engineering
+            relation: owner
+            object: folder:2
+        checkAssertions:
+          - tuple:
+              user: user:anne
+              relation: viewer
+              object: folder:1
+            expectation: true
+          - tuple:
+              user: user:anne
+              relation: viewer
+              object: folder:2
+            expectation: false
+          - tuple:
+              user: user:maria
+              relation: viewer
+              object: folder:1
+            expectation: true
+          - tuple:
+              user: user:maria
+              relation: viewer
+              object: folder:2
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:anne
+              type: folder
+              relation: viewer
+            expectation:
+              - folder:1
+          - request:
+              user: user:maria
+              type: folder
+              relation: viewer
+            expectation:
+              - folder:1
+              - folder:2
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: folder:1
+              relation: viewer
+            expectation:
+              - user:*
+          - request:
+              filters:
+                - user
+              object: folder:2
+              relation: viewer
+            expectation:
+              - user:maria
   - name: ttu_and_computed_ttu_wildcard
     stages:
       - model: |

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -5484,9 +5484,10 @@ tests:
           model
             schema 1.1
           type user
+          type user2
           type group
             relations
-              define member: [user, user:*]
+              define member: [user, user:*, user2, user2:*]
           type folder
             relations
               define viewer: [group#member]
@@ -5524,6 +5525,16 @@ tests:
               relation: viewer
               object: folder:2
             expectation: true
+          - tuple:
+              user: user2:foo
+              relation: viewer
+              object: folder:1
+            expectation: false
+          - tuple:
+              user: user2:foo
+              relation: viewer
+              object: folder:2
+            expectation: false
         listObjectsAssertions:
           - request:
               user: user:anne
@@ -5538,6 +5549,11 @@ tests:
             expectation:
               - folder:1
               - folder:2
+          - request:
+              user: user2:foo
+              type: folder
+              relation: viewer
+            expectation:
         listUsersAssertions:
           - request:
               filters:
@@ -5553,15 +5569,28 @@ tests:
               relation: viewer
             expectation:
               - user:maria
+          - request:
+              filters:
+                - user2
+              object: folder:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - user2
+              object: folder:2
+              relation: viewer
+            expectation:
   - name: simple_ttu_child_wildcard
     stages:
       - model: |
           model
             schema 1.1
           type user
+          type user2
           type group
             relations
-              define member: [user, user:*]
+              define member: [user, user:*, user2, user2:*]
           type folder
             relations
               define viewer: member from owner
@@ -5600,6 +5629,16 @@ tests:
               relation: viewer
               object: folder:2
             expectation: true
+          - tuple:
+              user: user2:foo
+              relation: viewer
+              object: folder:1
+            expectation: false
+          - tuple:
+              user: user2:foo
+              relation: viewer
+              object: folder:2
+            expectation: false
         listObjectsAssertions:
           - request:
               user: user:anne
@@ -5614,6 +5653,11 @@ tests:
             expectation:
               - folder:1
               - folder:2
+          - request:
+              user: user2:foo
+              type: folder
+              relation: viewer
+            expectation:
         listUsersAssertions:
           - request:
               filters:
@@ -5629,6 +5673,18 @@ tests:
               relation: viewer
             expectation:
               - user:maria
+          - request:
+              filters:
+                - user2
+              object: folder:1
+              relation: viewer
+            expectation:
+          - request:
+              filters:
+                - user2
+              object: folder:2
+              relation: viewer
+            expectation:
   - name: ttu_and_computed_ttu_wildcard
     stages:
       - model: |

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -648,22 +647,22 @@ func (c *LocalChecker) buildCheckAssociatedObjects(req *ResolveCheckRequest, obj
 		}
 
 		user := reqTupleKey.GetUser()
-		userType := strings.SplitN(user, ":", 2)
+		userType := tuple.GetType(user)
 
 		hasPubliclyAssignedType := false
 		// TODO: memorize the check for public wildcard
 		for _, directlyRelatedUsersetType := range directlyRelatedUsersetTypes {
-			if directlyRelatedUsersetType.GetWildcard() != nil && directlyRelatedUsersetType.GetType() == userType[0] {
+			if directlyRelatedUsersetType.GetWildcard() != nil && directlyRelatedUsersetType.GetType() == userType {
 				hasPubliclyAssignedType = true
 			}
 		}
 
 		userFilter := []*openfgav1.ObjectRelation{{
-			Object: reqTupleKey.GetUser(),
+			Object: user,
 		}}
 		if hasPubliclyAssignedType {
 			userFilter = append(userFilter, &openfgav1.ObjectRelation{
-				Object: userType[0] + ":*",
+				Object: tuple.TypedPublicWildcard(userType),
 			})
 		}
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -641,20 +641,13 @@ func (c *LocalChecker) buildCheckAssociatedObjects(req *ResolveCheckRequest, obj
 		}
 		objectType, relation := tuple.SplitObjectRelation(objectRel)
 
-		directlyRelatedUsersetTypes, err := typesys.DirectlyRelatedUsersets(objectType, relation)
-		if err != nil {
-			return nil, err
-		}
-
 		user := reqTupleKey.GetUser()
 		userType := tuple.GetType(user)
 
-		hasPubliclyAssignedType := false
-		// TODO: memorize the check for public wildcard
-		for _, directlyRelatedUsersetType := range directlyRelatedUsersetTypes {
-			if directlyRelatedUsersetType.GetWildcard() != nil && directlyRelatedUsersetType.GetType() == userType {
-				hasPubliclyAssignedType = true
-			}
+		relationReference := typesystem.DirectRelationReference(objectType, relation)
+		hasPubliclyAssignedType, err := typesys.IsPubliclyAssignable(relationReference, userType)
+		if err != nil {
+			return nil, err
 		}
 
 		userFilter := []*openfgav1.ObjectRelation{{

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -2976,7 +2976,7 @@ func TestResolvesExclusivelyToDirectlyAssignable(t *testing.T) {
 			relationReferences: []*openfgav1.RelationReference{
 				DirectRelationReference("group", "member"),
 			},
-			expectDirectlyAssignable: false,
+			expectDirectlyAssignable: true,
 			expectError:              false,
 		},
 		{
@@ -3308,7 +3308,7 @@ func TestTTUResolvesExclusivelyToDirectlyAssignable(t *testing.T) {
 			objectType:               "folder",
 			tuplesetRelation:         "parent",
 			computedRelation:         "member",
-			expectDirectlyAssignable: false,
+			expectDirectlyAssignable: true,
 			expectError:              false,
 		},
 		{
@@ -3433,26 +3433,6 @@ func TestTTUResolvesExclusivelyToDirectlyAssignable(t *testing.T) {
 							relations
 								define allowed: [user]
 								define member: [user] and allowed
-						type folder
-							relations
-								define parent: [group]
-								define viewer: member from parent
-					`,
-			objectType:               "folder",
-			tuplesetRelation:         "parent",
-			computedRelation:         "member",
-			expectDirectlyAssignable: false,
-			expectError:              false,
-		},
-		{
-			name: "ttu_child_public_wildcard",
-			model: `
-						model
-							schema 1.1
-						type user
-						type group
-							relations
-								define member: [user, user:*]
 						type folder
 							relations
 								define parent: [group]


### PR DESCRIPTION
## Description
Improvement in check latency where userset's and TTU's children are publicly wildcard assignable.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
