### PR TITLE
feat: create noop authorizer that meets the interface of Authorizer

### DIFF
--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -78,6 +78,33 @@ type Config struct {
 	ModelID string
 }
 
+type AuthorizerInterface interface {
+	Authorize(ctx context.Context, storeID, apiMethod string) error
+	AuthorizeCreateStore(ctx context.Context) error
+}
+
+type NoopAuthorizer struct {
+	config *Config
+	server ServerInterface
+	logger logger.Logger
+}
+
+func NewAuthorizerNoop(config *Config, server ServerInterface, logger logger.Logger) *NoopAuthorizer {
+	return &NoopAuthorizer{
+		config: config,
+		server: server,
+		logger: logger,
+	}
+}
+
+func (a *NoopAuthorizer) Authorize(ctx context.Context, storeID, apiMethod string) error {
+	return nil
+}
+
+func (a *NoopAuthorizer) AuthorizeCreateStore(ctx context.Context) error {
+	return nil
+}
+
 type Authorizer struct {
 	config *Config
 	server ServerInterface


### PR DESCRIPTION
Add Noop Authorizer so that we don't have to check if authorizer is set.

## Description
NoopAuthorizer and Authorizer meet the spec of AuthorizerInterface, allowing for either to be set on initial load.

## References
https://github.com/openfga/openfga/pull/1914#discussion_r1761865960
https://github.com/openfga/openfga/pull/1913

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
