### PR TITLE
refactor: check command execute params

### DIFF
--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -9,13 +9,11 @@ import (
 	"github.com/openfga/openfga/internal/cachecontroller"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/validation"
-	"github.com/openfga/openfga/pkg/middleware/validator"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
@@ -39,6 +37,14 @@ type CheckQuery struct {
 
 	resolveNodeLimit   uint32
 	maxConcurrentReads uint32
+}
+
+type CheckRequestParams struct {
+	StoreID          string
+	TupleKey         *openfgav1.CheckRequestTupleKey
+	ContextualTuples *openfgav1.ContextualTupleKeys
+	Context          *structpb.Struct
+	Consistency      openfgav1.ConsistencyPreference
 }
 
 type CheckQueryOption func(*CheckQuery)
@@ -84,27 +90,27 @@ func NewCheckCommand(datastore storage.RelationshipTupleReader, checkResolver gr
 	return cmd
 }
 
-func (c *CheckQuery) Execute(ctx context.Context, req *openfgav1.CheckRequest) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
-	err := validateCheckRequest(ctx, req, c.typesys)
+func (c *CheckQuery) Execute(ctx context.Context, params *CheckRequestParams) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
+	err := validateCheckRequest(c.typesys, params.TupleKey, params.ContextualTuples)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	cacheInvalidationTime := time.Time{}
 
-	if req.GetConsistency() != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
-		cacheInvalidationTime = c.cacheController.DetermineInvalidation(ctx, req.GetStoreId())
+	if params.Consistency != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
+		cacheInvalidationTime = c.cacheController.DetermineInvalidation(ctx, params.StoreID)
 	}
 
 	resolveCheckRequest := graph.ResolveCheckRequest{
-		StoreID:              req.GetStoreId(),
+		StoreID:              params.StoreID,
 		AuthorizationModelID: c.typesys.GetAuthorizationModelID(), // the resolved model ID
-		TupleKey:             tuple.ConvertCheckRequestTupleKeyToTupleKey(req.GetTupleKey()),
-		ContextualTuples:     req.GetContextualTuples().GetTupleKeys(),
-		Context:              req.GetContext(),
+		TupleKey:             tuple.ConvertCheckRequestTupleKeyToTupleKey(params.TupleKey),
+		ContextualTuples:     params.ContextualTuples.GetTupleKeys(),
+		Context:              params.Context,
 		VisitedPaths:         make(map[string]struct{}),
 		RequestMetadata:      graph.NewCheckRequestMetadata(c.resolveNodeLimit),
-		Consistency:          req.GetConsistency(),
+		Consistency:          params.Consistency,
 		// avoid having to read from cache consistently by propagating it
 		LastCacheInvalidationTime: cacheInvalidationTime,
 	}
@@ -118,20 +124,14 @@ func (c *CheckQuery) Execute(ctx context.Context, req *openfgav1.CheckRequest) (
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }
 
-func validateCheckRequest(ctx context.Context, req *openfgav1.CheckRequest, typesys *typesystem.TypeSystem) error {
-	if !validator.RequestIsValidatedFromContext(ctx) {
-		if err := req.Validate(); err != nil {
-			return status.Error(codes.InvalidArgument, err.Error())
-		}
-	}
-
+func validateCheckRequest(typesys *typesystem.TypeSystem, tupleKey *openfgav1.CheckRequestTupleKey, ctxTuples *openfgav1.ContextualTupleKeys) error {
 	// The input tuple Key should be validated loosely.
-	if err := validation.ValidateUserObjectRelation(typesys, tuple.ConvertCheckRequestTupleKeyToTupleKey(req.GetTupleKey())); err != nil {
+	if err := validation.ValidateUserObjectRelation(typesys, tuple.ConvertCheckRequestTupleKeyToTupleKey(tupleKey)); err != nil {
 		return serverErrors.ValidationError(err)
 	}
 
 	// But contextual tuples need to be validated more strictly, the same as an input to a Write Tuple request.
-	for _, ctxTuple := range req.GetContextualTuples().GetTupleKeys() {
+	for _, ctxTuple := range ctxTuples.GetTupleKeys() {
 		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
 			return serverErrors.HandleTupleValidateError(err)
 		}

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -124,14 +124,14 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }
 
-func validateCheckRequest(typesys *typesystem.TypeSystem, tupleKey *openfgav1.CheckRequestTupleKey, ctxTuples *openfgav1.ContextualTupleKeys) error {
+func validateCheckRequest(typesys *typesystem.TypeSystem, tupleKey *openfgav1.CheckRequestTupleKey, contextualTuples *openfgav1.ContextualTupleKeys) error {
 	// The input tuple Key should be validated loosely.
 	if err := validation.ValidateUserObjectRelation(typesys, tuple.ConvertCheckRequestTupleKeyToTupleKey(tupleKey)); err != nil {
 		return serverErrors.ValidationError(err)
 	}
 
 	// But contextual tuples need to be validated more strictly, the same as an input to a Write Tuple request.
-	for _, ctxTuple := range ctxTuples.GetTupleKeys() {
+	for _, ctxTuple := range contextualTuples.GetTupleKeys() {
 		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
 			return serverErrors.HandleTupleValidateError(err)
 		}

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -39,7 +39,7 @@ type CheckQuery struct {
 	maxConcurrentReads uint32
 }
 
-type CheckRequestParams struct {
+type CheckCommandParams struct {
 	StoreID          string
 	TupleKey         *openfgav1.CheckRequestTupleKey
 	ContextualTuples *openfgav1.ContextualTupleKeys
@@ -90,7 +90,7 @@ func NewCheckCommand(datastore storage.RelationshipTupleReader, checkResolver gr
 	return cmd
 }
 
-func (c *CheckQuery) Execute(ctx context.Context, params *CheckRequestParams) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
+func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
 	err := validateCheckRequest(c.typesys, params.TupleKey, params.ContextualTuples)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -43,28 +43,6 @@ type doc
 	ts, err := typesystem.NewAndValidate(context.Background(), model)
 	require.NoError(t, err)
 
-	t.Run("validates_store_id", func(t *testing.T) {
-		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, nil)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: "invalid",
-		})
-		require.ErrorContains(t, err, "invalid CheckRequest.StoreID: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
-	})
-
-	t.Run("validates_model_id", func(t *testing.T) {
-		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, nil)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			TupleKey: &openfgav1.CheckRequestTupleKey{
-				User:     "user:1",
-				Relation: "viewer",
-				Object:   "invalid:1",
-			},
-			//AuthorizationModelId: "invalid",
-		})
-		require.ErrorContains(t, err, "invalid CheckRequest.AuthorizationModelId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
-	})
-
 	t.Run("validates_input_user", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -45,7 +45,7 @@ type doc
 
 	t.Run("validates_input_user", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "invalid:1",
@@ -58,7 +58,7 @@ type doc
 
 	t.Run("validates_input_relation", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
@@ -71,7 +71,7 @@ type doc
 
 	t.Run("validates_input_object", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
@@ -84,7 +84,7 @@ type doc
 
 	t.Run("validates_input_contextual_tuple", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("invalid:1", "viewer", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
@@ -98,7 +98,7 @@ type doc
 
 	t.Run("validates_tuple_key_less_strictly_than_contextual_tuples", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer_computed", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
@@ -116,7 +116,7 @@ type doc
 		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).
 			Times(1).
 			Return(nil, nil)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
@@ -126,7 +126,7 @@ type doc
 	t.Run("no_validation_error_but_call_to_resolver_fails", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.ErrUnknown)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
@@ -139,7 +139,7 @@ type doc
 			require.Zero(t, req.GetLastCacheInvalidationTime())
 			return nil, nil
 		})
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:     ulid.Make().String(),
 			TupleKey:    tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
@@ -157,7 +157,7 @@ type doc
 			return nil, nil
 		})
 		cacheController.EXPECT().DetermineInvalidation(gomock.Any(), storeID).Return(invalidationTime)
-		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  storeID,
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -45,31 +45,31 @@ type doc
 
 	t.Run("validates_store_id", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, nil)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId: "invalid",
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: "invalid",
 		})
-		require.ErrorContains(t, err, "invalid CheckRequest.StoreId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
+		require.ErrorContains(t, err, "invalid CheckRequest.StoreID: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
 	})
 
 	t.Run("validates_model_id", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, nil)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId: ulid.Make().String(),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
 				Relation: "viewer",
 				Object:   "invalid:1",
 			},
-			AuthorizationModelId: "invalid",
+			//AuthorizationModelId: "invalid",
 		})
 		require.ErrorContains(t, err, "invalid CheckRequest.AuthorizationModelId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
 	})
 
 	t.Run("validates_input_user", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "invalid:1",
 				Relation: "viewer",
@@ -81,9 +81,9 @@ type doc
 
 	t.Run("validates_input_relation", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
 				Relation: "invalid",
@@ -95,9 +95,9 @@ type doc
 
 	t.Run("validates_input_object", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
 				Relation: "viewer",
@@ -109,10 +109,10 @@ type doc
 
 	t.Run("validates_input_contextual_tuple", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("invalid:1", "viewer", "user:1"),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey: tuple.NewCheckRequestTupleKey("invalid:1", "viewer", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
 				TupleKeys: []*openfgav1.TupleKey{
 					tuple.NewTupleKey("invalid:1", "viewer", "user:1"),
@@ -124,10 +124,10 @@ type doc
 
 	t.Run("validates_tuple_key_less_strictly_than_contextual_tuples", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("doc:1", "viewer_computed", "user:1"),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer_computed", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
 				TupleKeys: []*openfgav1.TupleKey{
 					// this isn't a tuple that you can write
@@ -143,10 +143,10 @@ type doc
 		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).
 			Times(1).
 			Return(nil, nil)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.NoError(t, err)
 	})
@@ -154,10 +154,10 @@ type doc
 	t.Run("no_validation_error_but_call_to_resolver_fails", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.ErrUnknown)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.ErrorIs(t, err, errors.ErrUnknown)
 	})
@@ -168,11 +168,11 @@ type doc
 			require.Zero(t, req.GetLastCacheInvalidationTime())
 			return nil, nil
 		})
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              ulid.Make().String(),
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
-			Consistency:          openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: ulid.Make().String(),
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey:    tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
+			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 		})
 		require.NoError(t, err)
 	})
@@ -187,10 +187,10 @@ type doc
 			return nil, nil
 		})
 		cacheController.EXPECT().DetermineInvalidation(gomock.Any(), storeID).Return(invalidationTime)
-		_, _, err := cmd.Execute(context.Background(), &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			AuthorizationModelId: ulid.Make().String(),
-			TupleKey:             tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
+		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
+			StoreID: storeID,
+			//AuthorizationModelId: ulid.Make().String(),
+			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.NoError(t, err)
 	})

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -47,7 +47,6 @@ type doc
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
 			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "invalid:1",
 				Relation: "viewer",
@@ -61,7 +60,6 @@ type doc
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
 			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
 				Relation: "invalid",
@@ -75,7 +73,6 @@ type doc
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
 			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				User:     "user:1",
 				Relation: "viewer",
@@ -88,8 +85,7 @@ type doc
 	t.Run("validates_input_contextual_tuple", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("invalid:1", "viewer", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
 				TupleKeys: []*openfgav1.TupleKey{
@@ -103,8 +99,7 @@ type doc
 	t.Run("validates_tuple_key_less_strictly_than_contextual_tuples", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer_computed", "user:1"),
 			ContextualTuples: &openfgav1.ContextualTupleKeys{
 				TupleKeys: []*openfgav1.TupleKey{
@@ -122,8 +117,7 @@ type doc
 			Times(1).
 			Return(nil, nil)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.NoError(t, err)
@@ -133,8 +127,7 @@ type doc
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
 		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).Return(nil, errors.ErrUnknown)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.ErrorIs(t, err, errors.ErrUnknown)
@@ -147,8 +140,7 @@ type doc
 			return nil, nil
 		})
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: ulid.Make().String(),
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:     ulid.Make().String(),
 			TupleKey:    tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 		})
@@ -166,8 +158,7 @@ type doc
 		})
 		cacheController.EXPECT().DetermineInvalidation(gomock.Any(), storeID).Return(invalidationTime)
 		_, _, err := cmd.Execute(context.Background(), &CheckRequestParams{
-			StoreID: storeID,
-			//AuthorizationModelId: ulid.Make().String(),
+			StoreID:  storeID,
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
 		})
 		require.NoError(t, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1098,8 +1098,13 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		return nil, err
 	}
 
-	const methodName = "check"
-	resp, checkRequestMetadata, err := commands.NewCheckCommand(
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
+
+	checkQuery := commands.NewCheckCommand(
 		s.checkDatastore,
 		s.checkResolver,
 		typesys,
@@ -1107,7 +1112,17 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		commands.WithCheckCommandMaxConcurrentReads(s.maxConcurrentReadsForCheck),
 		commands.WithCheckCommandResolveNodeLimit(s.resolveNodeLimit),
 		commands.WithCacheController(s.cacheController),
-	).Execute(ctx, req)
+	)
+
+	resp, checkRequestMetadata, err := checkQuery.Execute(ctx, &commands.CheckRequestParams{
+		StoreID:          storeID,
+		TupleKey:         req.GetTupleKey(),
+		ContextualTuples: req.GetContextualTuples(),
+		Context:          req.GetContext(),
+		Consistency:      req.GetConsistency(),
+	})
+
+	const methodName = "check"
 	if err != nil {
 		telemetry.TraceError(span, err)
 		if errors.Is(err, serverErrors.ThrottledTimeout) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1091,17 +1091,17 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		return nil, err
 	}
 
+	if !validator.RequestIsValidatedFromContext(ctx) {
+		if err := req.Validate(); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+	}
+
 	storeID := req.GetStoreId()
 
 	typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
 		return nil, err
-	}
-
-	if !validator.RequestIsValidatedFromContext(ctx) {
-		if err := req.Validate(); err != nil {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
-		}
 	}
 
 	checkQuery := commands.NewCheckCommand(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1114,7 +1114,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		commands.WithCacheController(s.cacheController),
 	)
 
-	resp, checkRequestMetadata, err := checkQuery.Execute(ctx, &commands.CheckRequestParams{
+	resp, checkRequestMetadata, err := checkQuery.Execute(ctx, &commands.CheckCommandParams{
 		StoreID:          storeID,
 		TupleKey:         req.GetTupleKey(),
 		ContextualTuples: req.GetContextualTuples(),

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2359,3 +2359,45 @@ func TestCheckWithCachedIterator(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, checkResponse.GetAllowed())
 }
+
+func TestCheckValidatesStoreID(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+	s := MustNewServerWithOpts(WithDatastore(mockDatastore))
+
+	t.Cleanup(func() {
+		mockDatastore.EXPECT().Close().Times(1)
+		s.Close()
+	})
+
+	_, err := s.Check(context.Background(), &openfgav1.CheckRequest{
+		StoreId:  "not a ulid",
+		TupleKey: tuple.NewCheckRequestTupleKey("license:1", "viewer", "user:1"),
+	})
+
+	require.ErrorContains(t, err, "invalid CheckRequest.StoreId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
+}
+
+func TestCheckValidatesModelID(t *testing.T) {
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+	s := MustNewServerWithOpts(WithDatastore(mockDatastore))
+
+	t.Cleanup(func() {
+		mockDatastore.EXPECT().Close().Times(1)
+		s.Close()
+	})
+
+	_, err := s.Check(context.Background(), &openfgav1.CheckRequest{
+		StoreId:              "01JAGC4TMBSVGFJ7TR18KGBVD6",
+		TupleKey:             tuple.NewCheckRequestTupleKey("license:1", "viewer", "user:1"),
+		AuthorizationModelId: "not a ulid",
+	})
+
+	require.ErrorContains(t, err, "invalid CheckRequest.AuthorizationModelId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
+
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2399,5 +2399,4 @@ func TestCheckValidatesModelID(t *testing.T) {
 	})
 
 	require.ErrorContains(t, err, "invalid CheckRequest.AuthorizationModelId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
-
 }

--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -393,7 +393,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				response, _, err := checkQuery.Execute(ctx, &commands.CheckRequestParams{
+				response, _, err := checkQuery.Execute(ctx, &commands.CheckCommandParams{
 					StoreID:  storeID,
 					TupleKey: bm.tupleKeyToCheck,
 					Context:  bm.contextGenerator(),
@@ -486,7 +486,7 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	b.Run("benchmark_with_bypass_userset_read", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			response, _, err := checkQuery.Execute(context.Background(), &commands.CheckRequestParams{
+			response, _, err := checkQuery.Execute(context.Background(), &commands.CheckCommandParams{
 				StoreID:  storeID,
 				TupleKey: tuple.NewCheckRequestTupleKey("document:budget", "viewer", "user:anne"),
 			})

--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -393,8 +393,8 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 
 		b.Run(name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				response, _, err := checkQuery.Execute(ctx, &openfgav1.CheckRequest{
-					StoreId:  storeID,
+				response, _, err := checkQuery.Execute(ctx, &commands.CheckRequestParams{
+					StoreID:  storeID,
 					TupleKey: bm.tupleKeyToCheck,
 					Context:  bm.contextGenerator(),
 				})
@@ -486,8 +486,8 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	b.Run("benchmark_with_bypass_userset_read", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			response, _, err := checkQuery.Execute(context.Background(), &openfgav1.CheckRequest{
-				StoreId:  storeID,
+			response, _, err := checkQuery.Execute(context.Background(), &commands.CheckRequestParams{
+				StoreID:  storeID,
 				TupleKey: tuple.NewCheckRequestTupleKey("document:budget", "viewer", "user:anne"),
 			})
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The upcoming BatchCheck work will be calling the CheckCommand, which currently requires its `.Execute` method to receive a `CheckRequest`. Passing the full request object isn't necessary; this PR pulls the required pieces of the `CheckRequest` into a struct and passes that struct into `.Execute` instead to increase reusability.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Creation of Check Command: https://github.com/openfga/openfga/pull/1857

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
