### PR TITLE
refactor: Using typesystem to determine when to apply TTU fast path 

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -5395,7 +5395,79 @@ tests:
               relation: can_read
             expectation:
               - user:anne
-  - name: ttu_and_computed_ttu
+  - name: ttu_multiple_tupleset_types
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type employee
+
+          type group
+            relations
+              define can_view: [employee]
+
+          type folder
+            relations
+              define can_view: [user]
+
+          type document
+            relations
+              define parent: [employee,group,folder]
+              define viewer: can_view from parent
+        tuples:
+          - user: employee:1
+            relation: can_view
+            object: group:1
+          - user: group:1
+            relation: parent
+            object: document:1
+          - user: user:1
+            relation: can_view
+            object: folder:1
+          - user: folder:1
+            relation: parent
+            object: document:1
+        checkAssertions:
+          - tuple:
+              user: employee:1
+              relation: viewer
+              object: document:1
+            expectation: true
+          - tuple:
+              user: user:1
+              relation: viewer
+              object: document:1
+            expectation: true
+  - name: xx_ttu_and_computed_ttu
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type folder
+            relations
+              define viewer: owner
+              define owner: [user]
+
+          type document
+            relations
+              define parent: [folder]
+              define can_view: viewer from parent
+        tuples:
+          - user: folder:1
+            relation: parent
+            object: document:1
+          - user: user:jose
+            relation: owner
+            object: folder:1
+        checkAssertions:
+          - tuple:
+              user: user:jose
+              relation: can_view
+              object: document:1
+            expectation: true
+  - name: ttu_and_computed_ttu_with_union
     stages:
       - model: |
           model

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -5439,7 +5439,7 @@ tests:
               relation: viewer
               object: document:1
             expectation: true
-  - name: xx_ttu_and_computed_ttu
+  - name: ttu_and_computed_ttu
     stages:
       - model: |
           model

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -654,7 +654,7 @@ func TestCachedCheckDatastoreQueryCount(t *testing.T) {
 	ttuLocalChecker.Close()
 
 	require.NoError(t, err)
-	require.Equal(t, uint32(2), res.GetResolutionMetadata().DatastoreQueryCount)
+	require.Equal(t, uint32(1), res.GetResolutionMetadata().DatastoreQueryCount)
 }
 
 func TestCachedCheckResolver_ResolveCheck_After_Stop_DoesNotPanic(t *testing.T) {

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1211,8 +1211,8 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		// If the user is a userset, we will not be able to use the shortcut because the algo
 		// will look up the objects associated with user.
 		if !tuple.IsObjectRelation(tk.GetUser()) {
-			if canShortCircuit := typesys.TTUCanFastPath(
-				tuple.GetType(object), req.GetTupleKey().GetRelation(), tuple.GetType(req.GetTupleKey().GetUser())); canShortCircuit {
+			if canFastPath := typesys.TTUCanFastPath(
+				tuple.GetType(object), req.GetTupleKey().GetRelation(), tuple.GetType(req.GetTupleKey().GetUser())); canFastPath {
 				resolver = c.checkTTUFastPath
 			}
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1077,15 +1077,28 @@ func (c *LocalChecker) checkTTUSlowPath(ctx context.Context, req *ResolveCheckRe
 //
 // check(user, viewer, doc) will find the intersection of all group assigned to the doc's parent AND
 // all group where the user is a member of.
+
 func (c *LocalChecker) checkTTUFastPath(ctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset, iter *storage.ConditionsFilteredTupleKeyIterator) (*ResolveCheckResponse, error) {
 	ctx, span := tracer.Start(ctx, "checkTTUFastPath")
 	defer span.End()
 
+	typesys, ok := typesystem.TypesystemFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("typesystem missing in context")
+	}
+
+	terminalRelations := typesys.GetTerminalRelationsForTTUFastPath(
+		tuple.GetType(req.GetTupleKey().GetObject()), req.GetTupleKey().GetRelation(), tuple.GetType(req.GetTupleKey().GetUser()),
+	)
+	if len(terminalRelations) != 1 {
+		return nil, fmt.Errorf("expected exactly one terminal relation for fast path, received %d", len(terminalRelations))
+	}
+
+	computedRelation := terminalRelations[0]
 	// usersetsMap is a map of all ObjectRelations and its Ids. For example,
 	// [group:1#member, group:2#member, group:1#owner, group:3#owner] will be stored as
 	// [group#member][1, 2]
 	// [group#owner][1, 3]
-	computedRelation := rewrite.GetTupleToUserset().GetComputedUserset().GetRelation()
 	usersetsMap := make(map[string]map[string]struct{})
 
 	for {
@@ -1198,8 +1211,8 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		// If the user is a userset, we will not be able to use the shortcut because the algo
 		// will look up the objects associated with user.
 		if !tuple.IsObjectRelation(tk.GetUser()) {
-			if canShortCircuit, err := typesys.TTUResolvesExclusivelyToDirectlyAssignable(
-				tuple.GetType(object), tuplesetRelation, computedRelation); err == nil && canShortCircuit {
+			if canShortCircuit := typesys.TTUCanFastPath(
+				tuple.GetType(object), req.GetTupleKey().GetRelation(), tuple.GetType(req.GetTupleKey().GetUser())); canShortCircuit {
 				resolver = c.checkTTUFastPath
 			}
 		}

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -64,7 +64,6 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 	switch rw := rewrite.GetUserset().(type) {
 	case *openfgav1.Userset_This:
 		assignableTypes := []string{}
-		var terminalRelation string
 
 		thisRelation, ok := t.relations[typeName][relationName]
 		if !ok {
@@ -81,14 +80,12 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 				t = tuple.TypedPublicWildcard(assignableType.GetType())
 			}
 			assignableTypes = append(assignableTypes, t)
-
-			terminalRelation = relationName
 		}
 
 		return []terminalTypesAndRelation{
 			{
 				terminalTypes:    assignableTypes,
-				terminalRelation: terminalRelation,
+				terminalRelation: relationName,
 			},
 		}
 	case *openfgav1.Userset_ComputedUserset:

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -78,6 +78,7 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 			t := assignableType.GetType()
 			if assignableType.GetWildcard() != nil {
 				t = tuple.TypedPublicWildcard(assignableType.GetType())
+				// return []terminalTypesAndRelation{}
 			}
 			assignableTypes = append(assignableTypes, t)
 
@@ -106,11 +107,6 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 		}
 
 		for _, assignableType := range tuplesetRelation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
-			// if assignableType.GetCondition() != "" {
-			// 	// Conditions not yet supported
-			// 	return []terminalTypesAndRelation{}
-			// }
-
 			assignableTypeName := assignableType.GetType()
 
 			if _, ok := t.relations[assignableTypeName][computedRelationName]; ok {

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -60,17 +60,17 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 		return terminalTypesAndRelations
 	}
 
-	relation, ok := t.relations[typeName][relationName]
-	if !ok {
-		return []terminalTypesAndRelation{}
-	}
-
 	switch rw := rewrite.GetUserset().(type) {
 	case *openfgav1.Userset_This:
 		assignableTypes := []string{}
 		var terminalRelation string
 
-		for _, assignableType := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+		thisRelation, ok := t.relations[typeName][relationName]
+		if !ok {
+			return []terminalTypesAndRelation{}
+		}
+
+		for _, assignableType := range thisRelation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 			if assignableType.GetRelation() != "" {
 				// Usersets not yet supported
 				return []terminalTypesAndRelation{}

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -115,6 +115,8 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 				return t.getTerminalUserTypeAndRelationsForConnectedTypes(assignableTypeName, computedRelationName, numTTU+1)
 			}
 		}
+	case *openfgav1.Userset_Intersection, *openfgav1.Userset_Difference, *openfgav1.Userset_Union:
+		return []terminalTypesAndRelation{}
 	}
 
 	return []terminalTypesAndRelation{}

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -1,0 +1,123 @@
+package typesystem
+
+import (
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/tuple"
+)
+
+// map[_objectType_]map[_relation_]map[_subjectType_] terminalRelation.
+type TypesystemConnectedTypes map[string]map[string]map[string][]string
+
+func (f TypesystemConnectedTypes) assign(objectType string, relation string, subjectType string, terminalRelation string) {
+	if f[objectType] == nil {
+		f[objectType] = make(map[string]map[string][]string)
+	}
+
+	if f[objectType][relation] == nil {
+		f[objectType][relation] = make(map[string][]string)
+	}
+
+	f[objectType][relation][subjectType] = append(f[objectType][relation][subjectType], terminalRelation)
+}
+
+// AssignTerminalTypes will populate the `connectedTypes` property on the typesystem to indicate for a given object type
+// what the terminal user types and relations.
+func (t *TypeSystem) AssignTerminalTypes(typeName, relationName string) {
+	terminalTypesAndRelations := t.getTerminalUserTypeAndRelationsForConnectedTypes(typeName, relationName, 0)
+	for _, terminalTypesAndRelation := range terminalTypesAndRelations {
+		for _, terminalType := range terminalTypesAndRelation.terminalTypes {
+			t.connectedTypes.assign(typeName, relationName, terminalType, terminalTypesAndRelation.terminalRelation)
+		}
+	}
+}
+
+type terminalTypesAndRelation struct {
+	terminalTypes    []string
+	terminalRelation string
+}
+
+func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
+	typeName string,
+	relationName string,
+	numTTU int,
+) []terminalTypesAndRelation {
+	rewrite := t.typeDefinitions[typeName].GetRelations()[relationName]
+
+	cache, ok := t.connectedTypes[typeName][relationName]
+	if ok {
+		terminalTypesAndRelations := []terminalTypesAndRelation{}
+
+		for subjectType, terminalRelations := range cache {
+			for _, terminalRelation := range terminalRelations {
+				terminalTypesAndRelations = append(terminalTypesAndRelations, terminalTypesAndRelation{
+					terminalTypes:    []string{subjectType},
+					terminalRelation: terminalRelation,
+				})
+			}
+		}
+
+		return terminalTypesAndRelations
+	}
+
+	relation, ok := t.relations[typeName][relationName]
+	if !ok {
+		return []terminalTypesAndRelation{}
+	}
+
+	switch rw := rewrite.GetUserset().(type) {
+	case *openfgav1.Userset_This:
+		assignableTypes := []string{}
+		var terminalRelation string
+
+		for _, assignableType := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+			if assignableType.GetRelation() != "" {
+				// Usersets not yet supported
+				return []terminalTypesAndRelation{}
+			}
+
+			t := assignableType.GetType()
+			if assignableType.GetWildcard() != nil {
+				t = tuple.TypedPublicWildcard(assignableType.GetType())
+			}
+			assignableTypes = append(assignableTypes, t)
+
+			terminalRelation = relationName
+		}
+
+		return []terminalTypesAndRelation{
+			{
+				terminalTypes:    assignableTypes,
+				terminalRelation: terminalRelation,
+			},
+		}
+	case *openfgav1.Userset_ComputedUserset:
+		return t.getTerminalUserTypeAndRelationsForConnectedTypes(typeName, rw.ComputedUserset.GetRelation(), numTTU)
+	case *openfgav1.Userset_TupleToUserset:
+		if numTTU > 0 {
+			return []terminalTypesAndRelation{}
+		}
+
+		tuplesetRelationName := rw.TupleToUserset.GetTupleset().GetRelation()
+		computedRelationName := rw.TupleToUserset.GetComputedUserset().GetRelation()
+
+		tuplesetRelation, ok := t.relations[typeName][tuplesetRelationName]
+		if !ok {
+			return []terminalTypesAndRelation{}
+		}
+
+		for _, assignableType := range tuplesetRelation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
+			// if assignableType.GetCondition() != "" {
+			// 	// Conditions not yet supported
+			// 	return []terminalTypesAndRelation{}
+			// }
+
+			assignableTypeName := assignableType.GetType()
+
+			if _, ok := t.relations[assignableTypeName][computedRelationName]; ok {
+				return t.getTerminalUserTypeAndRelationsForConnectedTypes(assignableTypeName, computedRelationName, numTTU+1)
+			}
+		}
+	}
+
+	return []terminalTypesAndRelation{}
+}

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -95,6 +95,7 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 		return t.getTerminalUserTypeAndRelationsForConnectedTypes(typeName, rw.ComputedUserset.GetRelation(), numTTU)
 	case *openfgav1.Userset_TupleToUserset:
 		if numTTU > 0 {
+			// Ensures that no chained TTU rewrites are eligible for fast-path TTU
 			return []terminalTypesAndRelation{}
 		}
 

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -2,6 +2,7 @@ package typesystem
 
 import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
 	"github.com/openfga/openfga/pkg/tuple"
 )
 

--- a/pkg/typesystem/connected_types.go
+++ b/pkg/typesystem/connected_types.go
@@ -21,8 +21,9 @@ func (f TypesystemConnectedTypes) assign(objectType string, relation string, sub
 	f[objectType][relation][subjectType] = append(f[objectType][relation][subjectType], terminalRelation)
 }
 
-// AssignTerminalTypes will populate the `connectedTypes` property on the typesystem to indicate for a given object type
-// what the terminal user types and relations.
+// AssignTerminalTypes will populate the `connectedTypes` property on the typesystem to indicate for a given
+// object type what the terminal user types and relations are. This is useful for quickly determining if two types
+// are connected via a relation and also for determining if the TTU "fast path" optimization can be applied.
 func (t *TypeSystem) AssignTerminalTypes(typeName, relationName string) {
 	terminalTypesAndRelations := t.getTerminalUserTypeAndRelationsForConnectedTypes(typeName, relationName, 0)
 	for _, terminalTypesAndRelation := range terminalTypesAndRelations {
@@ -72,14 +73,12 @@ func (t *TypeSystem) getTerminalUserTypeAndRelationsForConnectedTypes(
 
 		for _, assignableType := range thisRelation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 			if assignableType.GetRelation() != "" {
-				// Usersets not yet supported
-				return []terminalTypesAndRelation{}
+				return []terminalTypesAndRelation{} // Usersets not yet supported
 			}
 
 			t := assignableType.GetType()
 			if assignableType.GetWildcard() != nil {
 				t = tuple.TypedPublicWildcard(assignableType.GetType())
-				// return []terminalTypesAndRelation{}
 			}
 			assignableTypes = append(assignableTypes, t)
 

--- a/pkg/typesystem/connected_types_test.go
+++ b/pkg/typesystem/connected_types_test.go
@@ -122,7 +122,9 @@ func TestTypesystemConnectedTypesAssignment(t *testing.T) {
 					"parent": {
 						"folder": {"parent"},
 					},
-					// "public" contains wildcard, not yet supported
+					"public": {
+						"user:*": {"public"},
+					},
 					// "can_share" contains userset, not supported yet
 				},
 				"folder": map[string]map[string][]string{
@@ -213,9 +215,17 @@ func TestTypesystemConnectedTypesAssignment(t *testing.T) {
 			`,
 			expectedConnectedTypes: TypesystemConnectedTypes{
 				"document": map[string]map[string][]string{
+					"can_read": {
+						"user":   {"viewer"},
+						"user:*": {"viewer"},
+					},
 					"parent": {
 						"document": {"parent"},
 						"folder":   {"parent"},
+					},
+					"viewer": {
+						"user":   {"viewer"},
+						"user:*": {"viewer"},
 					},
 				},
 				"folder": map[string]map[string][]string{

--- a/pkg/typesystem/connected_types_test.go
+++ b/pkg/typesystem/connected_types_test.go
@@ -101,6 +101,9 @@ func TestTypesystemConnectedTypesAssignment(t *testing.T) {
 						define viewer: creator
 						define editor: [user] or creator
 						define collaborator: viewer and editor
+						define collaborator_computed: collaborator
+						define restricted: viewer but not owner
+						define restricted_computed: restricted
 						define creator: [user]
 						define owner: [group]
 						define admin: admin from owner

--- a/pkg/typesystem/connected_types_test.go
+++ b/pkg/typesystem/connected_types_test.go
@@ -1,0 +1,237 @@
+package typesystem
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/openfga/openfga/pkg/testutils"
+)
+
+func TestTypesystemConnectedTypesAssignment(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+	tests := []struct {
+		model                  string
+		expectedConnectedTypes TypesystemConnectedTypes
+	}{
+		{
+			model: `
+				model
+					schema 1.1
+				type user
+
+				type document
+					relations
+						define viewer: [user]
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"document": map[string]map[string][]string{
+					"viewer": {
+						"user": {"viewer"},
+					},
+				},
+			},
+		},
+		{
+			model: `
+				model
+					schema 1.1
+				type user
+
+				type folder
+					relations
+						define viewer: editor
+						define editor: owner
+						define owner: [user]
+
+				type document
+					relations
+						define parent: [folder]
+						define can_view: viewer from parent
+						define can_edit: editor from parent
+						define owner: owner from parent
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"document": map[string]map[string][]string{
+					"parent": {
+						"folder": {"parent"},
+					},
+					"can_view": {
+						"user": {"owner"},
+					},
+					"can_edit": {
+						"user": {"owner"},
+					},
+					"owner": {
+						"user": {"owner"},
+					},
+				},
+				"folder": map[string]map[string][]string{
+					"viewer": {
+						"user": {"owner"},
+					},
+					"editor": {
+						"user": {"owner"},
+					},
+					"owner": {
+						"user": {"owner"},
+					},
+				},
+			},
+		},
+		{
+			model: `
+				model
+					schema 1.1
+				type user
+				type employee
+
+				type group
+					relations
+						define admin: [user]
+						define owner: [user,employee]
+
+				type folder
+					relations
+						define viewer: creator
+						define editor: [user] or creator
+						define collaborator: viewer and editor
+						define creator: [user]
+						define owner: [group]
+						define admin: admin from owner
+
+				type document
+					relations
+						define parent: [folder]
+						define can_view: viewer from parent
+						define can_edit: editor from parent
+						define public: [user:*]
+						define can_share: [user, document#can_share]
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"document": map[string]map[string][]string{
+					"can_view": {
+						"user": {"creator"},
+					},
+					// "can_edit" directs to union, not supported yet
+					"parent": {
+						"folder": {"parent"},
+					},
+					// "public" contains wildcard, not yet supported
+					// "can_share" contains userset, not supported yet
+				},
+				"folder": map[string]map[string][]string{
+					"viewer": {
+						"user": {"creator"},
+					},
+					// "editor" contains union, not supported yet
+					// "collaborator" contains intersection, not supported yet
+					"creator": {
+						"user": {"creator"},
+					},
+					"owner": {
+						"group": {"owner"},
+					},
+					"admin": {
+						"user": {"admin"},
+					},
+				},
+				"group": map[string]map[string][]string{
+					"admin": {
+						"user": {"admin"},
+					},
+					"owner": {
+						"user":     {"owner"},
+						"employee": {"owner"},
+					},
+				},
+			},
+		},
+		{
+			model: `
+				model
+					schema 1.1
+				type user
+				type group
+					relations
+						define member: [user]
+				type folder
+					relations
+						define owner: [group]
+						define viewer: member from owner
+				type document
+					relations
+						define banned: [user]
+						define owner: [folder]
+						define viewer: viewer from owner
+						define can_view: viewer but not banned
+						define can_see: can_view
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"document": map[string]map[string][]string{
+					"banned": {
+						"user": {"banned"},
+					},
+					"owner": {
+						"folder": {"owner"},
+					},
+				},
+				"folder": map[string]map[string][]string{
+					"owner": {
+						"group": {"owner"},
+					},
+					"viewer": {
+						"user": {"member"},
+					},
+				},
+				"group": map[string]map[string][]string{
+					"member": {
+						"user": {"member"},
+					},
+				},
+			},
+		},
+		{
+			model: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define owner: [user]
+						define viewer: [user, user:*] or owner
+				type document
+					relations
+						define can_read: viewer from parent
+						define parent: [document, folder]
+						define viewer: [user, user:*]
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"document": map[string]map[string][]string{
+					"parent": {
+						"document": {"parent"},
+						"folder":   {"parent"},
+					},
+				},
+				"folder": map[string]map[string][]string{
+					"owner": {
+						"user": {"owner"},
+					},
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("stage-%d", i), func(t *testing.T) {
+			ts, err := NewAndValidate(context.Background(), testutils.MustTransformDSLToProtoWithID(test.model))
+			require.NoError(t, err)
+			require.Equal(t, test.expectedConnectedTypes, ts.connectedTypes)
+		})
+	}
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -416,11 +416,29 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
 
 // TTUCanFastPath returns whether object's tupleRelation's rewrite can support the fast path optimization.
 func (t *TypeSystem) TTUCanFastPath(objectType, computedRelation, userType string) bool {
+
+	tuplesetRelation := t.relations[objectType][computedRelation].GetRewrite().GetTupleToUserset().GetTupleset().GetRelation()
+
+	computedUsersetRelation := t.relations[objectType][computedRelation].GetRewrite().GetTupleToUserset().GetComputedUserset().GetRelation()
+	ttuParentTypes := t.relations[objectType][tuplesetRelation].GetTypeInfo().GetDirectlyRelatedUserTypes()
+
+	if len(ttuParentTypes) > 1 {
+		for _, parentType := range ttuParentTypes {
+			_, relationExists := t.relations[parentType.GetType()][computedUsersetRelation]
+			if !relationExists {
+				continue
+			}
+
+			terminalRelations := t.GetTerminalRelationsForTTUFastPath(parentType.GetType(), computedUsersetRelation, userType)
+			if len(terminalRelations) == 0 {
+				return false
+			}
+		}
+	}
+
 	terminalRelations := t.GetTerminalRelationsForTTUFastPath(objectType, computedRelation, userType)
 
-	can := len(terminalRelations) > 0
-
-	return can
+	return len(terminalRelations) > 0
 }
 
 // TTUCanFastPath returns whether object's tupleRelation's rewrite can support the fast path optimization.

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -416,7 +416,6 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
 
 // TTUCanFastPath returns whether object's tupleRelation's rewrite can support the fast path optimization.
 func (t *TypeSystem) TTUCanFastPath(objectType, computedRelation, userType string) bool {
-
 	tuplesetRelation := t.relations[objectType][computedRelation].GetRewrite().GetTupleToUserset().GetTupleset().GetRelation()
 
 	computedUsersetRelation := t.relations[objectType][computedRelation].GetRewrite().GetTupleToUserset().GetComputedUserset().GetRelation()

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -165,6 +165,8 @@ type TypeSystem struct {
 	// [objectType] => [relationName] => TTU relation.
 	ttuRelations map[string]map[string][]*openfgav1.TupleToUserset
 
+	connectedTypes TypesystemConnectedTypes
+
 	modelID       string
 	schemaVersion string
 }
@@ -216,6 +218,7 @@ func New(model *openfgav1.AuthorizationModel) *TypeSystem {
 		relations:       relations,
 		conditions:      uncompiledConditions,
 		ttuRelations:    ttuRelations,
+		connectedTypes:  make(TypesystemConnectedTypes),
 	}
 }
 
@@ -411,33 +414,19 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
 	return false, nil
 }
 
-// TTUResolvesExclusivelyToDirectlyAssignable returns whether the computedRelation of object's tupleRelation is directly assignable.
-func (t *TypeSystem) TTUResolvesExclusivelyToDirectlyAssignable(objectType, tuplesetRelation, computedRelation string) (bool, error) {
-	tuplesetRelationTypes, directlyAssignable, err := t.resolvesTypeRelationToDirectlyAssignable(objectType, tuplesetRelation)
-	if err != nil {
-		return false, err
-	}
-	if !directlyAssignable {
-		return false, nil
-	}
-	var relationUndefinedError *RelationUndefinedError
-	for _, tuplesetRelationType := range tuplesetRelationTypes {
-		_, childDirectlyAssignable, err := t.resolvesTypeRelationToDirectlyAssignable(tuplesetRelationType, computedRelation)
-		if err != nil {
-			// in the case of errors due to relation undefined, we can ignore the error because it is possible
-			// that some parents do not have the relation defined.
-			if errors.As(err, &relationUndefinedError) {
-				continue
-			}
+// TTUCanFastPath returns whether object's tupleRelation's rewrite can support the fast path optimization.
+func (t *TypeSystem) TTUCanFastPath(objectType, computedRelation, userType string) bool {
+	terminalRelations := t.GetTerminalRelationsForTTUFastPath(objectType, computedRelation, userType)
 
-			// otherwise, we do not know what the error is.  It is better to return error at this point.
-			return false, err
-		}
-		if !childDirectlyAssignable {
-			return false, nil
-		}
-	}
-	return true, nil
+	can := len(terminalRelations) > 0
+
+	return can
+}
+
+// TTUCanFastPath returns whether object's tupleRelation's rewrite can support the fast path optimization.
+func (t *TypeSystem) GetTerminalRelationsForTTUFastPath(objectType, computedRelation, userType string) []string {
+	terminalRelations := t.connectedTypes[objectType][computedRelation][userType]
+	return terminalRelations
 }
 
 // IsPubliclyAssignable checks if the provided objectType is part
@@ -850,6 +839,7 @@ func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*
 			if err != nil {
 				return nil, err
 			}
+			t.AssignTerminalTypes(typeName, relationName)
 		}
 	}
 

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -422,6 +422,7 @@ func (t *TypeSystem) TTUCanFastPath(objectType, computedRelation, userType strin
 	ttuParentTypes := t.relations[objectType][tuplesetRelation].GetTypeInfo().GetDirectlyRelatedUserTypes()
 
 	if len(ttuParentTypes) > 1 {
+		// For TTU with multiple assignable types, need to verify that each type has the computed relation and is eligible for fast-path
 		for _, parentType := range ttuParentTypes {
 			_, relationExists := t.relations[parentType.GetType()][computedUsersetRelation]
 			if !relationExists {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -3438,7 +3438,7 @@ func TestTTUCanUseFastTrack(t *testing.T) {
 			expectCanFastPath: true,
 		},
 		{
-			name: "multiple_ttu_references",
+			name: "multiple_ttu_references_to_multiple_types",
 			model: `
 				model
 					schema 1.1
@@ -3455,12 +3455,12 @@ func TestTTUCanUseFastTrack(t *testing.T) {
 						define owner: [group1, group2]
 						define viewer: member from owner`,
 			objectType:        "folder",
-			computedRelation:  "owner",
-			userType:          "group2",
+			computedRelation:  "viewer",
+			userType:          "user1",
 			expectCanFastPath: true,
 		},
 		{
-			name: "same_relation_name_different_type",
+			name: "multiple_ttu_references_different_terminal_types",
 			model: `
 				model
 					schema 1.1

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -3412,6 +3412,48 @@ func TestTTUCanUseFastTrack(t *testing.T) {
 			expectCanFastPath: true,
 		},
 		{
+			name: "multiple_ttu_references",
+			model: `
+				model
+					schema 1.1
+				type user1
+				type user2
+				type group1
+					relations
+						define member: [user1, user2]
+				type group2
+					relations
+						define member: [user1, user2]
+				type folder
+					relations
+						define owner: [group1, group2]
+						define viewer: member from owner`,
+			objectType:        "folder",
+			computedRelation:  "owner",
+			userType:          "group2",
+			expectCanFastPath: true,
+		},
+		{
+			name: "same_relation_name_different_type",
+			model: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+					define owner: [user]
+					define viewer: [user, user:*] or owner
+				type document
+					relations
+					define can_read: viewer from parent
+					define parent: [document, folder]
+					define viewer: [user, user:*]`,
+			objectType:        "document",
+			computedRelation:  "can_read",
+			userType:          "user",
+			expectCanFastPath: false,
+		},
+		{
 			name: "only_some_parent_have_relations",
 			model: `
 						model

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -3460,6 +3460,27 @@ func TestTTUCanUseFastTrack(t *testing.T) {
 			expectCanFastPath: true,
 		},
 		{
+
+			name: "multiple_ttu_references_only_one_has_tupleset_relation",
+			model: `
+				model
+					schema 1.1
+				type user1
+				type user2
+				type group1
+					relations
+						define member: [user1, user2]
+				type group2
+				type folder
+					relations
+						define owner: [group1, group2]
+						define viewer: member from owner`,
+			objectType:        "folder",
+			computedRelation:  "viewer",
+			userType:          "user1",
+			expectCanFastPath: true,
+		},
+		{
 			name: "multiple_ttu_references_different_terminal_types",
 			model: `
 				model


### PR DESCRIPTION
## Description
Determining the ultimate terminal types and terminal relations for a given object type and relation. This data is calculated at the time of typesystem creation and validations (`t.NewAndValidate()`) and associated in a multi-key map on the typesystem struct.

This work enables two different optimizations. The primary is an optimized TTU and userset lookup which requires knowledge of the terminal types and relations for a given userset to craft the appropriate query. Currently, this is limited to usersets that result in a direct relation and necessarily doesn't result in a computed relation, union, intersection, etc. This limitation can be observed in #1733. 

This PR _only_ supports TTU that result in direct relations, computed relations and public wildcards. It does not yet support the following rewrites: union, intersection, difference or usersets. However, the code establishes a pattern that will easily enable these in the future.

This work also has the potential to be used as an optimization in Check, ListObjects and ListUsers as a screen to determine if the request's relation and types are valid with respect to the model. If not, we can exit the process with a falsey outcome and prevent some DB requests. This work was previously visited in #1582 but this PR will reduce the computation to a O(1) lookup at runtime.

## References
- Supports: https://github.com/openfga/openfga/pull/1733, https://github.com/openfga/openfga/pull/1735, https://github.com/openfga/openfga/pull/1734
- Supersedes #1736 
- May help supersede: https://github.com/openfga/openfga/pull/1582

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
