### PR TITLE
perf: enable optimization for nested userset with public wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 * Added `start_time` parameter to `ReadChanges` API to allow filtering by specific time [#2020](https://github.com/openfga/openfga/pull/2020)
 
+### Performance
+* Improve `Check` performance in the case that the query involves resolving nested userset with type bound public access. Enable via experimental flag `enable-check-optimizations`. [#2063](https://github.com/openfga/openfga/pull/2063)
+
 ### Breaking changes
 * The storage adapter `ReadChanges`'s parameter ReadChangesOptions allows filtering by `StartTime` [#2020](https://github.com/openfga/openfga/pull/2020).
   As a part of the implementation a new component called ContinuationTokenSerializer was introduced.

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1259,17 +1259,16 @@ func (c *LocalChecker) buildNestedMapper(ctx context.Context, req *ResolveCheckR
 }
 
 func (c *LocalChecker) checkPublicAssignable(ctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
-	ctx, span := tracer.Start(ctx, "checkPublicAssignable")
-	defer span.End()
-
 	typesys, _ := typesystem.TypesystemFromContext(ctx)
-
 	ds, _ := storage.RelationshipTupleReaderFromContext(ctx)
 	storeID := req.GetStoreID()
 	reqTupleKey := req.GetTupleKey()
 	userType := tuple.GetType(reqTupleKey.GetUser())
 	wildcardRelationReference := typesystem.WildcardRelationReference(userType)
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
+		ctx, span := tracer.Start(ctx, "checkPublicAssignable")
+		defer span.End()
+
 		response := &ResolveCheckResponse{
 			Allowed: false,
 		}

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -1271,8 +1271,7 @@ func (c *LocalChecker) checkPublicAssignable(ctx context.Context, req *ResolveCh
 	wildcardRelationReference := typesystem.WildcardRelationReference(userType)
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		response := &ResolveCheckResponse{
-			Allowed:            false,
-			ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			Allowed: false,
 		}
 
 		opts := storage.ReadUsersetTuplesOptions{

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -4867,9 +4867,6 @@ func TestCheckPublicAssignable(t *testing.T) {
 			readUsersetTuplesError: nil,
 			expected: &ResolveCheckResponse{
 				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},
@@ -4881,9 +4878,6 @@ func TestCheckPublicAssignable(t *testing.T) {
 			readUsersetTuplesError: nil,
 			expected: &ResolveCheckResponse{
 				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
 			},
 			expectedError: nil,
 		},

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -4627,7 +4627,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 		readUserTupleError error
 		reqTupleKey        *openfgav1.TupleKey
 		context            map[string]interface{}
-		expected           *ResolveCheckResponse
+		expected           bool
 		expectedError      error
 	}{
 		{
@@ -4639,13 +4639,8 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
 			context:            map[string]interface{}{"x": "2"},
-			expected: &ResolveCheckResponse{
-				Allowed: true,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
-			},
-			expectedError: nil,
+			expected:           true,
+			expectedError:      nil,
 		},
 		{
 			name:  "directly_assigned_cond_not_match",
@@ -4656,13 +4651,8 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
 			context:            map[string]interface{}{"x": "200"},
-			expected: &ResolveCheckResponse{
-				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
-			},
-			expectedError: nil,
+			expected:           false,
+			expectedError:      nil,
 		},
 		{
 			name:  "missing_condition",
@@ -4673,7 +4663,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
 			context:            map[string]interface{}{},
-			expected:           nil,
+			expected:           false,
 			expectedError: condition.NewEvaluationError(
 				"condX",
 				fmt.Errorf("tuple 'group:1#member@user:bob' is missing context parameters '[x]'"),
@@ -4686,13 +4676,8 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTupleError: storage.ErrNotFound,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
 			context:            map[string]interface{}{"x": "200"},
-			expected: &ResolveCheckResponse{
-				Allowed: false,
-				ResolutionMetadata: &ResolveCheckResponseMetadata{
-					CycleDetected: false,
-				},
-			},
-			expectedError: nil,
+			expected:           false,
+			expectedError:      nil,
 		},
 		{
 			name:               "other_datastore_error",
@@ -4701,7 +4686,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTupleError: fmt.Errorf("mock_erorr"),
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
 			context:            map[string]interface{}{"x": "200"},
-			expected:           nil,
+			expected:           false,
 			expectedError:      fmt.Errorf("mock_erorr"),
 		},
 	}
@@ -4726,14 +4711,13 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			require.NoError(t, err)
 
 			checker := NewLocalChecker()
-			function := checker.checkDirectUserTuple(ctx, &ResolveCheckRequest{
+			resp, err := checker.checkDirectUserTuple(ctx, &ResolveCheckRequest{
 				StoreID:              storeID,
 				AuthorizationModelID: ulid.Make().String(),
 				TupleKey:             tt.reqTupleKey,
 				Context:              contextStruct,
 				RequestMetadata:      NewCheckRequestMetadata(20),
 			})
-			resp, err := function(ctx)
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.expected, resp)
 		})
@@ -4831,6 +4815,286 @@ func TestShouldCheckDirectTuple(t *testing.T) {
 
 			result := shouldCheckDirectTuple(ctx, tt.reqTupleKey)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCheckPublicAssignable(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	tests := []struct {
+		name                   string
+		readUsersetTuples      []*openfgav1.Tuple
+		readUsersetTuplesError error
+		expected               bool
+		expectedError          error
+	}{
+		{
+			name: "found",
+			readUsersetTuples: []*openfgav1.Tuple{
+				{
+					Key: tuple.NewTupleKey("group:1", "member", "user:*"),
+				},
+			},
+			readUsersetTuplesError: nil,
+			expected:               true,
+			expectedError:          nil,
+		},
+		{
+			name: "not_found",
+			readUsersetTuples: []*openfgav1.Tuple{
+				{},
+			},
+			readUsersetTuplesError: nil,
+			expected:               false,
+			expectedError:          nil,
+		},
+		{
+			name: "error",
+			readUsersetTuples: []*openfgav1.Tuple{
+				{},
+			},
+			readUsersetTuplesError: fmt.Errorf("mock_error"),
+			expected:               false,
+			expectedError:          fmt.Errorf("mock_error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			model := parser.MustTransformDSLToProto(`
+				model
+					schema 1.1
+				type user
+				type group
+					relations
+						define member: [user, user:*]
+				`)
+			storeID := ulid.Make().String()
+			ds := mocks.NewMockRelationshipTupleReader(ctrl)
+			ctx := context.Background()
+			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+
+			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
+
+			ts, err := typesystem.New(model)
+			require.NoError(t, err)
+			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			checker := NewLocalChecker()
+
+			result, err := checker.checkPublicAssignable(ctx, &ResolveCheckRequest{
+				StoreID:              storeID,
+				AuthorizationModelID: ulid.Make().String(),
+				TupleKey:             tuple.NewTupleKey("group:1", "member", "user:bob"),
+				RequestMetadata:      NewCheckRequestMetadata(20),
+			}, typesystem.WildcardRelationReference("user"))
+			require.Equal(t, tt.expectedError, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCheckDirectUserTupleWrapper(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+	directlyAssignedModel := parser.MustTransformDSLToProto(`
+	model
+		schema 1.1
+
+	type user
+	type group
+		relations
+			define member: [user]
+	`)
+	mixedDirectWildcardAssignedModel := parser.MustTransformDSLToProto(`
+	model
+		schema 1.1
+
+	type user
+	type group
+		relations
+			define member: [user, user:*]
+	`)
+	wildcardOnlyAssignedModel := parser.MustTransformDSLToProto(`
+	model
+		schema 1.1
+
+	type user
+	type group
+		relations
+			define member: [user:*]
+	`)
+	tests := []struct {
+		name                   string
+		model                  *openfgav1.AuthorizationModel
+		readUserTuple          *openfgav1.Tuple
+		readUserTupleError     error
+		readUsersetTuples      []*openfgav1.Tuple
+		readUsersetTuplesError error
+		reqTupleKey            *openfgav1.TupleKey
+		context                map[string]interface{}
+		expected               *ResolveCheckResponse
+		expectedError          error
+	}{
+		{
+			name:  "directly_assigned",
+			model: directlyAssignedModel,
+			readUserTuple: &openfgav1.Tuple{
+				Key: tuple.NewTupleKey("group:1", "member", "user:bob"),
+			},
+			readUserTupleError: nil,
+			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            true,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:               "not_found",
+			model:              directlyAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: storage.ErrNotFound,
+			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            false,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:               "other_datastore_error",
+			model:              directlyAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: fmt.Errorf("mock_erorr"),
+			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected:           nil,
+			expectedError:      fmt.Errorf("mock_erorr"),
+		},
+		{
+			name:               "mixed_wildcard_assigned",
+			model:              mixedDirectWildcardAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: storage.ErrNotFound,
+			readUsersetTuples: []*openfgav1.Tuple{
+				{
+					Key: tuple.NewTupleKey("group:1", "member", "user:*"),
+				},
+			},
+			readUsersetTuplesError: nil,
+			reqTupleKey:            tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            true,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:               "mixed_wildcard_not_assigned",
+			model:              mixedDirectWildcardAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: storage.ErrNotFound,
+			readUsersetTuples: []*openfgav1.Tuple{
+				{},
+			},
+			readUsersetTuplesError: nil,
+			reqTupleKey:            tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            false,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:               "mixed_wildcard_error",
+			model:              mixedDirectWildcardAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: storage.ErrNotFound,
+			readUsersetTuples: []*openfgav1.Tuple{
+				{},
+			},
+			readUsersetTuplesError: fmt.Errorf("mock_erorr"),
+			reqTupleKey:            tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected:               nil,
+			expectedError:          fmt.Errorf("mock_erorr"),
+		},
+		{
+			name:               "wildcard_assigned",
+			model:              wildcardOnlyAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: nil,
+			readUsersetTuples: []*openfgav1.Tuple{
+				{
+					Key: tuple.NewTupleKey("group:1", "member", "user:*"),
+				},
+			},
+			readUsersetTuplesError: nil,
+			reqTupleKey:            tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            true,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+		{
+			name:               "wildcard_not_assigned",
+			model:              wildcardOnlyAssignedModel,
+			readUserTuple:      nil,
+			readUserTupleError: nil,
+			readUsersetTuples: []*openfgav1.Tuple{
+				{},
+			},
+			readUsersetTuplesError: nil,
+			reqTupleKey:            tuple.NewTupleKey("group:1", "member", "user:bob"),
+			expected: &ResolveCheckResponse{
+				Allowed:            false,
+				ResolutionMetadata: &ResolveCheckResponseMetadata{},
+			},
+			expectedError: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			storeID := ulid.Make().String()
+			ds := mocks.NewMockRelationshipTupleReader(ctrl)
+			ctx := context.Background()
+			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+
+			if tt.readUserTuple != nil || tt.readUserTupleError != nil {
+				ds.EXPECT().ReadUserTuple(gomock.Any(), storeID, tt.reqTupleKey, gomock.Any()).Times(1).Return(tt.readUserTuple, tt.readUserTupleError)
+			}
+
+			if len(tt.readUsersetTuples) > 0 || tt.readUsersetTuplesError != nil {
+				ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
+			}
+
+			ts, err := typesystem.New(tt.model)
+			require.NoError(t, err)
+
+			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+
+			contextStruct, err := structpb.NewStruct(tt.context)
+			require.NoError(t, err)
+
+			checker := NewLocalChecker()
+			function := checker.checkDirectUserTupleWrapper(ctx, &ResolveCheckRequest{
+				StoreID:              storeID,
+				AuthorizationModelID: ulid.Make().String(),
+				TupleKey:             tt.reqTupleKey,
+				Context:              contextStruct,
+				RequestMetadata:      NewCheckRequestMetadata(20),
+			})
+			resp, err := function(ctx)
+			require.Equal(t, tt.expectedError, err)
+			require.Equal(t, tt.expected, resp)
 		})
 	}
 }

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -364,7 +364,7 @@ func (t *TypeSystem) DirectlyRelatedUsersets(objectType, relation string) ([]*op
 	}
 
 	for _, ref := range refs {
-		if ref.GetRelation() != "" || ref.GetWildcard() != nil {
+		if ref.GetRelation() != "" {
 			usersetRelationReferences = append(usersetRelationReferences, ref)
 		}
 	}
@@ -408,11 +408,6 @@ func (t *TypeSystem) resolvesTypeRelationToDirectlyAssignable(objectType, relati
 // UsersetCanFastPath returns whether object's userset's rewrite can support the fast path optimization.
 func (t *TypeSystem) UsersetCanFastPath(relationReferences []*openfgav1.RelationReference) bool {
 	for _, rr := range relationReferences {
-		// In the case they are publicly wildcarded for the relationReferences, slow path and fast path does not
-		// have any significant performance difference.  For the sake of simplicity, we defer it to use slowpath.
-		if _, ok := rr.GetRelationOrWildcard().(*openfgav1.RelationReference_Relation); !ok {
-			return false
-		}
 		if _, directlyAssignable, err := t.resolvesTypeRelationToDirectlyAssignable(rr.GetType(), rr.GetRelation()); err != nil || !directlyAssignable {
 			return false
 		}
@@ -423,22 +418,6 @@ func (t *TypeSystem) UsersetCanFastPath(relationReferences []*openfgav1.Relation
 type expectedEdgeAndNodeType struct {
 	expectedNodeForObjectRel *graph.AuthorizationModelNode
 	expectedEdgeType         graph.EdgeType
-}
-
-func (t *TypeSystem) hasPublicWildcardNode(originalNode *graph.AuthorizationModelNode) bool {
-	neighbourNodes := t.authorizationModelGraph.To(originalNode.ID())
-	for neighbourNodes.Next() {
-		curNode := neighbourNodes.Node()
-		curNeighbourAuthorizationModelNode, ok := curNode.(*graph.AuthorizationModelNode)
-		if !ok {
-			// Note: this should not happen, but adding the guard nonetheless
-			return false
-		}
-		if curNeighbourAuthorizationModelNode.NodeType() == graph.SpecificTypeWildcard {
-			return true
-		}
-	}
-	return false
 }
 
 // verifyNodeEdgesOptimizable returns whether the specified node has
@@ -507,8 +486,7 @@ func (t *TypeSystem) RecursiveUsersetCanFastPath(objectTypeRelation string, user
 		// this means the node cannot be found. The safe thing to do is to use the slow path.
 		return false
 	}
-	// FIXME: for now, we will disable fastpath for cases where publicly wildcard can be assigned to recursive userset.
-	return !t.hasPublicWildcardNode(curAuthorizationModelNode) && t.verifyNodeEdgesOptimizable(curAuthorizationModelNode,
+	return t.verifyNodeEdgesOptimizable(curAuthorizationModelNode,
 		expectedEdgeAndNodeType{expectedNodeForObjectRel: curAuthorizationModelNode, expectedEdgeType: graph.DirectEdge},
 		userType)
 }
@@ -620,20 +598,29 @@ func (t *TypeSystem) TTUCanFastPath(objectType, tuplesetRelation, computedRelati
 // In the example above, the 'user' objectType is publicly assignable to the 'document#viewer' relation.
 // If the input target is not a defined relation, it returns false and RelationUndefinedError.
 func (t *TypeSystem) IsPubliclyAssignable(target *openfgav1.RelationReference, objectType string) (bool, error) {
-	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
+	ref, err := t.PubliclyAssignableReferences(target, objectType)
 	if err != nil {
 		return false, err
+	}
+	return ref != nil, nil
+}
+
+// PubliclyAssignableReferences returns the publicly assignable references with the specified objectType.
+func (t *TypeSystem) PubliclyAssignableReferences(target *openfgav1.RelationReference, objectType string) (*openfgav1.RelationReference, error) {
+	relation, err := t.GetRelation(target.GetType(), target.GetRelation())
+	if err != nil {
+		return nil, err
 	}
 
 	for _, typeRestriction := range relation.GetTypeInfo().GetDirectlyRelatedUserTypes() {
 		if typeRestriction.GetType() == objectType {
 			if typeRestriction.GetWildcard() != nil {
-				return true, nil
+				return typeRestriction, nil
 			}
 		}
 	}
 
-	return false, nil
+	return nil, nil
 }
 
 // HasTypeInfo determines if a given objectType-relation pair has associated type information.

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -3377,12 +3377,10 @@ func TestDirectlyRelatedUsersets(t *testing.T) {
 						define allowed: [user, user:*]`,
 			objectType: "folder",
 			relation:   "allowed",
-			expected: []*openfgav1.RelationReference{
-				WildcardRelationReference("user"),
-			},
+			expected:   nil,
 		},
 		{
-			name: "with_ttu_relation",
+			name: "with_userset_relation",
 			model: `
 				model
 					schema 1.1
@@ -3401,7 +3399,7 @@ func TestDirectlyRelatedUsersets(t *testing.T) {
 			},
 		},
 		{
-			name: "mix_direct_and_public_relation",
+			name: "mix_direct_and_userset_relation",
 			model: `
 				model
 					schema 1.1
@@ -4621,7 +4619,7 @@ type group
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           false,
+			expected:           true,
 		},
 		{
 			name: "simple_recursive_wildcard_condition",
@@ -4638,7 +4636,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           false,
+			expected:           true,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_wildcard",
@@ -4652,7 +4650,7 @@ type group
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           false,
+			expected:           true,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_wildcard_cond",
@@ -4669,7 +4667,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           false,
+			expected:           true,
 		},
 		{
 			name: "simple_recursive_multi_direct_assignment_user_wildcard_cond",
@@ -4686,7 +4684,7 @@ condition cond(x: int) {
 `,
 			objectTypeRelation: "group#member",
 			userType:           "user",
-			expected:           false,
+			expected:           true,
 		},
 		{
 			name: "complex_recursive_due_to_type_not_found",


### PR DESCRIPTION
## Description
Enabling performance optimization for nested userset that has public wildcard.  This requires moving the handling of public wildcard to separate checker.

Special note: This has slight degrade in benchmark performance for `benchmark_with_bypass_userset_read` as it now requires two calls to ReadUsersetTuples (1 for public wildcard and 1 for userset) instead of a single ReadUsersetTuples call (1 call combining public wildcard and userset).

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
