### PR TITLE
feat: add contextual tuples to Expand API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added
 * Added `start_time` parameter to `ReadChanges` API to allow filtering by specific time [#2020](https://github.com/openfga/openfga/pull/2020)
+* Added support for Contextual Tuples in the `Expand` API. [#2045](https://github.com/openfga/openfga/pull/2045)
 
 ### Breaking changes
 * The storage adapter `ReadChanges`'s parameter ReadChangesOptions allows filtering by `StartTime` [#2020](https://github.com/openfga/openfga/pull/2020).

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.6
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20241028145042-7c098f10acd2
+	github.com/openfga/api/proto v0.0.0-20241104193559-ee46d6721514
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20240926131254-992b301a003f
 	github.com/pressly/goose/v3 v3.22.1
 	github.com/prometheus/client_golang v1.20.5
@@ -134,5 +134,3 @@ require (
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
 )
-
-replace github.com/openfga/api/proto => github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/karlseguin/ccache/v3 v3.0.6
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
-	github.com/openfga/api/proto v0.0.0-20241025174823-bf8e92bcc45a
+	github.com/openfga/api/proto v0.0.0-20241028145042-7c098f10acd2
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20240926131254-992b301a003f
 	github.com/pressly/goose/v3 v3.22.1
 	github.com/prometheus/client_golang v1.20.5
@@ -134,3 +134,5 @@ require (
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
 )
+
+replace github.com/openfga/api/proto => github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3 h1:dZ1WNxPTwFRtcDRyXl0YVESyh5txVTxpGRDf6XMOitc=
-github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
+github.com/openfga/api/proto v0.0.0-20241104193559-ee46d6721514 h1:ebCcwMV9LTbAG7so6PQt5qCLB6dz5VUW7/pf9sokG5M=
+github.com/openfga/api/proto v0.0.0-20241104193559-ee46d6721514/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,6 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20241025174823-bf8e92bcc45a h1:xUXOCr49hSeJspz8wCx2jFa6pMfij415sGQfUig6bwo=
-github.com/openfga/api/proto v0.0.0-20241025174823-bf8e92bcc45a/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20240926131254-992b301a003f h1:ZMZ7ntMnaHIPZxvVQv/aqC4ctzLqH+9Fqn4uw35kQpk=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20240926131254-992b301a003f/go.mod h1:ll/hN6kS4EE6B/7J/PbZqac9Nuv7ZHpI+Jfh36JLrbs=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -243,6 +241,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3 h1:dZ1WNxPTwFRtcDRyXl0YVESyh5txVTxpGRDf6XMOitc=
+github.com/sujitha-av/api/proto v0.0.0-20241031191721-50d1c0a9bae3/go.mod h1:gil5LBD8tSdFQbUkCQdnXsoeU9kDJdJgbGdHkgJfcd0=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -68,7 +68,7 @@ func (q *ExpandQuery) Execute(ctx context.Context, req *openfgav1.ExpandRequest)
 		}
 	}
 
-	err := validation.ValidateObject(typesys, tk);
+	err := validation.ValidateObject(typesys, tk)
 	if err != nil {
 		return nil, serverErrors.ValidationError(err)
 	}

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -3,14 +3,17 @@ package commands
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"golang.org/x/sync/errgroup"
 
+	openfgaErrors "github.com/openfga/openfga/internal/errors"
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	tupleUtils "github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
@@ -18,7 +21,7 @@ import (
 // ExpandQuery resolves a target TupleKey into a UsersetTree by expanding type definitions.
 type ExpandQuery struct {
 	logger    logger.Logger
-	datastore storage.OpenFGADatastore
+	datastore storage.RelationshipTupleReader
 }
 
 type ExpandQueryOption func(*ExpandQuery)
@@ -44,7 +47,6 @@ func NewExpandQuery(datastore storage.OpenFGADatastore, opts ...ExpandQueryOptio
 
 func (q *ExpandQuery) Execute(ctx context.Context, req *openfgav1.ExpandRequest) (*openfgav1.ExpandResponse, error) {
 	store := req.GetStoreId()
-	modelID := req.GetAuthorizationModelId()
 	tupleKey := req.GetTupleKey()
 	object := tupleKey.GetObject()
 	relation := tupleKey.GetRelation()
@@ -55,25 +57,19 @@ func (q *ExpandQuery) Execute(ctx context.Context, req *openfgav1.ExpandRequest)
 
 	tk := tupleUtils.NewTupleKey(object, relation, "")
 
-	model, err := q.datastore.ReadAuthorizationModel(ctx, store, modelID)
-	if err != nil {
-		if errors.Is(err, storage.ErrNotFound) {
-			return nil, serverErrors.AuthorizationModelNotFound(modelID)
+	typesys, ok := typesystem.TypesystemFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
+	}
+
+	for _, ctxTuple := range req.GetContextualTuples().GetTupleKeys() {
+		if err := validation.ValidateTupleForWrite(typesys, ctxTuple); err != nil {
+			return nil, serverErrors.HandleTupleValidateError(err)
 		}
-
-		return nil, serverErrors.HandleError("", err)
 	}
 
-	if !typesystem.IsSchemaVersionSupported(model.GetSchemaVersion()) {
-		return nil, serverErrors.ValidationError(typesystem.ErrInvalidSchemaVersion)
-	}
-
-	typesys, err := typesystem.NewAndValidate(ctx, model)
+	err := validation.ValidateObject(typesys, tk);
 	if err != nil {
-		return nil, serverErrors.ValidationError(typesystem.ErrInvalidModel)
-	}
-
-	if err = validation.ValidateObject(typesys, tk); err != nil {
 		return nil, serverErrors.ValidationError(err)
 	}
 
@@ -81,6 +77,11 @@ func (q *ExpandQuery) Execute(ctx context.Context, req *openfgav1.ExpandRequest)
 	if err != nil {
 		return nil, serverErrors.ValidationError(err)
 	}
+
+	q.datastore = storagewrappers.NewCombinedTupleReader(
+		q.datastore,
+		req.GetContextualTuples().GetTupleKeys(),
+	)
 
 	objectType := tupleUtils.GetType(object)
 	rel, err := typesys.GetRelation(objectType, relation)

--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -172,7 +172,7 @@ func TestExpandWithContextualTuples(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, resp)
-			require.Equal(t, tc.expected, resp.Tree.Root)
+			require.Equal(t, tc.expected, resp.GetTree().GetRoot())
 		})
 	}
 }

--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -1,0 +1,178 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/require"
+
+	serverErrors "github.com/openfga/openfga/pkg/server/errors"
+	"github.com/openfga/openfga/pkg/storage/memory"
+	storagetest "github.com/openfga/openfga/pkg/storage/test"
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+)
+
+func TestExpandWithContextualTuples(t *testing.T) {
+	tests := []struct {
+		name             string
+		modelStr         string
+		tuples           []string
+		contextualTuples []*openfgav1.TupleKey
+		expandTupleKey   *openfgav1.ExpandRequestTupleKey
+		expected         *openfgav1.UsersetTree_Node
+		expectedErr      error
+	}{
+		{
+			name: "invalid_contextual_tuple_fails_validation",
+			modelStr: `
+				model
+					schema 1.1
+				type user
+
+				type document
+					relations
+						define viewer: [user]
+						define can_view: viewer`,
+			tuples: []string{},
+			contextualTuples: []*openfgav1.TupleKey{
+				{
+					Object:   "document:1",
+					Relation: "invalid_relation",
+					User:     "user:bob",
+				},
+			},
+			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
+				Object:   "document:1",
+				Relation: "can_view",
+			},
+			expectedErr: serverErrors.HandleTupleValidateError(
+				&tuple.InvalidTupleError{
+					Cause: &tuple.RelationNotFoundError{
+						Relation: "invalid_relation",
+						TypeName: "document",
+					},
+					TupleKey: &openfgav1.TupleKey{
+						User:     "user:bob",
+						Relation: "invalid_relation",
+						Object:   "document:1",
+					}}),
+		},
+		{
+			name: "expand_with_only_contextual_tuples",
+			modelStr: `
+				model
+					schema 1.1
+
+				type user
+
+				type document
+					relations
+						define viewer: [user]
+						define can_view: viewer
+			`,
+			tuples: []string{},
+			contextualTuples: []*openfgav1.TupleKey{
+				{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:bob",
+				},
+			},
+			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
+				Object:   "document:1",
+				Relation: "viewer",
+			},
+			expected: &openfgav1.UsersetTree_Node{
+				Name: "document:1#viewer",
+				Value: &openfgav1.UsersetTree_Node_Leaf{
+					Leaf: &openfgav1.UsersetTree_Leaf{
+						Value: &openfgav1.UsersetTree_Leaf_Users{
+							Users: &openfgav1.UsersetTree_Users{
+								Users: []string{"user:bob"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "multiple_contextual_tuples_expand_correctly",
+			modelStr: `
+					model
+						schema 1.1
+					type user
+
+					type document
+					relations
+						define viewer: [user]
+						define can_view: viewer`,
+			tuples: []string{},
+			contextualTuples: []*openfgav1.TupleKey{
+				{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:bob",
+				},
+				{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:alice",
+				},
+			},
+			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
+				Object:   "document:1",
+				Relation: "viewer",
+			},
+			expected: &openfgav1.UsersetTree_Node{
+				Name: "document:1#viewer",
+				Value: &openfgav1.UsersetTree_Node_Leaf{
+					Leaf: &openfgav1.UsersetTree_Leaf{
+						Value: &openfgav1.UsersetTree_Leaf_Users{
+							Users: &openfgav1.UsersetTree_Users{
+								Users: []string{"user:bob", "user:alice"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := memory.New()
+			t.Cleanup(ds.Close)
+			storeID, model := storagetest.BootstrapFGAStore(t, ds, tc.modelStr, tc.tuples)
+			ctx := context.Background()
+			ts, err := typesystem.NewAndValidate(
+				ctx,
+				model,
+			)
+			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			require.NoError(t, err)
+
+			expandQuery := NewExpandQuery(ds)
+
+			resp, err := expandQuery.Execute(ctx, &openfgav1.ExpandRequest{
+				StoreId:  storeID,
+				TupleKey: tc.expandTupleKey,
+				ContextualTuples: &openfgav1.ContextualTupleKeys{
+					TupleKeys: tc.contextualTuples,
+				},
+			})
+
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+			require.Equal(t, tc.expected, resp.Tree.Root)
+		})
+	}
+}

--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-func TestExpandWithContextualTuples(t *testing.T) {
+func TestExpand(t *testing.T) {
 	tests := []struct {
 		name             string
 		modelStr         string

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1220,12 +1220,14 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 	}
 
 	q := commands.NewExpandQuery(s.datastore, commands.WithExpandQueryLogger(s.logger))
-	return q.Execute(ctx, &openfgav1.ExpandRequest{
-		StoreId:              storeID,
-		AuthorizationModelId: typesys.GetAuthorizationModelID(), // the resolved model id
-		TupleKey:             tk,
-		Consistency:          req.GetConsistency(),
-	})
+	return q.Execute(
+		typesystem.ContextWithTypesystem(ctx, typesys),
+		&openfgav1.ExpandRequest{
+			StoreId:          storeID,
+			TupleKey:         tk,
+			Consistency:      req.GetConsistency(),
+			ContextualTuples: req.GetContextualTuples(),
+		})
 }
 
 func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.ReadAuthorizationModelRequest) (*openfgav1.ReadAuthorizationModelResponse, error) {

--- a/pkg/server/test/expand.go
+++ b/pkg/server/test/expand.go
@@ -789,6 +789,10 @@ func TestExpandQuery(t *testing.T, datastore storage.OpenFGADatastore) {
 			err := datastore.WriteAuthorizationModel(ctx, store, test.model)
 			require.NoError(t, err)
 
+			ts, err := typesystem.NewAndValidate(ctx, test.model)
+			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			require.NoError(t, err)
+
 			err = datastore.Write(
 				ctx,
 				store,
@@ -949,6 +953,10 @@ func TestExpandQueryErrors(t *testing.T, datastore storage.OpenFGADatastore) {
 			// arrange
 			store := ulid.Make().String()
 			err := datastore.WriteAuthorizationModel(ctx, store, test.model)
+			require.NoError(t, err)
+
+			ts, err := typesystem.NewAndValidate(ctx, test.model)
+			ctx = typesystem.ContextWithTypesystem(ctx, ts)
 			require.NoError(t, err)
 
 			err = datastore.Write(


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Adds contextual tuples support to Expand request.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
#951 

1. [PR](https://github.com/openfga/api/pull/202) to add Contextual tuples to the request in openfga/api
2. [PR](https://github.com/openfga/api/pull/209) to add documentation for the same

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above] - Yet to
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected
