### PR TITLE
fix: goreleaser docker manifests

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,35 +84,40 @@ docker_manifests:
     image_templates:
       - openfga/openfga:latest-amd64
       - openfga/openfga:latest-arm64
-      # ghcr.io
-      - "ghcr.io/openfga/openfga:latest-amd64"
-      - "ghcr.io/openfga/openfga:latest-arm64"
   - name_template: openfga/openfga:v{{ .Version }}
     image_templates:
       - openfga/openfga:v{{ .Version }}-amd64
       - openfga/openfga:v{{ .Version }}-arm64
-      # ghcr.io
-      - "ghcr.io/openfga/openfga:v{{ .Version }}-amd64"
-      - "ghcr.io/openfga/openfga:v{{ .Version }}-arm64"
   - name_template: openfga/openfga:v{{ .Major }}
     image_templates:
       - openfga/openfga:v{{ .Major }}-amd64
       - openfga/openfga:v{{ .Major }}-arm64
-      # ghcr.io
-      - "ghcr.io/openfga/openfga:v{{ .Major }}-amd64"
-      - "ghcr.io/openfga/openfga:v{{ .Major }}-arm64"
   - name_template: openfga/openfga:v{{ .Major }}.{{ .Minor }}
     image_templates:
       - openfga/openfga:v{{ .Major }}.{{ .Minor }}-amd64
       - openfga/openfga:v{{ .Major }}.{{ .Minor }}-arm64
-      # ghcr.io
-      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-amd64"
-      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-arm64"
   - name_template: openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
     image_templates:
       - openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64
       - openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64
-      # ghcr.io
+  - name_template: ghcr.io/openfga/openfga:latest
+    image_templates:
+      - "ghcr.io/openfga/openfga:latest-amd64"
+      - "ghcr.io/openfga/openfga:latest-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Version }}
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}
+    image_templates:
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

tries to fix the following:

```
 ⨯ release failed after 5m6s                error=docker manifests: failed to publish artifacts: failed to push ***/***:latest: exit status 1: cannot use source images from a different registry than the target image: ghcr.io != docker.io
```

## References

https://github.com/openfga/openfga/actions/runs/10115398660/job/27977786555

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
