### PR TITLE
fix: requests cancelled by client should be 4xx, not 5xx. deadlines e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 * Stack trace when logging panics [#1904](https://github.com/openfga/openfga/pull/1904)
 
+## Fixed
+
+* When a request gets cancelled by a client, throw a 4xx, not a 5xx. [#1905](https://github.com/openfga/openfga/pull/1905)
+
 ## [1.6.0] - 2024-08-30
 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.5.9...v1.6.0)

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/openfga/openfga
 
 go 1.22.6
 
+replace github.com/openfga/api/proto => /Users/maria.inesparnisari/GitHub/api/proto
+
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/MicahParks/keyfunc/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/openfga/openfga
 
 go 1.22.6
 
-replace github.com/openfga/api/proto => /Users/maria.inesparnisari/GitHub/api/proto
-
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/MicahParks/keyfunc/v2 v2.1.0
@@ -26,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.5
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9
+	github.com/openfga/api/proto v0.0.0-20240904164335-41eb32fcd5e9
 	github.com/openfga/language/pkg/go v0.2.0-beta.0
 	github.com/pressly/goose/v3 v3.21.1
 	github.com/prometheus/client_golang v1.20.2

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9 h1:Y0fIAHrYECcf5lpa/o1AbH21bS7rsco/FoH4A4NGlZE=
-github.com/openfga/api/proto v0.0.0-20240807201305-c96ec773cae9/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.2.0-beta.0 h1:dTvgDkQImfNnH1iDvxnUIbz4INvKr4kS46dI12oAEzM=
 github.com/openfga/language/pkg/go v0.2.0-beta.0/go.mod h1:mCwEY2IQvyNgfEwbfH0C0ERUwtL8z6UjSAF8zgn5Xbg=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
+github.com/openfga/api/proto v0.0.0-20240904164335-41eb32fcd5e9 h1:zY8IyzzKOlZADlMJ5MhSEbszUm0cPk0XL0AGvNL35Bk=
+github.com/openfga/api/proto v0.0.0-20240904164335-41eb32fcd5e9/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.2.0-beta.0 h1:dTvgDkQImfNnH1iDvxnUIbz4INvKr4kS46dI12oAEzM=
 github.com/openfga/language/pkg/go v0.2.0-beta.0/go.mod h1:mCwEY2IQvyNgfEwbfH0C0ERUwtL8z6UjSAF8zgn5Xbg=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/server/errors/encoded_errors.go
+++ b/pkg/server/errors/encoded_errors.go
@@ -227,7 +227,7 @@ func ConvertToEncodedErrorCode(statusError *status.Status) int32 {
 	case codes.Unauthenticated:
 		return int32(openfgav1.AuthErrorCode_unauthenticated)
 	case codes.Canceled:
-		return int32(openfgav1.InternalErrorCode_cancelled)
+		return int32(openfgav1.ErrorCode_cancelled)
 	case codes.Unknown:
 		// we will return InternalError as our implementation of
 		// InternalError does not have a status code - which will result

--- a/pkg/server/errors/encoded_errors_test.go
+++ b/pkg/server/errors/encoded_errors_test.go
@@ -156,7 +156,7 @@ func TestConvertToEncodedErrorCode(t *testing.T) {
 		{
 			_name:             "cancelled",
 			status:            status.New(codes.Canceled, "other error"),
-			expectedErrorCode: int32(openfgav1.InternalErrorCode_cancelled),
+			expectedErrorCode: int32(openfgav1.ErrorCode_cancelled),
 		},
 		{
 			_name:             "unknown",

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -2,6 +2,7 @@
 package errors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -24,8 +25,7 @@ var (
 	UnsupportedUserSet                     = status.Error(codes.Code(openfgav1.ErrorCode_unsupported_user_set), "Userset is not supported (right now)")
 	StoreIDNotFound                        = status.Error(codes.Code(openfgav1.NotFoundErrorCode_store_id_not_found), "Store ID not found")
 	MismatchObjectType                     = status.Error(codes.Code(openfgav1.ErrorCode_query_string_type_continuation_token_mismatch), "The type in the querystring and the continuation token don't match")
-	RequestCancelled                       = status.Error(codes.Code(openfgav1.InternalErrorCode_cancelled), "Request Cancelled")
-	RequestDeadlineExceeded                = status.Error(codes.Code(openfgav1.InternalErrorCode_deadline_exceeded), "Request Deadline Exceeded")
+	RequestCancelled                       = status.Error(codes.Code(openfgav1.ErrorCode_cancelled), "Request Cancelled")
 	ThrottledTimeout                       = status.Error(codes.Code(openfgav1.UnprocessableContentErrorCode_throttled_timeout_error), "timeout due to throttling on complex request")
 )
 
@@ -126,10 +126,12 @@ func HandleError(public string, err error) error {
 		return InvalidContinuationToken
 	case errors.Is(err, storage.ErrMismatchObjectType):
 		return MismatchObjectType
-	case errors.Is(err, storage.ErrCancelled):
+	case errors.Is(err, storage.ErrCancelled) || errors.Is(err, context.Canceled):
+		// cancel by a client is not an "internal server error"
 		return RequestCancelled
-	case errors.Is(err, storage.ErrDeadlineExceeded):
-		return RequestDeadlineExceeded
+	case errors.Is(err, storage.ErrDeadlineExceeded) || errors.Is(err, context.DeadlineExceeded):
+		public = "Request Deadline Exceeded"
+		fallthrough // it's an internal server error
 	default:
 		return NewInternalError(public, err)
 	}

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -64,17 +64,9 @@ func TestHandleErrors(t *testing.T) {
 			storageErr:              storage.ErrMismatchObjectType,
 			expectedTranslatedError: MismatchObjectType,
 		},
-		`context_cancelled`: {
-			storageErr:              storage.ErrCancelled,
-			expectedTranslatedError: RequestCancelled,
-		},
 		`context_cancelled_2`: {
 			storageErr:              context.Canceled,
 			expectedTranslatedError: RequestCancelled,
-		},
-		`context_deadline_exceeded`: {
-			storageErr:              storage.ErrDeadlineExceeded,
-			expectedTranslatedError: storage.ErrDeadlineExceeded,
 		},
 		`context_deadline_exceeded_2`: {
 			storageErr:              context.DeadlineExceeded,

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -1,6 +1,7 @@
 package errors
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -50,7 +51,7 @@ func TestInternalError(t *testing.T) {
 	})
 }
 
-func TestHandleStorageErrors(t *testing.T) {
+func TestHandleErrors(t *testing.T) {
 	tests := map[string]struct {
 		storageErr              error
 		expectedTranslatedError error
@@ -67,9 +68,17 @@ func TestHandleStorageErrors(t *testing.T) {
 			storageErr:              storage.ErrCancelled,
 			expectedTranslatedError: RequestCancelled,
 		},
-		`context_deadline_exceeeded`: {
+		`context_cancelled_2`: {
+			storageErr:              context.Canceled,
+			expectedTranslatedError: RequestCancelled,
+		},
+		`context_deadline_exceeded`: {
 			storageErr:              storage.ErrDeadlineExceeded,
-			expectedTranslatedError: RequestDeadlineExceeded,
+			expectedTranslatedError: storage.ErrDeadlineExceeded,
+		},
+		`context_deadline_exceeded_2`: {
+			storageErr:              context.DeadlineExceeded,
+			expectedTranslatedError: context.DeadlineExceeded,
 		},
 		`invalid_write_input`: {
 			storageErr:              storage.ErrInvalidWriteInput,

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -64,13 +64,13 @@ func TestHandleErrors(t *testing.T) {
 			storageErr:              storage.ErrMismatchObjectType,
 			expectedTranslatedError: MismatchObjectType,
 		},
-		`context_cancelled_2`: {
+		`context_cancelled`: {
 			storageErr:              context.Canceled,
 			expectedTranslatedError: RequestCancelled,
 		},
-		`context_deadline_exceeded_2`: {
+		`context_deadline_exceeded`: {
 			storageErr:              context.DeadlineExceeded,
-			expectedTranslatedError: context.DeadlineExceeded,
+			expectedTranslatedError: RequestDeadlineExceeded,
 		},
 		`invalid_write_input`: {
 			storageErr:              storage.ErrInvalidWriteInput,

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -30,12 +30,6 @@ var (
 	// ErrExceededWriteBatchLimit is returned when MaxTuplesPerWrite is exceeded.
 	ErrExceededWriteBatchLimit = errors.New("number of operations exceeded write batch limit")
 
-	// ErrCancelled is returned when the request has been cancelled.
-	ErrCancelled = errors.New("request has been cancelled")
-
-	// ErrDeadlineExceeded is returned when the request's deadline is exceeded.
-	ErrDeadlineExceeded = errors.New("request deadline exceeded")
-
 	// ErrNotFound is returned when the object does not exist.
 	ErrNotFound = errors.New("not found")
 )


### PR DESCRIPTION
…xceeded should be 5xx

## Description
I'm working on fixing the HTTP status codes returned to users.

- `context.Canceled` should be HTTP 499.
- `context.DeadlineExceeded` should be HTTP 500.

## References
needs https://github.com/openfga/api/pull/192