### PR TITLE
chore: add trace for consumeUsersets and produceUsersets

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -847,6 +847,9 @@ func (c *LocalChecker) checkMembership(ctx context.Context, req *ResolveCheckReq
 }
 
 func (c *LocalChecker) consumeUsersets(ctx context.Context, req *ResolveCheckRequest, usersetsChan chan usersetsChannelType) (*ResolveCheckResponse, error) {
+	ctx, span := tracer.Start(ctx, "consumeUsersets")
+	defer span.End()
+
 	var finalErr error
 	dbReads := req.GetRequestMetadata().DatastoreQueryCount
 
@@ -898,6 +901,9 @@ ConsumerLoop:
 }
 
 func (c *LocalChecker) produceUsersets(ctx context.Context, usersetsChan chan usersetsChannelType, iter *storage.ConditionsFilteredTupleKeyIterator, usersetDetails checkutil.UsersetDetailsFunc) {
+	ctx, span := tracer.Start(ctx, "produceUsersets")
+	defer span.End()
+
 	usersetsMap := make(usersetsMapType)
 	defer close(usersetsChan)
 	for {


### PR DESCRIPTION
## Description
Allow better association of ds store query with the correpsonding check
![Screenshot 2024-09-16 at 2 54 05 PM](https://github.com/user-attachments/assets/3538d8ee-8e01-4e99-a926-8aef1129dcfb)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
