### PR TITLE
refactor: removed unused WithMaxConcurrentReads function code

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -41,7 +41,6 @@ type checkOutcome struct {
 type LocalChecker struct {
 	delegate           CheckResolver
 	concurrencyLimit   uint32
-	maxConcurrentReads uint32
 	usersetBatchSize   uint32
 	logger             logger.Logger
 }
@@ -76,7 +75,6 @@ func WithLocalCheckerLogger(logger logger.Logger) LocalCheckerOption {
 func NewLocalChecker(opts ...LocalCheckerOption) *LocalChecker {
 	checker := &LocalChecker{
 		concurrencyLimit:   serverconfig.DefaultResolveNodeBreadthLimit,
-		maxConcurrentReads: serverconfig.DefaultMaxConcurrentReadsForCheck,
 		usersetBatchSize:   serverconfig.DefaultUsersetBatchSize,
 		logger:             logger.NewNoopLogger(),
 	}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -62,13 +62,6 @@ func WithUsersetBatchSize(usersetBatchSize uint32) LocalCheckerOption {
 	}
 }
 
-// WithMaxConcurrentReads see server.WithMaxConcurrentReadsForCheck.
-func WithMaxConcurrentReads(limit uint32) LocalCheckerOption {
-	return func(d *LocalChecker) {
-		d.maxConcurrentReads = limit
-	}
-}
-
 func WithLocalCheckerLogger(logger logger.Logger) LocalCheckerOption {
 	return func(d *LocalChecker) {
 		d.logger = logger


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Removed unused WithMaxConcurrentReads function in openfga/internal/graph/check.go file. This is already set here: [openfga/pkg/server/server.go](https://github.com/openfga/openfga/blob/d07302bbb8cbbb095bcc3d887692d79974009e26/pkg/server/server.go#L985-L993)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Issue Resolved: #1920 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
