### PR TITLE
chore: upgrade go1.22 in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.29@sha256:33e4617185dbc89d14ddafbe44f3e0cfb59a227e733c51d6513a024062c77377 as grpc_health_probe
-FROM cgr.dev/chainguard/go:1.21@sha256:40fb38b3f61d1ecdecd2bfe3d14fa621ab5e9ecb4c9ebba590276c2992f3e282 AS builder
+FROM cgr.dev/chainguard/go:1.22@sha256:80ebff2d788e242fa5c03a0788f7cf0660d4ab470df95839b3eeb6ced45b3108 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- Upgrade to latest version of go 1.22 as the current version (1.21) has a CVE, and the go version used in the project is go 1.22.5: https://github.com/openfga/openfga/blob/main/go.mod#L3
```
grype openfga/openfga
 ✔ Vulnerability DB                [updated]
 ✔ Pulled image
 ✔ Loaded image                                                                                                                                                                               openfga/openfga:latest
 ✔ Parsed image                                                                                                                              sha256:94bccb263cedd9b13ad754bf78ca4350e7edcfaea85d65551141e7f7de30c61c
 ✔ Cataloged contents                                                                                                                               96c887e311780a2453bf81b478cf85ca4643cc81e806ba217e43c22ffda3e324
   ├── ✔ Packages                        [126 packages]
   ├── ✔ File digests                    [397 files]
   ├── ✔ File metadata                   [397 locations]
   └── ✔ Executables                     [2 executables]
 ✔ Scanned for vulnerabilities     [1 vulnerability matches]
   ├── by severity: 0 critical, 1 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 1 not-fixed, 0 ignored
NAME    INSTALLED  FIXED-IN  TYPE       VULNERABILITY   SEVERITY
stdlib  go1.22.4             go-module  CVE-2024-24791  High
```
## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
