### PR TITLE
test: testing the return of func constructAuthorizationModelFromSQLRows

### DIFF
--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -317,8 +317,8 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 	res, err := ds.ReadAuthorizationModel(ctx, store, modelID)
 	require.NoError(t, err)
 	// AuthorizationModel should return only 1 type which is of type "document"
-	require.Equal(t, 1, len(res.TypeDefinitions))
-	require.Equal(t, "document", res.TypeDefinitions[0].Type)
+	require.Len(t, res.GetTypeDefinitions(), 1)
+	require.Equal(t, "document", res.GetTypeDefinitions()[0].Type)
 }
 func TestFindLatestModel(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -318,7 +318,7 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 	require.NoError(t, err)
 	// AuthorizationModel should return only 1 type which is of type "document"
 	require.Len(t, res.GetTypeDefinitions(), 1)
-	require.Equal(t, "document", res.GetTypeDefinitions()[0].Type)
+	require.Equal(t, "document", res.GetTypeDefinitions()[0].GetType())
 }
 
 func TestFindLatestModel(t *testing.T) {

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -293,6 +293,32 @@ func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
 	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }
 
+func TestReadAuthorizationModelReturnValue(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	defer ds.Close()
+	store := "store"
+	modelID := "foo"
+	schemaVersion := typesystem.SchemaVersion1_0
+
+	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+
+	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?)", store, modelID, schemaVersion, "document", bytes, nil)
+
+	require.NoError(t, err)
+
+	res, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+	require.NoError(t, err)
+	// AuthorizationModel should return only 1 type which is of type "document"
+	require.Equal(t, 1, len(res.TypeDefinitions))
+	require.Equal(t, "document", res.TypeDefinitions[0].Type)
+}
 func TestFindLatestModel(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -320,6 +320,7 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 	require.Len(t, res.GetTypeDefinitions(), 1)
 	require.Equal(t, "document", res.GetTypeDefinitions()[0].Type)
 }
+
 func TestFindLatestModel(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
 

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -317,7 +317,7 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 	require.NoError(t, err)
 	// AuthorizationModel should return only 1 type which is of type "document"
 	require.Len(t, res.GetTypeDefinitions(), 1)
-	require.Equal(t, "document", res.GetTypeDefinitions()[0].Type)
+	require.Equal(t, "document", res.GetTypeDefinitions()[0].GetType())
 }
 
 func TestFindLatestModel(t *testing.T) {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -316,8 +316,8 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 
 	require.NoError(t, err)
 	// AuthorizationModel should return only 1 type which is of type "document"
-	require.Equal(t, 1, len(res.TypeDefinitions))
-	require.Equal(t, "document", res.TypeDefinitions[0].Type)
+	require.Len(t, res.GetTypeDefinitions(), 1)
+	require.Equal(t, "document", res.GetTypeDefinitions()[0].Type)
 }
 
 func TestFindLatestModel(t *testing.T) {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -291,6 +291,34 @@ func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
 	require.Contains(t, err.Error(), "cannot parse invalid wire-format data")
 }
 
+func TestReadAuthorizationModelReturnValue(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	defer ds.Close()
+	store := "store"
+	modelID := "foo"
+	schemaVersion := typesystem.SchemaVersion1_0
+
+	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+	require.NoError(t, err)
+
+	_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, nil)
+
+	require.NoError(t, err)
+
+	res, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+
+	require.NoError(t, err)
+	// AuthorizationModel should return only 1 type which is of type "document"
+	require.Equal(t, 1, len(res.TypeDefinitions))
+	require.Equal(t, "document", res.TypeDefinitions[0].Type)
+}
+
 func TestFindLatestModel(t *testing.T) {
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 


### PR DESCRIPTION
## Description
Added tests to check the return value of function constructAuthorizationModelFromSQLRows

## References
Issue #1952

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
