### PR TITLE
feat: support subject validation when using OIDC AuthN mode

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -567,12 +567,18 @@
                 },
                 "issuerAliases": {
                     "description": "the OIDC issuer DNS aliases that will be accepted as valid when verifying tokens.",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_ISSUER_ALIASES"
                 },
                 "subjects": {
                     "description": "the OIDC subject names to authenticate whom the token refers to.",
-                    "type": "string",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_SUBJECTS"
                 }
             },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -564,6 +564,16 @@
                     "description": "The OIDC audience of the tokens being signed by the authorization server.",
                     "type": "string",
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_AUDIENCE"
+                },
+                "issuerAliases": {
+                    "description": "the OIDC issuer DNS aliases that will be accepted as valid when verifying tokens.",
+                    "type": "string",
+                    "x-env-variable": "OPENFGA_AUTHN_OIDC_ISSUER_ALIASES"
+                },
+                "subjects": {
+                    "description": "the OIDC subject names to authenticate whom the token refers to.",
+                    "type": "string",
+                    "x-env-variable": "OPENFGA_AUTHN_OIDC_SUBJECTS"
                 }
             },
             "required": ["issuer", "audience"]

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -69,6 +69,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("authn.oidc.issuerAliases", flags.Lookup("authn-oidc-issuer-aliases"))
 		util.MustBindEnv("authn.oidc.issuerAliases", "OPENFGA_AUTHN_OIDC_ISSUER_ALIASES")
 
+		util.MustBindPFlag("authn.oidc.subjects", flags.Lookup("authn-oidc-subjects"))
+		util.MustBindEnv("authn.oidc.subjects", "OPENFGA_AUTHN_OIDC_SUBJECTS")
+
 		util.MustBindPFlag("datastore.engine", flags.Lookup("datastore-engine"))
 		util.MustBindEnv("datastore.engine", "OPENFGA_DATASTORE_ENGINE")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -126,6 +126,8 @@ func NewRunCommand() *cobra.Command {
 
 	flags.StringSlice("authn-oidc-issuer-aliases", defaultConfig.Authn.IssuerAliases, "the OIDC issuer DNS aliases that will be accepted as valid when verifying tokens")
 
+	flags.StringSlice("authn-oidc-subjects", defaultConfig.Authn.Subjects, "the OIDC subject names to authenticate whom the token refers to")
+
 	flags.String("datastore-engine", defaultConfig.Datastore.Engine, "the datastore engine that will be used for persistence")
 
 	flags.String("datastore-uri", defaultConfig.Datastore.URI, "the connection uri to use to connect to the datastore (for any engine other than 'memory')")
@@ -405,7 +407,7 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 		authenticator, err = presharedkey.NewPresharedKeyAuthenticator(config.Authn.Keys)
 	case "oidc":
 		s.Logger.Info("using 'oidc' authentication")
-		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audience)
+		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audience, config.Authn.Subjects)
 	default:
 		return nil, fmt.Errorf("unsupported authentication method '%v'", config.Authn.Method)
 	}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -612,6 +612,7 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 	oidcServerPort2, oidcServerPortReleaser2 := testutils.TCPRandomPort()
 	oidcServerURL1 := fmt.Sprintf("http://localhost:%d", oidcServerPort1)
 	oidcServerURL2 := fmt.Sprintf("http://localhost:%d", oidcServerPort2)
+	subject := "some-user"
 
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 	cfg.Authn.Method = "oidc"
@@ -619,6 +620,7 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 		Audience:      "openfga.dev",
 		Issuer:        oidcServerURL1,
 		IssuerAliases: []string{oidcServerURL2},
+		Subjects:      []string{subject},
 	}
 
 	oidcServerPortReleaser1()
@@ -631,7 +633,7 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 	trustedIssuerServer2 := trustedIssuerServer1.NewAliasMockServer(oidcServerURL2)
 	t.Cleanup(trustedIssuerServer2.Stop)
 
-	trustedTokenFromAlias, err := trustedIssuerServer2.GetToken("openfga.dev", "some-user")
+	trustedTokenFromAlias, err := trustedIssuerServer2.GetToken("openfga.dev", subject)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -37,6 +37,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "right_issuer",
 						"aud": "right_audience",
@@ -57,6 +58,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "right_issuer",
 						"aud": "right_audience",
@@ -76,6 +78,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "right_issuer",
 						"aud": "right_audience",
@@ -97,6 +100,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"",
 					"",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"exp": time.Now().Add(10 * time.Minute).Unix(),
 					},
@@ -115,6 +119,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"",
 					"",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"exp": time.Now().Add(10 * time.Minute).Unix(),
 					},
@@ -132,6 +137,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "wrong_issuer",
 						"exp": time.Now().Add(10 * time.Minute).Unix(),
@@ -150,6 +156,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "right_issuer",
 						"aud": "wrong_audience",
@@ -169,10 +176,32 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss": "right_issuer",
 						"aud": "right_audience",
 						"sub": 12,
+						"exp": time.Now().Add(10 * time.Minute).Unix(),
+					},
+					nil,
+				)
+			},
+			expectedError: "invalid subject",
+		},
+		{
+			testDescription: "when_the_subject_of_the_token_is_not_a_string,_MUST_return_'invalid_subject'_error",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, error) {
+				return quickConfigSetup(
+					"kid_1",
+					"kid_1",
+					"right_issuer",
+					"right_audience",
+					nil,
+					[]string{"some-user"},
+					jwt.MapClaims{
+						"iss": "right_issuer",
+						"aud": "right_audience",
+						"sub": "openfga client",
 						"exp": time.Now().Add(10 * time.Minute).Unix(),
 					},
 					nil,
@@ -209,6 +238,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					nil,
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss":   "right_issuer",
 						"aud":   "right_audience",
@@ -229,6 +259,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					[]string{"issuer_alias"},
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss":   "issuer_alias",
 						"aud":   "right_audience",
@@ -249,6 +280,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					"right_issuer",
 					"right_audience",
 					[]string{"issuer_alias"},
+					[]string{"openfga client"},
 					jwt.MapClaims{
 						"iss":   "right_issuer",
 						"aud":   "right_audience",
@@ -282,7 +314,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 }
 
 // quickConfigSetup sets up a basic configuration for testing purposes.
-func quickConfigSetup(jwkKid, jwtKid, issuerURL, audience string, issuerAliases []string, jwtClaims jwt.MapClaims, privateKeyOverride *rsa.PrivateKey) (*RemoteOidcAuthenticator, context.Context, error) {
+func quickConfigSetup(jwkKid, jwtKid, issuerURL, audience string, issuerAliases []string, subjects []string, jwtClaims jwt.MapClaims, privateKeyOverride *rsa.PrivateKey) (*RemoteOidcAuthenticator, context.Context, error) {
 	// Generate JWT signature keys
 	privateKey, publicKey := generateJWTSignatureKeys()
 	if privateKeyOverride != nil {
@@ -292,7 +324,7 @@ func quickConfigSetup(jwkKid, jwtKid, issuerURL, audience string, issuerAliases 
 	fetchJWKs = fetchKeysMock(publicKey, jwkKid)
 
 	// Initialize RemoteOidcAuthenticator
-	oidc, err := NewRemoteOidcAuthenticator(issuerURL, issuerAliases, audience)
+	oidc, err := NewRemoteOidcAuthenticator(issuerURL, issuerAliases, audience, subjects)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -129,6 +129,7 @@ type AuthnConfig struct {
 type AuthnOIDCConfig struct {
 	Issuer        string
 	IssuerAliases []string
+	Subjects      []string
 	Audience      string
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Support subject validation when using OIDC AuthN mode, using OPENFGA_AUTHN_OIDC_SUBJECTS env variable or authn-oidc-subjects config.

## Description
<!-- Provide a detailed description of the changes -->

**User story:** 
As a platform owner, I wanna limit which services could call OpenFGA, so that to avoid unexpected model or relations modifications by none eligible services.

For example, in a Kubernetes cluster, even if Kubernetes's OIDC configured as AuthN approach, any pod using any service account could call OpenFGA. It introduces security risks because no limits of subjects, namely service account.

With subjects limit feature added, platform owner could restrict services authenticated by Kuberenetes or other OIDC providers. For instance, in Kubernetes, the flag/env-var could be configured like this: "system:serviceaccount:{allowed-namespace}:{allowed-kubernetes-service-account}"

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#serviceaccount-token-volume-projection

## Review Checklist
- [√] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev] -- will add (https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ √] The correct base branch is being used, if not `main`
- [ √] I have added tests to validate that the change in functionality is working as expected
