### PR TITLE
test: add usersets tuple_cycle2 and tuple_cycle3 tests

### DIFF
--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -997,4 +997,73 @@ var usersetCompleteTestingModelTest = []*stage{
 			},
 		},
 	},
+	{
+		Name: "usersets_tuple_cycle2",
+		Tuples: []*openfgav1.TupleKey{
+			// user exists so no cycle
+			{Object: "directs-user:utc2_1", Relation: "tuple_cycle2", User: "user:utc2_1"},
+			{Object: "ttus:utc2_1", Relation: "direct_parent", User: "directs-user:utc2_1"},
+			{Object: "usersets-user:utc2_1", Relation: "tuple_cycle2", User: "ttus:utc2_1#tuple_cycle2"},
+			{Object: "directs-user:utc2_2", Relation: "tuple_cycle2", User: "usersets-user:utc2_1#tuple_cycle2"},
+			{Object: "ttus:utc2_2", Relation: "direct_parent", User: "directs-user:utc2_2"},
+			{Object: "usersets-user:utc2_2", Relation: "tuple_cycle2", User: "ttus:utc2_1#tuple_cycle2"},
+
+			// missing user leads to a cycle
+			{Object: "directs-user:utc2_4", Relation: "tuple_cycle2", User: "usersets-user:utc2_4#tuple_cycle2"},
+			{Object: "ttus:utc2_4", Relation: "direct_parent", User: "directs-user:utc2_4"},
+			{Object: "usersets-user:utc2_4", Relation: "tuple_cycle2", User: "ttus:utc2_4#tuple_cycle2"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "valid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc2_2", Relation: "tuple_cycle2", User: "user:utc2_1"},
+				Expectation: true,
+			},
+			{
+				Name:        "cycle",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc2_4", Relation: "tuple_cycle2", User: "user:utc2_1"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc2_1", Relation: "tuple_cycle2", User: "user:utc2_3"},
+				Expectation: false,
+			},
+		},
+	},
+	{
+		Name: "usersets_tuple_cycle3",
+		Tuples: []*openfgav1.TupleKey{
+			// user exists so no cycle
+			{Object: "ttus:utc3_1", Relation: "userset_parent", User: "usersets-user:utc3_1"},
+			{Object: "complexity3:utc3_1", Relation: "cycle_nested", User: "ttus:utc3_1#tuple_cycle3"},
+			{Object: "directs-user:utc3_1", Relation: "tuple_cycle3", User: "user:utc3_1"},
+			{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "directs-user:utc3_1#compute_tuple_cycle3"},
+			{Object: "directs-user:utc3_2", Relation: "tuple_cycle3", User: "complexity3:utc3_1#cycle_nested"},
+			{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "directs-user:utc3_2#compute_tuple_cycle3"},
+
+			// missing user leads to cycle
+			{Object: "ttus:utc3_4", Relation: "userset_parent", User: "usersets-user:utc3_4"},
+			{Object: "complexity3:utc3_4", Relation: "cycle_nested", User: "ttus:utc3_4#tuple_cycle3"},
+			{Object: "directs-user:utc3_4", Relation: "tuple_cycle3", User: "complexity3:utc3_4#cycle_nested"},
+			{Object: "usersets-user:utc3_4", Relation: "tuple_cycle3", User: "directs-user:utc3_4#compute_tuple_cycle3"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "valid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "user:utc3_1"},
+				Expectation: true,
+			},
+			{
+				Name:        "cycle",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc3_4", Relation: "tuple_cycle3", User: "user:utc3_1"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc3_3", Relation: "tuple_cycle3", User: "user:utc3_2"},
+				Expectation: false,
+			},
+		},
+	},
 }

--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -1006,7 +1006,7 @@ var usersetCompleteTestingModelTest = []*stage{
 			{Object: "usersets-user:utc2_1", Relation: "tuple_cycle2", User: "ttus:utc2_1#tuple_cycle2"},
 			{Object: "directs-user:utc2_2", Relation: "tuple_cycle2", User: "usersets-user:utc2_1#tuple_cycle2"},
 			{Object: "ttus:utc2_2", Relation: "direct_parent", User: "directs-user:utc2_2"},
-			{Object: "usersets-user:utc2_2", Relation: "tuple_cycle2", User: "ttus:utc2_1#tuple_cycle2"},
+			{Object: "directs-user:utc2_1", Relation: "tuple_cycle2", User: "usersets-user:utc2_1#tuple_cycle2"},
 
 			// missing user leads to a cycle
 			{Object: "directs-user:utc2_4", Relation: "tuple_cycle2", User: "usersets-user:utc2_4#tuple_cycle2"},
@@ -1016,7 +1016,7 @@ var usersetCompleteTestingModelTest = []*stage{
 		CheckAssertions: []*checktest.Assertion{
 			{
 				Name:        "valid_user",
-				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc2_2", Relation: "tuple_cycle2", User: "user:utc2_1"},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc2_1", Relation: "tuple_cycle2", User: "user:utc2_1"},
 				Expectation: true,
 			},
 			{
@@ -1038,9 +1038,8 @@ var usersetCompleteTestingModelTest = []*stage{
 			{Object: "ttus:utc3_1", Relation: "userset_parent", User: "usersets-user:utc3_1"},
 			{Object: "complexity3:utc3_1", Relation: "cycle_nested", User: "ttus:utc3_1#tuple_cycle3"},
 			{Object: "directs-user:utc3_1", Relation: "tuple_cycle3", User: "user:utc3_1"},
+			{Object: "directs-user:utc3_1", Relation: "tuple_cycle3", User: "complexity3:utc3_1#cycle_nested"},
 			{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "directs-user:utc3_1#compute_tuple_cycle3"},
-			{Object: "directs-user:utc3_2", Relation: "tuple_cycle3", User: "complexity3:utc3_1#cycle_nested"},
-			{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "directs-user:utc3_2#compute_tuple_cycle3"},
 
 			// missing user leads to cycle
 			{Object: "ttus:utc3_4", Relation: "userset_parent", User: "usersets-user:utc3_4"},

--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -1004,8 +1004,6 @@ var usersetCompleteTestingModelTest = []*stage{
 			{Object: "directs-user:utc2_1", Relation: "tuple_cycle2", User: "user:utc2_1"},
 			{Object: "ttus:utc2_1", Relation: "direct_parent", User: "directs-user:utc2_1"},
 			{Object: "usersets-user:utc2_1", Relation: "tuple_cycle2", User: "ttus:utc2_1#tuple_cycle2"},
-			{Object: "directs-user:utc2_2", Relation: "tuple_cycle2", User: "usersets-user:utc2_1#tuple_cycle2"},
-			{Object: "ttus:utc2_2", Relation: "direct_parent", User: "directs-user:utc2_2"},
 			{Object: "directs-user:utc2_1", Relation: "tuple_cycle2", User: "usersets-user:utc2_1#tuple_cycle2"},
 
 			// missing user leads to a cycle
@@ -1060,7 +1058,7 @@ var usersetCompleteTestingModelTest = []*stage{
 			},
 			{
 				Name:        "invalid_user",
-				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc3_3", Relation: "tuple_cycle3", User: "user:utc3_2"},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:utc3_1", Relation: "tuple_cycle3", User: "user:utc3_2"},
 				Expectation: false,
 			},
 		},


### PR DESCRIPTION
## Description

Adds tests that cover the `tuple_cycle2` and `tuple_cycle3` relations in usersets, verified the cycle cases by logging in the cycle detection logic.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
