### PR TITLE
perf(check): use a sorted set to store usersets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/docker/docker v26.0.2+incompatible
 	github.com/docker/go-connections v0.5.0
+	github.com/emirpasic/gods v1.18.1
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/cel-go v0.20.1

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
+github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -629,6 +629,7 @@ func (c *LocalChecker) buildCheckAssociatedObjects(req *ResolveCheckRequest, obj
 		if !ok {
 			return nil, fmt.Errorf("typesystem missing in context")
 		}
+
 		ds, ok := storage.RelationshipTupleReaderFromContext(ctx)
 		if !ok {
 			return nil, fmt.Errorf("relationship tuple reader datastore missing in context")

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -3,7 +3,6 @@ package memory
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -504,10 +503,8 @@ func (s *MemoryBackend) ReadStartingWithUser(
 			continue
 		}
 
-		if len(filter.ObjectIDs) > 0 {
-			if !slices.Contains(filter.ObjectIDs, t.ObjectID) {
-				continue
-			}
+		if filter.ObjectIDs != nil && !filter.ObjectIDs.Exists(t.ObjectID) {
+			continue
 		}
 
 		for _, userFilter := range filter.UserFilter {

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -347,8 +347,8 @@ func (m *MySQL) ReadStartingWithUser(
 			"_user":       targetUsersArg,
 		})
 
-	if len(opts.ObjectIDs) > 0 {
-		builder = builder.Where(sq.Eq{"object_id": opts.ObjectIDs})
+	if opts.ObjectIDs != nil && opts.ObjectIDs.Size() > 0 {
+		builder = builder.Where(sq.Eq{"object_id": opts.ObjectIDs.Values()})
 	}
 
 	rows, err := builder.QueryContext(ctx)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -348,8 +348,8 @@ func (p *Postgres) ReadStartingWithUser(ctx context.Context, store string, opts 
 			"_user":       targetUsersArg,
 		})
 
-	if len(opts.ObjectIDs) > 0 {
-		builder = builder.Where(sq.Eq{"object_id": opts.ObjectIDs})
+	if opts.ObjectIDs != nil && opts.ObjectIDs.Size() > 0 {
+		builder = builder.Where(sq.Eq{"object_id": opts.ObjectIDs.Values()})
 	}
 
 	rows, err := builder.QueryContext(ctx)

--- a/pkg/storage/sortedset.go
+++ b/pkg/storage/sortedset.go
@@ -6,10 +6,16 @@ import "github.com/emirpasic/gods/trees/redblacktree"
 // in a way that also provides fast sorted access.
 type SortedSet interface {
 	Size() int
+
+	// Min returns an empty string if the set is empty.
 	Min() string
+
+	// Max returns an empty string if the set is empty.
 	Max() string
-	Add(key string)
-	Exists(key string) bool
+	Add(value string)
+	Exists(value string) bool
+
+	// Values returns the elements in the set in sorted order (ascending).
 	Values() []string
 }
 
@@ -27,19 +33,25 @@ func NewSortedSet() *RedBlackTreeSet {
 }
 
 func (r *RedBlackTreeSet) Min() string {
-	return r.inner.Left().Value.(string)
+	if r.Size() == 0 {
+		return ""
+	}
+	return r.inner.Left().Key.(string)
 }
 
 func (r *RedBlackTreeSet) Max() string {
-	return r.inner.Right().Value.(string)
+	if r.Size() == 0 {
+		return ""
+	}
+	return r.inner.Right().Key.(string)
 }
 
-func (r *RedBlackTreeSet) Add(key string) {
-	r.inner.Put(key, nil)
+func (r *RedBlackTreeSet) Add(value string) {
+	r.inner.Put(value, nil)
 }
 
-func (r *RedBlackTreeSet) Exists(key string) bool {
-	_, ok := r.inner.Get(key)
+func (r *RedBlackTreeSet) Exists(value string) bool {
+	_, ok := r.inner.Get(value)
 	return ok
 }
 

--- a/pkg/storage/sortedset.go
+++ b/pkg/storage/sortedset.go
@@ -1,0 +1,56 @@
+package storage
+
+import "github.com/emirpasic/gods/trees/redblacktree"
+
+// SortedSet stores a set (no duplicates allowed) of string IDs in memory
+// in a way that also provides fast sorted access.
+type SortedSet interface {
+	Size() int
+	Min() string
+	Max() string
+	Add(key string)
+	Exists(key string) bool
+	Values() []string
+}
+
+type RedBlackTreeSet struct {
+	inner *redblacktree.Tree
+}
+
+var _ SortedSet = (*RedBlackTreeSet)(nil)
+
+func NewSortedSet() *RedBlackTreeSet {
+	c := &RedBlackTreeSet{
+		inner: redblacktree.NewWithStringComparator(),
+	}
+	return c
+}
+
+func (r *RedBlackTreeSet) Min() string {
+	return r.inner.Left().Value.(string)
+}
+
+func (r *RedBlackTreeSet) Max() string {
+	return r.inner.Right().Value.(string)
+}
+
+func (r *RedBlackTreeSet) Add(key string) {
+	r.inner.Put(key, nil)
+}
+
+func (r *RedBlackTreeSet) Exists(key string) bool {
+	_, ok := r.inner.Get(key)
+	return ok
+}
+
+func (r *RedBlackTreeSet) Size() int {
+	return r.inner.Size()
+}
+
+func (r *RedBlackTreeSet) Values() []string {
+	values := make([]string, 0, r.inner.Size())
+	for _, v := range r.inner.Keys() {
+		values = append(values, v.(string))
+	}
+	return values
+}

--- a/pkg/storage/sortedset_test.go
+++ b/pkg/storage/sortedset_test.go
@@ -1,0 +1,34 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedBlackTree(t *testing.T) {
+	t.Run("empty_tree", func(t *testing.T) {
+		tree := NewSortedSet()
+		assert.Equal(t, "", tree.Min())
+		assert.Equal(t, "", tree.Max())
+		assert.Equal(t, []string{}, tree.Values())
+		assert.Equal(t, 0, tree.Size())
+		assert.False(t, tree.Exists("1"))
+	})
+
+	t.Run("non-empty_tree", func(t *testing.T) {
+		tree := NewSortedSet()
+		tree.Add("3")
+		tree.Add("2")
+		tree.Add("1")
+
+		assert.Equal(t, "1", tree.Min())
+		assert.Equal(t, "3", tree.Max())
+		assert.Equal(t, []string{"1", "2", "3"}, tree.Values())
+		assert.Equal(t, 3, tree.Size())
+		assert.True(t, tree.Exists("1"))
+		assert.True(t, tree.Exists("2"))
+		assert.True(t, tree.Exists("3"))
+		assert.False(t, tree.Exists("4"))
+	})
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -177,9 +177,9 @@ type ReadStartingWithUserFilter struct {
 	// Mandatory.
 	UserFilter []*openfgav1.ObjectRelation
 
-	// Optional. If present, it will be sorted in ascending order.
+	// Optional. It can be nil. If present, it will be sorted in ascending order.
 	// The datastore should return the intersection between this filter and what is in the database.
-	ObjectIDs []string
+	ObjectIDs SortedSet
 }
 
 // ReadUsersetTuplesFilter specifies the filter options that

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -133,14 +133,16 @@ type RelationshipTupleReader interface {
 	) (TupleIterator, error)
 
 	// ReadStartingWithUser performs a reverse read of relationship tuples starting at one or
-	// more user(s) or userset(s) and filtered by object type and relation.
+	// more user(s) or userset(s) and filtered by object type and relation and possibly a list of object IDs.
 	//
 	// For example, given the following relationship tuples:
 	//   document:doc1, viewer, user:jon
 	//   document:doc2, viewer, group:eng#member
 	//   document:doc3, editor, user:jon
+	//   document:doc4, viewer, group:eng#member
 	//
-	// ReverseReadTuples for ['user:jon', 'group:eng#member'] filtered by 'document#viewer' would
+	// ReadStartingWithUser for ['user:jon', 'group:eng#member'] filtered by 'document#viewer'
+	// and 'document:doc1, document:doc2' would
 	// return ['document:doc1#viewer@user:jon', 'document:doc2#viewer@group:eng#member'].
 	// There is NO guarantee on the order returned on the iterator.
 	ReadStartingWithUser(
@@ -168,10 +170,16 @@ type RelationshipTupleWriter interface {
 // ReadStartingWithUserFilter specifies the filter options that will be used
 // to constrain the [RelationshipTupleReader.ReadStartingWithUser] query.
 type ReadStartingWithUserFilter struct {
+	// Mandatory.
 	ObjectType string
-	Relation   string
+	// Mandatory.
+	Relation string
+	// Mandatory.
 	UserFilter []*openfgav1.ObjectRelation
-	ObjectIDs  []string // Optional. If present, the datastore returns the intersection between this filter and what is in the database
+
+	// Optional. If present, it will be sorted in ascending order.
+	// The datastore should return the intersection between this filter and what is in the database.
+	ObjectIDs []string
 }
 
 // ReadUsersetTuplesFilter specifies the filter options that

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1137,6 +1137,24 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		},
 	}
 
+	t.Run("accepts_nil_object_ids", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		_, err := datastore.ReadStartingWithUser(
+			ctx,
+			storeID,
+			storage.ReadStartingWithUserFilter{
+				ObjectType: "document",
+				Relation:   "viewer",
+				UserFilter: []*openfgav1.ObjectRelation{
+					{
+						Object: "user:maria",
+					},
+				},
+			},
+		)
+		require.NoError(t, err)
+	})
+
 	t.Run("returns_results_with_two_user_filters", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
@@ -1250,6 +1268,10 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 
 		err := datastore.Write(ctx, storeID, nil, tuples)
 		require.NoError(t, err)
+		objectIDs := storage.NewSortedSet()
+		for _, v := range []string{"doc1", "doc2", "doc3"} {
+			objectIDs.Add(v)
+		}
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
 			ctx,
@@ -1262,7 +1284,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 						Object: "user:jon",
 					},
 				},
-				ObjectIDs: []string{"doc1", "doc2", "doc3"},
+				ObjectIDs: objectIDs,
 			},
 		)
 		require.NoError(t, err)


### PR DESCRIPTION
## Description
Follow-up to https://github.com/openfga/openfga/pull/1734 and https://github.com/openfga/openfga/pull/1735.

This PR is a breaking change to the interface `ReadStartingWIthUser`. Now, the `objectIDs` parameter will be given as a **sorted** list so that datastore implementations don't have to sort it.
