### PR TITLE
fix: set consistency when calling ResolveCheck from TrackerCheckResolver

### DIFF
--- a/internal/graph/track_check_resolver.go
+++ b/internal/graph/track_check_resolver.go
@@ -204,16 +204,7 @@ func (t *TrackerCheckResolver) ResolveCheck(
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(attribute.Bool("track_execution", true))
 
-	resp, err := t.delegate.ResolveCheck(ctx, &ResolveCheckRequest{
-		StoreID:              req.GetStoreID(),
-		AuthorizationModelID: req.GetAuthorizationModelID(),
-		TupleKey:             req.GetTupleKey(),
-		ContextualTuples:     req.GetContextualTuples(),
-		RequestMetadata:      req.GetRequestMetadata(),
-		VisitedPaths:         req.VisitedPaths,
-		Context:              req.GetContext(),
-		Consistency:          req.GetConsistency(),
-	})
+	resp, err := t.delegate.ResolveCheck(ctx, req)
 
 	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		t.addPathHits(req)

--- a/internal/graph/track_check_resolver.go
+++ b/internal/graph/track_check_resolver.go
@@ -212,6 +212,7 @@ func (t *TrackerCheckResolver) ResolveCheck(
 		RequestMetadata:      req.GetRequestMetadata(),
 		VisitedPaths:         req.VisitedPaths,
 		Context:              req.GetContext(),
+		Consistency:          req.GetConsistency(),
 	})
 
 	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {


### PR DESCRIPTION
## Description

The consistency parameter is getting dropped when enabling the TrackerCheckResolver, add it to the `ResolveCheckRequest` being constructed so that it's passed through and can be used.

I'm not sure whether we can potentially move to something similar to `CloneResolveCheckResponse` so that we only need to update once place to ensure that properties get carried across?

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
