### PR TITLE
Extend request timeout to 10s for slow tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 * When a request gets cancelled by a client, throw a 4xx, not a 5xx. [#1905](https://github.com/openfga/openfga/pull/1905)
 * Makes the `pkg.logger.Logger.With` immutable by creating a child logger instead of mutating the delegate one to prevent side effects [1906](https://github.com/openfga/openfga/pull/1906)
+* Extend request timeout to 10s for slow tests [1926](https://github.com/openfga/openfga/pull/1926)
 
 ## Performance
 

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -52,6 +53,8 @@ func testRunTestMatrix(t *testing.T, engine string, experimental bool) {
 		cfg.Datastore.Engine = engine
 		cfg.ListUsersDeadline = 0   // no deadline
 		cfg.ListObjectsDeadline = 0 // no deadline
+		// extend the timeout for the tests, coverage makes them slower
+		cfg.RequestTimeout = 10 * time.Second
 
 		tests.StartServer(t, cfg)
 
@@ -330,6 +333,8 @@ func testRunAll(t *testing.T, engine string) {
 	cfg := config.MustDefaultConfig()
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine
+	// extend the timeout for the tests, coverage makes them slower
+	cfg.RequestTimeout = 10 * time.Second
 
 	tests.StartServer(t, cfg)
 
@@ -400,6 +405,8 @@ func setupBenchmarkTest(b *testing.B, engine string) (openfgav1.OpenFGAServiceCl
 	cfg := config.MustDefaultConfig()
 	cfg.Log.Level = "none"
 	cfg.Datastore.Engine = engine
+	// extend the timeout for the tests, coverage makes them slower
+	cfg.RequestTimeout = 10 * time.Second
 
 	tests.StartServer(b, cfg)
 

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -35,6 +35,7 @@ func testRunAll(t *testing.T, engine string) {
 	cfg := config.MustDefaultConfig()
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine
+	cfg.ListObjectsDeadline = 0 // no deadline
 	// extend the timeout for the tests, coverage makes them slower
 	cfg.RequestTimeout = 10 * time.Second
 

--- a/tests/listobjects/listobjects_test.go
+++ b/tests/listobjects/listobjects_test.go
@@ -2,6 +2,7 @@ package listobjects
 
 import (
 	"testing"
+	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.uber.org/goleak"
@@ -34,6 +35,8 @@ func testRunAll(t *testing.T, engine string) {
 	cfg := config.MustDefaultConfig()
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine
+	// extend the timeout for the tests, coverage makes them slower
+	cfg.RequestTimeout = 10 * time.Second
 
 	tests.StartServer(t, cfg)
 


### PR DESCRIPTION
This PR extends the RequestTimeout to 10s for some of the tests. We run tests with code coverage enabled which can make them take longer than the default 3s timeout.

This appears to impact SQLite more than it does Postgres or MySQL, which may be due to the fact that the entirety of SQLite is pure go running in-process, vs just the client for the other databases.