### PR TITLE
feat: Support Contextual Tuples in Assertions API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d
+	github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9
 	github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/prometheus/client_golang v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240723155248-7e5be7b65c27
+	github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2
 	github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/prometheus/client_golang v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2
+	github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d
 	github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2 h1:w+hPTNpQAXUYgoYSUzoZ7amrMZ0fJf8OgLq43GasbXs=
 github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
+github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d h1:3YjsXusDc0kzLtxuPJ8yzRyw+nZBX+A28/+5qGjf6xU=
+github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d h1:n44DfITs+CLCYJIgsryJkG2ElwOZJ3huekPZKydPi7U=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d/go.mod h1:wkI4GcY3yNNuFMU2ncHPWqBaF7XylQTkJYfBi2pIpK8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20240723155248-7e5be7b65c27 h1:4DI5cY46DLLjZoKNGpe9FRluNl+mN4yxkRL9VjWRbFk=
-github.com/openfga/api/proto v0.0.0-20240723155248-7e5be7b65c27/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
+github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2 h1:w+hPTNpQAXUYgoYSUzoZ7amrMZ0fJf8OgLq43GasbXs=
+github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d h1:n44DfITs+CLCYJIgsryJkG2ElwOZJ3huekPZKydPi7U=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d/go.mod h1:wkI4GcY3yNNuFMU2ncHPWqBaF7XylQTkJYfBi2pIpK8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/go.sum
+++ b/go.sum
@@ -164,10 +164,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2 h1:w+hPTNpQAXUYgoYSUzoZ7amrMZ0fJf8OgLq43GasbXs=
-github.com/openfga/api/proto v0.0.0-20240806194506-0eeb3efc2de2/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
-github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d h1:3YjsXusDc0kzLtxuPJ8yzRyw+nZBX+A28/+5qGjf6xU=
-github.com/openfga/api/proto v0.0.0-20240807164716-316aa1c0bb6d/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
+github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9 h1:Y0fIAHrYECcf5lpa/o1AbH21bS7rsco/FoH4A4NGlZE=
+github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d h1:n44DfITs+CLCYJIgsryJkG2ElwOZJ3huekPZKydPi7U=
 github.com/openfga/language/pkg/go v0.0.0-20240409225820-a53ea2892d6d/go.mod h1:wkI4GcY3yNNuFMU2ncHPWqBaF7XylQTkJYfBi2pIpK8=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/server/commands/write_assertions.go
+++ b/pkg/server/commands/write_assertions.go
@@ -66,7 +66,7 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgav1.Wri
 			return nil, serverErrors.ValidationError(err)
 		}
 
-		for _, ct := range assertion.GetContextualTuples().GetTupleKeys() {
+		for _, ct := range assertion.GetContextualTuples() {
 			// but contextual tuples need to be validated the same as an input to a Write Tuple request
 			if err = validation.ValidateTuple(typesys, ct); err != nil {
 				return nil, serverErrors.ValidationError(err)

--- a/pkg/server/commands/write_assertions.go
+++ b/pkg/server/commands/write_assertions.go
@@ -61,8 +61,16 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgav1.Wri
 	typesys := typesystem.New(model)
 
 	for _, assertion := range assertions {
+		// an assertion should be validated the same as the input tuple key to a Check request
 		if err := validation.ValidateUserObjectRelation(typesys, tupleUtils.ConvertAssertionTupleKeyToTupleKey(assertion.GetTupleKey())); err != nil {
 			return nil, serverErrors.ValidationError(err)
+		}
+
+		for _, ct := range assertion.GetContextualTuples().GetTupleKeys() {
+			// but contextual tuples need to be validated the same as an input to a Write Tuple request
+			if err = validation.ValidateTuple(typesys, ct); err != nil {
+				return nil, serverErrors.ValidationError(err)
+			}
 		}
 	}
 

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -7,7 +7,7 @@ import (
 )
 
 func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
-	// RunQueryTests(t, ds)
+	RunQueryTests(t, ds)
 	RunCommandTests(t, ds)
 }
 

--- a/pkg/server/test/server.go
+++ b/pkg/server/test/server.go
@@ -7,7 +7,7 @@ import (
 )
 
 func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
-	RunQueryTests(t, ds)
+	// RunQueryTests(t, ds)
 	RunCommandTests(t, ds)
 }
 
@@ -44,7 +44,6 @@ func RunCommandTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestWriteCommand", func(t *testing.T) { TestWriteCommand(t, ds) })
 	t.Run("TestWriteAuthorizationModel", func(t *testing.T) { WriteAuthorizationModelTest(t, ds) })
 	t.Run("TestWriteAndReadAssertions", func(t *testing.T) { TestWriteAndReadAssertions(t, ds) })
-	t.Run("TestWriteAssertionsFailure", func(t *testing.T) { TestWriteAssertionsFailure(t, ds) })
 	t.Run("TestCreateStore", func(t *testing.T) { TestCreateStore(t, ds) })
 	t.Run("TestDeleteStore", func(t *testing.T) { TestDeleteStore(t, ds) })
 }

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -2,62 +2,78 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/openfga/openfga/pkg/server/commands"
-	serverErrors "github.com/openfga/openfga/pkg/server/errors"
-	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
+
+	"github.com/openfga/openfga/pkg/server/commands"
+	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/tuple"
-	"github.com/openfga/openfga/pkg/typesystem"
 )
 
 func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore) {
-	type writeAssertionsTestSettings struct {
-		_name      string
-		assertions []*openfgav1.Assertion
+	store := ulid.Make().String()
+
+	model := parser.MustTransformDSLToProto(`
+	model
+		schema 1.1
+	type user
+
+	type repo
+		relations
+			define reader: [user, user with condX]
+			define can_read: reader
+
+	condition condX(x :int) {
+		x > 0
 	}
+	`)
 
-	store := testutils.CreateRandomString(10)
+	writeAuthzModelCmd := commands.NewWriteAuthorizationModelCommand(datastore)
 
-	githubModelReq := &openfgav1.WriteAuthorizationModelRequest{
-		StoreId: store,
-		TypeDefinitions: parser.MustTransformDSLToProto(`
-			model
-				schema 1.1
-			type user
+	writeModelResponse, err := writeAuthzModelCmd.Execute(context.Background(), &openfgav1.WriteAuthorizationModelRequest{
+		StoreId:         store,
+		TypeDefinitions: model.GetTypeDefinitions(),
+		SchemaVersion:   model.GetSchemaVersion(),
+		Conditions:      model.GetConditions(),
+	})
+	require.NoError(t, err)
+	modelID := writeModelResponse.GetAuthorizationModelId()
 
-			type repo
-				relations
-					define reader: [user]
-					define can_read: reader`).GetTypeDefinitions(),
-		SchemaVersion: typesystem.SchemaVersion1_1,
+	type writeAssertionsTestSettings struct {
+		_name                string
+		inputModelID         string
+		assertions           []*openfgav1.Assertion
+		expectErrWhenWriting string
 	}
 
 	var tests = []writeAssertionsTestSettings{
 		{
-			_name: "writing_assertions_succeeds",
+			_name:        "writing_assertion_succeeds",
+			inputModelID: modelID,
 			assertions: []*openfgav1.Assertion{{
 				TupleKey:    tuple.NewAssertionTupleKey("repo:test", "reader", "user:elbuo"),
 				Expectation: false,
 			}},
 		},
 		{
-			_name: "writing_assertions_succeeds_when_it_is_not_directly_assignable",
+			_name:        "writing_assertion_succeeds_when_it_is_not_directly_assignable",
+			inputModelID: modelID,
 			assertions: []*openfgav1.Assertion{{
 				TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 				Expectation: false,
 			}},
 		},
 		{
-			_name: "writing_multiple_assertions_succeeds",
+			_name:        "writing_multiple_assertions_succeeds",
+			inputModelID: modelID,
 			assertions: []*openfgav1.Assertion{
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "reader", "user:elbuo"),
@@ -78,7 +94,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		},
 		{
-			_name: "writing_multiple_assertions_succeeds_when_it_is_not_directly_assignable",
+			_name:        "writing_multiple_assertions_succeeds_when_it_is_not_directly_assignable",
+			inputModelID: modelID,
 			assertions: []*openfgav1.Assertion{
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
@@ -95,77 +112,125 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		},
 		{
-			_name:      "writing_empty_assertions_succeeds",
-			assertions: []*openfgav1.Assertion{},
+			_name:        "writing_empty_assertions_succeeds",
+			inputModelID: modelID,
+			assertions:   []*openfgav1.Assertion{},
 		},
-	}
-
-	ctx := context.Background()
-
-	for _, test := range tests {
-		t.Run(test._name, func(t *testing.T) {
-			model := githubModelReq
-
-			writeAuthzModelCmd := commands.NewWriteAuthorizationModelCommand(datastore)
-
-			modelID, err := writeAuthzModelCmd.Execute(ctx, model)
-			require.NoError(t, err)
-			request := &openfgav1.WriteAssertionsRequest{
-				StoreId:              store,
-				Assertions:           test.assertions,
-				AuthorizationModelId: modelID.GetAuthorizationModelId(),
-			}
-
-			writeAssertionCmd := commands.NewWriteAssertionsCommand(datastore)
-			_, err = writeAssertionCmd.Execute(ctx, request)
-			require.NoError(t, err)
-			query := commands.NewReadAssertionsQuery(datastore)
-			actualResponse, actualError := query.Execute(ctx, store, modelID.GetAuthorizationModelId())
-			require.NoError(t, actualError)
-
-			expectedResponse := &openfgav1.ReadAssertionsResponse{
-				AuthorizationModelId: modelID.GetAuthorizationModelId(),
-				Assertions:           test.assertions,
-			}
-			if diff := cmp.Diff(expectedResponse, actualResponse, protocmp.Transform()); diff != "" {
-				t.Errorf("store mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestWriteAssertionsFailure(t *testing.T, datastore storage.OpenFGADatastore) {
-	type writeAssertionsTestSettings struct {
-		_name      string
-		assertions []*openfgav1.Assertion
-		modelID    string
-		err        error
-	}
-
-	store := testutils.CreateRandomString(10)
-
-	githubModelReq := &openfgav1.WriteAuthorizationModelRequest{
-		StoreId: store,
-		TypeDefinitions: parser.MustTransformDSLToProto(`
-			model
-				schema 1.1
-			type user
-
-			type repo
-				relations
-					define reader: [user]
-					define can_read: reader`).GetTypeDefinitions(),
-		SchemaVersion: typesystem.SchemaVersion1_1,
-	}
-	ctx := context.Background()
-
-	writeAuthzModelCmd := commands.NewWriteAuthorizationModelCommand(datastore)
-	modelID, err := writeAuthzModelCmd.Execute(ctx, githubModelReq)
-	require.NoError(t, err)
-
-	var tests = []writeAssertionsTestSettings{
 		{
-			_name: "writing_assertion_with_invalid_relation_fails",
+			_name:        "writing_assertion_with_contextual_tuple_succeeds",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
+						},
+					},
+				},
+			},
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_with_condition_succeeds",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
+								testutils.MustNewStruct(t, map[string]interface{}{"x": 0})),
+						},
+					},
+				},
+			},
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_with_condition_fails_because_invalid_context_parameter",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
+								testutils.MustNewStruct(t, map[string]interface{}{"unknownparam": 0})),
+						},
+					},
+				},
+			},
+			expectErrWhenWriting: "Invalid tuple 'repo:test#reader@user:elbuo (condition condX)'. Reason: found invalid context parameter: unknownparam",
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_with_condition_fails_because_undefined_condition",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condundefined", nil),
+						},
+					},
+				},
+			},
+			expectErrWhenWriting: "Invalid tuple 'repo:test#reader@user:elbuo (condition condundefined)'. Reason: undefined condition",
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_fails_because_contextual_tuple_is_not_directly_assignable",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
+						},
+					},
+				},
+			},
+			expectErrWhenWriting: "Invalid tuple 'repo:test#can_read@user:elbuo'. Reason: type 'user' is not an allowed type restriction for 'repo#can_read'",
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_fails_because_invalid_relation_in_contextual_tuple",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKey("repo:test", "invalidrelation", "user:elbuo"),
+						},
+					},
+				},
+			},
+			expectErrWhenWriting: "Invalid tuple 'repo:test#invalidrelation@user:elbuo'. Reason: relation 'repo#invalidrelation' not found",
+		},
+		{
+			_name:        "writing_assertion_with_contextual_tuple_fails_because_invalid_type_in_contextual_tuple",
+			inputModelID: modelID,
+			assertions: []*openfgav1.Assertion{
+				{
+					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
+					Expectation: false,
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							tuple.NewTupleKey("unknown:test", "reader", "user:elbuo"),
+						},
+					},
+				},
+			},
+			expectErrWhenWriting: "Invalid tuple 'unknown:test#reader@user:elbuo'. Reason: type 'unknown' not found",
+		},
+		{
+			_name:        "writing_assertion_with_invalid_relation_fails",
+			inputModelID: modelID,
 			assertions: []*openfgav1.Assertion{
 				{
 					TupleKey: tuple.NewAssertionTupleKey(
@@ -176,37 +241,44 @@ func TestWriteAssertionsFailure(t *testing.T, datastore storage.OpenFGADatastore
 					Expectation: false,
 				},
 			},
-			modelID: modelID.GetAuthorizationModelId(),
-			err: serverErrors.ValidationError(
-				fmt.Errorf("relation 'repo#invalidrelation' not found"),
-			),
+			expectErrWhenWriting: "relation 'repo#invalidrelation' not found",
 		},
 		{
-			_name: "writing_assertion_with_not_found_id",
+			_name:        "writing_assertion_with_invalid_model_id",
+			inputModelID: "not_valid_id",
 			assertions: []*openfgav1.Assertion{
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
 				},
 			},
-			modelID: "not_valid_id",
-			err: serverErrors.AuthorizationModelNotFound(
-				"not_valid_id",
-			),
+			expectErrWhenWriting: "Authorization Model 'not_valid_id' not found",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test._name, func(t *testing.T) {
-			request := &openfgav1.WriteAssertionsRequest{
+			_, err := commands.NewWriteAssertionsCommand(datastore).Execute(context.Background(), &openfgav1.WriteAssertionsRequest{
 				StoreId:              store,
 				Assertions:           test.assertions,
-				AuthorizationModelId: test.modelID,
-			}
+				AuthorizationModelId: test.inputModelID,
+			})
+			if test.expectErrWhenWriting != "" {
+				require.ErrorContains(t, err, test.expectErrWhenWriting)
+			} else {
+				require.NoError(t, err)
 
-			writeAssertionCmd := commands.NewWriteAssertionsCommand(datastore)
-			_, err = writeAssertionCmd.Execute(ctx, request)
-			require.ErrorIs(t, test.err, err)
+				actualResponse, err := commands.NewReadAssertionsQuery(datastore).Execute(context.Background(), store, test.inputModelID)
+				require.NoError(t, err)
+
+				expectedResponse := &openfgav1.ReadAssertionsResponse{
+					AuthorizationModelId: test.inputModelID,
+					Assertions:           test.assertions,
+				}
+				if diff := cmp.Diff(expectedResponse, actualResponse, protocmp.Transform()); diff != "" {
+					t.Errorf("store mismatch (-want +got):\n%s", diff)
+				}
+			}
 		})
 	}
 }

--- a/pkg/server/test/write_assertions.go
+++ b/pkg/server/test/write_assertions.go
@@ -123,10 +123,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKey("repo:test", "reader", "user:elbuo"),
 					},
 				},
 			},
@@ -138,11 +136,9 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
-								testutils.MustNewStruct(t, map[string]interface{}{"x": 0})),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
+							testutils.MustNewStruct(t, map[string]interface{}{"x": 0})),
 					},
 				},
 			},
@@ -154,11 +150,9 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
-								testutils.MustNewStruct(t, map[string]interface{}{"unknownparam": 0})),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
+							testutils.MustNewStruct(t, map[string]interface{}{"unknownparam": 0})),
 					},
 				},
 			},
@@ -171,10 +165,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condundefined", nil),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condundefined", nil),
 					},
 				},
 			},
@@ -187,10 +179,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKey("repo:test", "can_read", "user:elbuo"),
 					},
 				},
 			},
@@ -203,10 +193,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKey("repo:test", "invalidrelation", "user:elbuo"),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKey("repo:test", "invalidrelation", "user:elbuo"),
 					},
 				},
 			},
@@ -219,10 +207,8 @@ func TestWriteAndReadAssertions(t *testing.T, datastore storage.OpenFGADatastore
 				{
 					TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 					Expectation: false,
-					ContextualTuples: &openfgav1.ContextualTupleKeys{
-						TupleKeys: []*openfgav1.TupleKey{
-							tuple.NewTupleKey("unknown:test", "reader", "user:elbuo"),
-						},
+					ContextualTuples: []*openfgav1.TupleKey{
+						tuple.NewTupleKey("unknown:test", "reader", "user:elbuo"),
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Supersedes https://github.com/openfga/openfga/pull/1635. Also:

- Re-worked unit tests so that they are shorter
- Fixed validation performed on contextual tuples
- Add tests with contextual tuples that have contexts

## References

- Closes https://github.com/openfga/openfga/issues/946
- Depends on API changes https://github.com/openfga/api/pull/185
- Supersedes https://github.com/openfga/openfga/pull/1635