### PR TITLE
test: only listen on localhost to avoid prompting for permission

### DIFF
--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -814,7 +814,7 @@ func testServerMetricsReporting(t *testing.T, engine string) {
 	metricsPort, metricsPortReleaser := testutils.TCPRandomPort()
 	metricsPortReleaser()
 
-	cfg.Metrics.Addr = fmt.Sprintf("0.0.0.0:%d", metricsPort)
+	cfg.Metrics.Addr = fmt.Sprintf("localhost:%d", metricsPort)
 
 	cfg.MaxConcurrentReadsForCheck = 30
 	cfg.MaxConcurrentReadsForListObjects = 30

--- a/internal/mocks/mock_oidc_server.go
+++ b/internal/mocks/mock_oidc_server.go
@@ -60,7 +60,7 @@ func (server *mockOidcServer) NewAliasMockServer(aliasURL string) *mockOidcServe
 }
 
 func createHTTPServer(issuerURL string, publicKey *rsa.PublicKey) *http.Server {
-	port := strings.Split(issuerURL, ":")[2]
+	addr := strings.Split(issuerURL, "http://")[1]
 
 	mockHandler := http.NewServeMux()
 
@@ -90,7 +90,7 @@ func createHTTPServer(issuerURL string, publicKey *rsa.PublicKey) *http.Server {
 		}
 	})
 
-	return &http.Server{Addr: ":" + port, Handler: mockHandler}
+	return &http.Server{Addr: addr, Handler: mockHandler}
 }
 
 func (server *mockOidcServer) start() {

--- a/internal/mocks/mock_tracing_server.go
+++ b/internal/mocks/mock_tracing_server.go
@@ -32,7 +32,7 @@ func (s *mockTracingServer) Export(context.Context, *otlpcollector.ExportTraceSe
 func NewMockTracingServer(t testing.TB, port int) *mockTracingServer {
 	mockServer := &mockTracingServer{exportCount: 0, server: grpc.NewServer()}
 	otlpcollector.RegisterTraceServiceServer(mockServer.server, mockServer)
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", port))
 	require.NoError(t, err)
 	t.Cleanup(mockServer.server.GracefulStop)
 

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -241,8 +241,8 @@ func MustDefaultConfigWithRandomPorts() *serverconfig.Config {
 	grpcPort, grpcPortReleaser := TCPRandomPort()
 	defer grpcPortReleaser()
 
-	config.GRPC.Addr = fmt.Sprintf("0.0.0.0:%d", grpcPort)
-	config.HTTP.Addr = fmt.Sprintf("0.0.0.0:%d", httpPort)
+	config.GRPC.Addr = fmt.Sprintf("localhost:%d", grpcPort)
+	config.HTTP.Addr = fmt.Sprintf("localhost:%d", httpPort)
 
 	return config
 }
@@ -250,7 +250,7 @@ func MustDefaultConfigWithRandomPorts() *serverconfig.Config {
 // TCPRandomPort tries to find a random TCP Port. If it can't find one, it panics. Else, it returns the port and a function that releases the port.
 // It is the responsibility of the caller to call the release function right before trying to listen on the given port.
 func TCPRandomPort() (int, func()) {
-	l, err := net.Listen("tcp", "")
+	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		panic(err)
 	}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -40,9 +40,9 @@ func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *r
 	ctx, cancel := context.WithCancel(context.Background())
 
 	httpPort, httpPortReleaser := testutils.TCPRandomPort()
-	cfg.HTTP.Addr = fmt.Sprintf("0.0.0.0:%d", httpPort)
+	cfg.HTTP.Addr = fmt.Sprintf("localhost:%d", httpPort)
 	grpcPort, grpcPortReleaser := testutils.TCPRandomPort()
-	cfg.GRPC.Addr = fmt.Sprintf("0.0.0.0:%d", grpcPort)
+	cfg.GRPC.Addr = fmt.Sprintf("localhost:%d", grpcPort)
 
 	// these two functions release the ports so that the server can start listening on them
 	httpPortReleaser()


### PR DESCRIPTION
## Description

Currently when starting HTTP/gRPC servers for testing we don't specify the host so the servers will be listen on all available network interfaces. This will most likely pop up a prompt for permission to do this (as it will expose ports on your machine), which can get irritating.

Instead, specifically listen on localhost which won't require permission. 

## References

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
