### PR TITLE
fix: faster tuple validation when reading from datastore

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -999,7 +999,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 
 			// filter out invalid tuples yielded by the database query
 			tupleKey := t.GetKey()
-			err = validation.ValidateTuple(typesys, tupleKey)
+			err = validation.ValidateTupleForRead(typesys, tupleKey)
 			if err != nil {
 				return response, nil
 			}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -31,7 +31,7 @@ func ValidateUserObjectRelation(typesys *typesystem.TypeSystem, tk *openfgav1.Tu
 
 // ValidateTupleForWrite returns nil if a tuple is well formed and valid according to the provided model.
 // It is a superset of ValidateUserObjectRelation and ValidateTupleForRead;
-// ONLY meant to be used in Write and contextual tuples (since these mimic being written in the datastore)
+// ONLY meant to be used in Write and contextual tuples (since these mimic being written in the datastore).
 func ValidateTupleForWrite(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) error {
 	if err := ValidateUserObjectRelation(typesys, tk); err != nil {
 		return &tuple.InvalidTupleError{Cause: err, TupleKey: tk}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-func TestValidateTuple(t *testing.T) {
+func TestValidateTupleForWrite(t *testing.T) {
 	tests := []struct {
 		name          string
 		tuple         *openfgav1.TupleKey
@@ -756,7 +756,7 @@ func TestValidateTuple(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ts, err := typesystem.New(test.model)
 			require.NoError(t, err)
-			err = ValidateTuple(ts, test.tuple)
+			err = ValidateTupleForWrite(ts, test.tuple)
 			if test.expectedError != nil {
 				require.ErrorIs(t, err, test.expectedError)
 				require.Equal(t, err.Error(), test.expectedError.Error())
@@ -765,7 +765,348 @@ func TestValidateTuple(t *testing.T) {
 	}
 }
 
-func BenchmarkValidateTuple(b *testing.B) {
+func TestValidateTupleForRead(t *testing.T) {
+	tests := []struct {
+		name          string
+		tuple         *openfgav1.TupleKey
+		model         *openfgav1.AuthorizationModel
+		expectedError error
+	}{
+		{
+			name:  "untyped_wildcard_(1.0_model)",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "typed_wildcard_with_undefined_object_type",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "employee:*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("the typed wildcard 'employee:*' is not an allowed type restriction for 'document#viewer'"),
+				TupleKey: tuple.NewTupleKey("document:1", "viewer", "employee:*"),
+			},
+		},
+		{
+			name:  "typed_wildcard_with_valid_object_type_in_1.1_model",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+										typesystem.WildcardRelationReference("user"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "incorrect_user_object_reference_in_tupleset_relation",
+			tuple: tuple.NewTupleKey("document:1", "parent", "someuser"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.TupleToUserset("parent", "viewer"),
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("unexpected user 'someuser' with tupleset relation 'document#parent'"),
+				TupleKey: tuple.NewTupleKey("document:1", "parent", "someuser"),
+			},
+		},
+		{
+			name:  "untyped_wildcard_value_in_tupleset_relation",
+			tuple: tuple.NewTupleKey("document:1", "parent", "*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.TupleToUserset("parent", "viewer"),
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("unexpected wildcard relationship with tupleset relation 'document#parent'"),
+				TupleKey: tuple.NewTupleKey("document:1", "parent", "*"),
+			},
+		},
+		{
+			name:  "userset_user_value_in_tupleset_relation",
+			tuple: tuple.NewTupleKey("document:1", "ancestor", "folder:1#parent"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "folder",
+						Relations: map[string]*openfgav1.Userset{
+							"parent": typesystem.This(),
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"ancestor": typesystem.This(),
+							"viewer":   typesystem.TupleToUserset("ancestor", "viewer"),
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("unexpected user 'folder:1#parent' with tupleset relation 'document#ancestor'"),
+				TupleKey: tuple.NewTupleKey("document:1", "ancestor", "folder:1#parent"),
+			},
+		},
+		{
+			name:  "typed_wildcard_value_in_tupleset_relation_(1.1_models)",
+			tuple: tuple.NewTupleKey("document:1", "parent", "folder:*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "folder",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"parent": typesystem.This(),
+							"viewer": typesystem.TupleToUserset("parent", "viewer"),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"parent": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "folder"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("unexpected wildcard relationship with tupleset relation 'document#parent'"),
+				TupleKey: tuple.NewTupleKey("document:1", "parent", "folder:*"),
+			},
+		},
+		{
+			name:  "tupleset_relation_involving_rewrite_returns_error",
+			tuple: tuple.NewTupleKey("document:1", "parent", "folder:1"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_0,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "folder",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"parent": typesystem.ComputedUserset("editor"),
+							"editor": typesystem.This(),
+							"viewer": typesystem.TupleToUserset("parent", "viewer"),
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("unexpected rewrite encountered with tupleset relation 'document#parent'"),
+				TupleKey: tuple.NewTupleKey("document:1", "parent", "folder:1"),
+			},
+		},
+		{
+			name:  "typed_wildcard_without_allowed_type_restriction",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("the typed wildcard 'user:*' is not an allowed type restriction for 'document#viewer'"),
+				TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			},
+		},
+		{
+			name:  "relation_reference_without_allowed_type_restriction",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "group",
+						Relations: map[string]*openfgav1.Userset{
+							"member": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"member": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										{Type: "user"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("'group#member' is not an allowed type restriction for 'document#viewer'"),
+				TupleKey: tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			},
+		},
+		{
+			name:  "type_without_allowed_type_restriction",
+			tuple: tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+			model: &openfgav1.AuthorizationModel{
+				SchemaVersion: typesystem.SchemaVersion1_1,
+				TypeDefinitions: []*openfgav1.TypeDefinition{
+					{
+						Type: "user",
+					},
+					{
+						Type: "document",
+						Relations: map[string]*openfgav1.Userset{
+							"viewer": typesystem.This(),
+						},
+						Metadata: &openfgav1.Metadata{
+							Relations: map[string]*openfgav1.RelationMetadata{
+								"viewer": {
+									DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+										typesystem.WildcardRelationReference("user"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedError: &tuple.InvalidTupleError{
+				Cause:    fmt.Errorf("type 'user' is not an allowed type restriction for 'document#viewer'"),
+				TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:jon"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts, err := typesystem.New(test.model)
+			require.NoError(t, err)
+			err = ValidateTupleForRead(ts, test.tuple)
+			if test.expectedError != nil {
+				require.ErrorIs(t, err, test.expectedError)
+				require.Equal(t, err.Error(), test.expectedError.Error())
+			}
+		})
+	}
+}
+
+func BenchmarkValidateTupleForWrite(b *testing.B) {
 	model := &openfgav1.AuthorizationModel{
 		SchemaVersion: typesystem.SchemaVersion1_1,
 		TypeDefinitions: []*openfgav1.TypeDefinition{
@@ -810,7 +1151,57 @@ func BenchmarkValidateTuple(b *testing.B) {
 	require.NoError(b, err)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := ValidateTuple(ts, tuple.NewTupleKey("folder:x", "viewer", fmt.Sprintf("user:%v", i)))
+		err := ValidateTupleForWrite(ts, tuple.NewTupleKey("folder:x", "viewer", fmt.Sprintf("user:%v", i)))
+		require.NoError(b, err)
+	}
+}
+
+func BenchmarkValidateTupleForRead(b *testing.B) {
+	model := &openfgav1.AuthorizationModel{
+		SchemaVersion: typesystem.SchemaVersion1_1,
+		TypeDefinitions: []*openfgav1.TypeDefinition{
+			{
+				Type: "user",
+			},
+			{
+				Type: "folder",
+				Relations: map[string]*openfgav1.Userset{
+					"viewer": typesystem.This(),
+				},
+				Metadata: &openfgav1.Metadata{
+					Relations: map[string]*openfgav1.RelationMetadata{
+						"viewer": {
+							DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+								{Type: "user"},
+							},
+						},
+					},
+				},
+			},
+			{
+				Type: "document",
+				Relations: map[string]*openfgav1.Userset{
+					"parent": typesystem.This(),
+					"viewer": typesystem.TupleToUserset("parent", "viewer"),
+				},
+				Metadata: &openfgav1.Metadata{
+					Relations: map[string]*openfgav1.RelationMetadata{
+						"parent": {
+							DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+								{Type: "folder"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ts, err := typesystem.New(model)
+	require.NoError(b, err)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := ValidateTupleForRead(ts, tuple.NewTupleKey("folder:x", "viewer", fmt.Sprintf("user:%v", i)))
 		require.NoError(b, err)
 	}
 }

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -113,7 +113,7 @@ func validateCheckRequest(ctx context.Context, req *openfgav1.CheckRequest, type
 
 	// But contextual tuples need to be validated more strictly, the same as an input to a Write Tuple request.
 	for _, ctxTuple := range req.GetContextualTuples().GetTupleKeys() {
-		if err := validation.ValidateTuple(typesys, ctxTuple); err != nil {
+		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
 			return serverErrors.HandleTupleValidateError(err)
 		}
 	}

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -220,7 +220,7 @@ func (q *ListObjectsQuery) evaluate(
 	}
 
 	for _, ctxTuple := range req.GetContextualTuples().GetTupleKeys() {
-		if err := validation.ValidateTuple(typesys, ctxTuple); err != nil {
+		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
 			return serverErrors.HandleTupleValidateError(err)
 		}
 	}

--- a/pkg/server/commands/listusers/validate.go
+++ b/pkg/server/commands/listusers/validate.go
@@ -28,7 +28,7 @@ func ValidateListUsersRequest(ctx context.Context, req *openfgav1.ListUsersReque
 
 func validateContextualTuples(request *openfgav1.ListUsersRequest, typeSystem *typesystem.TypeSystem) error {
 	for _, contextualTuple := range request.GetContextualTuples() {
-		if err := validation.ValidateTuple(typeSystem, contextualTuple); err != nil {
+		if err := validation.ValidateTupleForWrite(typeSystem, contextualTuple); err != nil {
 			return serverErrors.HandleTupleValidateError(err)
 		}
 	}

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -426,7 +426,7 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					// NOTE this tuple is invalid
-					{Key: tuple.NewTupleKey("group:eng#member", "member", "group:fga#member")},
+					{Key: tuple.NewTupleKey("group:eng", "member", "fail:fga#member")},
 				}), nil
 			}),
 	},

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -103,7 +103,7 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgav1.
 		}
 
 		for _, tk := range writes {
-			err := validation.ValidateTuple(typesys, tk)
+			err := validation.ValidateTupleForWrite(typesys, tk)
 			if err != nil {
 				return serverErrors.ValidationError(err)
 			}

--- a/pkg/server/commands/write_assertions.go
+++ b/pkg/server/commands/write_assertions.go
@@ -88,7 +88,7 @@ func (w *WriteAssertionsCommand) Execute(ctx context.Context, req *openfgav1.Wri
 
 		for _, ct := range assertion.GetContextualTuples() {
 			// but contextual tuples need to be validated the same as an input to a Write Tuple request
-			if err = validation.ValidateTuple(typesys, ct); err != nil {
+			if err = validation.ValidateTupleForWrite(typesys, ct); err != nil {
 				return nil, serverErrors.ValidationError(err)
 			}
 		}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -315,14 +315,8 @@ func IsWildcard(s string) bool {
 // IsTypedWildcard returns true if the string 's' is a typed wildcard. A typed wildcard
 // has the form 'type:*'.
 func IsTypedWildcard(s string) bool {
-	if IsValidObject(s) {
-		_, id := SplitObject(s)
-		if id == Wildcard {
-			return true
-		}
-	}
-
-	return false
+	t, id := SplitObject(s)
+	return t != "" && id == Wildcard
 }
 
 // TypedPublicWildcard returns the string tuple representation for a given object type (ex: "user:*").


### PR DESCRIPTION
Validations when reading from the datastore do not have to be the same ones as when we write to the datastore. Thus paying the penalty on each tuple read, is unnecessary. 

Additionally, some validations where being done explicitly and then implicitly under more complex types again, this PR aims to reduce the duplication also to improve overall validation.


Before:
```
BenchmarkValidateTuple
BenchmarkValidateTuple-16    	 1000000	      1167 ns/op
```
After:
```
BenchmarkValidateTupleForWrite
BenchmarkValidateTupleForWrite-16    	 1201627	       986.8 ns/op
BenchmarkValidateTupleForRead
BenchmarkValidateTupleForRead-16    	 3549020	       331.4 ns/op
```

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
