### PR TITLE
fix(test): Fix flaky test in ListObjects dispatch throttling

### DIFF
--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -151,14 +151,12 @@ func TestListObjectsDispatchCount(t *testing.T) {
 			tuples: []string{
 				"folder:C#can_delete@user:jon",
 				"folder:C#editor@group:fga#member",
-				"folder:C#editor@group:fga1#member",
 				"group:fga#member@user:jon",
-				"group:fga1#member@user:jon",
 			},
 			objectType:              "folder",
 			relation:                "can_delete",
 			user:                    "user:jon",
-			expectedDispatchCount:   3,
+			expectedDispatchCount:   2,
 			expectedThrottlingValue: 1,
 		},
 		{
@@ -239,7 +237,7 @@ func TestListObjectsDispatchCount(t *testing.T) {
 			checker, checkResolverCloser := graph.NewOrderedCheckResolvers(
 				graph.WithDispatchThrottlingCheckResolverOpts(true, []graph.DispatchThrottlingCheckResolverOpt{
 					graph.WithDispatchThrottlingCheckResolverConfig(graph.DispatchThrottlingCheckResolverConfig{
-						DefaultThreshold: 1,
+						DefaultThreshold: 0,
 						MaxThreshold:     0,
 					}),
 					graph.WithThrottler(mockThrottler),


### PR DESCRIPTION
This test fixes flakiness in List Objects dispatch throttling.

## Description
- This issue fixes the problem where we are trying LO on multiple objects, leading to flakiness. We will use a single LO and reduce the throttling value inside the check to achieve this. Ran the test with `-test.count 10000` to ensure flakiness is not reproducing.

## References
https://github.com/openfga/openfga/actions/runs/11418224120/job/31773914192

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
