### PR TITLE
refactor: consolidate check_command error handling

### DIFF
--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -28,6 +28,30 @@ const (
 	defaultMaxConcurrentReadsForCheck = math.MaxUint32
 )
 
+type InvalidTupleError struct {
+	Message string
+}
+
+func (e *InvalidTupleError) Error() string {
+	return e.Message
+}
+
+type InvalidRelationError struct {
+	Message string
+}
+
+func (e *InvalidRelationError) Error() string {
+	return e.Message
+}
+
+type ThrottledError struct {
+	Message string
+}
+
+func (e *ThrottledError) Error() string {
+	return e.Message
+}
+
 type CheckQuery struct {
 	logger          logger.Logger
 	checkResolver   graph.CheckResolver
@@ -119,7 +143,11 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 
 	resp, err := c.checkResolver.ResolveCheck(ctx, &resolveCheckRequest)
 	if err != nil {
-		return nil, nil, translateError(resolveCheckRequest.GetRequestMetadata(), err)
+		if errors.Is(err, context.DeadlineExceeded) && resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
+			return nil, nil, &ThrottledError{Message: err.Error()}
+		}
+
+		return nil, nil, err
 	}
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }
@@ -127,13 +155,13 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 func validateCheckRequest(typesys *typesystem.TypeSystem, tupleKey *openfgav1.CheckRequestTupleKey, contextualTuples *openfgav1.ContextualTupleKeys) error {
 	// The input tuple Key should be validated loosely.
 	if err := validation.ValidateUserObjectRelation(typesys, tuple.ConvertCheckRequestTupleKeyToTupleKey(tupleKey)); err != nil {
-		return serverErrors.ValidationError(err)
+		return &InvalidRelationError{Message: err.Error()}
 	}
 
 	// But contextual tuples need to be validated more strictly, the same as an input to a Write Tuple request.
 	for _, ctxTuple := range contextualTuples.GetTupleKeys() {
 		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
-			return serverErrors.HandleTupleValidateError(err)
+			return &InvalidTupleError{Message: err.Error()}
 		}
 	}
 	return nil

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -11,10 +11,8 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/validation"
-	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -181,20 +179,4 @@ func buildCheckContext(ctx context.Context, typesys *typesystem.TypeSystem, data
 		),
 	)
 	return ctx
-}
-
-func translateError(reqMetadata *graph.ResolveCheckRequestMetadata, err error) error {
-	if errors.Is(err, graph.ErrResolutionDepthExceeded) {
-		return serverErrors.AuthorizationModelResolutionTooComplex
-	}
-
-	if errors.Is(err, condition.ErrEvaluationFailed) {
-		return serverErrors.ValidationError(err)
-	}
-
-	if errors.Is(err, context.DeadlineExceeded) && reqMetadata.WasThrottled.Load() {
-		return serverErrors.ThrottledTimeout
-	}
-
-	return serverErrors.HandleError("", err)
 }

--- a/pkg/server/commands/errors.go
+++ b/pkg/server/commands/errors.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openfga/openfga/internal/condition"
+	"github.com/openfga/openfga/internal/graph"
+	serverErrors "github.com/openfga/openfga/pkg/server/errors"
+	"github.com/openfga/openfga/pkg/tuple"
+)
+
+type InvalidTupleError struct {
+	Cause error
+}
+
+func (e *InvalidTupleError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *InvalidTupleError) Error() string {
+	return e.Unwrap().Error()
+}
+
+type InvalidRelationError struct {
+	Cause error
+}
+
+func (e *InvalidRelationError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *InvalidRelationError) Error() string {
+	return e.Unwrap().Error()
+}
+
+type ThrottledError struct {
+	Cause error
+}
+
+func (e *ThrottledError) Unwrap() error {
+	return e.Cause
+}
+
+func (e *ThrottledError) Error() string {
+	return e.Unwrap().Error()
+}
+
+func CheckCommandErrorToServerError(err error) error {
+	var invalidRelationError *InvalidRelationError
+	if errors.As(err, &invalidRelationError) {
+		return serverErrors.ValidationError(err)
+	}
+
+	var invalidTupleError *InvalidTupleError
+	if errors.As(err, &invalidTupleError) {
+		tupleError := tuple.InvalidTupleError{Cause: err}
+		return serverErrors.HandleTupleValidateError(&tupleError)
+	}
+
+	if errors.Is(err, graph.ErrResolutionDepthExceeded) {
+		return serverErrors.AuthorizationModelResolutionTooComplex
+	}
+
+	if errors.Is(err, condition.ErrEvaluationFailed) {
+		return serverErrors.ValidationError(err)
+	}
+
+	var throttledError *ThrottledError
+	if errors.As(err, &throttledError) {
+		return serverErrors.ThrottledTimeout
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		return serverErrors.RequestDeadlineExceeded
+	}
+
+	return serverErrors.HandleError("", err)
+}

--- a/pkg/server/commands/errors.go
+++ b/pkg/server/commands/errors.go
@@ -46,6 +46,8 @@ func (e *ThrottledError) Error() string {
 	return e.Unwrap().Error()
 }
 
+// CheckCommandErrorToServerError converts internal errors thrown during the
+// check_command into consumer-facing errors to be sent over the wire.
 func CheckCommandErrorToServerError(err error) error {
 	var invalidRelationError *InvalidRelationError
 	if errors.As(err, &invalidRelationError) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/openfga/openfga/pkg/tuple"
 	"net/http"
 	"slices"
 	"sort"
 	"strconv"
 	"time"
+
+	"github.com/openfga/openfga/pkg/tuple"
 
 	"github.com/oklog/ulid/v2"
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openfga/openfga/internal/condition"
-
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	language "github.com/openfga/language/pkg/go/transformer"
@@ -29,7 +27,6 @@ import (
 	"github.com/openfga/openfga/cmd/migrate"
 	"github.com/openfga/openfga/cmd/util"
 	"github.com/openfga/openfga/internal/build"
-	ofga_errors "github.com/openfga/openfga/internal/errors"
 	"github.com/openfga/openfga/internal/graph"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
 	serverconfig "github.com/openfga/openfga/internal/server/config"
@@ -2402,47 +2399,4 @@ func TestCheckValidatesModelID(t *testing.T) {
 	})
 
 	require.ErrorContains(t, err, "invalid CheckRequest.AuthorizationModelId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"")
-}
-
-func TestTranslateCheckError(t *testing.T) {
-	testcases := map[string]struct {
-		inputError    error
-		expectedError error
-	}{
-		`1`: {
-			inputError:    &commands.InvalidRelationError{Message: "oh no"},
-			expectedError: serverErrors.ValidationError(&commands.InvalidRelationError{Message: "oh no"}),
-		},
-		`2`: {
-			inputError: &commands.InvalidTupleError{Message: "oh no"},
-			expectedError: serverErrors.HandleTupleValidateError(
-				&tuple.InvalidTupleError{
-					Cause: &commands.InvalidTupleError{Message: "oh no"},
-				},
-			),
-		},
-		`3`: {
-			inputError:    graph.ErrResolutionDepthExceeded,
-			expectedError: serverErrors.AuthorizationModelResolutionTooComplex,
-		},
-		`4`: {
-			inputError:    condition.ErrEvaluationFailed,
-			expectedError: serverErrors.ValidationError(condition.ErrEvaluationFailed),
-		},
-		`5`: {
-			inputError:    &commands.ThrottledError{},
-			expectedError: serverErrors.ThrottledTimeout,
-		},
-		`6`: {
-			inputError:    ofga_errors.ErrUnknown,
-			expectedError: ofga_errors.ErrUnknown,
-		},
-	}
-
-	for name, testCase := range testcases {
-		t.Run(name, func(t *testing.T) {
-			actualError := translateCheckError(testCase.inputError)
-			require.ErrorIs(t, actualError, testCase.expectedError)
-		})
-	}
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The CheckCommand was built with the assumption that we would be running only single checks in a request. As a result, the `check_command` itself is translating internal errors into external facing GRPC error types. For BatchCheck, we need error handling on a per-check basis (in addition to per-request).

This PR refactors the error handling in the `check_command` to make it completely agnostic to the transport layer. It just returns specific error types which the server (or BatchCheck) can transform as they need.

No logic was changed as part of this PR, it's a pure refactor.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
Closely related to #2031 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
