### PR TITLE
fix: remove flakeyness from TestCheckWithCachedIterator

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2211,7 +2211,7 @@ func TestCheckWithCachedIterator(t *testing.T) {
 
 	mockDatastore.EXPECT().
 		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-		Times(2).
+		AnyTimes().
 		Return(userTuple, nil)
 
 	mockDatastore.EXPECT().
@@ -2242,7 +2242,7 @@ func TestCheckWithCachedIterator(t *testing.T) {
 	require.True(t, checkResponse.GetAllowed())
 
 	// Sleep for a while to ensure that the iterator is cached
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
 
 	// If we check for the same request, data should come from cached iterator and number of ReadUsersetTuples should still be 1
 	checkResponse, err = s.Check(ctx, &openfgav1.CheckRequest{


### PR DESCRIPTION
## Description

Previous to this change this test would fail sometimes

```
 go test -v -race -count 1000 -run '^TestCheckWithCachedIterator$' pkg/server/*.go
```

would usually fail like this:

```
=== RUN   TestCheckWithCachedIterator
 --- FAIL: TestCheckWithCachedIterator (0.01s)
    controller.go:243: missing call(s) to *mocks.MockOpenFGADatastore.ReadUsersetTuples(is anything, is equal to 01J9D47GKMG11MCH8VGP2T26ZS (string), is anything, is anything) /home/runner/work/openfga/openfga/pkg/server/server_test.go:2218
    controller.go:243: aborting test due to missing call(s)
```

With this small change, I have not yet seen the flake.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://github.com/openfga/openfga/pull/1924

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
