### PR TITLE
test: fix flakiness in TestServerLogs

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -335,7 +335,9 @@ func (s *ServerContext) telemetryConfig(config *serverconfig.Config) func() erro
 		tp := telemetry.MustNewTracerProvider(options...)
 		return func() error {
 			// can take up to 5 seconds to complete (https://github.com/open-telemetry/opentelemetry-go/blob/aebcbfcbc2962957a578e9cb3e25dc834125e318/sdk/trace/batch_span_processor.go#L97)
-			return errors.Join(tp.ForceFlush(context.Background()), tp.Shutdown(context.Background()))
+			ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
+			defer cancel()
+			return errors.Join(tp.ForceFlush(ctx), tp.Shutdown(ctx))
 		}
 	}
 	otel.SetTracerProvider(noop.NewTracerProvider())

--- a/internal/mocks/mock_tracing_server.go
+++ b/internal/mocks/mock_tracing_server.go
@@ -39,7 +39,7 @@ func NewMockTracingServer(t testing.TB, port int) *mockTracingServer {
 	go func() {
 		if err := mockServer.server.Serve(listener); err != nil {
 			if !errors.Is(err, grpc.ErrServerStopped) {
-				t.Log("mock tracing server failed to serve: %v", err)
+				t.Log("mock tracing server failed to serve", err)
 			}
 		}
 	}()

--- a/internal/mocks/mock_tracing_server.go
+++ b/internal/mocks/mock_tracing_server.go
@@ -2,14 +2,13 @@ package mocks
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log"
 	"net"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
 	otlpcollector "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 )
@@ -35,13 +34,14 @@ func NewMockTracingServer(t testing.TB, port int) *mockTracingServer {
 	otlpcollector.RegisterTraceServiceServer(mockServer.server, mockServer)
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	require.NoError(t, err)
-	t.Cleanup(mockServer.server.Stop)
+	t.Cleanup(mockServer.server.GracefulStop)
 
 	go func() {
 		if err := mockServer.server.Serve(listener); err != nil {
-			log.Fatalf("failed to serve: %v", err)
+			if !errors.Is(err, grpc.ErrServerStopped) {
+				t.Log("mock tracing server failed to serve: %v", err)
+			}
 		}
-		log.Println("server closed")
 	}()
 
 	return mockServer

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -54,7 +54,7 @@ func TestServerLogs(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 
-	// create mock OTLP server
+	// create mock OTLP server so we can assert that field "trace_id" is populated
 	otlpServerPort, otlpServerPortReleaser := testutils.TCPRandomPort()
 	localOTLPServerURL := fmt.Sprintf("localhost:%d", otlpServerPort)
 	otlpServerPortReleaser()


### PR DESCRIPTION
## Description

Experimenting with some changes to fix

```
--- FAIL: TestServerLogs (0.09s)
    tests.go:62: creating connection to address 0.0.0.0:39189
    --- FAIL: TestServerLogs/streamed_list_objects_success (0.00s)
        check_test.go:268: 
            	Error Trace:	/home/runner/work/openfga/openfga/tests/check/check_test.go:268
            	Error:      	"[]" should have 1 item(s), but has 0
            	Test:       	TestServerLogs/streamed_list_objects_success
```


```
$ go test ./tests/check -race -run="TestServerLogs" -count=100
ok      github.com/openfga/openfga/tests/check  59.203s

```