### PR TITLE
perf: do not need to handle direct assignment for nested userset

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -5433,26 +5433,6 @@ func TestMatchUsersetFromUserAndUsersetFromObject(t *testing.T) {
 				expectedError:                fmt.Errorf("mock_error"),
 			},
 			{
-				name: "direct_assignment",
-				userToUsersetMessages: []usersetMessage{
-					{
-						userset: "group:1",
-						err:     nil,
-					},
-				},
-				objectToUsersetMessages: []usersetMessage{},
-				expectedResolveCheckResponse: &ResolveCheckResponse{
-					Allowed: true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						DatastoreQueryCount: 2,
-						CycleDetected:       false,
-					},
-				},
-				expectedUserToUserset:   nil,
-				expectedObjectToUserset: nil,
-				expectedError:           nil,
-			},
-			{
 				name: "items_not_match",
 				userToUsersetMessages: []usersetMessage{
 					{
@@ -5608,27 +5588,6 @@ func TestNestedUsersetFastpath(t *testing.T) {
 				},
 			},
 			{
-				name: "user_directly_assigned_to_main_group",
-				readStartingWithUserTuples: []*openfgav1.Tuple{
-					{
-						Key: tuple.NewTupleKey("group:1", "member", "user:maria"),
-					},
-					{
-						Key: tuple.NewTupleKey("group:2", "member", "user:maria"),
-					},
-				},
-				readUsersetTuples: [][]*openfgav1.Tuple{
-					{},
-				},
-				expected: &ResolveCheckResponse{
-					Allowed: true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						DatastoreQueryCount: 2,
-						CycleDetected:       false,
-					},
-				},
-			},
-			{
 				name: "user_assigned_to_first_level_sub_group",
 				readStartingWithUserTuples: []*openfgav1.Tuple{
 					{
@@ -5714,6 +5673,11 @@ func TestNestedUsersetFastpath(t *testing.T) {
 				readStartingWithUserTuples:      []*openfgav1.Tuple{},
 				readStartingWithUserTuplesError: fmt.Errorf("mock error"),
 				readUsersetTuples: [][]*openfgav1.Tuple{
+					{
+						{
+							Key: tuple.NewTupleKey("group:1", "member", "group:2#member"),
+						},
+					},
 					{},
 				},
 				expected:      nil,


### PR DESCRIPTION

## Description
Unit test for BenchmarkCheckWithTTUs failed due to request taking too long.
Optimize performance by not handling direct assignment for nested userset + not request iter that is not used.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
