### PR TITLE
chore: refactor TypeSystem::IsDirectlyRelated for more fine-grained testing.

### DIFF
--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -346,23 +346,21 @@ func (t *TypeSystem) UsersetCanFastPath(relationReferences []*openfgav1.Relation
 }
 
 func RelationEquals(a *openfgav1.RelationReference, b *openfgav1.RelationReference) bool {
-	if a.GetType() == b.GetType() {
-		// Type with no relation or wildcard (e.g. 'user').
-		if a.GetRelationOrWildcard() == nil && b.GetRelationOrWildcard() == nil {
-			return true
-		}
-
-		// Typed wildcard (e.g. 'user:*').
-		if a.GetWildcard() != nil && b.GetWildcard() != nil {
-			return true
-		}
-
-		if a.GetRelation() != "" && b.GetRelation() != "" &&
-			a.GetRelation() == b.GetRelation() {
-			return true
-		}
+	if a.GetType() != b.GetType() {
+		return false
 	}
-	return false
+
+	// Type with no relation or wildcard (e.g. 'user').
+	if a.GetRelationOrWildcard() == nil && b.GetRelationOrWildcard() == nil {
+		return true
+	}
+
+	// Typed wildcard (e.g. 'user:*').
+	if a.GetWildcard() != nil && b.GetWildcard() != nil {
+		return true
+	}
+
+	return a.GetRelation() != "" && b.GetRelation() != "" && a.GetRelation() == b.GetRelation()
 }
 
 // IsDirectlyRelated determines whether the type of the target DirectRelationReference contains the source DirectRelationReference.

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -345,6 +345,26 @@ func (t *TypeSystem) UsersetCanFastPath(relationReferences []*openfgav1.Relation
 	return true
 }
 
+func RelationEquals(a *openfgav1.RelationReference, b *openfgav1.RelationReference) bool {
+	if a.GetType() == b.GetType() {
+		// Type with no relation or wildcard (e.g. 'user').
+		if a.GetRelationOrWildcard() == nil && b.GetRelationOrWildcard() == nil {
+			return true
+		}
+
+		// Typed wildcard (e.g. 'user:*').
+		if a.GetWildcard() != nil && b.GetWildcard() != nil {
+			return true
+		}
+
+		if a.GetRelation() != "" && b.GetRelation() != "" &&
+			a.GetRelation() == b.GetRelation() {
+			return true
+		}
+	}
+	return false
+}
+
 // IsDirectlyRelated determines whether the type of the target DirectRelationReference contains the source DirectRelationReference.
 func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, source *openfgav1.RelationReference) (bool, error) {
 	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
@@ -353,24 +373,10 @@ func (t *TypeSystem) IsDirectlyRelated(target *openfgav1.RelationReference, sour
 	}
 
 	for _, typeRestriction := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
-		if source.GetType() == typeRestriction.GetType() {
-			// Type with no relation or wildcard (e.g. 'user').
-			if typeRestriction.GetRelationOrWildcard() == nil && source.GetRelationOrWildcard() == nil {
-				return true, nil
-			}
-
-			// Typed wildcard (e.g. 'user:*').
-			if typeRestriction.GetWildcard() != nil && source.GetWildcard() != nil {
-				return true, nil
-			}
-
-			if typeRestriction.GetRelation() != "" && source.GetRelation() != "" &&
-				typeRestriction.GetRelation() == source.GetRelation() {
-				return true, nil
-			}
+		if RelationEquals(source, typeRestriction) {
+			return true, nil
 		}
 	}
-
 	return false, nil
 }
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -172,7 +172,7 @@ func TestRelationEquals(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			require.True(t, RelationEquals(tc.a, tc.b) == tc.o)
+			require.Equal(t, tc.o, RelationEquals(tc.a, tc.b))
 		})
 	}
 }

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -17,6 +17,166 @@ type relationDetails struct {
 	hasLoop        bool
 }
 
+func TestRelationEquals(t *testing.T) {
+	tests := map[string]struct {
+		a *openfgav1.RelationReference
+		b *openfgav1.RelationReference
+		o bool
+	}{
+		"nil_and_nil": {
+			a: nil,
+			b: nil,
+			o: true,
+		},
+		"existing_and_nil": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			b: nil,
+			o: false,
+		},
+		"nil_and_existing": {
+			a: nil,
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			o: false,
+		},
+		"different_types": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "document",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			o: false,
+		},
+		"same_types_two_wildcards": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			o: true,
+		},
+		"same_types_one_wildcard_one_relation": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Wildcard{
+					Wildcard: &openfgav1.Wildcard{},
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "viewer",
+				},
+			},
+			o: false,
+		},
+		"same_types_same_relations": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "viewer",
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "viewer",
+				},
+			},
+			o: true,
+		},
+		"same_types_different_relations": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "viewer",
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "writer",
+				},
+			},
+			o: false,
+		},
+		"same_types_empty_relations": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "",
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "",
+				},
+			},
+			o: false,
+		},
+		"same_types_first_relation_empty": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "",
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "writer",
+				},
+			},
+			o: false,
+		},
+		"same_types_second_relation_empty": {
+			a: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "viewer",
+				},
+			},
+			b: &openfgav1.RelationReference{
+				Type: "user",
+				RelationOrWildcard: &openfgav1.RelationReference_Relation{
+					Relation: "",
+				},
+			},
+			o: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.True(t, RelationEquals(tc.a, tc.b) == tc.o)
+		})
+	}
+}
+
 func TestHasEntrypoints(t *testing.T) {
 	tests := map[string]struct {
 		model         string


### PR DESCRIPTION
This PR exists to showcase an example of refactoring to increase test comprehensiveness.

## Description
`TypeSystem::IsDirectlyRelated` is refactored by pulling out the function `RelationEquals`. By doing so, it is easier to more comprehensively test the logic for comparing two `RelationReference` instances.
