### PR TITLE
chore: run matrix memory tests once

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -39,12 +38,11 @@ var tuples = []*openfgav1.TupleKey{
 }
 
 func TestMatrixMemory(t *testing.T) {
-	testRunTestMatrix(t, "memory", false)
-	testRunTestMatrix(t, "memory", true)
+	testRunTestMatrix(t, "memory")
 }
 
-func testRunTestMatrix(t *testing.T, engine string, experimental bool) {
-	t.Run("test_matrix_experimental_"+strconv.FormatBool(experimental), func(t *testing.T) {
+func testRunTestMatrix(t *testing.T, engine string) {
+	t.Run("test_matrix_"+engine, func(t *testing.T) {
 		t.Cleanup(func() {
 			goleak.VerifyNone(t)
 		})


### PR DESCRIPTION
## Description

Experimental flags related to this were already removed so no need to run the same tests twice

## References

https://github.com/openfga/openfga/pull/1895

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
