### PR TITLE
chore!: add Head for iterator

### DIFF
--- a/internal/mocks/mock_error_iterator.go
+++ b/internal/mocks/mock_error_iterator.go
@@ -35,6 +35,23 @@ func (s *errorTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error)
 	return next, nil
 }
 
+func (s *errorTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	// we want to simulate returning error after the first read
+	if len(s.items) != s.originalLength {
+		return nil, fmt.Errorf("simulated errors")
+	}
+
+	if len(s.items) == 0 {
+		return nil, nil
+	}
+
+	return s.items[0], nil
+}
+
 func (s *errorTupleIterator) Stop() {}
 
 var _ storage.TupleIterator = (*errorTupleIterator)(nil)

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -23,8 +23,10 @@ type Iterator[T any] interface {
 	// the underlying iterator.
 	Stop()
 
-	// Head will return the first item or ErrIteratorDone if the list
+	// Head will return the first item or ErrIteratorDone if the iterator
 	// is empty.
+	// It's possible for this method to advance the iterator internally, but a subsequent call to Next will not miss any results.
+	// Calling Head() continuously without calling Next() will yield the same result (the first one) over and over.
 	Head(ctx context.Context) (T, error)
 }
 

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -343,7 +343,8 @@ func (f *ConditionsFilteredTupleKeyIterator) Stop() {
 
 // Head returns the next most tuple in the underlying iterator that meets
 // the filter function this iterator was constructed with.
-// The underlying iterator will not advance.
+// The underlying iterator may advance but calling consecutive Head will yield consistent result.
+// Further, calling Head following by Next will also yield consistent result.
 // This function is not thread-safe.
 func (f *ConditionsFilteredTupleKeyIterator) Head(ctx context.Context) (*openfgav1.TupleKey, error) {
 	for {

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -256,7 +256,7 @@ func (f *filteredTupleKeyIterator) Stop() {
 
 // Head returns the next most tuple in the underlying iterator that meets
 // the filter function this iterator was constructed with.
-// Note: the underlying iterator for unmatched filter may advance until head is satisfied.
+// Note: the underlying iterator for unmatched filter may advance until filter is satisfied.
 func (f *filteredTupleKeyIterator) Head(ctx context.Context) (*openfgav1.TupleKey, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -154,7 +154,10 @@ var _ TupleKeyIterator = (*tupleKeyIterator)(nil)
 // Next see [Iterator.Next].
 func (t *tupleKeyIterator) Next(ctx context.Context) (*openfgav1.TupleKey, error) {
 	tuple, err := t.iter.Next(ctx)
-	return tuple.GetKey(), err
+	if err != nil {
+		return nil, err
+	}
+	return tuple.GetKey(), nil
 }
 
 // Stop see [Iterator.Stop].
@@ -165,7 +168,10 @@ func (t *tupleKeyIterator) Stop() {
 // Head see [Iterator.Head].
 func (t *tupleKeyIterator) Head(ctx context.Context) (*openfgav1.TupleKey, error) {
 	tuple, err := t.iter.Head(ctx)
-	return tuple.GetKey(), err
+	if err != nil {
+		return nil, err
+	}
+	return tuple.GetKey(), nil
 }
 
 // NewTupleKeyIteratorFromTupleIterator takes a [TupleIterator] and yields
@@ -355,7 +361,7 @@ func (f *ConditionsFilteredTupleKeyIterator) Head(ctx context.Context) (*openfga
 			f.lastError = err
 			_, err = f.iter.Next(ctx)
 			if err != nil {
-				// should never happen
+				// should never happen except if the underlying ds has error
 				return nil, err
 			}
 			continue
@@ -363,7 +369,7 @@ func (f *ConditionsFilteredTupleKeyIterator) Head(ctx context.Context) (*openfga
 		if !valid {
 			_, err = f.iter.Next(ctx)
 			if err != nil {
-				// should never happen
+				// should never happen except if the underlying ds has error
 				return nil, err
 			}
 			continue

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -318,12 +318,10 @@ func TestCombinedIterator(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		_, err := iter.Head(ctx)
-		require.Error(t, err)
-		require.NotErrorIs(t, err, ErrIteratorDone)
+		require.ErrorIs(t, err, context.Canceled)
 
 		_, err = iter.Next(ctx)
-		require.Error(t, err)
-		require.NotErrorIs(t, err, ErrIteratorDone)
+		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -4,7 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/google/go-cmp/cmp"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -15,94 +21,341 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
-func TestStaticTupleKeyIterator(t *testing.T) {
-	expected := []*openfgav1.TupleKey{
-		tuple.NewTupleKey("document:doc1", "viewer", "bill"),
-		tuple.NewTupleKey("document:doc2", "editor", "bob"),
-	}
+func TestEmptyIterator(t *testing.T) {
+	t.Run("next", func(t *testing.T) {
+		iter := emptyTupleIterator{}
+		defer iter.Stop()
 
-	iter := NewStaticTupleKeyIterator(expected)
-
-	var actual []*openfgav1.TupleKey
-	for {
 		tk, err := iter.Next(context.Background())
-		if err != nil {
-			if errors.Is(err, ErrIteratorDone) {
-				break
-			}
-			require.Fail(t, "no error was expected")
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+	t.Run("head", func(t *testing.T) {
+		iter := emptyTupleIterator{}
+		defer iter.Stop()
+
+		tk, err := iter.Head(context.Background())
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+}
+
+func TestStaticTupleKeyIterator(t *testing.T) {
+	t.Run("next", func(t *testing.T) {
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		actual = append(actual, tk)
-	}
+		iter := NewStaticTupleKeyIterator(expected)
+		defer iter.Stop()
 
-	require.Equal(t, expected, actual)
+		var actual []*openfgav1.TupleKey
+		for {
+			tk, err := iter.Next(context.Background())
+			if err != nil {
+				if errors.Is(err, ErrIteratorDone) {
+					break
+				}
+				require.Fail(t, "no error was expected")
+			}
+
+			actual = append(actual, tk)
+		}
+
+		require.Equal(t, expected, actual)
+	})
+	t.Run("head_empty", func(t *testing.T) {
+		var expected []*openfgav1.TupleKey
+		iter := NewStaticTupleKeyIterator(expected)
+		defer iter.Stop()
+
+		tk, err := iter.Head(context.Background())
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+	t.Run("head_not_empty", func(t *testing.T) {
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+			tuple.NewTupleKey("document:doc2", "editor", "bob"),
+		}
+		iter := NewStaticTupleKeyIterator(expected)
+		defer iter.Stop()
+
+		tk, err := iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+
+		// Ensure the iterator does not increment
+		tk, err = iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+	})
+}
+
+func TestStaticTupleIterator(t *testing.T) {
+	t.Run("next", func(t *testing.T) {
+		expected := []*openfgav1.Tuple{
+			{
+				Key:       tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+				Timestamp: timestamppb.New(time.Now()),
+			},
+			{
+				Key:       tuple.NewTupleKey("document:doc2", "editor", "bob"),
+				Timestamp: timestamppb.New(time.Now()),
+			},
+		}
+
+		iter := NewStaticTupleIterator(expected)
+		defer iter.Stop()
+
+		var actual []*openfgav1.Tuple
+		for {
+			tk, err := iter.Next(context.Background())
+			if err != nil {
+				if errors.Is(err, ErrIteratorDone) {
+					break
+				}
+				require.Fail(t, "no error was expected")
+			}
+
+			actual = append(actual, tk)
+		}
+
+		require.Equal(t, expected, actual)
+	})
+	t.Run("head_empty", func(t *testing.T) {
+		var expected []*openfgav1.Tuple
+		iter := NewStaticTupleIterator(expected)
+		defer iter.Stop()
+
+		tk, err := iter.Head(context.Background())
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+	t.Run("head_not_empty", func(t *testing.T) {
+		expected := []*openfgav1.Tuple{
+			{
+				Key:       tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+				Timestamp: timestamppb.New(time.Now()),
+			},
+			{
+				Key:       tuple.NewTupleKey("document:doc2", "editor", "bob"),
+				Timestamp: timestamppb.New(time.Now()),
+			},
+		}
+		iter := NewStaticTupleIterator(expected)
+		defer iter.Stop()
+		tk, err := iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+
+		// Ensure the iterator does not increment.
+		tk, err = iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+	})
+	t.Run("check_for_race", func(t *testing.T) {
+		t.Skip("TODO: whether static tuple iterator is intended to be thread safe")
+		const numberItem = 50
+		tks := make([]*openfgav1.Tuple, numberItem)
+		for i := 0; i < numberItem; i++ {
+			tks[i] = &openfgav1.Tuple{
+				Key:       tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "bill"),
+				Timestamp: timestamppb.New(time.Now()),
+			}
+		}
+		iter := NewStaticTupleIterator(tks)
+		defer iter.Stop()
+
+		var wg errgroup.Group
+		for i := 0; i < numberItem; i++ {
+			wg.Go(func() error {
+				_, err := iter.Next(context.Background())
+				return err
+			})
+		}
+
+		err := wg.Wait()
+		require.NoError(t, err)
+	})
 }
 
 func TestCombinedIterator(t *testing.T) {
-	expected := []*openfgav1.TupleKey{
-		tuple.NewTupleKey("document:doc1", "viewer", "bill"),
-		tuple.NewTupleKey("document:doc2", "editor", "bob"),
-	}
-
-	iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
-	iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]})
-	iter := NewCombinedIterator(iter1, iter2)
-
-	var actual []*openfgav1.TupleKey
-	for {
-		tk, err := iter.Next(context.Background())
-		if err != nil {
-			if errors.Is(err, ErrIteratorDone) {
-				break
-			}
-			require.Fail(t, "no error was expected")
+	t.Run("next", func(t *testing.T) {
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		actual = append(actual, tk)
-	}
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]})
+		iter := NewCombinedIterator(iter1, iter2)
 
-	cmpOpts := []cmp.Option{
-		testutils.TupleKeyCmpTransformer,
-		protocmp.Transform(),
-	}
+		var actual []*openfgav1.TupleKey
+		for {
+			tk, err := iter.Next(context.Background())
+			if err != nil {
+				if errors.Is(err, ErrIteratorDone) {
+					break
+				}
+				require.Fail(t, "no error was expected")
+			}
 
-	if diff := cmp.Diff(expected, actual, cmpOpts...); diff != "" {
-		t.Fatalf("mismatch (-want +got):\n%s", diff)
-	}
+			actual = append(actual, tk)
+		}
+
+		cmpOpts := []cmp.Option{
+			testutils.TupleKeyCmpTransformer,
+			protocmp.Transform(),
+		}
+
+		if diff := cmp.Diff(expected, actual, cmpOpts...); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("head_empty_slices", func(t *testing.T) {
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{})
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{})
+		iter := NewCombinedIterator(iter1, iter2)
+		tk, err := iter.Head(context.Background())
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+	t.Run("head_not_empty", func(t *testing.T) {
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
+			tuple.NewTupleKey("document:doc2", "editor", "bob"),
+			tuple.NewTupleKey("document:doc2", "editor", "charles"),
+		}
+
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1], expected[2]})
+		iter := NewCombinedIterator(iter1, iter2)
+		tk, err := iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+
+		tk, err = iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, expected[0], tk)
+	})
 }
 
-func ExampleNewFilteredTupleKeyIterator() {
-	tuples := []*openfgav1.TupleKey{
-		tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
-		tuple.NewTupleKey("document:doc1", "editor", "user:elbuo"),
-	}
-
-	iter := NewFilteredTupleKeyIterator(
-		NewStaticTupleKeyIterator(tuples),
-		func(tk *openfgav1.TupleKey) bool {
-			return tk.GetRelation() == "editor"
-		},
-	)
-	defer iter.Stop()
-
-	var filtered []string
-	for {
-		tuple, err := iter.Next(context.Background())
-		if err != nil {
-			if err == ErrIteratorDone {
-				break
+func TestFilteredTupleKeyIterator(t *testing.T) {
+	t.Run("next", func(t *testing.T) {
+		tuples := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+			tuple.NewTupleKey("document:doc1", "editor", "user:elbuo"),
+			tuple.NewTupleKey("document:doc2", "viewer", "user:elbuo"),
+			tuple.NewTupleKey("document:doc2", "editor", "user:charlie"),
+		}
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "editor", "user:elbuo"),
+			tuple.NewTupleKey("document:doc2", "editor", "user:charlie"),
+		}
+		iter := NewFilteredTupleKeyIterator(
+			NewStaticTupleKeyIterator(tuples),
+			func(tk *openfgav1.TupleKey) bool {
+				return tk.GetRelation() == "editor"
+			},
+		)
+		defer iter.Stop()
+		var actual []*openfgav1.TupleKey
+		for {
+			tk, err := iter.Next(context.Background())
+			if err != nil {
+				if errors.Is(err, ErrIteratorDone) {
+					break
+				}
+				require.Fail(t, "no error was expected")
 			}
 
-			// Handle the error in some way.
-			panic(err)
+			actual = append(actual, tk)
 		}
 
-		filtered = append(filtered, fmt.Sprintf("%s#%s@%s", tuple.GetObject(), tuple.GetRelation(), tuple.GetUser()))
-	}
+		cmpOpts := []cmp.Option{
+			testutils.TupleKeyCmpTransformer,
+			protocmp.Transform(),
+		}
 
-	fmt.Println(filtered)
-	// Output: [document:doc1#editor@user:elbuo]
+		if diff := cmp.Diff(expected, actual, cmpOpts...); diff != "" {
+			t.Fatalf("mismatch (-want +got):\n%s", diff)
+		}
+	})
+	t.Run("head_empty_slices", func(t *testing.T) {
+		var tuples []*openfgav1.TupleKey
+
+		iter := NewFilteredTupleKeyIterator(
+			NewStaticTupleKeyIterator(tuples),
+			func(tk *openfgav1.TupleKey) bool {
+				return tk.GetRelation() == "editor"
+			},
+		)
+		defer iter.Stop()
+		tk, err := iter.Head(context.Background())
+		require.ErrorIs(t, err, ErrIteratorDone)
+		require.Nil(t, tk)
+	})
+	t.Run("head_non_slices", func(t *testing.T) {
+		tuples := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc1", "viewer", "user:jon"),
+			tuple.NewTupleKey("document:doc1", "editor", "user:elbuo"),
+			tuple.NewTupleKey("document:doc2", "viewer", "user:elbuo"),
+			tuple.NewTupleKey("document:doc2", "editor", "user:charlie"),
+		}
+
+		iter := NewFilteredTupleKeyIterator(
+			NewStaticTupleKeyIterator(tuples),
+			func(tk *openfgav1.TupleKey) bool {
+				return tk.GetRelation() == "editor"
+			},
+		)
+		defer iter.Stop()
+		tk, err := iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, tuples[1], tk)
+
+		// ensure the underlying iterator is not updated
+		tk, err = iter.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, tuples[1], tk)
+	})
+	t.Run("race_condition", func(t *testing.T) {
+		t.Skip("TODO: underlying static tuple key iterator is not thread safe")
+		const numMatchingIterator = 50
+		tuples := make([]*openfgav1.TupleKey, numMatchingIterator*3)
+		for i := 0; i < numMatchingIterator; i++ {
+			tuples[3*i] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "user:jon")
+			tuples[3*i+1] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "editor", "user:elbuo")
+			tuples[3*i+2] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "user:charlie")
+		}
+		iter := NewFilteredTupleKeyIterator(
+			NewStaticTupleKeyIterator(tuples),
+			func(tk *openfgav1.TupleKey) bool {
+				return tk.GetRelation() == "editor"
+			},
+		)
+		defer iter.Stop()
+		var wg errgroup.Group
+
+		for i := 0; i < numMatchingIterator; i++ {
+			wg.Go(func() error {
+				_, err := iter.Head(context.Background())
+				return err
+			})
+		}
+
+		for i := 0; i < numMatchingIterator-1; i++ {
+			wg.Go(func() error {
+				_, err := iter.Next(context.Background())
+				return err
+			})
+		}
+
+		err := wg.Wait()
+		require.NoError(t, err)
+	})
 }
 
 func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
@@ -118,110 +371,294 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 	}
 
 	t.Run("no_error", func(t *testing.T) {
-		tuples := []*openfgav1.TupleKey{
-			tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
+			{
+				name:  "mixed_head_next",
+				mixed: true,
+			},
 		}
-		iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
-		t.Cleanup(iter.Stop)
-		var actual []*openfgav1.TupleKey
-		for {
-			tk, err := iter.Next(context.Background())
-			if err != nil {
-				if errors.Is(err, ErrIteratorDone) {
-					break
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tuples := []*openfgav1.TupleKey{
+					tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 				}
-				require.Fail(t, "no error was expected")
-			}
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				t.Cleanup(iter.Stop)
 
-			actual = append(actual, tk)
+				var actual []*openfgav1.TupleKey
+				var actualHead []*openfgav1.TupleKey
+
+				for {
+					if tt.mixed {
+						headTk, err := iter.Head(context.Background())
+						if err != nil {
+							if errors.Is(err, ErrIteratorDone) {
+								break
+							}
+							require.Fail(t, "no error was expected")
+						}
+						actualHead = append(actualHead, headTk)
+
+						_, err = iter.Head(context.Background())
+						if err != nil {
+							require.Fail(t, "no error was expected")
+						}
+					}
+					tk, err := iter.Next(context.Background())
+					if err != nil {
+						if errors.Is(err, ErrIteratorDone) {
+							break
+						}
+						require.Fail(t, "no error was expected")
+					}
+
+					actual = append(actual, tk)
+					if tt.mixed {
+						_, err := iter.Head(context.Background())
+						if err != nil {
+							if errors.Is(err, ErrIteratorDone) {
+								break
+							}
+							require.Fail(t, "no error was expected")
+						}
+					}
+				}
+				expected := []*openfgav1.TupleKey{tuples[0], tuples[2]}
+				require.Equal(t, expected, actual)
+				if tt.mixed {
+					require.Equal(t, expected, actualHead)
+				}
+			})
 		}
-		expected := []*openfgav1.TupleKey{tuples[0], tuples[2]}
-		require.Equal(t, expected, actual)
 	})
 
 	t.Run("has_some_valid_but_middle_invalid", func(t *testing.T) {
-		tuples := []*openfgav1.TupleKey{
-			tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition3", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
-		}
-		iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
-		t.Cleanup(iter.Stop)
-		var actual []*openfgav1.TupleKey
-		for {
-			tk, err := iter.Next(context.Background())
-			if err != nil {
-				// Notice that we don't expect errors as some tuples are valid.
-				if errors.Is(err, ErrIteratorDone) {
-					break
-				}
-				require.Fail(t, "no error was expected")
-			}
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
 
-			actual = append(actual, tk)
+			{
+				name:  "mixed_head_next",
+				mixed: true,
+			},
 		}
-		expected := []*openfgav1.TupleKey{tuples[0], tuples[2]}
-		require.Equal(t, expected, actual)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tuples := []*openfgav1.TupleKey{
+					tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition3", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
+				}
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				t.Cleanup(iter.Stop)
+				var actual []*openfgav1.TupleKey
+				var actualHead []*openfgav1.TupleKey
+
+				for {
+					if tt.mixed {
+						headTk, err := iter.Head(context.Background())
+						if err != nil {
+							// Notice that we don't expect errors as some tuples are valid.
+							if errors.Is(err, ErrIteratorDone) {
+								break
+							}
+							require.Fail(t, "no error was expected")
+						}
+						actualHead = append(actualHead, headTk)
+						_, err = iter.Head(context.Background())
+						if err != nil {
+							require.Fail(t, "no error was expected")
+						}
+					}
+					tk, err := iter.Next(context.Background())
+					if err != nil {
+						// Notice that we don't expect errors as some tuples are valid.
+						if errors.Is(err, ErrIteratorDone) {
+							break
+						}
+						require.Fail(t, "no error was expected")
+					}
+
+					actual = append(actual, tk)
+				}
+				expected := []*openfgav1.TupleKey{tuples[0], tuples[2]}
+				require.Equal(t, expected, actual)
+				if tt.mixed {
+					require.Equal(t, expected, actualHead)
+				}
+			})
+		}
 	})
 
 	t.Run("has_some_valid_but_last_invalid", func(t *testing.T) {
-		tuples := []*openfgav1.TupleKey{
-			tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
+			{
+				name:  "mixed_head_next",
+				mixed: true,
+			},
 		}
-		iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
-		t.Cleanup(iter.Stop)
-		var actual []*openfgav1.TupleKey
-		for {
-			tk, err := iter.Next(context.Background())
-			if err != nil {
-				// Notice that we don't expect errors as some tuples are valid.
-				if errors.Is(err, ErrIteratorDone) {
-					break
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tuples := []*openfgav1.TupleKey{
+					tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition1", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
 				}
-				require.Fail(t, "no error was expected")
-			}
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				t.Cleanup(iter.Stop)
+				var actual []*openfgav1.TupleKey
+				var actualHead []*openfgav1.TupleKey
 
-			actual = append(actual, tk)
+				for {
+					if tt.mixed {
+						headTk, err := iter.Head(context.Background())
+						if err != nil {
+							// Notice that we don't expect errors as some tuples are valid.
+							if errors.Is(err, ErrIteratorDone) {
+								break
+							}
+							require.Fail(t, "no error was expected")
+						}
+						actualHead = append(actualHead, headTk)
+						_, err = iter.Head(context.Background())
+						if err != nil {
+							require.Fail(t, "no error was expected")
+						}
+					}
+					tk, err := iter.Next(context.Background())
+					if err != nil {
+						// Notice that we don't expect errors as some tuples are valid.
+						if errors.Is(err, ErrIteratorDone) {
+							break
+						}
+						require.Fail(t, "no error was expected")
+					}
+
+					actual = append(actual, tk)
+				}
+				expected := []*openfgav1.TupleKey{tuples[0]}
+				require.Equal(t, expected, actual)
+				if tt.mixed {
+					require.Equal(t, expected, actualHead)
+				}
+			})
 		}
-		expected := []*openfgav1.TupleKey{tuples[0]}
-		require.Equal(t, expected, actual)
 	})
 
 	t.Run("empty_list", func(t *testing.T) {
-		var tuples []*openfgav1.TupleKey
-		iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
-		t.Cleanup(iter.Stop)
-		var actual []*openfgav1.TupleKey
-		for {
-			tk, err := iter.Next(context.Background())
-			if err != nil {
-				if errors.Is(err, ErrIteratorDone) {
-					break
-				}
-				require.Fail(t, "no error was expected")
-			}
-
-			actual = append(actual, tk)
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
+			{
+				name:  "mixed_head_next",
+				mixed: true,
+			},
 		}
-		var expected []*openfgav1.TupleKey
-		require.Equal(t, expected, actual)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var tuples []*openfgav1.TupleKey
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				t.Cleanup(iter.Stop)
+				var actual []*openfgav1.TupleKey
+				var actualHead []*openfgav1.TupleKey
+
+				for {
+					if tt.mixed {
+						headTk, err := iter.Head(context.Background())
+						if err != nil {
+							// Notice that we don't expect errors as some tuples are valid.
+							if errors.Is(err, ErrIteratorDone) {
+								break
+							}
+							require.Fail(t, "no error was expected")
+						}
+						actualHead = append(actualHead, headTk)
+						_, err = iter.Head(context.Background())
+						if err != nil {
+							require.Fail(t, "no error was expected")
+						}
+					}
+					tk, err := iter.Next(context.Background())
+					if err != nil {
+						if errors.Is(err, ErrIteratorDone) {
+							break
+						}
+						require.Fail(t, "no error was expected")
+					}
+
+					actual = append(actual, tk)
+				}
+				var expected []*openfgav1.TupleKey
+				require.Equal(t, expected, actual)
+				if tt.mixed {
+					require.Equal(t, expected, actualHead)
+				}
+			})
+		}
 	})
 
 	t.Run("all_invalid", func(t *testing.T) {
-		tuples := []*openfgav1.TupleKey{
-			tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition3", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition4", nil),
-			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
+			{
+				name:  "mixed_head_next",
+				mixed: true,
+			},
 		}
-		iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
-		tk, err := iter.Next(context.Background())
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tuples := []*openfgav1.TupleKey{
+					tuple.NewTupleKeyWithCondition("document:doc1", "viewer", "user:jon", "condition3", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition4", nil),
+					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
+				}
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				t.Cleanup(iter.Stop)
+				if tt.mixed {
+					tk, err := iter.Head(context.Background())
 
-		// only the last error is returned
-		require.Equal(t, "unknown condition: condition5", err.Error())
-		require.Nil(t, tk)
+					// only the last error is returned
+					require.Equal(t, "unknown condition: condition5", err.Error())
+					require.Nil(t, tk)
+				}
+				tk, err := iter.Next(context.Background())
+
+				// only the last error is returned
+				require.Equal(t, "unknown condition: condition5", err.Error())
+				require.Nil(t, tk)
+			})
+		}
 	})
 }

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -75,6 +75,22 @@ func (s *staticIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 // Stop does not do anything for staticIterator.
 func (s *staticIterator) Stop() {}
 
+// Head see [storage.Iterator].Next.
+func (s *staticIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.records) == 0 {
+		return nil, storage.ErrIteratorDone
+	}
+
+	rec := s.records[0]
+	return rec.AsTuple(), nil
+}
+
 // ToArray converts the entire sequence of tuples in the staticIterator to an array format.
 func (s *staticIterator) ToArray(ctx context.Context) ([]*openfgav1.Tuple, []byte, error) {
 	var res []*openfgav1.Tuple

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -23,6 +23,42 @@ func TestMemdbStorage(t *testing.T) {
 	test.RunAllTests(t, ds)
 }
 
+func TestStaticTupleIterator(t *testing.T) {
+	t.Run("empty_iterator", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			mixed bool
+		}{
+			{
+				name:  "next_only",
+				mixed: false,
+			},
+			{
+				name:  "mixed",
+				mixed: true,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				iter := &staticIterator{
+					records: []*storage.TupleRecord{},
+				}
+				defer iter.Stop()
+				if tt.mixed {
+					_, err := iter.Head(context.Background())
+					require.ErrorIs(t, err, storage.ErrIteratorDone)
+				}
+				_, err := iter.Next(context.Background())
+				require.ErrorIs(t, err, storage.ErrIteratorDone)
+				if tt.mixed {
+					_, err := iter.Head(context.Background())
+					require.ErrorIs(t, err, storage.ErrIteratorDone)
+				}
+			})
+		}
+	})
+}
+
 func TestStaticTupleIteratorNoRace(t *testing.T) {
 	t.Run("next_only", func(t *testing.T) {
 		now := timestamppb.Now()

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -23,97 +24,194 @@ func TestMemdbStorage(t *testing.T) {
 }
 
 func TestStaticTupleIteratorNoRace(t *testing.T) {
-	now := timestamppb.Now()
+	t.Run("next_only", func(t *testing.T) {
+		now := timestamppb.Now()
 
-	iter := &staticIterator{
-		records: []*storage.TupleRecord{
-			{
-				Store:      "store",
-				ObjectType: "document",
-				ObjectID:   "1",
-				Relation:   "viewer",
-				User:       "user:jon",
-				Ulid:       ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
-				InsertedAt: now.AsTime(),
+		iter := &staticIterator{
+			records: []*storage.TupleRecord{
+				{
+					Store:      "store",
+					ObjectType: "document",
+					ObjectID:   "1",
+					Relation:   "viewer",
+					User:       "user:jon",
+					Ulid:       ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
+					InsertedAt: now.AsTime(),
+				},
+				{
+					Store:            "store",
+					ObjectType:       "document",
+					ObjectID:         "1",
+					Relation:         "viewer",
+					User:             "user:jon",
+					ConditionName:    "condition",
+					ConditionContext: &structpb.Struct{},
+					Ulid:             ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
+					InsertedAt:       now.AsTime(),
+				},
 			},
-			{
+		}
+		defer iter.Stop()
+
+		var wg errgroup.Group
+
+		wg.Go(func() error {
+			_, err := iter.Next(context.Background())
+			return err
+		})
+
+		wg.Go(func() error {
+			_, err := iter.Next(context.Background())
+			return err
+		})
+
+		err := wg.Wait()
+		require.NoError(t, err)
+	})
+	t.Run("mixing_head_next", func(t *testing.T) {
+		now := timestamppb.Now()
+		const numIterator = 50
+
+		tupleRecords := make([]*storage.TupleRecord, numIterator)
+		for i := 0; i < numIterator; i++ {
+			tupleRecords[i] = &storage.TupleRecord{
 				Store:            "store",
 				ObjectType:       "document",
-				ObjectID:         "1",
+				ObjectID:         strconv.Itoa(i),
 				Relation:         "viewer",
 				User:             "user:jon",
 				ConditionName:    "condition",
 				ConditionContext: &structpb.Struct{},
 				Ulid:             ulid.MustNew(ulid.Timestamp(now.AsTime()), ulid.DefaultEntropy()).String(),
 				InsertedAt:       now.AsTime(),
-			},
-		},
-	}
-	defer iter.Stop()
+			}
+		}
+		iter := &staticIterator{
+			records: tupleRecords,
+		}
+		defer iter.Stop()
 
-	var wg errgroup.Group
+		var wg errgroup.Group
 
-	wg.Go(func() error {
-		_, err := iter.Next(context.Background())
-		return err
+		for i := 0; i < numIterator; i++ {
+			wg.Go(func() error {
+				_, err := iter.Head(context.Background())
+				return err
+			})
+		}
+		// important that when we call next, we will have 1 less
+		// element because we don't want to be done.
+		for i := 0; i < numIterator-1; i++ {
+			wg.Go(func() error {
+				_, err := iter.Next(context.Background())
+				return err
+			})
+		}
+		err := wg.Wait()
+		require.NoError(t, err)
 	})
-
-	wg.Go(func() error {
-		_, err := iter.Next(context.Background())
-		return err
-	})
-
-	err := wg.Wait()
-	require.NoError(t, err)
 }
 
 func TestStaticTupleIteratorContextCanceled(t *testing.T) {
-	iter := &staticIterator{
-		records: []*storage.TupleRecord{
-			{
-				ObjectType: "document",
-				ObjectID:   "1",
-				Relation:   "viewer",
-				User:       "user:jon",
-			},
+	tests := []struct {
+		_name string
+		next  bool
+	}{
+		{
+			_name: "next",
+			next:  true,
+		},
+		{
+			_name: "head",
+			next:  false,
 		},
 	}
-	defer iter.Stop()
+	for _, tt := range tests {
+		t.Run(tt._name, func(t *testing.T) {
+			iter := &staticIterator{
+				records: []*storage.TupleRecord{
+					{
+						ObjectType: "document",
+						ObjectID:   "1",
+						Relation:   "viewer",
+						User:       "user:jon",
+					},
+				},
+			}
+			defer iter.Stop()
 
-	ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
 
-	_, err := iter.Next(ctx)
-	require.NoError(t, err)
+			var err error
+			if tt.next {
+				_, err = iter.Next(ctx)
+			} else {
+				_, err = iter.Head(ctx)
+			}
+			require.NoError(t, err)
 
-	cancel()
+			cancel()
 
-	_, err = iter.Next(ctx)
-	require.ErrorIs(t, err, context.Canceled)
+			if tt.next {
+				_, err = iter.Next(ctx)
+			} else {
+				_, err = iter.Head(ctx)
+			}
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
 }
 
 func TestStaticTupleIteratorContextDeadlineExceeded(t *testing.T) {
-	iter := &staticIterator{
-		records: []*storage.TupleRecord{
-			{
-				ObjectType: "document",
-				ObjectID:   "1",
-				Relation:   "viewer",
-				User:       "user:jon",
-			},
+	tests := []struct {
+		_name string
+		next  bool
+	}{
+		{
+			_name: "next",
+			next:  true,
+		},
+		{
+			_name: "head",
+			next:  false,
 		},
 	}
-	defer iter.Stop()
+	for _, tt := range tests {
+		t.Run(tt._name, func(t *testing.T) {
+			iter := &staticIterator{
+				records: []*storage.TupleRecord{
+					{
+						ObjectType: "document",
+						ObjectID:   "1",
+						Relation:   "viewer",
+						User:       "user:jon",
+					},
+				},
+			}
+			defer iter.Stop()
 
-	deadlineCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
+			deadlineCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
 
-	_, err := iter.Next(deadlineCtx)
-	require.NoError(t, err)
+			var err error
 
-	time.Sleep(2 * time.Second)
+			if tt.next {
+				_, err = iter.Next(deadlineCtx)
+			} else {
+				_, err = iter.Head(deadlineCtx)
+			}
+			require.NoError(t, err)
 
-	_, err = iter.Next(deadlineCtx)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+			time.Sleep(2 * time.Second)
+
+			if tt.next {
+				_, err = iter.Next(deadlineCtx)
+			} else {
+				_, err = iter.Head(deadlineCtx)
+			}
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+	}
 }
 
 func TestTupleRecordMatchTupleKey(t *testing.T) {

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -54,6 +54,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 	store := "store"
 	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
 	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
+	thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
 	err = sqlcommon.Write(ctx,
 		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
@@ -72,22 +73,49 @@ func TestReadEnsureNoOrder(t *testing.T) {
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 
+	// Tweak time so that ULID is smaller.
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{thirdTuple},
+		time.Now().Add(time.Minute*-2))
+	require.NoError(t, err)
+
 	iter, err := ds.Read(ctx, store, tuple.NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
 	defer iter.Stop()
 
 	require.NoError(t, err)
 
 	// We expect that objectID1 will return first because it is inserted first.
-	curTuple, err := iter.Next(ctx)
+
+	curTuple, err := iter.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, firstTuple, curTuple.GetKey())
+
+	// calling head should not change the order
+	curTuple, err = iter.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, firstTuple, curTuple.GetKey())
+
+	curTuple, err = iter.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, firstTuple, curTuple.GetKey())
 
 	curTuple, err = iter.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, secondTuple, curTuple.GetKey())
+
+	curTuple, err = iter.Head(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thirdTuple, curTuple.GetKey())
+
+	curTuple, err = iter.Next(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thirdTuple, curTuple.GetKey())
 }
 
-// TestReadPageEnsureNoOrder asserts that the read page is ordered by ulid.
+// TestReadPageEnsureOrder asserts that the read page is ordered by ulid.
 func TestReadPageEnsureOrder(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -43,138 +43,180 @@ func TestMySQLDatastoreAfterCloseIsNotReady(t *testing.T) {
 
 // TestReadEnsureNoOrder asserts that the read response is not ordered by ulid.
 func TestReadEnsureNoOrder(t *testing.T) {
-	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+	tests := []struct {
+		name  string
+		mixed bool
+	}{
+		{
+			name:  "nextOnly",
+			mixed: false,
+		},
+		{
+			name:  "mixed",
+			mixed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI(true)
-	ds, err := New(uri, sqlcommon.NewConfig())
-	require.NoError(t, err)
-	defer ds.Close()
+			uri := testDatastore.GetConnectionURI(true)
+			ds, err := New(uri, sqlcommon.NewConfig())
+			require.NoError(t, err)
+			defer ds.Close()
 
-	ctx := context.Background()
-	store := "store"
-	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
-	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
-	thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
+			ctx := context.Background()
+			store := "store"
+			firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
+			secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
+			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{firstTuple},
-		time.Now())
-	require.NoError(t, err)
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{firstTuple},
+				time.Now())
+			require.NoError(t, err)
 
-	// Tweak time so that ULID is smaller.
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{secondTuple},
-		time.Now().Add(time.Minute*-1))
-	require.NoError(t, err)
+			// Tweak time so that ULID is smaller.
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{secondTuple},
+				time.Now().Add(time.Minute*-1))
+			require.NoError(t, err)
 
-	// Tweak time so that ULID is smaller.
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{thirdTuple},
-		time.Now().Add(time.Minute*-2))
-	require.NoError(t, err)
+			// Tweak time so that ULID is smaller.
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{thirdTuple},
+				time.Now().Add(time.Minute*-2))
+			require.NoError(t, err)
 
-	iter, err := ds.Read(ctx, store, tuple.NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
-	defer iter.Stop()
+			iter, err := ds.Read(ctx, store, tuple.NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
+			defer iter.Stop()
 
-	require.NoError(t, err)
+			require.NoError(t, err)
 
-	// We expect that objectID1 will return first because it is inserted first.
+			// We expect that objectID1 will return first because it is inserted first.
+			if tt.mixed {
+				curTuple, err := iter.Head(ctx)
+				require.NoError(t, err)
+				require.Equal(t, firstTuple, curTuple.GetKey())
 
-	curTuple, err := iter.Head(ctx)
-	require.NoError(t, err)
-	require.Equal(t, firstTuple, curTuple.GetKey())
+				// calling head should not change the order
+				curTuple, err = iter.Head(ctx)
+				require.NoError(t, err)
+				require.Equal(t, firstTuple, curTuple.GetKey())
+			}
 
-	// calling head should not change the order
-	curTuple, err = iter.Head(ctx)
-	require.NoError(t, err)
-	require.Equal(t, firstTuple, curTuple.GetKey())
+			curTuple, err := iter.Next(ctx)
+			require.NoError(t, err)
+			require.Equal(t, firstTuple, curTuple.GetKey())
 
-	curTuple, err = iter.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, firstTuple, curTuple.GetKey())
+			curTuple, err = iter.Next(ctx)
+			require.NoError(t, err)
+			require.Equal(t, secondTuple, curTuple.GetKey())
 
-	curTuple, err = iter.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, secondTuple, curTuple.GetKey())
+			if tt.mixed {
+				curTuple, err = iter.Head(ctx)
+				require.NoError(t, err)
+				require.Equal(t, thirdTuple, curTuple.GetKey())
+			}
 
-	curTuple, err = iter.Head(ctx)
-	require.NoError(t, err)
-	require.Equal(t, thirdTuple, curTuple.GetKey())
+			curTuple, err = iter.Next(ctx)
+			require.NoError(t, err)
+			require.Equal(t, thirdTuple, curTuple.GetKey())
 
-	curTuple, err = iter.Next(ctx)
-	require.NoError(t, err)
-	require.Equal(t, thirdTuple, curTuple.GetKey())
+			if tt.mixed {
+				_, err = iter.Head(ctx)
+				require.ErrorIs(t, err, storage.ErrIteratorDone)
+			}
 
-	_, err = iter.Head(ctx)
-	require.ErrorIs(t, err, storage.ErrIteratorDone)
-
-	_, err = iter.Next(ctx)
-	require.ErrorIs(t, err, storage.ErrIteratorDone)
+			_, err = iter.Next(ctx)
+			require.ErrorIs(t, err, storage.ErrIteratorDone)
+		})
+	}
 }
 
 func TestCtxCancel(t *testing.T) {
-	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+	tests := []struct {
+		name  string
+		mixed bool
+	}{
+		{
+			name:  "nextOnly",
+			mixed: false,
+		},
+		{
+			name:  "mixed",
+			mixed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 
-	uri := testDatastore.GetConnectionURI(true)
-	ds, err := New(uri, sqlcommon.NewConfig())
-	require.NoError(t, err)
-	defer ds.Close()
+			uri := testDatastore.GetConnectionURI(true)
+			ds, err := New(uri, sqlcommon.NewConfig())
+			require.NoError(t, err)
+			defer ds.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(context.Background())
 
-	store := "store"
-	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
-	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
-	thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
+			store := "store"
+			firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
+			secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
+			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{firstTuple},
-		time.Now())
-	require.NoError(t, err)
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{firstTuple},
+				time.Now())
+			require.NoError(t, err)
 
-	// Tweak time so that ULID is smaller.
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{secondTuple},
-		time.Now().Add(time.Minute*-1))
-	require.NoError(t, err)
+			// Tweak time so that ULID is smaller.
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{secondTuple},
+				time.Now().Add(time.Minute*-1))
+			require.NoError(t, err)
 
-	// Tweak time so that ULID is smaller.
-	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
-		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{thirdTuple},
-		time.Now().Add(time.Minute*-2))
-	require.NoError(t, err)
+			// Tweak time so that ULID is smaller.
+			err = sqlcommon.Write(ctx,
+				sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+				store,
+				[]*openfgav1.TupleKeyWithoutCondition{},
+				[]*openfgav1.TupleKey{thirdTuple},
+				time.Now().Add(time.Minute*-2))
+			require.NoError(t, err)
 
-	iter, err := ds.Read(ctx, store, tuple.
-		NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
-	defer iter.Stop()
-	require.NoError(t, err)
+			iter, err := ds.Read(ctx, store, tuple.
+				NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
+			defer iter.Stop()
+			require.NoError(t, err)
 
-	cancel()
-	_, err = iter.Head(ctx)
-	require.Error(t, err)
-	require.NotEqual(t, storage.ErrIteratorDone, err)
+			cancel()
 
-	_, err = iter.Next(ctx)
-	require.Error(t, err)
-	require.NotEqual(t, storage.ErrIteratorDone, err)
+			if tt.mixed {
+				_, err = iter.Head(ctx)
+				require.Error(t, err)
+				require.NotEqual(t, storage.ErrIteratorDone, err)
+			}
+
+			_, err = iter.Next(ctx)
+			require.Error(t, err)
+			require.NotEqual(t, storage.ErrIteratorDone, err)
+		})
+	}
 }
 
 // TestReadPageEnsureOrder asserts that the read page is ordered by ulid.

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -113,6 +113,68 @@ func TestReadEnsureNoOrder(t *testing.T) {
 	curTuple, err = iter.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, thirdTuple, curTuple.GetKey())
+
+	_, err = iter.Head(ctx)
+	require.ErrorIs(t, err, storage.ErrIteratorDone)
+
+	_, err = iter.Next(ctx)
+	require.ErrorIs(t, err, storage.ErrIteratorDone)
+}
+
+func TestCtxCancel(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := "store"
+	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
+	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
+	thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
+
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{firstTuple},
+		time.Now())
+	require.NoError(t, err)
+
+	// Tweak time so that ULID is smaller.
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{secondTuple},
+		time.Now().Add(time.Minute*-1))
+	require.NoError(t, err)
+
+	// Tweak time so that ULID is smaller.
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, sq.Expr("NOW()")),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{thirdTuple},
+		time.Now().Add(time.Minute*-2))
+	require.NoError(t, err)
+
+	iter, err := ds.Read(ctx, store, tuple.
+		NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
+	defer iter.Stop()
+	require.NoError(t, err)
+
+	cancel()
+	_, err = iter.Head(ctx)
+	require.Error(t, err)
+	require.NotEqual(t, storage.ErrIteratorDone, err)
+
+	_, err = iter.Next(ctx)
+	require.Error(t, err)
+	require.NotEqual(t, storage.ErrIteratorDone, err)
 }
 
 // TestReadPageEnsureOrder asserts that the read page is ordered by ulid.

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -111,6 +111,67 @@ func TestReadEnsureNoOrder(t *testing.T) {
 	curTuple, err = iter.Next(ctx)
 	require.NoError(t, err)
 	require.Equal(t, thirdTuple, curTuple.GetKey())
+
+	_, err = iter.Head(ctx)
+	require.ErrorIs(t, err, storage.ErrIteratorDone)
+
+	_, err = iter.Next(ctx)
+	require.ErrorIs(t, err, storage.ErrIteratorDone)
+}
+
+func TestCtxCancel(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	store := "store"
+	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
+	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
+	thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
+
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, "NOW()"),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{firstTuple},
+		time.Now())
+	require.NoError(t, err)
+
+	// Tweak time so that ULID is smaller.
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, "NOW()"),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{secondTuple},
+		time.Now().Add(time.Minute*-1))
+	require.NoError(t, err)
+
+	err = sqlcommon.Write(ctx,
+		sqlcommon.NewDBInfo(ds.db, ds.stbl, "NOW()"),
+		store,
+		[]*openfgav1.TupleKeyWithoutCondition{},
+		[]*openfgav1.TupleKey{thirdTuple},
+		time.Now().Add(time.Minute*-2))
+	require.NoError(t, err)
+
+	iter, err := ds.Read(ctx, store, tuple.
+		NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
+	defer iter.Stop()
+	require.NoError(t, err)
+
+	cancel()
+	_, err = iter.Head(ctx)
+	require.Error(t, err)
+	require.NotEqual(t, storage.ErrIteratorDone, err)
+
+	_, err = iter.Next(ctx)
+	require.Error(t, err)
+	require.NotEqual(t, storage.ErrIteratorDone, err)
 }
 
 // TestReadPageEnsureNoOrder asserts that the read page is ordered by ulid.

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -187,7 +187,7 @@ var _ storage.TupleIterator = (*SQLTupleIterator)(nil)
 // NewSQLTupleIterator returns a SQL tuple iterator.
 func NewSQLTupleIterator(rows *sql.Rows) *SQLTupleIterator {
 	return &SQLTupleIterator{
-		rows:     rows,
+		rows:     rows, // GUARDED_BY(mu)
 		resultCh: make(chan *storage.TupleRecord, 1),
 		errCh:    make(chan error, 1),
 		firstRow: nil, // GUARDED_BY(mu). The firstRow is used as a temporary storage place if head is called.

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -190,7 +190,7 @@ func NewSQLTupleIterator(rows *sql.Rows) *SQLTupleIterator {
 		rows:     rows,
 		resultCh: make(chan *storage.TupleRecord, 1),
 		errCh:    make(chan error, 1),
-		firstRow: nil,
+		firstRow: nil, // GUARDED_BY(mu)
 		mu:       sync.Mutex{},
 	}
 }


### PR DESCRIPTION
## Description
Iterator function Head to look at the first item without advancing iterator.

Note: custom datastore implementation will need to be updated to support Head()

This is needed in preparation for check latency optimization for TTU & userset where the child is an intersection/union/exclusion. 

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected
