### PR TITLE
fix: close cache once

### DIFF
--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -1,0 +1,34 @@
+package storage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestInMemoryCache(t *testing.T) {
+	cache := NewInMemoryLRUCache[string]()
+	defer cache.Stop()
+
+	t.Run("set_and_get", func(t *testing.T) {
+		t.Cleanup(func() {
+			goleak.VerifyNone(t)
+		})
+		defer cache.Stop()
+		cache.Set("key", "value", 1*time.Second)
+		result := cache.Get("key")
+		require.Equal(t, "value", result.Value)
+		require.False(t, result.Expired)
+	})
+
+	t.Run("stop_multiple_times", func(t *testing.T) {
+		t.Cleanup(func() {
+			goleak.VerifyNone(t)
+		})
+
+		cache.Stop()
+		cache.Stop()
+	})
+}


### PR DESCRIPTION
## Description

Previous to this calling `.Close()` more than once would result in a goroutine leak.

## References

Previously identified and fixed in https://github.com/openfga/openfga/pull/1924

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
