### PR TITLE
perf: nested TTUs in Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 * Cache Controller to extend Sub-problems and Iterators lifetime in cache [#2006](https://github.com/openfga/openfga/pull/2006)
 * Add access control experimental feature [#1913](https://github.com/openfga/openfga/pull/1913)
 
+## Changed
+Improve check performance in the case that the query involves resolving nested tuple to userset relations. Enable via experimental flag `enable-check-optimizations`. [#2025](https://github.com/openfga/openfga/pull/2025)
+
 ### Fixed
 * Label ListUsers API calls [#2000](https://github.com/openfga/openfga/pull/2000)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 * Cache Controller to extend Sub-problems and Iterators lifetime in cache [#2006](https://github.com/openfga/openfga/pull/2006)
 * Add access control experimental feature [#1913](https://github.com/openfga/openfga/pull/1913)
 
-## Changed
-Improve check performance in the case that the query involves resolving nested tuple to userset relations. Enable via experimental flag `enable-check-optimizations`. [#2025](https://github.com/openfga/openfga/pull/2025)
+### Performance
+* Improve check performance in the case that the query involves resolving nested tuple to userset relations. Enable via experimental flag `enable-check-optimizations`. [#2025](https://github.com/openfga/openfga/pull/2025)
 
 ### Fixed
 * Label ListUsers API calls [#2000](https://github.com/openfga/openfga/pull/2000)

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -991,16 +991,21 @@ func trySendUsersetsAndDeleteFromMap(ctx context.Context, usersetsMap usersetsMa
 // recursiveMatchUserUsersetCommonData groups common parameters needed
 // for recursiveMatchUserUserset for convenience purpose.
 type recursiveMatchUserUsersetCommonData struct {
-	typesys                     *typesystem.TypeSystem
-	ds                          storage.RelationshipTupleReader
-	allowedUserTypeRestrictions []*openfgav1.RelationReference
-	userToUsersetMapping        storage.SortedSet
-	concurrencyLimit            int
-	tupleMapperKind             TupleMapperKind
+	typesys              *typesystem.TypeSystem
+	ds                   storage.RelationshipTupleReader
+	userToUsersetMapping storage.SortedSet
+	concurrencyLimit     int
+	tupleMapperKind      TupleMapperKind
 	// The following member are atomic/sync in anticipation
 	// that the algorithm will parallelize the lookup.
 	dsCount        *atomic.Uint32
 	visitedUserset *sync.Map
+
+	// only when tupleMapperKind == NestedUsersetKind
+	allowedUserTypeRestrictions []*openfgav1.RelationReference
+
+	// only when tupleMapperKind == NestedTTUKind
+	tuplesetRelation string
 }
 
 // recursiveMatchUserUsersetFunc defines a function that recursively evaluates whether objects' matches userToUsersetMapping.
@@ -1347,6 +1352,7 @@ func nestedUsersetFastpath(ctx context.Context,
 	req *ResolveCheckRequest,
 	mapperKind TupleMapperKind,
 	allowedUserTypeRestrictions []*openfgav1.RelationReference,
+	tuplesetRelation string,
 	concurrencyLimit int) (*ResolveCheckResponse, error) {
 	ctx, span := tracer.Start(ctx, "nestedUsersetFastpath")
 	defer span.End()
@@ -1365,6 +1371,7 @@ func nestedUsersetFastpath(ctx context.Context,
 		concurrencyLimit:            concurrencyLimit,
 		tupleMapperKind:             mapperKind,
 		allowedUserTypeRestrictions: allowedUserTypeRestrictions,
+		tuplesetRelation:            tuplesetRelation,
 		visitedUserset:              &sync.Map{},
 	}
 
@@ -1416,7 +1423,23 @@ func buildMapper(ctx context.Context, req *ResolveCheckRequest, common *recursiv
 		)
 		return &NestedUsersetMapper{Iter: filteredIter}, nil
 	case NestedTTUKind:
-		panic("TODO not implemented")
+		iter, err := common.ds.Read(ctx, req.GetStoreID(), tuple.NewTupleKey(req.GetTupleKey().GetObject(), common.tuplesetRelation, ""),
+			storage.ReadOptions{
+				Consistency: storage.ConsistencyOptions{
+					Preference: req.GetConsistency(),
+				},
+			})
+		if err != nil {
+			return nil, err
+		}
+		filteredIter := storage.NewConditionsFilteredTupleKeyIterator(
+			storage.NewFilteredTupleKeyIterator(
+				storage.NewTupleKeyIteratorFromTupleIterator(iter),
+				validation.FilterInvalidTuples(common.typesys),
+			),
+			checkutil.BuildTupleKeyConditionFilter(ctx, req.GetContext(), common.typesys),
+		)
+		return &NestedTTUMapper{Iter: filteredIter}, nil
 	}
 
 	return nil, fmt.Errorf("unsupported mapper kind %v", common.tupleMapperKind)
@@ -1517,7 +1540,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				} else if c.optimizationsEnabled && typesys.RecursiveUsersetCanFastPath(
 					tuple.ToObjectRelationString(tuple.GetType(reqTupleKey.GetObject()), reqTupleKey.GetRelation()),
 					tuple.GetType(reqTupleKey.GetUser())) {
-					return nestedUsersetFastpath(ctx, typesys, ds, req, NestedUsersetKind, directlyRelatedUsersetTypes, int(c.concurrencyLimit))
+					return nestedUsersetFastpath(ctx, typesys, ds, req, NestedUsersetKind, directlyRelatedUsersetTypes, "", int(c.concurrencyLimit))
 				}
 			}
 
@@ -1692,6 +1715,15 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 		typesys, _ := typesystem.TypesystemFromContext(parentctx) // note: use of 'parentctx' not 'ctx' - this is important
 
 		ds, _ := storage.RelationshipTupleReaderFromContext(parentctx)
+
+		objectType, relation := tuple.GetType(req.GetTupleKey().GetObject()), req.GetTupleKey().GetRelation()
+		objectTypeRelation := tuple.ToObjectRelationString(objectType, relation)
+
+		userType := tuple.GetType(req.GetTupleKey().GetUser())
+		if c.optimizationsEnabled && typesys.RecursiveTTUCanFastPath(objectTypeRelation, userType) {
+			tuplesetRelation := rewrite.GetTupleToUserset().GetTupleset().GetRelation()
+			return nestedUsersetFastpath(ctx, typesys, ds, req, NestedTTUKind, nil, tuplesetRelation, int(c.concurrencyLimit))
+		}
 
 		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)

--- a/internal/graph/tuplemapper.go
+++ b/internal/graph/tuplemapper.go
@@ -28,6 +28,8 @@ type NestedUsersetMapper struct {
 	Iter storage.TupleKeyIterator
 }
 
+var _ TupleMapper = (*NestedUsersetMapper)(nil)
+
 func (n NestedUsersetMapper) Next(ctx context.Context) (string, error) {
 	tupleRes, err := n.Iter.Next(ctx)
 	if err != nil {
@@ -55,4 +57,34 @@ func (n NestedUsersetMapper) doMap(t *openfgav1.TupleKey) (string, error) {
 		return "", fmt.Errorf("unexpected userset %s with no relation", t.GetUser())
 	}
 	return usersetName, nil
+}
+
+type NestedTTUMapper struct {
+	Iter storage.TupleKeyIterator
+}
+
+var _ TupleMapper = (*NestedTTUMapper)(nil)
+
+func (n NestedTTUMapper) Next(ctx context.Context) (string, error) {
+	tupleRes, err := n.Iter.Next(ctx)
+	if err != nil {
+		return "", err
+	}
+	return n.doMap(tupleRes)
+}
+
+func (n NestedTTUMapper) Stop() {
+	n.Iter.Stop()
+}
+
+func (n NestedTTUMapper) Head(ctx context.Context) (string, error) {
+	tupleRes, err := n.Iter.Head(ctx)
+	if err != nil {
+		return "", err
+	}
+	return n.doMap(tupleRes)
+}
+
+func (n NestedTTUMapper) doMap(t *openfgav1.TupleKey) (string, error) {
+	return t.GetUser(), nil
 }

--- a/internal/graph/tuplemapper_test.go
+++ b/internal/graph/tuplemapper_test.go
@@ -26,6 +26,7 @@ func TestNestedUsersetTupleMapper(t *testing.T) {
 
 	mapper := &NestedUsersetMapper{innerIter}
 	require.NotNil(t, mapper)
+	defer mapper.Stop()
 
 	t.Run("head_success", func(t *testing.T) {
 		res, err := mapper.Head(context.Background())
@@ -45,5 +46,32 @@ func TestNestedUsersetTupleMapper(t *testing.T) {
 		res, err := mapper.Next(context.Background())
 		require.Error(t, err)
 		require.Equal(t, "", res)
+	})
+}
+
+func TestNestedTTUTupleMapper(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("group:fga", "member", "group:2#member"),
+	}
+
+	innerIter := storage.NewStaticTupleKeyIterator(tks)
+
+	mapper := &NestedTTUMapper{innerIter}
+	require.NotNil(t, mapper)
+	defer mapper.Stop()
+
+	t.Run("head_success", func(t *testing.T) {
+		res, err := mapper.Head(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "group:2#member", res)
+	})
+
+	t.Run("map_success", func(t *testing.T) {
+		res, err := mapper.Next(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "group:2#member", res)
 	})
 }


### PR DESCRIPTION
## Description
Extend https://github.com/openfga/openfga/pull/2004 to support the nested TTU scenario.

## References
Part of https://github.com/openfga/openfga/issues/1945

## Testing

With `OPENFGA_EXPERIMENTALS=enable-check-optimizations`

Test this model:

```
    model
      schema 1.1
    type user
    type group
      relations
        define parent: [group]
        define member: [user] or member from parent
```

with:

```
STORE_ID=$(curl --silent --location 'localhost:8080/stores' \
--header 'Content-Type: application/json' \
--data '{"name":"pr2007"}' | jq .id --raw-output)

curl --silent --location "localhost:8080/stores/$STORE_ID/authorization-models" \
--header 'Content-Type: application/json' \
--header 'Accept: application/json' \
--data '{"schema_version":"1.1","type_definitions":[{"type":"user","relations":{},"metadata":null},{"type":"group","relations":{"parent":{"this":{}},"member":{"union":{"child":[{"this":{}},{"tupleToUserset":{"computedUserset":{"relation":"member"},"tupleset":{"relation":"parent"}}}]}}},"metadata":{"relations":{"parent":{"directly_related_user_types":[{"type":"group"}]},"member":{"directly_related_user_types":[{"type":"user"}]}}}}]}'

fga model test --tests model.fga.yaml --store-id $STORE_ID
```

```
# model.fga.yaml
tuples:
    - user: user:maria
      relation: member
      object: group:1
    - user: group:1
      relation: parent
      object: group:2
    - user: group:2
      relation: parent
      object: group:3
tests:
  - name: test-1
    check:
      - user: user:maria
        object: group:3
        assertions:
          member: true
  
```

### Before

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/9cb2e44f-203b-4e5d-b037-05b8bdd7420b">

### After

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/0bab8416-c0fd-4fa4-814c-f63ae24d7433">


