### PR TITLE
fix: clone request to avoid data race

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1275,8 +1275,9 @@ func (c *LocalChecker) nestedFastPath(ctx context.Context, req *ResolveCheckRequ
 		}
 	}
 
-	req.GetRequestMetadata().DatastoreQueryCount = res.GetResolutionMetadata().DatastoreQueryCount
-	return c.recursiveMatchUserUserset(ctx, req, mapping, usersetFromObject, usersetFromUser)
+	newReq := req.clone()
+	newReq.GetRequestMetadata().DatastoreQueryCount = res.GetResolutionMetadata().DatastoreQueryCount
+	return c.recursiveMatchUserUserset(ctx, newReq, mapping, usersetFromObject, usersetFromUser)
 }
 
 func (c *LocalChecker) nestedTTUFastPath(ctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset, iter storage.TupleKeyIterator) (*ResolveCheckResponse, error) {


### PR DESCRIPTION
## Description

```
2024/10/28 19:36:35 [DEBUG] GET http://localhost:39425/healthz
==================
WARNING: DATA RACE
Read at 0x00c00286a244 by goroutine 6916:
  github.com/openfga/openfga/internal/graph.(*LocalChecker).checkRewrite.(*LocalChecker).checkDirect.func2.1()
      /home/runner/work/openfga/openfga/internal/graph/check.go:1373 +0x3fa
  github.com/openfga/openfga/internal/graph.resolver.func1.2()
      /home/runner/work/openfga/openfga/internal/graph/check.go:155 +0x69

Previous write at 0x00c00286a244 by goroutine 6909:
  github.com/openfga/openfga/internal/graph.(*LocalChecker).nestedFastPath()
      /home/runner/work/openfga/openfga/internal/graph/check.go:1278 +0x1b2a
  github.com/openfga/openfga/internal/graph.(*LocalChecker).nestedTTUFastPath()
      /home/runner/work/openfga/openfga/internal/graph/check.go:1286 +0x356
  github.com/openfga/openfga/internal/graph.(*LocalChecker).nestedTTUFastPath-fm()
      <autogenerated>:1 +0x89
  github.com/openfga/openfga/internal/graph.(*LocalChecker).checkRewrite.(*LocalChecker).checkTTU.func3()
      /home/runner/work/openfga/openfga/internal/graph/check.go:1670 +0xa99
  github.com/openfga/openfga/internal/graph.resolver.func1.2()
      /home/runner/work/openfga/openfga/internal/graph/check.go:155 +0x69

Goroutine 6916 (running) created at:
  github.com/openfga/openfga/internal/graph.resolver.func1()
      /home/runner/work/openfga/openfga/internal/graph/check.go:154 +0x274
  github.com/openfga/openfga/internal/graph.resolver.func2.gowrap1()
      /home/runner/work/openfga/openfga/internal/graph/check.go:176 +0x41

Goroutine 6909 (running) created at:
  github.com/openfga/openfga/internal/graph.resolver.func1()
      /home/runner/work/openfga/openfga/internal/graph/check.go:154 +0x274
  github.com/openfga/openfga/internal/graph.resolver.func2.gowrap1()
      /home/runner/work/openfga/openfga/internal/graph/check.go:176 +0x41
==================
2024/10/28 19:36:48 [DEBUG] GET http://localhost:43709/healthz
--- FAIL: TestMatrixMemory (28.30s)
    --- FAIL: TestMatrixMemory/test_matrix_memory_experimental_true (13.59s)
        tests.go:62: creating connection to address localhost:39041
        --- FAIL: TestMatrixMemory/test_matrix_memory_experimental_true/complete_testing_model (13.57s)
            --- FAIL: TestMatrixMemory/test_matrix_memory_experimental_true/complete_testing_model/stage_nested_ttu_public (0.46s)
                --- FAIL: TestMatrixMemory/test_matrix_memory_experimental_true/complete_testing_model/stage_nested_ttu_public/assertion_check_nested_ttu_public_wildcard_level_4 (0.02s)
                    testing.go:1398: race detected during execution of test
        tests.go:56: waiting for server to stop
        tests.go:59: server stopped with error:  <nil>
```

## References

https://github.com/openfga/openfga/actions/runs/11561288530/job/32179955365

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
