### PR TITLE
fix: reduce max concurrent connections in check benchmark test

### DIFF
--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -19,6 +19,9 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
+// to prevent overwhelming server on expensive queries
+const maxConcurrentReads = 50
+
 // Some of the benchmark tests require context blocks to be built
 // but many do not. This noop method is a placeholder for the non-context test cases.
 func noopContextGenerator() *structpb.Struct {
@@ -382,9 +385,9 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 
 		checkQuery := commands.NewCheckCommand(
 			ds,
-			graph.NewLocalChecker(),
+			graph.NewLocalChecker(graph.WithOptimizations(true)),
 			typeSystem,
-			commands.WithCheckCommandMaxConcurrentReads(config.DefaultMaxConcurrentReadsForCheck),
+			commands.WithCheckCommandMaxConcurrentReads(maxConcurrentReads),
 			commands.WithCheckCommandResolveNodeLimit(config.DefaultResolveNodeLimit),
 		)
 
@@ -396,8 +399,8 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 					Context:  bm.contextGenerator(),
 				})
 
-				require.Equal(b, bm.expected, response.GetAllowed())
 				require.NoError(b, err)
+				require.Equal(b, bm.expected, response.GetAllowed())
 			}
 		})
 	}
@@ -475,9 +478,9 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	checkQuery := commands.NewCheckCommand(
 		ds,
-		graph.NewLocalChecker(),
+		graph.NewLocalChecker(graph.WithOptimizations(true)),
 		typeSystemTwo,
-		commands.WithCheckCommandMaxConcurrentReads(config.DefaultMaxConcurrentReadsForCheck),
+		commands.WithCheckCommandMaxConcurrentReads(maxConcurrentReads),
 		commands.WithCheckCommandResolveNodeLimit(config.DefaultResolveNodeLimit),
 	)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Follow up to #2024. Max concurrent connections in that PR was set to server default max connections, which was max uint32, and [enough to overwhelm benchmark containers](https://github.com/openfga/openfga/pull/2024#discussion_r1803944443). This sets the max concurrent connections to 50.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
