### PR TITLE
refactor: resolve check response

### DIFF
--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -500,9 +500,6 @@ func TestResolveCheck_ConcurrentCachedReadsAndWrites(t *testing.T) {
 		ResolveCheck(gomock.Any(), gomock.Any()).
 		Return(&ResolveCheckResponse{
 			Allowed: true,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
-				CycleDetected: false,
-			},
 		}, nil)
 
 	_, err := dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
@@ -629,7 +626,7 @@ func TestCachedCheckResolver_FieldsInResponse(t *testing.T) {
 		ResolveCheck(gomock.Any(), gomock.Any()).
 		Return(&ResolveCheckResponse{
 			Allowed: false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
+			ResolutionMetadata: ResolveCheckResponseMetadata{
 				CycleDetected: true,
 			},
 		}, nil)
@@ -659,7 +656,7 @@ func TestCachedCheckResolver_ResolveCheck_After_Stop_DoesNotPanic(t *testing.T) 
 		Times(1).
 		Return(&ResolveCheckResponse{
 			Allowed: false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
+			ResolutionMetadata: ResolveCheckResponseMetadata{
 				CycleDetected: true,
 			},
 		}, nil)

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -229,7 +229,7 @@ func union(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandle
 
 	return &ResolveCheckResponse{
 		Allowed: false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{
+		ResolutionMetadata: ResolveCheckResponseMetadata{
 			CycleDetected: cycleDetected,
 		},
 	}, nil
@@ -240,8 +240,7 @@ func union(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandle
 func intersection(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHandlerFunc) (*ResolveCheckResponse, error) {
 	if len(handlers) == 0 {
 		return &ResolveCheckResponse{
-			Allowed:            false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: false,
 		}, nil
 	}
 
@@ -282,8 +281,7 @@ func intersection(ctx context.Context, concurrencyLimit uint32, handlers ...Chec
 	}
 
 	return &ResolveCheckResponse{
-		Allowed:            true,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: true,
 	}, nil
 }
 
@@ -334,8 +332,7 @@ func exclusion(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHa
 	}()
 
 	response := &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}
 
 	var baseErr error
@@ -353,7 +350,7 @@ func exclusion(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHa
 			if baseResult.resp.GetCycleDetected() {
 				return &ResolveCheckResponse{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
+					ResolutionMetadata: ResolveCheckResponseMetadata{
 						CycleDetected: true,
 					},
 				}, nil
@@ -373,7 +370,7 @@ func exclusion(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHa
 			if subResult.resp.GetCycleDetected() {
 				return &ResolveCheckResponse{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
+					ResolutionMetadata: ResolveCheckResponseMetadata{
 						CycleDetected: true,
 					},
 				}, nil
@@ -397,8 +394,7 @@ func exclusion(ctx context.Context, concurrencyLimit uint32, handlers ...CheckHa
 	}
 
 	return &ResolveCheckResponse{
-		Allowed:            true,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: true,
 	}, nil
 }
 
@@ -450,7 +446,7 @@ func (c *LocalChecker) ResolveCheck(
 		span.SetAttributes(attribute.Bool("cycle_detected", true))
 		return &ResolveCheckResponse{
 			Allowed: false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
+			ResolutionMetadata: ResolveCheckResponseMetadata{
 				CycleDetected: true,
 			},
 		}, nil
@@ -462,8 +458,7 @@ func (c *LocalChecker) ResolveCheck(
 
 	if tuple.IsSelfDefining(req.GetTupleKey()) {
 		return &ResolveCheckResponse{
-			Allowed:            true,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: true,
 		}, nil
 	}
 
@@ -538,8 +533,7 @@ func checkAssociatedObjects(ctx context.Context, req *ResolveCheckRequest, objec
 	}
 
 	return &ResolveCheckResponse{
-		Allowed:            allowed,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: allowed,
 	}, nil
 }
 
@@ -615,8 +609,7 @@ func (c *LocalChecker) processDispatches(ctx context.Context, limit uint32, disp
 				}
 				if msg.shortCircuit {
 					resp := &ResolveCheckResponse{
-						Allowed:            true,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: true,
 					}
 					concurrency.TrySendThroughChannel(ctx, checkOutcome{resp: resp}, outcomes)
 					return
@@ -642,8 +635,7 @@ func (c *LocalChecker) consumeDispatches(ctx context.Context, limit uint32, disp
 
 	var finalErr error
 	finalResult := &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}
 
 ConsumerLoop:
@@ -841,8 +833,7 @@ func (c *LocalChecker) consumeUsersets(ctx context.Context, req *ResolveCheckReq
 
 	var finalErr error
 	finalResult := &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}
 
 ConsumerLoop:
@@ -996,8 +987,7 @@ func (c *LocalChecker) breadthFirstNestedMatch(ctx context.Context, req *Resolve
 				userset := usersetMsg.userset
 				if usersetFromUser.Contains(userset) {
 					concurrency.TrySendThroughChannel(ctx, checkOutcome{resp: &ResolveCheckResponse{
-						Allowed:            true,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: true,
 					}}, checkOutcomeChan)
 					return ErrShortCircuit // cancel will be propagated to the remaining goroutines
 				}
@@ -1016,8 +1006,7 @@ func (c *LocalChecker) breadthFirstNestedMatch(ctx context.Context, req *Resolve
 	}
 
 	concurrency.TrySendThroughChannel(ctx, checkOutcome{resp: &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}}, checkOutcomeChan)
 	c.breadthFirstNestedMatch(ctx, req, mapping, visitedUserset, nextUsersetLevel, usersetFromUser, checkOutcomeChan)
 }
@@ -1044,8 +1033,7 @@ func (c *LocalChecker) recursiveMatchUserUserset(ctx context.Context, req *Resol
 
 	var finalErr error
 	finalResult := &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}
 
 ConsumerLoop:
@@ -1145,8 +1133,7 @@ func (c *LocalChecker) nestedFastPath(ctx context.Context, req *ResolveCheckRequ
 	objectToUsersetMessageChan := streamedLookupUsersetFromIterator(cancellableCtx, objectToUsersetIter)
 
 	res := &ResolveCheckResponse{
-		Allowed:            false,
-		ResolutionMetadata: &ResolveCheckResponseMetadata{},
+		Allowed: false,
 	}
 
 	// check to see if there are any nested userset assigned. If not,
@@ -1284,8 +1271,7 @@ func (c *LocalChecker) checkDirectUserTuple(ctx context.Context, req *ResolveChe
 		defer span.End()
 
 		response := &ResolveCheckResponse{
-			Allowed:            false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: false,
 		}
 
 		opts := storage.ReadUserTupleOptions{

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -40,15 +40,13 @@ import (
 var (
 	falseHandler = func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
-			Allowed:            false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: false,
 		}, nil
 	}
 
 	trueHandler = func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
-			Allowed:            true,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: true,
 		}, nil
 	}
 
@@ -59,7 +57,7 @@ var (
 	cyclicErrorHandler = func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
 			Allowed: false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
+			ResolutionMetadata: ResolveCheckResponseMetadata{
 				CycleDetected: true,
 			},
 		}, nil
@@ -1387,15 +1385,13 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 
 	falseHandler := func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
-			Allowed:            false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: false,
 		}, nil
 	}
 
 	trueHandler := func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
-			Allowed:            true,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: true,
 		}, nil
 	}
 
@@ -2145,8 +2141,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 			},
 			context: map[string]interface{}{},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: false,
 		},
@@ -2172,8 +2167,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 			objectIDs: []string{},
 			context:   map[string]interface{}{},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: false,
 		},
@@ -2219,8 +2213,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 			},
 			context: map[string]interface{}{},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expectedError: false,
 		},
@@ -2247,8 +2240,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 			},
 			context: map[string]interface{}{},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expectedError: false,
 		},
@@ -2272,8 +2264,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 			objectIDs: []string{"8"},
 			context:   map[string]interface{}{},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: false,
 		},
@@ -2304,8 +2295,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 				"x": 200,
 			},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: false,
 		},
@@ -2336,8 +2326,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 				"x": 10,
 			},
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expectedError: false,
 		},
@@ -2430,8 +2419,7 @@ func TestConsumeUsersets(t *testing.T) {
 			},
 			ctxCancelled: false,
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			errorExpected: nil,
 		},
@@ -2477,8 +2465,7 @@ func TestConsumeUsersets(t *testing.T) {
 			},
 			ctxCancelled: false,
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			errorExpected: nil,
 		},
@@ -2499,8 +2486,7 @@ func TestConsumeUsersets(t *testing.T) {
 			},
 			ctxCancelled: false,
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			errorExpected: nil,
 		},
@@ -2539,8 +2525,7 @@ func TestConsumeUsersets(t *testing.T) {
 			},
 			ctxCancelled: false,
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			errorExpected: nil,
 		},
@@ -2627,8 +2612,7 @@ func TestConsumeUsersets(t *testing.T) {
 			},
 			ctxCancelled: false,
 			expectedResolveCheckResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			errorExpected: nil,
 		},
@@ -3148,8 +3132,7 @@ func TestProcessDispatch(t *testing.T) {
 			expectedOutcomes: []checkOutcome{
 				{
 					resp: &ResolveCheckResponse{
-						Allowed:            true,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: true,
 					},
 				},
 			},
@@ -3169,8 +3152,7 @@ func TestProcessDispatch(t *testing.T) {
 			expectedOutcomes: []checkOutcome{
 				{
 					resp: &ResolveCheckResponse{
-						Allowed:            true,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: true,
 					},
 				},
 			},
@@ -3195,25 +3177,21 @@ func TestProcessDispatch(t *testing.T) {
 			},
 			mockedDispatchResponse: []*ResolveCheckResponse{
 				{
-					Allowed:            true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: true,
 				},
 				{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				},
 			},
 			expectedOutcomes: []checkOutcome{
 				{
 					resp: &ResolveCheckResponse{
-						Allowed:            true,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: true,
 					},
 				},
 				{
 					resp: &ResolveCheckResponse{
-						Allowed:            false,
-						ResolutionMetadata: &ResolveCheckResponseMetadata{},
+						Allowed: false,
 					},
 				},
 			},
@@ -3311,14 +3289,14 @@ func TestConsumeDispatch(t *testing.T) {
 			mockedDispatchResponse: []*ResolveCheckResponse{
 				{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
+					ResolutionMetadata: ResolveCheckResponseMetadata{
 						CycleDetected: true,
 					},
 				},
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
+				ResolutionMetadata: ResolveCheckResponseMetadata{
 					CycleDetected: true,
 				},
 			},
@@ -3345,22 +3323,13 @@ func TestConsumeDispatch(t *testing.T) {
 			mockedDispatchResponse: []*ResolveCheckResponse{
 				{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						CycleDetected: false,
-					},
 				},
 				{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						CycleDetected: false,
-					},
 				},
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -3385,22 +3354,13 @@ func TestConsumeDispatch(t *testing.T) {
 			mockedDispatchResponse: []*ResolveCheckResponse{
 				{
 					Allowed: false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						CycleDetected: false,
-					},
 				},
 				{
 					Allowed: true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						CycleDetected: false,
-					},
 				},
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -3419,16 +3379,10 @@ func TestConsumeDispatch(t *testing.T) {
 			mockedDispatchResponse: []*ResolveCheckResponse{
 				{
 					Allowed: true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{
-						CycleDetected: false,
-					},
 				},
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -3512,8 +3466,7 @@ func TestCheckUsersetSlowPath(t *testing.T) {
 				tuple.NewTupleKeyWithCondition("group:1", "member", "group:2#member", "condition1", nil),
 			},
 			expected: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expectedError: nil,
 		},
@@ -3529,8 +3482,7 @@ func TestCheckUsersetSlowPath(t *testing.T) {
 			name:   "notFound",
 			tuples: []*openfgav1.TupleKey{},
 			expected: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: nil,
 		},
@@ -3605,8 +3557,7 @@ func TestCheckTTUSlowPath(t *testing.T) {
 			rewrite: typesystem.TupleToUserset("owner", "member"),
 			tuples:  []*openfgav1.TupleKey{},
 			expected: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: nil,
 		},
@@ -3626,12 +3577,10 @@ func TestCheckTTUSlowPath(t *testing.T) {
 				tuple.NewTupleKeyWithCondition("document:doc1", "owner", "group:1", "condition1", nil),
 			},
 			dispatchResponse: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expected: &ResolveCheckResponse{
-				Allowed:            true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: true,
 			},
 			expectedError: nil,
 		},
@@ -3642,12 +3591,10 @@ func TestCheckTTUSlowPath(t *testing.T) {
 				tuple.NewTupleKeyWithCondition("document:doc1", "owner", "group:1", "condition1", nil),
 			},
 			dispatchResponse: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expected: &ResolveCheckResponse{
-				Allowed:            false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+				Allowed: false,
 			},
 			expectedError: nil,
 		},
@@ -3709,8 +3656,7 @@ func TestBreadthFirstNestedMatch(t *testing.T) {
 			},
 			expectedOutcomes: []checkOutcome{
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 			},
 		},
@@ -3725,12 +3671,10 @@ func TestBreadthFirstNestedMatch(t *testing.T) {
 			},
 			expectedOutcomes: []checkOutcome{
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 			},
 		},
@@ -3745,8 +3689,7 @@ func TestBreadthFirstNestedMatch(t *testing.T) {
 			},
 			expectedOutcomes: []checkOutcome{
 				{resp: &ResolveCheckResponse{
-					Allowed:            true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: true,
 				}},
 			},
 		},
@@ -3761,8 +3704,7 @@ func TestBreadthFirstNestedMatch(t *testing.T) {
 			},
 			expectedOutcomes: []checkOutcome{
 				{resp: &ResolveCheckResponse{
-					Allowed:            true,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: true,
 				}},
 			},
 		},
@@ -3783,16 +3725,13 @@ func TestBreadthFirstNestedMatch(t *testing.T) {
 			},
 			expectedOutcomes: []checkOutcome{
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 				{resp: &ResolveCheckResponse{
-					Allowed:            false,
-					ResolutionMetadata: &ResolveCheckResponseMetadata{},
+					Allowed: false,
 				}},
 			},
 		},
@@ -4128,9 +4067,6 @@ func TestNestedTTUFastPath(t *testing.T) {
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 		},
 	}
@@ -4202,9 +4138,6 @@ func TestNestedUsersetFastPath(t *testing.T) {
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 		},
 		{
@@ -4226,9 +4159,6 @@ func TestNestedUsersetFastPath(t *testing.T) {
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 		},
 		{
@@ -4255,9 +4185,6 @@ func TestNestedUsersetFastPath(t *testing.T) {
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 		},
 		{
@@ -4280,9 +4207,6 @@ func TestNestedUsersetFastPath(t *testing.T) {
 			},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 		},
 		{
@@ -4641,9 +4565,6 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			context:            map[string]interface{}{"x": "2"},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -4658,9 +4579,6 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			context:            map[string]interface{}{"x": "200"},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -4688,9 +4606,6 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			context:            map[string]interface{}{"x": "200"},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},

--- a/internal/graph/resolve_check_request.go
+++ b/internal/graph/resolve_check_request.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"sync/atomic"
 	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -19,6 +20,30 @@ type ResolveCheckRequest struct {
 	VisitedPaths              map[string]struct{}
 	Consistency               openfgav1.ConsistencyPreference
 	LastCacheInvalidationTime time.Time
+}
+
+type ResolveCheckRequestMetadata struct {
+	// Thinking of a Check as a tree of evaluations,
+	// Depth is the current level in the tree in the current path that we are exploring.
+	// When we jump one level, we decrement 1. If it hits 0, we throw ErrResolutionDepthExceeded.
+	Depth uint32
+
+	// DispatchCounter is the address to a shared counter that keeps track of how many calls to ResolveCheck we had to do
+	// to solve the root/parent problem.
+	// The contents of this counter will be written by concurrent goroutines.
+	// After the root problem has been solved, this value can be read.
+	DispatchCounter *atomic.Uint32
+
+	// WasThrottled indicates whether the request was throttled
+	WasThrottled *atomic.Bool
+}
+
+func NewCheckRequestMetadata(maxDepth uint32) *ResolveCheckRequestMetadata {
+	return &ResolveCheckRequestMetadata{
+		Depth:           maxDepth,
+		DispatchCounter: new(atomic.Uint32),
+		WasThrottled:    new(atomic.Bool),
+	}
 }
 
 func (r *ResolveCheckRequest) clone() *ResolveCheckRequest {

--- a/internal/graph/resolve_check_response.go
+++ b/internal/graph/resolve_check_response.go
@@ -1,5 +1,13 @@
 package graph
 
+type ResolveCheckResponseMetadata struct {
+	// Number of Read operations accumulated after this request completes.
+	DatastoreQueryCount uint32
+	// Indicates if the ResolveCheck subproblem that was evaluated involved
+	// a cycle in the evaluation.
+	CycleDetected bool
+}
+
 // clone clones the provided ResolveCheckResponse.
 func (r *ResolveCheckResponse) clone() *ResolveCheckResponse {
 	return &ResolveCheckResponse{

--- a/internal/graph/resolve_check_response.go
+++ b/internal/graph/resolve_check_response.go
@@ -1,27 +1,16 @@
 package graph
 
 // clone clones the provided ResolveCheckResponse.
-//
-// If 'r' defines a nil ResolutionMetadata then this function returns
-// an empty value struct for the resolution metadata instead of nil.
 func (r *ResolveCheckResponse) clone() *ResolveCheckResponse {
-	resolutionMetadata := &ResolveCheckResponseMetadata{
-		CycleDetected: false,
-	}
-
-	if r.GetResolutionMetadata() != nil {
-		resolutionMetadata.CycleDetected = r.GetResolutionMetadata().CycleDetected
-	}
-
 	return &ResolveCheckResponse{
 		Allowed:            r.GetAllowed(),
-		ResolutionMetadata: resolutionMetadata,
+		ResolutionMetadata: r.GetResolutionMetadata(),
 	}
 }
 
 type ResolveCheckResponse struct {
 	Allowed            bool
-	ResolutionMetadata *ResolveCheckResponseMetadata
+	ResolutionMetadata ResolveCheckResponseMetadata
 }
 
 func (r *ResolveCheckResponse) GetCycleDetected() bool {
@@ -38,9 +27,9 @@ func (r *ResolveCheckResponse) GetAllowed() bool {
 	return r.Allowed
 }
 
-func (r *ResolveCheckResponse) GetResolutionMetadata() *ResolveCheckResponseMetadata {
+func (r *ResolveCheckResponse) GetResolutionMetadata() ResolveCheckResponseMetadata {
 	if r == nil {
-		return nil
+		return ResolveCheckResponseMetadata{}
 	}
 	return r.ResolutionMetadata
 }

--- a/internal/graph/resolve_check_response_test.go
+++ b/internal/graph/resolve_check_response_test.go
@@ -10,9 +10,7 @@ func TestCloneResolveCheckResponse(t *testing.T) {
 	t.Run("clone_and_modify_orig", func(t *testing.T) {
 		resp1 := &ResolveCheckResponse{
 			Allowed: true,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{
-				CycleDetected: false,
-			},
+			// default values for ResolveCheckResponseMetadata
 		}
 		clonedResp1 := resp1.clone()
 
@@ -23,36 +21,18 @@ func TestCloneResolveCheckResponse(t *testing.T) {
 		// unchanged
 		clonedResp1.Allowed = false
 		clonedResp1.ResolutionMetadata.CycleDetected = true
+		clonedResp1.ResolutionMetadata.DatastoreQueryCount = 1
 		require.True(t, resp1.GetAllowed())
 		require.False(t, resp1.GetResolutionMetadata().CycleDetected)
-	})
-
-	t.Run("clone_empty_ResolutionMetadata", func(t *testing.T) {
-		resp2 := &ResolveCheckResponse{
-			Allowed: true,
-		}
-		clonedResp2 := resp2.clone()
-
-		require.NotSame(t, resp2, clonedResp2)
-		require.Equal(t, resp2.GetAllowed(), clonedResp2.GetAllowed())
-		require.NotNil(t, clonedResp2.ResolutionMetadata)
-		require.False(t, clonedResp2.GetResolutionMetadata().CycleDetected)
-	})
-
-	t.Run("clone_nil_ResolutionMetadata", func(t *testing.T) {
-		var resp2 *ResolveCheckResponse
-		clonedResp2 := resp2.clone()
-
-		require.NotSame(t, resp2, clonedResp2)
-		require.Equal(t, resp2.GetAllowed(), clonedResp2.GetAllowed())
-		require.NotNil(t, clonedResp2.ResolutionMetadata)
-		require.False(t, clonedResp2.GetResolutionMetadata().CycleDetected)
+		require.Zero(t, resp1.GetResolutionMetadata().DatastoreQueryCount)
 	})
 }
 
 func TestResolveCheckResponseDefaultValue(t *testing.T) {
-	var r *ResolveCheckResponse
+	var r ResolveCheckResponse
 	require.False(t, r.GetCycleDetected())
 	require.False(t, r.GetAllowed())
-	require.Nil(t, r.GetResolutionMetadata())
+	require.NotNil(t, r.GetResolutionMetadata())
+	require.Zero(t, r.GetResolutionMetadata().DatastoreQueryCount)
+	require.False(t, r.GetResolutionMetadata().CycleDetected)
 }

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -122,7 +122,7 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 		return nil, nil, err
 	}
 	if resp != nil {
-		resp.GetResolutionMetadata().DatastoreQueryCount = c.datastore.GetMetrics().DatastoreQueryCount
+		resp.ResolutionMetadata.DatastoreQueryCount = c.datastore.GetMetrics().DatastoreQueryCount
 	}
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -131,9 +131,7 @@ type doc
 			Times(1).
 			DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest) (*graph.ResolveCheckResponse, error) {
 				_, _ = cmd.datastore.Read(ctx, req.StoreID, nil, storage.ReadOptions{})
-				return &graph.ResolveCheckResponse{
-					ResolutionMetadata: &graph.ResolveCheckResponseMetadata{},
-				}, nil
+				return &graph.ResolveCheckResponse{}, nil
 			})
 		checkResp, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),


### PR DESCRIPTION
Follow-up to https://github.com/openfga/openfga/pull/2022.

- I'm getting rid of a pointer reference in favor of a value(?) reference to simplify the code:

```go
type ResolveCheckResponse struct {
	   Allowed            bool
---	ResolutionMetadata *ResolveCheckResponseMetadata
+++ ResolutionMetadata ResolveCheckResponseMetadata
}
```

- I also moved some code around, namely `ResolveCheckRequestMetadata` and `ResolveCheckResponseMetadata`