### PR TITLE
chore: move check directly assignable function out to its own function

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1337,10 +1337,10 @@ func (c *LocalChecker) buildNestedMapper(ctx context.Context, req *ResolveCheckR
 	return wrapIterator(mapping.kind, filteredIter), nil
 }
 
-func (c *LocalChecker) checkDirectUserTuple(parentctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
-	typesys, _ := typesystem.TypesystemFromContext(parentctx) // note: use of 'parentctx' not 'ctx' - this is important
+func (c *LocalChecker) checkDirectUserTuple(ctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
+	typesys, _ := typesystem.TypesystemFromContext(ctx)
 
-	ds, _ := storage.RelationshipTupleReaderFromContext(parentctx)
+	ds, _ := storage.RelationshipTupleReaderFromContext(ctx)
 	storeID := req.GetStoreID()
 	reqTupleKey := req.GetTupleKey()
 
@@ -1386,7 +1386,6 @@ func (c *LocalChecker) checkDirectUserTuple(parentctx context.Context, req *Reso
 		if conditionMet {
 			span.SetAttributes(attribute.Bool("allowed", true))
 			response.Allowed = true
-			return response, nil
 		}
 		return response, nil
 	}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1337,6 +1337,61 @@ func (c *LocalChecker) buildNestedMapper(ctx context.Context, req *ResolveCheckR
 	return wrapIterator(mapping.kind, filteredIter), nil
 }
 
+func (c *LocalChecker) checkDirectUserTuple(parentctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
+	typesys, _ := typesystem.TypesystemFromContext(parentctx) // note: use of 'parentctx' not 'ctx' - this is important
+
+	ds, _ := storage.RelationshipTupleReaderFromContext(parentctx)
+	storeID := req.GetStoreID()
+	reqTupleKey := req.GetTupleKey()
+
+	return func(ctx context.Context) (*ResolveCheckResponse, error) {
+		ctx, span := tracer.Start(ctx, "checkDirectUserTuple",
+			trace.WithAttributes(attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(reqTupleKey))))
+		defer span.End()
+
+		response := &ResolveCheckResponse{
+			Allowed: false,
+			ResolutionMetadata: &ResolveCheckResponseMetadata{
+				DatastoreQueryCount: req.GetRequestMetadata().DatastoreQueryCount + 1,
+			},
+		}
+
+		opts := storage.ReadUserTupleOptions{
+			Consistency: storage.ConsistencyOptions{
+				Preference: req.GetConsistency(),
+			},
+		}
+
+		t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, opts)
+		if err != nil {
+			if errors.Is(err, storage.ErrNotFound) {
+				return response, nil
+			}
+
+			return nil, err
+		}
+
+		// filter out invalid tuples yielded by the database query
+		tupleKey := t.GetKey()
+		err = validation.ValidateTupleForRead(typesys, tupleKey)
+		if err != nil {
+			return response, nil
+		}
+		tupleKeyConditionFilter := checkutil.BuildTupleKeyConditionFilter(ctx, req.Context, typesys)
+		conditionMet, err := tupleKeyConditionFilter(tupleKey)
+		if err != nil {
+			telemetry.TraceError(span, err)
+			return nil, err
+		}
+		if conditionMet {
+			span.SetAttributes(attribute.Bool("allowed", true))
+			response.Allowed = true
+			return response, nil
+		}
+		return response, nil
+	}
+}
+
 // checkDirect composes two CheckHandlerFunc which evaluate direct relationships with the provided
 // 'object#relation'. The first handler looks up direct matches on the provided 'object#relation@user',
 // while the second handler looks up relationships between the target 'object#relation' and any usersets
@@ -1362,52 +1417,7 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 		// directlyRelatedUsersetTypes could be "user:*" or "group#member"
 		directlyRelatedUsersetTypes, _ := typesys.DirectlyRelatedUsersets(objectType, relation)
 
-		// TODO(jpadilla): can we lift this function up?
-		checkDirectUserTuple := func(ctx context.Context) (*ResolveCheckResponse, error) {
-			ctx, span := tracer.Start(ctx, "checkDirectUserTuple",
-				trace.WithAttributes(attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(reqTupleKey))))
-			defer span.End()
-
-			response := &ResolveCheckResponse{
-				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					DatastoreQueryCount: req.GetRequestMetadata().DatastoreQueryCount + 1,
-				},
-			}
-
-			opts := storage.ReadUserTupleOptions{
-				Consistency: storage.ConsistencyOptions{
-					Preference: req.GetConsistency(),
-				},
-			}
-			t, err := ds.ReadUserTuple(ctx, storeID, reqTupleKey, opts)
-			if err != nil {
-				if errors.Is(err, storage.ErrNotFound) {
-					return response, nil
-				}
-
-				return nil, err
-			}
-
-			// filter out invalid tuples yielded by the database query
-			tupleKey := t.GetKey()
-			err = validation.ValidateTupleForRead(typesys, tupleKey)
-			if err != nil {
-				return response, nil
-			}
-			tupleKeyConditionFilter := checkutil.BuildTupleKeyConditionFilter(ctx, req.Context, typesys)
-			conditionMet, err := tupleKeyConditionFilter(tupleKey)
-			if err != nil {
-				telemetry.TraceError(span, err)
-				return nil, err
-			}
-			if conditionMet {
-				span.SetAttributes(attribute.Bool("allowed", true))
-				response.Allowed = true
-				return response, nil
-			}
-			return response, nil
-		}
+		checkDirectUserTuple := c.checkDirectUserTuple(parentctx, req)
 
 		// TODO(jpadilla): can we lift this function up?
 		checkDirectUsersetTuples := func(ctx context.Context) (*ResolveCheckResponse, error) {

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -3251,6 +3251,20 @@ func TestIsPubliclyAssignable(t *testing.T) {
 			result:     false,
 		},
 		{
+			name: "is_publicly_assignable_mix_public_non_public",
+			model: `
+				model
+					schema 1.1
+				type user
+
+				type document
+					relations
+						define viewer: [user, user:*]`,
+			target:     DirectRelationReference("document", "viewer"),
+			objectType: "user",
+			result:     true,
+		},
+		{
 			name: "is_not_publicly_assignable_mismatch_type",
 			model: `
 				model


### PR DESCRIPTION
## Description

Small refactor to move checkDirectUserTuple to its own function in preparation of optimizing nested userset with public wildcard assignable.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
