### PR TITLE
fix: amend #1980

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 * Handle all permutations of SQLite busy / locked errors [#1936](https://github.com/openfga/openfga/pull/1936)
 * Goroutine leak in Check API introduced in v1.6.1 [#1962](https://github.com/openfga/openfga/pull/1962)
-* Broken migration from v.1.4.3 to v1.5.4 (https://github.com/openfga/openfga/issues/1668) [1980](https://github.com/openfga/openfga/issues/1980)
+* Broken migration from v.1.4.3 to v1.5.4 (https://github.com/openfga/openfga/issues/1668) [1980](https://github.com/openfga/openfga/issues/1980) and [1986](https://github.com/openfga/openfga/issues/1986)
 
 ## [1.6.1] - 2024-09-12
 

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -9,9 +9,10 @@ import (
 	mysqldriver "github.com/go-sql-driver/mysql"
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	parser "github.com/openfga/language/pkg/go/transformer"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/openfga/openfga/pkg/testutils"
 
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
@@ -303,24 +304,43 @@ func TestFindLatestModel(t *testing.T) {
 
 	ctx := context.Background()
 	store := ulid.Make().String()
-	modelID := ulid.Make().String()
+
 	schemaVersion := typesystem.SchemaVersion1_1
 
-	t.Run("works_when_model_is_one_row", func(t *testing.T) {
-		model := parser.MustTransformDSLToProto(`
+	t.Run("works_when_first_model_is_one_row_and_second_model_is_split", func(t *testing.T) {
+		model := testutils.MustTransformDSLToProtoWithID(`
 			model
 				schema 1.1
-			type user1
-			type user2`)
+			type user1`)
 		err := ds.WriteAuthorizationModel(ctx, store, model)
 		require.NoError(t, err)
 
 		latestModel, err := ds.FindLatestAuthorizationModel(ctx, store)
 		require.NoError(t, err)
+		require.Len(t, latestModel.GetTypeDefinitions(), 1)
+
+		modelID := ulid.Make().String()
+		// write type "document"
+		bytesDocumentType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
+		require.NoError(t, err)
+		_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?)",
+			store, modelID, schemaVersion, "document", bytesDocumentType, nil)
+		require.NoError(t, err)
+
+		// write type "user"
+		bytesUserType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "user"})
+		require.NoError(t, err)
+		_, err = ds.db.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES (?, ?, ?, ?, ?, ?)",
+			store, modelID, schemaVersion, "user", bytesUserType, nil)
+		require.NoError(t, err)
+
+		latestModel, err = ds.FindLatestAuthorizationModel(ctx, store)
+		require.NoError(t, err)
 		require.Len(t, latestModel.GetTypeDefinitions(), 2)
 	})
 
-	t.Run("works_when_model_is_split_in_rows", func(t *testing.T) {
+	t.Run("works_when_first_model_is_split_and_second_model_is_one_row", func(t *testing.T) {
+		modelID := ulid.Make().String()
 		// write type "document"
 		bytesDocumentType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
 		require.NoError(t, err)
@@ -338,6 +358,17 @@ func TestFindLatestModel(t *testing.T) {
 		latestModel, err := ds.FindLatestAuthorizationModel(ctx, store)
 		require.NoError(t, err)
 		require.Len(t, latestModel.GetTypeDefinitions(), 2)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+			model
+				schema 1.1
+			type user1`)
+		err = ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err)
+
+		latestModel, err = ds.FindLatestAuthorizationModel(ctx, store)
+		require.NoError(t, err)
+		require.Len(t, latestModel.GetTypeDefinitions(), 1)
 	})
 }
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -558,6 +558,8 @@ func WriteAuthorizationModel(
 	return nil
 }
 
+// constructAuthorizationModelFromSQLRows tries first to read and return a model that was written in one row (the new format).
+// If it can't find one, it will then look for a model that was written across multiple rows (the old format).
 func constructAuthorizationModelFromSQLRows(rows *sql.Rows) (*openfgav1.AuthorizationModel, error) {
 	var modelID string
 	var schemaVersion string
@@ -571,8 +573,8 @@ func constructAuthorizationModelFromSQLRows(rows *sql.Rows) (*openfgav1.Authoriz
 			return nil, err
 		}
 
-		// Prefer building an authorization model from the first row that has it available.
 		if len(marshalledModel) > 0 {
+			// Prefer building an authorization model from the first row that has it available.
 			var model openfgav1.AuthorizationModel
 			if err := proto.Unmarshal(marshalledModel, &model); err != nil {
 				return nil, err


### PR DESCRIPTION
## Description
I introduced a regression in https://github.com/openfga/openfga/commit/540b94c56a5c74113930854ea4a690bc998f0054 wherein if the latest auth model written is split across rows (it should never happen in real life because this is the old format), FindLatestModel doesn't return the right data.

I detected this regression by looking at [code coverage](https://app.codecov.io/gh/openfga/openfga/blob/main/pkg%2Fstorage%2Fsqlcommon%2Fsqlcommon.go) when I was reviewing https://github.com/openfga/openfga/pull/1983. I thought: "why didn't I make coverage better when I merged https://github.com/openfga/openfga/commit/540b94c56a5c74113930854ea4a690bc998f0054 if I wrote a test specifically for that?"
