### PR TITLE
Switch to local HandleSQLError function for SQLite

### DIFF
--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -403,13 +403,6 @@ func HandleSQLError(err error, args ...interface{}) error {
 			}
 		}
 		return storage.ErrCollision
-	} else if strings.Contains(err.Error(), "UNIQUE constraint failed:") { // Sqlite.
-		if len(args) > 0 {
-			if tk, ok := args[0].(*openfgav1.TupleKey); ok {
-				return storage.InvalidWriteInputError(tk, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)
-			}
-		}
-		return storage.ErrCollision
 	}
 
 	return fmt.Errorf("sql error: %w", err)


### PR DESCRIPTION
This PR allows us to remove the special handling for SQLite from sqlcommon by switching to a local implementation that just handles the SQLite errors.

This also removes `dbInfo` from SQLite since it is never used.

This approach won't work for MySQL or Postgres today since they do rely on the sqlcommon functions, but it may be possible to pass a handler in via dbInfo for those cases, or return the raw errors from sqlcommon and move the error translation out into the storage implementations.