### PR TITLE
fix: data race on server close

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -558,13 +558,13 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 	var metricsServer *http.Server
 	if config.Metrics.Enabled {
-		s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics server on '%s'", config.Metrics.Addr))
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+
+		metricsServer = &http.Server{Addr: config.Metrics.Addr, Handler: mux}
 
 		go func() {
-			mux := http.NewServeMux()
-			mux.Handle("/metrics", promhttp.Handler())
-
-			metricsServer = &http.Server{Addr: config.Metrics.Addr, Handler: mux}
+			s.Logger.Info(fmt.Sprintf("📈 starting prometheus metrics server on '%s'", config.Metrics.Addr))
 			if err := metricsServer.ListenAndServe(); err != nil {
 				if err != http.ErrServerClosed {
 					s.Logger.Fatal("failed to start prometheus metrics server", zap.Error(err))


### PR DESCRIPTION
## Description
Fixes a potential data race that can occur if `cfg.Metrics.Enabled = true` and the server stops too fast. `metricsServer` variable may be in progress of being written, and on server close we do `if metricsServer != nil` (read), we have a race.

```
2024-07-24T08:50:43.927-0700    INFO    attempting to shutdown gracefully...
2024-07-24T08:50:43.927-0700    INFO    HTTP server shut down.
==================
WARNING: DATA RACE
Read at 0x00c0009ae178 by goroutine 1512:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:835 +0x6ec4
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44

Previous write at 0x00c0009ae178 by goroutine 1521:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:567 +0x1c0

Goroutine 1512 (running) created at:
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:822 +0x354
  github.com/openfga/openfga/cmd/run.TestServerMetricsReporting.func3()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:795 +0x34
  testing.tRunner()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1742 +0x40

Goroutine 1521 (running) created at:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:563 +0x2d98
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44
==================
==================
WARNING: DATA RACE
Write at 0x00c0001fc260 by goroutine 1512:
  ??()
      -:0 +0x1055c73fc
  sync/atomic.StoreUint32()
      <autogenerated>:1 +0x14
  net/http.(*Server).Shutdown()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/net/http/server.go:2991 +0x48
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:836 +0x6efc
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44

Previous write at 0x00c0001fc260 by goroutine 1521:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:567 +0xd4

Goroutine 1512 (running) created at:
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:822 +0x354
  github.com/openfga/openfga/cmd/run.TestServerMetricsReporting.func3()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:795 +0x34
  testing.tRunner()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1742 +0x40

Goroutine 1521 (running) created at:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:563 +0x2d98
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44
==================
==================
WARNING: DATA RACE
Write at 0x00c0001fc288 by goroutine 1512:
  ??()
      -:0 +0x1055ccb24
  sync/atomic.CompareAndSwapInt32()
      <autogenerated>:1 +0x18
  net/http.(*Server).Shutdown()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/net/http/server.go:2993 +0x58
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:836 +0x6efc
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44

Previous write at 0x00c0001fc288 by goroutine 1521:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:567 +0xd4

Goroutine 1512 (running) created at:
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:822 +0x354
  github.com/openfga/openfga/cmd/run.TestServerMetricsReporting.func3()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:795 +0x34
  testing.tRunner()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1689 +0x180
  testing.(*T).Run.gowrap1()
      /Users/maria.inesparnisari/go-mod-cache/golang.org/toolchain@v0.0.1-go1.22.5.darwin-arm64/src/testing/testing.go:1742 +0x40

Goroutine 1521 (running) created at:
  github.com/openfga/openfga/cmd/run.(*ServerContext).Run()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run.go:563 +0x2d98
  github.com/openfga/openfga/cmd/run.runServer()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:186 +0x104
  github.com/openfga/openfga/cmd/run.testServerMetricsReporting.func2()
      /Users/maria.inesparnisari/GitHub/openfga-main/cmd/run/run_test.go:823 +0x44
==================
2024-07-24T08:50:43.928-0700    INFO    metrics server shut down.
2024/07/24 08:50:43 🐳 Terminating container: 210f39f78884
2024-07-24T08:50:43.929-0700    INFO    gRPC server shut down.
2024-07-24T08:50:43.929-0700    INFO    server exited. goodbye 👋
2024/07/24 08:50:44 🚫 Container terminated: 210f39f78884
--- FAIL: TestServerMetricsReporting (17.71s)
    --- FAIL: TestServerMetricsReporting/postgres (6.67s)
```
