### PR TITLE
feat: add stats on number of allowed response in check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## Added
 
 * Stack trace when logging panics [#1904](https://github.com/openfga/openfga/pull/1904)
+* Statistics on number of allowed vs. non-allowed check [#1911](https://github.com/openfga/openfga/pull/1911)
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## Added
 
 * Stack trace when logging panics [#1904](https://github.com/openfga/openfga/pull/1904)
-* Statistics on number of allowed vs. non-allowed check [#1911](https://github.com/openfga/openfga/pull/1911)
+* New metric on number of allowed vs. non-allowed Check responses [#1911](https://github.com/openfga/openfga/pull/1911)
 
 ## Fixed
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -52,6 +52,7 @@ type ExperimentalFeatureFlag string
 const (
 	AuthorizationModelIDHeader = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey    = "authorization_model_id"
+	allowedLabel               = "allowed"
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -92,6 +93,13 @@ var (
 		NativeHistogramMaxBucketNumber:  100,
 		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"grpc_service", "grpc_method", "datastore_query_count", "dispatch_count", "consistency"})
+
+	checkResultCounterName = "check_result_count"
+	checkResultCounter     = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      checkResultCounterName,
+		Help:      "The total number of check requests by response result",
+	}, []string{allowedLabel})
 )
 
 // A Server implements the OpenFGA service backend as both
@@ -1023,6 +1031,8 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	res := &openfgav1.CheckResponse{
 		Allowed: resp.Allowed,
 	}
+
+	checkResultCounter.With(prometheus.Labels{allowedLabel: strconv.FormatBool(resp.GetAllowed())}).Inc()
 
 	span.SetAttributes(attribute.KeyValue{Key: "allowed", Value: attribute.BoolValue(res.GetAllowed())})
 


### PR DESCRIPTION
## Description
Adding stats on number of allowed vs. non-allowed response in check.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
