### PR TITLE
test: update to run matrix tests for all datastore

### DIFF
--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1368,6 +1368,6 @@ func assertListUsers(ctx context.Context, t *testing.T, assertion *checktest.Ass
 	}
 }
 
-func runTestMatrixSuite(t *testing.T, client ClientInterface) {
+func RunTestMatrixSuite(t *testing.T, client ClientInterface) {
 	runTestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 }

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -38,13 +37,8 @@ var tuples = []*openfgav1.TupleKey{
 	tuple.NewTupleKey("team:openfga", "member", "user:github|iaco@openfga"),
 }
 
-func TestMatrixMemory(t *testing.T) {
-	testRunTestMatrix(t, "memory", false)
-	testRunTestMatrix(t, "memory", true)
-}
-
-func testRunTestMatrix(t *testing.T, engine string, experimental bool) {
-	t.Run("test_matrix_experimental_"+strconv.FormatBool(experimental), func(t *testing.T) {
+func testRunTestMatrix(t *testing.T, engine string) {
+	t.Run("test_matrix_"+engine, func(t *testing.T) {
 		t.Cleanup(func() {
 			goleak.VerifyNone(t)
 		})
@@ -60,7 +54,7 @@ func testRunTestMatrix(t *testing.T, engine string, experimental bool) {
 
 		conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
 
-		runTestMatrixSuite(t, openfgav1.NewOpenFGAServiceClient(conn))
+		RunTestMatrixSuite(t, openfgav1.NewOpenFGAServiceClient(conn))
 	})
 }
 
@@ -68,16 +62,32 @@ func TestCheckMemory(t *testing.T) {
 	testRunAll(t, "memory")
 }
 
+func TestMatrixMemory(t *testing.T) {
+	testRunTestMatrix(t, "memory")
+}
+
 func TestCheckPostgres(t *testing.T) {
 	testRunAll(t, "postgres")
+}
+
+func TestMatrixPostgres(t *testing.T) {
+	testRunTestMatrix(t, "postgres")
 }
 
 func TestCheckMySQL(t *testing.T) {
 	testRunAll(t, "mysql")
 }
 
+func TestMatrixMySQL(t *testing.T) {
+	testRunTestMatrix(t, "mysql")
+}
+
 func TestCheckSQLite(t *testing.T) {
 	testRunAll(t, "sqlite")
+}
+
+func TestMatrixSQLite(t *testing.T) {
+	testRunTestMatrix(t, "sqlite")
 }
 
 // TODO move elsewhere as this isn't asserting on just Check API logs.


### PR DESCRIPTION

## Description
Currently the matrix tests are only run for in-memory store.  We want to have it run for all stores. 

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
