### PR TITLE
refactor: remove unused `emptyTupleIterator

### DIFF
--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -40,31 +40,6 @@ type TupleIterator = Iterator[*openfgav1.Tuple]
 // returns an [ErrIteratorDone] error.
 type TupleKeyIterator = Iterator[*openfgav1.TupleKey]
 
-type emptyTupleIterator struct{}
-
-var _ TupleIterator = (*emptyTupleIterator)(nil)
-
-// Next see [Iterator.Next].
-func (e *emptyTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
-	return nil, ErrIteratorDone
-}
-
-// Stop see [Iterator.Stop].
-func (e *emptyTupleIterator) Stop() {}
-
-// Head see [Iterator.Head].
-func (e *emptyTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
-	return nil, ErrIteratorDone
-}
-
 type combinedIterator[T any] struct {
 	iters []Iterator[T]
 }

--- a/pkg/storage/iterators_test.go
+++ b/pkg/storage/iterators_test.go
@@ -21,56 +21,6 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
-func TestEmptyIterator(t *testing.T) {
-	t.Run("next", func(t *testing.T) {
-		iter := emptyTupleIterator{}
-		defer iter.Stop()
-
-		tk, err := iter.Next(context.Background())
-		require.ErrorIs(t, err, ErrIteratorDone)
-		require.Nil(t, tk)
-	})
-	t.Run("head", func(t *testing.T) {
-		iter := emptyTupleIterator{}
-		defer iter.Stop()
-
-		tk, err := iter.Head(context.Background())
-		require.ErrorIs(t, err, ErrIteratorDone)
-		require.Nil(t, tk)
-	})
-	t.Run("cancelled", func(t *testing.T) {
-		tests := []struct {
-			name  string
-			mixed bool
-		}{
-			{
-				name:  "next_only",
-				mixed: false,
-			},
-			{
-				name:  "mixed",
-				mixed: true,
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				iter := emptyTupleIterator{}
-				defer iter.Stop()
-				ctx, cancel := context.WithCancel(context.Background())
-
-				cancel()
-				var err error
-				if tt.mixed {
-					_, err = iter.Next(ctx)
-				} else {
-					_, err = iter.Head(ctx)
-				}
-				require.ErrorIs(t, err, context.Canceled)
-			})
-		}
-	})
-}
-
 func TestStaticTupleKeyIterator(t *testing.T) {
 	t.Run("next", func(t *testing.T) {
 		expected := []*openfgav1.TupleKey{


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This pull request removes the unused `emptyTupleIterator` struct from `iterators.go` and the associated test case `TestEmptyIterator` from `iterators_test.go`. The struct was not being used and can be safely removed.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

fixes #1823

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have updated tests to validate that the change in functionality is working as expected
