### PR TITLE
fix: proper nesting of spans in Check API if computed usersets

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1036,9 +1036,6 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 // checkComputedUserset evaluates the Check request with the rewritten relation (e.g. the computed userset relation).
 func (c *LocalChecker) checkComputedUserset(ctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset) CheckHandlerFunc {
-	_, span := tracer.Start(ctx, "checkComputedUserset")
-	defer span.End()
-
 	rewrittenTupleKey := tuple.NewTupleKey(
 		req.GetTupleKey().GetObject(),
 		rewrite.GetComputedUserset().GetRelation(),
@@ -1049,6 +1046,8 @@ func (c *LocalChecker) checkComputedUserset(ctx context.Context, req *ResolveChe
 	childRequest.TupleKey = rewrittenTupleKey
 
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
+		ctx, span := tracer.Start(ctx, "checkComputedUserset")
+		defer span.End()
 		// No dispatch here, as we don't want to increase resolution depth.
 		return c.ResolveCheck(ctx, childRequest)
 	}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1035,7 +1035,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 }
 
 // checkComputedUserset evaluates the Check request with the rewritten relation (e.g. the computed userset relation).
-func (c *LocalChecker) checkComputedUserset(ctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset) CheckHandlerFunc {
+func (c *LocalChecker) checkComputedUserset(_ context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset) CheckHandlerFunc {
 	rewrittenTupleKey := tuple.NewTupleKey(
 		req.GetTupleKey().GetObject(),
 		rewrite.GetComputedUserset().GetRelation(),


### PR DESCRIPTION
## Description

Before:
<img width="804" alt="image" src="https://github.com/user-attachments/assets/f7785837-8a60-41ff-b566-7c03cc5a287f">


After:

<img width="825" alt="image" src="https://github.com/user-attachments/assets/749db755-1190-4a87-869b-7149fb739eea">


