### PR TITLE
ci: add permissions block to changelog enforcement

### DIFF
--- a/.github/workflows/enforce-changelog-entry.yaml
+++ b/.github/workflows/enforce-changelog-entry.yaml
@@ -4,6 +4,9 @@ on:
     # By default labeled/unlabeled are not included in the pull_request even so we need to list out what we want
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This is flagged on the [OpenSSF scorecard](https://securityscorecards.dev/viewer/?uri=github.com/openfga/openfga) so we need to explicitly state the permissions.

## References

https://securityscorecards.dev/viewer/?uri=github.com/openfga/openfga

See [run 1](https://github.com/openfga/openfga/actions/runs/10664490408/job/29555851673?pr=1899) and [run 2](https://github.com/openfga/openfga/actions/runs/10664498537/job/29555875702?pr=1899) of the job to ensure it still works with these permissions

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
