### PR TITLE
feat: minor improvements in tracing of Check API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+### Added
+
+* Improve tracing in Check API by enhancing discoverability of model ID. [#1964](https://github.com/openfga/openfga/pull/1964)
+
 ### Removed
 
 * Removed deprecated opentelemetry-connector `memory_ballast` extension.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 
 * Improve tracing in Check API by enhancing discoverability of model ID. [#1964](https://github.com/openfga/openfga/pull/1964)
+* Improve tracing in all APIs by adding the store ID to the span. [#1965](https://github.com/openfga/openfga/pull/1965)
 
 ### Removed
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -453,6 +453,17 @@ func (c *LocalChecker) ResolveCheck(
 	))
 	defer span.End()
 
+	typesys, ok := typesystem.TypesystemFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
+	}
+	span.SetAttributes(attribute.String("authorization_model_id", typesys.GetAuthorizationModelID()))
+
+	_, ok = storage.RelationshipTupleReaderFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: relationship tuple reader datastore missing in context", openfgaErrors.ErrUnknown)
+	}
+
 	if req.GetRequestMetadata().Depth == 0 {
 		return nil, ErrResolutionDepthExceeded
 	}
@@ -482,15 +493,6 @@ func (c *LocalChecker) ResolveCheck(
 				DatastoreQueryCount: req.GetRequestMetadata().DatastoreQueryCount,
 			},
 		}, nil
-	}
-
-	typesys, ok := typesystem.TypesystemFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
-	}
-	_, ok = storage.RelationshipTupleReaderFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("%w: relationship tuple reader datastore missing in context", openfgaErrors.ErrUnknown)
 	}
 
 	objectType, _ := tuple.SplitObject(object)

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -453,17 +453,6 @@ func (c *LocalChecker) ResolveCheck(
 	))
 	defer span.End()
 
-	typesys, ok := typesystem.TypesystemFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
-	}
-	span.SetAttributes(attribute.String("authorization_model_id", typesys.GetAuthorizationModelID()))
-
-	_, ok = storage.RelationshipTupleReaderFromContext(ctx)
-	if !ok {
-		return nil, fmt.Errorf("%w: relationship tuple reader datastore missing in context", openfgaErrors.ErrUnknown)
-	}
-
 	if req.GetRequestMetadata().Depth == 0 {
 		return nil, ErrResolutionDepthExceeded
 	}
@@ -493,6 +482,15 @@ func (c *LocalChecker) ResolveCheck(
 				DatastoreQueryCount: req.GetRequestMetadata().DatastoreQueryCount,
 			},
 		}, nil
+	}
+
+	typesys, ok := typesystem.TypesystemFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
+	}
+	_, ok = storage.RelationshipTupleReaderFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: relationship tuple reader datastore missing in context", openfgaErrors.ErrUnknown)
 	}
 
 	objectType, _ := tuple.SplitObject(object)

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -176,7 +176,9 @@ func (l *listUsersQuery) ListUsers(
 	ctx context.Context,
 	req *openfgav1.ListUsersRequest,
 ) (*listUsersResponse, error) {
-	ctx, span := tracer.Start(ctx, "ListUsers")
+	ctx, span := tracer.Start(ctx, "ListUsers", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	cancellableCtx, cancelCtx := context.WithCancel(ctx)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1390,7 +1390,6 @@ func (s *Server) resolveTypesystem(ctx context.Context, storeID, modelID string)
 
 	resolvedModelID := typesys.GetAuthorizationModelID()
 
-	span.SetAttributes(attribute.KeyValue{Key: authorizationModelIDKey, Value: attribute.StringValue(resolvedModelID)})
 	grpc_ctxtags.Extract(ctx).Set(authorizationModelIDKey, resolvedModelID)
 	s.transport.SetHeader(ctx, AuthorizationModelIDHeader, resolvedModelID)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1366,9 +1366,6 @@ func (s *Server) IsReady(ctx context.Context) (bool, error) {
 // resolveTypesystem resolves the underlying TypeSystem given the storeID and modelID and
 // it sets some response metadata based on the model resolution.
 func (s *Server) resolveTypesystem(ctx context.Context, storeID, modelID string) (*typesystem.TypeSystem, error) {
-	ctx, span := tracer.Start(ctx, "resolveTypesystem")
-	defer span.End()
-
 	typesys, err := s.typesystemResolver(ctx, storeID, modelID)
 	if err != nil {
 		if errors.Is(err, typesystem.ErrModelNotFound) {
@@ -1384,7 +1381,6 @@ func (s *Server) resolveTypesystem(ctx context.Context, storeID, modelID string)
 		}
 
 		err = serverErrors.HandleError("", err)
-		telemetry.TraceError(span, err)
 		return nil, err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -653,6 +653,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	targetObjectType := req.GetType()
 
 	ctx, span := tracer.Start(ctx, "ListObjects", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
 		attribute.String("object_type", targetObjectType),
 		attribute.String("relation", req.GetRelation()),
 		attribute.String("user", req.GetUser()),
@@ -762,6 +763,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 
 	ctx := srv.Context()
 	ctx, span := tracer.Start(ctx, "StreamedListObjects", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
 		attribute.String("object_type", req.GetType()),
 		attribute.String("relation", req.GetRelation()),
 		attribute.String("user", req.GetUser()),
@@ -857,6 +859,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
 	tk := req.GetTupleKey()
 	ctx, span := tracer.Start(ctx, "Read", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},
 		attribute.KeyValue{Key: "user", Value: attribute.StringValue(tk.GetUser())},
@@ -889,7 +892,9 @@ func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfga
 }
 
 func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openfgav1.WriteResponse, error) {
-	ctx, span := tracer.Start(ctx, "Write")
+	ctx, span := tracer.Start(ctx, "Write", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1057,6 +1062,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*openfgav1.ExpandResponse, error) {
 	tk := req.GetTupleKey()
 	ctx, span := tracer.Start(ctx, "Expand", trace.WithAttributes(
+		attribute.KeyValue{Key: "store_id", Value: attribute.StringValue(req.GetStoreId())},
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},
 		attribute.KeyValue{Key: "consistency", Value: attribute.StringValue(req.GetConsistency().String())},
@@ -1092,6 +1098,7 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 
 func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.ReadAuthorizationModelRequest) (*openfgav1.ReadAuthorizationModelResponse, error) {
 	ctx, span := tracer.Start(ctx, "ReadAuthorizationModel", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: authorizationModelIDKey, Value: attribute.StringValue(req.GetId())},
 	))
 	defer span.End()
@@ -1112,7 +1119,9 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.Read
 }
 
 func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.WriteAuthorizationModelRequest) (*openfgav1.WriteAuthorizationModelResponse, error) {
-	ctx, span := tracer.Start(ctx, "WriteAuthorizationModel")
+	ctx, span := tracer.Start(ctx, "WriteAuthorizationModel", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1141,7 +1150,9 @@ func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.Wri
 }
 
 func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgav1.ReadAuthorizationModelsRequest) (*openfgav1.ReadAuthorizationModelsResponse, error) {
-	ctx, span := tracer.Start(ctx, "ReadAuthorizationModels")
+	ctx, span := tracer.Start(ctx, "ReadAuthorizationModels", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1163,7 +1174,9 @@ func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgav1.Rea
 }
 
 func (s *Server) WriteAssertions(ctx context.Context, req *openfgav1.WriteAssertionsRequest) (*openfgav1.WriteAssertionsResponse, error) {
-	ctx, span := tracer.Start(ctx, "WriteAssertions")
+	ctx, span := tracer.Start(ctx, "WriteAssertions", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1200,7 +1213,9 @@ func (s *Server) WriteAssertions(ctx context.Context, req *openfgav1.WriteAssert
 }
 
 func (s *Server) ReadAssertions(ctx context.Context, req *openfgav1.ReadAssertionsRequest) (*openfgav1.ReadAssertionsResponse, error) {
-	ctx, span := tracer.Start(ctx, "ReadAssertions")
+	ctx, span := tracer.Start(ctx, "ReadAssertions", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1225,6 +1240,7 @@ func (s *Server) ReadAssertions(ctx context.Context, req *openfgav1.ReadAssertio
 
 func (s *Server) ReadChanges(ctx context.Context, req *openfgav1.ReadChangesRequest) (*openfgav1.ReadChangesResponse, error) {
 	ctx, span := tracer.Start(ctx, "ReadChangesQuery", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: "type", Value: attribute.StringValue(req.GetType())},
 	))
 	defer span.End()
@@ -1275,7 +1291,9 @@ func (s *Server) CreateStore(ctx context.Context, req *openfgav1.CreateStoreRequ
 }
 
 func (s *Server) DeleteStore(ctx context.Context, req *openfgav1.DeleteStoreRequest) (*openfgav1.DeleteStoreResponse, error) {
-	ctx, span := tracer.Start(ctx, "DeleteStore")
+	ctx, span := tracer.Start(ctx, "DeleteStore", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -1301,7 +1319,9 @@ func (s *Server) DeleteStore(ctx context.Context, req *openfgav1.DeleteStoreRequ
 }
 
 func (s *Server) GetStore(ctx context.Context, req *openfgav1.GetStoreRequest) (*openfgav1.GetStoreResponse, error) {
-	ctx, span := tracer.Start(ctx, "GetStore")
+	ctx, span := tracer.Start(ctx, "GetStore", trace.WithAttributes(
+		attribute.String("store_id", req.GetStoreId()),
+	))
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1380,6 +1380,8 @@ func (s *Server) resolveTypesystem(ctx context.Context, storeID, modelID string)
 			return nil, serverErrors.ValidationError(err)
 		}
 
+		parentSpan := trace.SpanFromContext(ctx)
+		telemetry.TraceError(parentSpan, err)
 		err = serverErrors.HandleError("", err)
 		return nil, err
 	}

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -40,7 +40,10 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		ctx, span := tracer.Start(ctx, "MemoizedTypesystemResolverFunc", trace.WithAttributes(
 			attribute.String("store_id", storeID),
 		))
-		defer span.End()
+		defer func() {
+			span.SetAttributes(attribute.String("authorization_model_id", modelID))
+			span.End()
+		}()
 
 		var err error
 
@@ -67,8 +70,6 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 			model = v.(*openfgav1.AuthorizationModel)
 			modelID = model.GetId()
 		}
-
-		span.SetAttributes(attribute.String("authorization_model_id", modelID))
 
 		key = fmt.Sprintf("%s/%s", storeID, modelID)
 		item := cache.Get(key)

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -39,13 +39,13 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 	return func(ctx context.Context, storeID, modelID string) (*TypeSystem, error) {
 		ctx, span := tracer.Start(ctx, "MemoizedTypesystemResolverFunc", trace.WithAttributes(
 			attribute.String("store_id", storeID),
-			attribute.String("authorization_model_id", modelID),
 		))
 		defer span.End()
 
 		var err error
 
 		if modelID != "" {
+
 			if _, err := ulid.Parse(modelID); err != nil {
 				return nil, ErrModelNotFound
 			}
@@ -68,6 +68,8 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 			model = v.(*openfgav1.AuthorizationModel)
 			modelID = model.GetId()
 		}
+
+		span.SetAttributes(attribute.String("authorization_model_id", modelID))
 
 		key = fmt.Sprintf("%s/%s", storeID, modelID)
 		item := cache.Get(key)

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -37,7 +37,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 	cache := storage.NewInMemoryLRUCache[*TypeSystem]()
 
 	return func(ctx context.Context, storeID, modelID string) (*TypeSystem, error) {
-		ctx, span := tracer.Start(ctx, "MemoizedTypesystemResolverFunc", trace.WithAttributes(
+		ctx, span := tracer.Start(ctx, "resolveTypesystem", trace.WithAttributes(
 			attribute.String("store_id", storeID),
 		))
 		defer func() {

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -45,7 +45,6 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		var err error
 
 		if modelID != "" {
-
 			if _, err := ulid.Parse(modelID); err != nil {
 				return nil, ErrModelNotFound
 			}


### PR DESCRIPTION
## Description
When trying to find patterns in Check requests via tracing information, i want to be able to find all top-level "Check" spans and gather all the information from there, and not have to manually dig into children spans.

I'm also improving attribute information for the model ID resolution which is a bit hard to find right now.

## Testing

`docker-compose up --build`

After this PR:

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/8103695c-73fd-4f13-9954-f218bff3e3a6">
