### PR TITLE
[1935] - health checks added for grpc logs

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -579,6 +579,12 @@
             "type": "duration",
             "default": "3s",
             "x-env-variable": "OPENFGA_REQUEST_TIMEOUT"
+        },
+        "silentHealthChecks": {
+            "description": "Enables or disables the OpenFGA Silent Checks logs.",
+            "type": "boolean",
+            "default": false,
+            "x-env-variable": "OPENFGA_SILENT_HEALTHCHECK"
         }
     },
     "definitions": {

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -258,5 +258,8 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 
 		util.MustBindPFlag("requestTimeout", flags.Lookup("request-timeout"))
 		util.MustBindEnv("requestTimeout", "OPENFGA_REQUEST_TIMEOUT")
+
+		util.MustBindPFlag("silentHealthChecks", flags.Lookup("silent-healthchecks"))
+		util.MustBindEnv("silentHealthChecks", "OPENFGA_SILENT_HEALTHCHECK")
 	}
 }

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -260,6 +260,7 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Duration("request-timeout", defaultConfig.RequestTimeout, "configures request timeout.  If both HTTP upstream timeout and request timeout are specified, request timeout will be used.")
 
+	flags.Bool("silent-healthchecks", defaultConfig.SilentHealthChecks, "Suppress logs for health checks")
 	// NOTE: if you add a new flag here, update the function below, too
 
 	cmd.PreRun = bindRunFlagsFunc(flags)

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1245,6 +1245,10 @@ func TestDefaultConfig(t *testing.T) {
 	val = res.Get("properties.requestTimeout.default")
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.String(), cfg.RequestTimeout.String())
+
+	val = res.Get("properties.silentHealthChecks.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.Bool(), cfg.SilentHealthChecks)
 }
 
 func TestRunCommandNoConfigDefaultValues(t *testing.T) {
@@ -1331,6 +1335,7 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 	t.Setenv("OPENFGA_DISPATCH_THROTTLING_THRESHOLD", "120")
 	t.Setenv("OPENFGA_DISPATCH_THROTTLING_MAX_THRESHOLD", "130")
 	t.Setenv("OPENFGA_MAX_CONDITION_EVALUATION_COST", "120")
+	t.Setenv("OPENFGA_SILENT_HEALTHCHECKS", "true")
 
 	runCmd := NewRunCommand()
 	runCmd.RunE = func(cmd *cobra.Command, _ []string) error {
@@ -1348,6 +1353,7 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 		require.Equal(t, "130", viper.GetString("dispatch-throttling-max-threshold"))
 		require.Equal(t, "120", viper.GetString("max-condition-evaluation-cost"))
 		require.Equal(t, uint64(120), viper.GetUint64("max-condition-evaluation-cost"))
+		require.True(t, viper.GetBool("silent-healthchecks"))
 
 		return nil
 	}

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -58,6 +58,8 @@ const (
 
 	DefaultRequestTimeout     = 3 * time.Second
 	additionalUpstreamTimeout = 3 * time.Second
+
+	DefaultSilentHealthChecks = false
 )
 
 type DatastoreMetricsConfig struct {
@@ -276,6 +278,8 @@ type Config struct {
 	// request timeout will be prioritized
 	RequestTimeout time.Duration
 
+	SilentHealthChecks bool
+
 	Datastore                     DatastoreConfig
 	GRPC                          GRPCConfig
 	HTTP                          HTTPConfig
@@ -435,6 +439,10 @@ func (cfg *Config) Verify() error {
 
 	if cfg.MaxConditionEvaluationCost < 100 {
 		return errors.New("maxConditionsEvaluationCosts less than 100 can cause API compatibility problems with Conditions")
+	}
+
+	if cfg.SilentHealthChecks {
+		return errors.New("'silentHealthChecks' must be of type: boolean")
 	}
 
 	return nil
@@ -619,7 +627,8 @@ func DefaultConfig() *Config {
 			Threshold:    DefaultListUsersDispatchThrottlingDefaultThreshold,
 			MaxThreshold: DefaultListUsersDispatchThrottlingMaxThreshold,
 		},
-		RequestTimeout: DefaultRequestTimeout,
+		RequestTimeout:     DefaultRequestTimeout,
+		SilentHealthChecks: DefaultSilentHealthChecks,
 	}
 }
 

--- a/pkg/server/health/health.go
+++ b/pkg/server/health/health.go
@@ -18,7 +18,8 @@ type TargetService interface {
 type Checker struct {
 	healthv1pb.UnimplementedHealthServer
 	TargetService
-	TargetServiceName string
+	TargetServiceName  string
+	SilentHealthChecks bool
 }
 
 var _ grpcauth.ServiceAuthFuncOverride = (*Checker)(nil)
@@ -29,6 +30,9 @@ func (o *Checker) AuthFuncOverride(ctx context.Context, fullMethodName string) (
 }
 
 func (o *Checker) Check(ctx context.Context, req *healthv1pb.HealthCheckRequest) (*healthv1pb.HealthCheckResponse, error) {
+	if o.SilentHealthChecks {
+		return &healthv1pb.HealthCheckResponse{Status: healthv1pb.HealthCheckResponse_SERVING}, nil
+	}
 	requestedService := req.GetService()
 	if requestedService == "" || requestedService == o.TargetServiceName {
 		ready, err := o.TargetService.IsReady(ctx)


### PR DESCRIPTION
Description
This PR introduces a new feature to suppress health check logs, addressing the issue of noisy logs in production environments, especially in Kubernetes deployments with frequent health probes.

Changes
Added a new --silent-healthchecks flag
Implemented silent health checks in the health checker for grpc logs
Updated configuration and logging to support the new feature
Added tests for the new functionality

Usage
To enable silent health checks, use:

CLI flag:

--silent-healthchecks
Or, set in configuration:

silent-healthchecks: true
Or, via environment variable:

OPENFGA_SILENT_HEALTHCHECKS=true
This feature allows users to maintain detailed logging for their application while preventing health check requests.

References
fixes https://github.com/openfga/openfga/issues/1935

Review Checklist
[x] ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
[]I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev (https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
[x] The correct base branch is being used, if not main
[x] I have added tests to validate that the change in functionality is working as expected