### PR TITLE
fix: disable fastpath optimization for  nested userset with public wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 * Goroutine leak when ListObjects or StreamedListObjects call cannot be completed within REQUEST_TIMEOUT. [#2030](https://github.com/openfga/openfga/pull/2030)
 * Label ListUsers API calls [#2000](https://github.com/openfga/openfga/pull/2000)
 * Fixed incorrect dispatch counts in List Objects [2013](https://github.com/openfga/openfga/pull/2013)
+* Internal error for check where model has nested userset with publicly assignable wildcard. [#2049](https://github.com/openfga/openfga/pull/2049) 
 
 ### Breaking changes
 * The storage adapter `ListStores`'s parameter ListStoresOptions allows filtering by `IDs` [#1913](https://github.com/openfga/openfga/pull/1913)

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -508,9 +508,9 @@ func (t *TypeSystem) RecursiveUsersetCanFastPath(objectTypeRelation string, user
 		return false
 	}
 	// FIXME: for now, we will disable fastpath for cases where publicly wildcard can be assigned to recursive userset.
-	return t.verifyNodeEdgesOptimizable(curAuthorizationModelNode,
+	return !t.hasPublicWildcardNode(curAuthorizationModelNode) && t.verifyNodeEdgesOptimizable(curAuthorizationModelNode,
 		expectedEdgeAndNodeType{expectedNodeForObjectRel: curAuthorizationModelNode, expectedEdgeType: graph.DirectEdge},
-		userType) && !t.hasPublicWildcardNode(curAuthorizationModelNode)
+		userType)
 }
 
 // recursiveTTUNodeCanFastpath is a helper function to determine whether the node (object#relation) has

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -4607,7 +4607,7 @@ type group
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           true,
+			expected:           false,
 		},
 		{
 			name: "simple_recursive_wildcard_condition",
@@ -4624,7 +4624,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           true,
+			expected:           false,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_wildcard",
@@ -4638,7 +4638,7 @@ type group
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           true,
+			expected:           false,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_wildcard_cond",
@@ -4655,7 +4655,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           true,
+			expected:           false,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_user_wildcard_cond",
@@ -4672,7 +4672,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           true,
+			expected:           false,
 		},
 		{
 			name: "complex_recursive_due_to_type_not_found",

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1115,6 +1115,7 @@ type usersets-user
     define userset_to_and_computed:[directs-user#and_computed]
     define userset_recursive: [user, usersets-user#userset_recursive]
     define userset_recursive_public: [user, user:*, usersets-user#userset_recursive_public]
+    define userset_recursive_public_only: [user:*, usersets-user#userset_recursive_public_only]
     define userset_recursive_mixed_direct_assignment: [user, usersets-user#userset_recursive_mixed_direct_assignment, usersets-user#userset]
     define or_userset: userset or userset_to_computed_cond
     define and_userset: userset_to_computed_cond and userset_to_computed_wild
@@ -1155,6 +1156,10 @@ type ttus
     define or_ttu: direct_pa_direct_ch or direct_cond_pa_direct_ch
     define and_ttu: or_comp_from_direct_parent and direct_pa_direct_ch
     define nested_butnot_ttu: or_comp_from_direct_parent but not userset_pa_userset_comp_wild_ch
+	define nested_ttu_parent: [ttus]
+	define nested_ttu: [directs-user] or nested_ttu from nested_ttu_parent
+	define nested_ttu_public: [directs-user, directs-user:*] or nested_ttu_public from nested_ttu_parent
+
 type complexity3
   relations
     define ttu_parent: [ttus]

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1114,6 +1114,7 @@ type usersets-user
     define userset_to_butnot_computed: [directs-user#butnot_computed]
     define userset_to_and_computed:[directs-user#and_computed]
     define userset_recursive: [user, usersets-user#userset_recursive]
+    define userset_recursive_public: [user, user:*, usersets-user#userset_recursive_public]
     define userset_recursive_mixed_direct_assignment: [user, usersets-user#userset_recursive_mixed_direct_assignment, usersets-user#userset]
     define or_userset: userset or userset_to_computed_cond
     define and_userset: userset_to_computed_cond and userset_to_computed_wild

--- a/tests/check/check_ttu.go
+++ b/tests/check/check_ttu.go
@@ -751,4 +751,158 @@ var ttuCompleteTestingModelTest = []*stage{
 			},
 		},
 	},
+	{
+		Name: "nested_ttu",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "ttus:ttus_nested_ttu_direct_assign", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+			{Object: "ttus:ttus_nested_ttu_parent_case_1_1", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_direct_assign"},
+			{Object: "ttus:ttus_nested_ttu_parent_case_1_2", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_parent_case_1_1"},
+			{Object: "ttus:ttus_nested_ttu_parent_case_1_3", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_parent_case_1_2"},
+			{Object: "ttus:ttus_nested_ttu_parent_case_1_4", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_parent_case_1_3"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "nested_ttu_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_direct_assign", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_direct_assign", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_1", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_1", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_2", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_2", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_3",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_3", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_3",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_3", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_4", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_parent_case_1_4", Relation: "nested_ttu", User: "directs-user:ttus_nested_ttu_not_direct_assign"},
+				Expectation: false,
+			},
+		},
+	},
+	{
+		Name: "nested_ttu_public",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "ttus:ttus_nested_ttu_public_direct_assign", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+			{Object: "ttus:ttus_nested_ttu_public_parent_case_1_1", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_direct_assign"},
+			{Object: "ttus:ttus_nested_ttu_public_parent_case_1_2", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_parent_case_1_1"},
+			{Object: "ttus:ttus_nested_ttu_public_parent_case_1_3", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_parent_case_1_2"},
+			{Object: "ttus:ttus_nested_ttu_public_parent_case_1_4", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_parent_case_1_3"},
+			{Object: "ttus:ttus_nested_ttu_public_wildcard", Relation: "nested_ttu_public", User: "directs-user:*"},
+			{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_1", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_wildcard"},
+			{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_2", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_1"},
+			{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_3", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_2"},
+			{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_4", Relation: "nested_ttu_parent", User: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_3"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "nested_ttu_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_direct_assign", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_direct_assign", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_1", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_1", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_2", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_2", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_3",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_3", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_3",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_3", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_4", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_not_direct_assigned_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_parent_case_1_4", Relation: "nested_ttu_public", User: "directs-user:ttus_nested_ttu_public_not_direct_assign"},
+				Expectation: false,
+			},
+			{
+				Name:        "nested_ttu_public_wildcard",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_wildcard", Relation: "nested_ttu_public", User: "directs-user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_public_wildcard_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_1", Relation: "nested_ttu_public", User: "directs-user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_public_wildcard_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_2", Relation: "nested_ttu_public", User: "directs-user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_public_wildcard_level_3",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_3", Relation: "nested_ttu_public", User: "directs-user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "nested_ttu_public_wildcard_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_nested_ttu_public_wildcard_parent_case_1_4", Relation: "nested_ttu_public", User: "directs-user:any"},
+				Expectation: true,
+			},
+		},
+	},
 }

--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -544,7 +544,11 @@ var usersetCompleteTestingModelTest = []*stage{
 			{Object: "usersets-user:userset_recursive_public_multi_level_3", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_4#userset_recursive_public"},
 			{Object: "usersets-user:userset_recursive_public_multi_level_4", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_multi_level"},
 			{Object: "usersets-user:userset_recursive_public_invalid_object", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_object"},
-			{Object: "usersets-user:userset_recursive_public_public", Relation: "userset_recursive_public", User: "user:*"},
+			{Object: "usersets-user:userset_recursive_public_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_1#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_public_multi_level_1", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_2#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_public_multi_level_2", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_3#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_public_multi_level_3", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_4#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_public_multi_level_4", Relation: "userset_recursive_public", User: "user:*"},
 		},
 		CheckAssertions: []*checktest.Assertion{
 			{
@@ -584,17 +588,114 @@ var usersetCompleteTestingModelTest = []*stage{
 			},
 			{
 				Name:        "invalid_object",
-				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_1", Relation: "userset_recursive", User: "user:userset_recursive_user_public_invalid_object"},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_1", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_object"},
 				Expectation: false,
 			},
 			{
 				Name:        "invalid_object_multi_level",
-				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive", User: "user:userset_recursive_user_public_invalid_object"},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_object"},
 				Expectation: false,
 			},
 			{
-				Name:        "public_user",
-				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public", Relation: "userset_recursive_public", User: "user:any"},
+				Name:        "valid_user_multi_level_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_4_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level_4", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_3_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level_3", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_2_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level_2", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_1_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level_1", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_2_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_2#userset_recursive_public"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_3_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_3#userset_recursive_public"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_4_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_public_multi_level_4#userset_recursive_public"},
+				Expectation: true,
+			},
+		},
+	},
+	{
+		Name: "usersets_userset_recursive_public_only",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "usersets-user:userset_recursive_public_only_multi_level", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_1#userset_recursive_public_only"},
+			{Object: "usersets-user:userset_recursive_public_only_multi_level_1", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_2#userset_recursive_public_only"},
+			{Object: "usersets-user:userset_recursive_public_only_multi_level_2", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_3#userset_recursive_public_only"},
+			{Object: "usersets-user:userset_recursive_public_only_multi_level_3", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_4#userset_recursive_public_only"},
+			{Object: "usersets-user:userset_recursive_public_only_multi_level_4", Relation: "userset_recursive_public_only", User: "user:*"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "invalid_object",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_invalid_object", Relation: "userset_recursive_public_only", User: "user:userset_recursive_user_public_invalid_object"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_object_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_invalid_multi_level", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_invalid_multi_level_root#userset_recursive_public_only"},
+				Expectation: false,
+			},
+			{
+				Name:        "valid_user_multi_level_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level", Relation: "userset_recursive_public_only", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_4_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level_4", Relation: "userset_recursive_public_only", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_3_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level_3", Relation: "userset_recursive_public_only", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_2_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level_2", Relation: "userset_recursive_public_only", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level_1_public",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level_1", Relation: "userset_recursive_public_only", User: "user:any"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_2_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_2#userset_recursive_public_only"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_3_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_3#userset_recursive_public_only"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level_4_public_relation",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_multi_level", Relation: "userset_recursive_public_only", User: "usersets-user:userset_recursive_public_only_multi_level_4#userset_recursive_public_only"},
 				Expectation: true,
 			},
 		},

--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -534,6 +534,72 @@ var usersetCompleteTestingModelTest = []*stage{
 		},
 	},
 	{
+		Name: "usersets_userset_recursive_public",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "usersets-user:userset_recursive_public_1", Relation: "userset_recursive_public", User: "user:userset_recursive_public_user_1"},
+			{Object: "usersets-user:userset_recursive_public_1", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_2#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_1#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_multi_level_1", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_2#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_multi_level_2", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_3#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_multi_level_3", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_4#userset_recursive_public"},
+			{Object: "usersets-user:userset_recursive_public_multi_level_4", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_multi_level"},
+			{Object: "usersets-user:userset_recursive_public_invalid_object", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_object"},
+			{Object: "usersets-user:userset_recursive_public_public", Relation: "userset_recursive_public", User: "user:*"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "valid_recursive",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_1", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_2#userset_recursive_public"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_1", Relation: "userset_recursive_public", User: "user:userset_recursive_public_user_1"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_user_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_multi_level"},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_userset_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive_public", User: "usersets-user:userset_recursive_public_multi_level_4#userset_recursive_public"},
+				Expectation: true,
+			},
+			{
+				Name:        "invalid_recursive",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_1", Relation: "userset_recursive_public", User: "usersets-user:userset_3#userset_recursive_public"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_1", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_user"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_user_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive_public", User: "user:userset_recursive_user_public_invalid_user"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_object",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_1", Relation: "userset_recursive", User: "user:userset_recursive_user_public_invalid_object"},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_object_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_multi_level", Relation: "userset_recursive", User: "user:userset_recursive_user_public_invalid_object"},
+				Expectation: false,
+			},
+			{
+				Name:        "public_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_public", Relation: "userset_recursive_public", User: "user:any"},
+				Expectation: true,
+			},
+		},
+	},
+	{
 		Name: "userset_recursive_mixed_direct_assignment_mixed_direct_assignment",
 		Tuples: []*openfgav1.TupleKey{
 			{Object: "usersets-user:userset_recursive_mixed_direct_assignment_1", Relation: "userset_recursive_mixed_direct_assignment", User: "user:userset_recursive_mixed_direct_assignment_user_1"},


### PR DESCRIPTION

## Description
The current fastpath optimization for nested userset does not handle case 

## References
Close https://github.com/openfga/openfga/issues/2048


## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
