### PR TITLE
chore: standardize text of 'missing context' error in ListUsers

### DIFF
--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -477,7 +477,9 @@ LoopOnIterator:
 		if len(condEvalResult.MissingParameters) > 0 {
 			err := condition.NewEvaluationError(
 				tupleKey.GetCondition().GetName(),
-				fmt.Errorf("context is missing parameters '%v'", condEvalResult.MissingParameters),
+				fmt.Errorf("tuple '%s' is missing context parameters '%v'",
+					tuple.TupleKeyToString(tupleKey),
+					condEvalResult.MissingParameters),
 			)
 			telemetry.TraceError(span, err)
 			errs = errors.Join(errs, err)
@@ -904,7 +906,9 @@ LoopOnIterator:
 		if len(condEvalResult.MissingParameters) > 0 {
 			err := condition.NewEvaluationError(
 				tupleKey.GetCondition().GetName(),
-				fmt.Errorf("context is missing parameters '%v'", condEvalResult.MissingParameters),
+				fmt.Errorf("tuple '%s' is missing context parameters '%v'",
+					tuple.TupleKeyToString(tupleKey),
+					condEvalResult.MissingParameters),
 			)
 			telemetry.TraceError(span, err)
 			errs = errors.Join(errs, err)

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -1060,7 +1060,7 @@ func TestListUsersConditions(t *testing.T) {
 				tuple.NewTupleKeyWithCondition("document:1", "viewer", "user:will", "isEqualToFive", nil),
 				tuple.NewTupleKeyWithCondition("document:1", "viewer", "user:maria", "isEqualToTen", nil),
 			},
-			expectedErrorMsg: "failed to evaluate relationship condition: 'isEqualToTen' - context is missing parameters '[param2]'",
+			expectedErrorMsg: "failed to evaluate relationship condition: 'isEqualToTen' - tuple 'document:1#viewer@user:maria' is missing context parameters '[param2]",
 		},
 		{
 			name: "multiple_conditions_all_params_provided",
@@ -3538,7 +3538,7 @@ func TestListUsersConfig_Deadline(t *testing.T) {
 			},
 			inputConfigDeadline: 0 * time.Millisecond, // infinite
 			inputReadDelay:      50 * time.Millisecond,
-			expectError:         "context is missing parameters '[x]'",
+			expectError:         "failed to evaluate relationship condition: 'condX' - tuple 'repo:target#admin@user:1' is missing context parameters '[x]",
 		},
 		`deadline_very_small_returns_nothing`: {
 			inputModel: `


### PR DESCRIPTION
## Description
I am making the EvaluationError emitted by ListUsers the same as the one emitted in Check and ListObjects:

https://github.com/openfga/openfga/blob/47fb83bc711008fbd3d76cfe30cf07348ba9658f/internal/graph/check.go#L852-L857

https://github.com/openfga/openfga/blob/47fb83bc711008fbd3d76cfe30cf07348ba9658f/pkg/server/commands/reverseexpand/reverse_expand.go#L537-L542

ideally we wouldn't have to craft this error by hand in every API, but... baby steps
