### PR TITLE
fix: flakey test

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -256,6 +256,7 @@ func TestServerLogs(t *testing.T) {
 				var resp *http.Response
 
 				resp, err = client.Do(httpReq)
+				_, _ = io.Copy(io.Discard, resp.Body)
 				resp.Body.Close()
 			}
 			if test.expectedError && test.grpcReq != nil {


### PR DESCRIPTION
The TestServerLogs/streamed_list_objects_success test is flakey. This PR changes the test to read the entire streaming HTTP response before closing the body and attempting to read the logs.

## Description
The suspected cause of this issue: Currently, the test does not read the response body data for HTTP requests, and instead closes the body immediately after the client returns. This causes the client to close and discard the TCP connection immediately and move on. The `StreamedListObjects` sends response objects concurrently, and will attempt to send all objects, regardless of the state of the connection. This creates a race condition between the server sending all of the response objects before emitting the log, and the test attempting to read the logs. Hence the flakiness of this test.

To fix the issue, we will now read the entire streaming response body, to EOF, before attempting to read the logs. This will ensure that the test waits until the server has processed and sent all response objects and had a chance to emit the log that the test is expecting.

## References
This PR attempts to address the same issue stated in #1762

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
