### PR TITLE
fix: add check for oidc set as authn method

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -634,7 +634,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		server.WithListUsersDispatchThrottlingThreshold(config.ListUsersDispatchThrottling.Threshold),
 		server.WithListUsersDispatchThrottlingMaxThreshold(config.ListUsersDispatchThrottling.MaxThreshold),
 		server.WithExperimentals(experimentals...),
-		server.WithAccessControlParams(config.AccessControl),
+		server.WithAccessControlParams(config.AccessControl, config.Authn.Method),
 		server.WithContext(ctx),
 		server.WithCheckTrackerEnabled(config.CheckTrackerEnabled),
 	)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -140,6 +140,7 @@ type Server struct {
 	maxAuthorizationModelSizeInBytes int
 	experimentals                    []ExperimentalFeatureFlag
 	AccessControl                    serverconfig.AccessControlConfig
+	AuthnMethod                      string
 	serviceName                      string
 
 	// NOTE don't use this directly, use function resolveTypesystem. See https://github.com/openfga/openfga/issues/1527
@@ -364,9 +365,10 @@ func WithExperimentals(experimentals ...ExperimentalFeatureFlag) OpenFGAServiceV
 }
 
 // WithAccessControlParams sets enabled, the storeID, and modelID for the access control feature.
-func WithAccessControlParams(accessControl serverconfig.AccessControlConfig) OpenFGAServiceV1Option {
+func WithAccessControlParams(accessControl serverconfig.AccessControlConfig, authnMethod string) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.AccessControl = accessControl
+		s.AuthnMethod = authnMethod
 	}
 }
 
@@ -1530,6 +1532,9 @@ func (s *Server) validateAccessControlEnabled() error {
 	if s.IsAccessControlEnabled() {
 		if (s.AccessControl == serverconfig.AccessControlConfig{} || s.AccessControl.StoreID == "" || s.AccessControl.ModelID == "") {
 			return fmt.Errorf("access control parameters are not enabled. They can be enabled for experimental use by passing the `--experimentals enable-access-control` configuration option when running OpenFGA server. Additionally, the `--access-control-store-id` and `--access-control-model-id` parameters must not be empty")
+		}
+		if s.AuthnMethod != "oidc" {
+			return fmt.Errorf("access control is enabled, but the authentication method is not OIDC. Access control is only supported with OIDC authentication")
 		}
 		_, err := ulid.Parse(s.AccessControl.StoreID)
 		if err != nil {


### PR DESCRIPTION
Access Control requires OIDC to be set as Authn method.

## Description
Add a check to see whether OIDC was set as Authn method, throw error if it is not set but access control is enabled.

## References
(https://github.com/openfga/openfga/pull/1913)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
