### PR TITLE
fix: incorrect check result with userset and ttu

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -9843,3 +9843,111 @@ tests:
               relation: viewer
             expectation:
               - user:anne
+  - name: ttu_to_userset
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type role
+            relations
+              define assignee: [user]
+          type permission
+            relations
+              define assignee: assignee from role
+              define role: [role]
+          type job
+            relations
+              define can_read: [permission#assignee]
+              define cannot_read: [user] but not can_read
+        tuples:
+          - user: user:1
+            relation: assignee
+            object: role:admin
+          - object: permission:readJobs
+            user: role:admin
+            relation: role
+          - object: job:1
+            user: permission:readJobs#assignee
+            relation: can_read
+          - object: job:1
+            user: user:1
+            relation: cannot_read
+        checkAssertions:
+          - tuple:
+              user: user:1
+              relation: cannot_read
+              object: job:1
+            expectation: false
+          - tuple:
+              user: user:1
+              relation: can_read
+              object: job:1
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:1
+              type: job
+              relation: can_read
+            expectation:
+              - job:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: job:1
+              relation: can_read
+            expectation:
+              - user:1
+  - name: userset_to_ttu
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type role
+            relations
+              define assignee: [user]
+          type permission
+            relations
+              define assignee: [role#assignee]
+          type job
+            relations
+              define can_read: assignee from permission
+              define permission: [permission]
+        tuples:
+          - user: user:1
+            relation: assignee
+            object: role:admin
+          - object: permission:readJobs
+            user: role:admin#assignee
+            relation: assignee
+          - object: job:1
+            user: permission:readJobs
+            relation: permission
+        checkAssertions:
+          - tuple:
+              user: user:1
+              relation: can_read
+              object: job:1
+            expectation: true
+          - tuple:
+              user: user:1
+              relation: assignee
+              object: permission:readJobs
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:1
+              type: job
+              relation: can_read
+            expectation:
+              - job:1
+        listUsersAssertions:
+          - request:
+              filters:
+                - user
+              object: job:1
+              relation: can_read
+            expectation:
+              - user:1

--- a/pkg/typesystem/connected_types_test.go
+++ b/pkg/typesystem/connected_types_test.go
@@ -276,6 +276,42 @@ func TestTypesystemConnectedTypesAssignment(t *testing.T) {
 				},
 			},
 		},
+		{
+			model: `
+				model
+          schema 1.1
+      
+        type user
+      
+        type role
+          relations
+            define assignee: [user]
+      
+        type permission
+          relations
+            define assignee: assignee from role
+            define role: [role]
+      
+        type job
+          relations
+            define can_read: [permission#assignee]
+			`,
+			expectedConnectedTypes: TypesystemConnectedTypes{
+				"permission": map[string]map[string][]string{
+					"assignee": {
+						"user": {"assignee"},
+					},
+					"role": {
+						"role": {"role"},
+					},
+				},
+				"role": map[string]map[string][]string{
+					"assignee": {
+						"user": {"assignee"},
+					},
+				},
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## Description
In the case where relation has both userset and TTU, check may return incorrect result.

## References
Close https://github.com/openfga/openfga/issues/1828


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
