### PR TITLE
refactor(!): remove token serialization from datastore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
   If you are using a custom storage adapter, you will need to pick either a SQL or String Token Serializer, or implement your own one.
 * The storage adapter `ReadPage` return parameters changed from `([]*openfgav1.Tuple, []byte, error)` to `([]*openfgav1.Tuple, string, error)` [#2064](https://github.com/openfga/openfga/pull/2064)
   If you are using a custom storage adapter or consume `ReadPage` func in your code, you will need to update the return type and/or handling of the `ReadPage` function.
+* `ErrMismatchObjectType` error type removed from `openfga` package [#2064](https://github.com/openfga/openfga/pull/2064) as storage is not validating this anymore. 
+  Validation moved to `ReadChangesQuery` implementation.
 
 ## [1.7.0] - 2024-10-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Breaking changes
 * The storage adapter `ReadChanges`'s parameter ReadChangesOptions allows filtering by `StartTime` [#2020](https://github.com/openfga/openfga/pull/2020).
-  As a part of the implementation a new component called ContinuationTokenSerializer was introduced.
-  If you are using a custom storage adapter, you will need to pick either a SQL or String Token Serializer, or implement your own one.
+  As a part of the implementation, a new server setting called `WithContinuationTokenSerializer` was introduced.
+  If you are using OpenFGA as a library, you will need to pass in either `StringContinuationTokenSerializer`, or `SQLContinuationTokenSerializer`, or implement your own (if you also have your own storage adapter)
 * The storage adapter `ReadPage` return parameters changed from `([]*openfgav1.Tuple, []byte, error)` to `([]*openfgav1.Tuple, string, error)` [#2064](https://github.com/openfga/openfga/pull/2064)
   If you are using a custom storage adapter or consume `ReadPage` func in your code, you will need to update the return type and/or handling of the `ReadPage` function.
 * `ErrMismatchObjectType` error type removed from `openfga` package [#2064](https://github.com/openfga/openfga/pull/2064) as storage is not validating this anymore. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 * The storage adapter `ReadChanges`'s parameter ReadChangesOptions allows filtering by `StartTime` [#2020](https://github.com/openfga/openfga/pull/2020).
   As a part of the implementation a new component called ContinuationTokenSerializer was introduced.
   If you are using a custom storage adapter, you will need to pick either a SQL or String Token Serializer, or implement your own one.
+* The storage adapter `ReadPage` return parameters changed from `([]*openfgav1.Tuple, []byte, error)` to `([]*openfgav1.Tuple, string, error)` [#2064](https://github.com/openfga/openfga/pull/2064)
+  If you are using a custom storage adapter or consume `ReadPage` func in your code, you will need to update the return type and/or handling of the `ReadPage` function.
 
 ## [1.7.0] - 2024-10-29
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -385,7 +385,6 @@ func (s *ServerContext) datastoreConfig(config *serverconfig.Config) (storage.Op
 		sqlcommon.WithMaxIdleConns(config.Datastore.MaxIdleConns),
 		sqlcommon.WithConnMaxIdleTime(config.Datastore.ConnMaxIdleTime),
 		sqlcommon.WithConnMaxLifetime(config.Datastore.ConnMaxLifetime),
-		sqlcommon.WithContinuationTokenSerializer(tokenSerializer),
 	}
 
 	if config.Datastore.Metrics.Enabled {
@@ -403,7 +402,6 @@ func (s *ServerContext) datastoreConfig(config *serverconfig.Config) (storage.Op
 		opts := []memory.StorageOption{
 			memory.WithMaxTypesPerAuthorizationModel(config.MaxTypesPerAuthorizationModel),
 			memory.WithMaxTuplesPerWrite(config.MaxTuplesPerWrite),
-			memory.WithContinuationTokenSerializer(tokenSerializer),
 		}
 		datastore = memory.New(opts...)
 	case "mysql":

--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -144,7 +144,7 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 					validationResults = append(validationResults, validationResult)
 				}
 
-				continuationTokenModels = string(tokenModels)
+				continuationTokenModels = tokenModels
 
 				if continuationTokenModels == "" {
 					break
@@ -153,7 +153,7 @@ func ValidateAllAuthorizationModels(ctx context.Context, db storage.OpenFGADatas
 		}
 
 		// next page of stores
-		continuationTokenStores = string(tokenStores)
+		continuationTokenStores = tokenStores
 
 		if continuationTokenStores == "" {
 			break

--- a/internal/cachecontroller/cache_controller.go
+++ b/internal/cachecontroller/cache_controller.go
@@ -102,7 +102,7 @@ func (c *InMemoryCacheController) DetermineInvalidation(
 	return lastModified.(time.Time)
 }
 
-func (c *InMemoryCacheController) findChanges(ctx context.Context, storeID string) ([]*openfgav1.TupleChange, []byte, error) {
+func (c *InMemoryCacheController) findChanges(ctx context.Context, storeID string) ([]*openfgav1.TupleChange, string, error) {
 	opts := storage.ReadChangesOptions{
 		SortDesc: true,
 		Pagination: storage.PaginationOptions{

--- a/internal/cachecontroller/cache_controller_test.go
+++ b/internal/cachecontroller/cache_controller_test.go
@@ -57,7 +57,7 @@ func TestInMemoryCacheController_DetermineInvalidation(t *testing.T) {
 						Relation: "viewer",
 						User:     "test",
 					}},
-			}, []byte{}, nil),
+			}, "", nil),
 			cache.EXPECT().Set(storage.GetChangelogCacheKey(storeID), gomock.Any(), gomock.Any()),
 		)
 		invalidationTime := cacheController.DetermineInvalidation(ctx, storeID)
@@ -246,7 +246,7 @@ func TestInMemoryCacheController_findChangesAndInvalidate(t *testing.T) {
 			}
 
 			datastore := mocks.NewMockOpenFGADatastore(ctrl)
-			datastore.EXPECT().ReadChanges(gomock.Any(), test.storeID, gomock.Any(), gomock.Any()).Return(test.readChangesResults.changes, []byte{}, test.readChangesResults.err)
+			datastore.EXPECT().ReadChanges(gomock.Any(), test.storeID, gomock.Any(), gomock.Any()).Return(test.readChangesResults.changes, "", test.readChangesResults.err)
 			cacheController := &InMemoryCacheController{
 				ds:               datastore,
 				cache:            cache,

--- a/internal/mocks/mock_slow_storage.go
+++ b/internal/mocks/mock_slow_storage.go
@@ -31,7 +31,7 @@ func (m *slowDataStorage) Read(ctx context.Context, store string, key *openfgav1
 	return m.OpenFGADatastore.Read(ctx, store, key, options)
 }
 
-func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *slowDataStorage) ReadPage(ctx context.Context, store string, key *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	time.Sleep(m.readTuplesDelay)
 	return m.OpenFGADatastore.ReadPage(ctx, store, key, options)
 }

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -71,11 +71,11 @@ func (mr *MockTupleBackendMockRecorder) Read(ctx, store, tupleKey, options any) 
 }
 
 // ReadPage mocks base method.
-func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockTupleBackend) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -184,11 +184,11 @@ func (mr *MockRelationshipTupleReaderMockRecorder) Read(ctx, store, tupleKey, op
 }
 
 // ReadPage mocks base method.
-func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockRelationshipTupleReader) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -349,11 +349,11 @@ func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModel(
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelReadBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -483,11 +483,11 @@ func (mr *MockAuthorizationModelBackendMockRecorder) ReadAuthorizationModel(ctx,
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockAuthorizationModelBackend) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -580,11 +580,11 @@ func (mr *MockStoresBackendMockRecorder) GetStore(ctx, id any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockStoresBackend) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockStoresBackend) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStores", ctx, options)
 	ret0, _ := ret[0].([]*openfgav1.Store)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -671,11 +671,11 @@ func (m *MockChangelogBackend) EXPECT() *MockChangelogBackendMockRecorder {
 }
 
 // ReadChanges mocks base method.
-func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockChangelogBackend) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, filter, options)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -796,11 +796,11 @@ func (mr *MockOpenFGADatastoreMockRecorder) IsReady(ctx any) *gomock.Call {
 }
 
 // ListStores mocks base method.
-func (m *MockOpenFGADatastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
+func (m *MockOpenFGADatastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStores", ctx, options)
 	ret0, _ := ret[0].([]*openfgav1.Store)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -885,11 +885,11 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModel(ctx, store, i
 }
 
 // ReadAuthorizationModels mocks base method.
-func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (m *MockOpenFGADatastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadAuthorizationModels", ctx, store, options)
 	ret0, _ := ret[0].([]*openfgav1.AuthorizationModel)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -901,11 +901,11 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadAuthorizationModels(ctx, store, 
 }
 
 // ReadChanges mocks base method.
-func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, []byte, error) {
+func (m *MockOpenFGADatastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadChanges", ctx, store, filter, options)
 	ret0, _ := ret[0].([]*openfgav1.TupleChange)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -917,11 +917,11 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadChanges(ctx, store, filter, opti
 }
 
 // ReadPage mocks base method.
-func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *MockOpenFGADatastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadPage", ctx, store, tupleKey, options)
 	ret0, _ := ret[0].([]*openfgav1.Tuple)
-	ret1, _ := ret[1].([]byte)
+	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }

--- a/pkg/encoder/token_serializer.go
+++ b/pkg/encoder/token_serializer.go
@@ -1,3 +1,5 @@
+//go:generate mockgen -source token_serializer.go -destination ../../internal/mocks/mock_token_serializer.go -package mocks OpenFGADatastore
+
 package encoder
 
 import (

--- a/pkg/server/commands/list_stores.go
+++ b/pkg/server/commands/list_stores.go
@@ -59,7 +59,7 @@ func (q *ListStoresQuery) Execute(ctx context.Context, req *openfgav1.ListStores
 		return nil, serverErrors.HandleError("", err)
 	}
 
-	encodedToken, err := q.encoder.Encode(continuationToken)
+	encodedToken, err := q.encoder.Encode([]byte(continuationToken))
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -81,6 +81,14 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 		return nil, serverErrors.InvalidContinuationToken
 	}
 
+	if len(decodedContToken) > 0 {
+		from, _, err := q.tokenSerializer.Deserialize(string(decodedContToken))
+		if err != nil {
+			return nil, serverErrors.InvalidContinuationToken
+		}
+		decodedContToken = []byte(from)
+	}
+
 	opts := storage.ReadPageOptions{
 		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
 	}

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -19,9 +19,10 @@ import (
 // a given object ID or userset in a type, optionally
 // constrained by a relation name.
 type ReadQuery struct {
-	datastore storage.OpenFGADatastore
-	logger    logger.Logger
-	encoder   encoder.Encoder
+	datastore       storage.OpenFGADatastore
+	logger          logger.Logger
+	encoder         encoder.Encoder
+	tokenSerializer encoder.ContinuationTokenSerializer
 }
 
 type ReadQueryOption func(*ReadQuery)
@@ -38,12 +39,19 @@ func WithReadQueryEncoder(e encoder.Encoder) ReadQueryOption {
 	}
 }
 
+func WithReadQueryTokenSerializer(serializer encoder.ContinuationTokenSerializer) ReadQueryOption {
+	return func(rq *ReadQuery) {
+		rq.tokenSerializer = serializer
+	}
+}
+
 // NewReadQuery creates a ReadQuery using the provided OpenFGA datastore implementation.
 func NewReadQuery(datastore storage.OpenFGADatastore, opts ...ReadQueryOption) *ReadQuery {
 	rq := &ReadQuery{
-		datastore: datastore,
-		logger:    logger.NewNoopLogger(),
-		encoder:   encoder.NewBase64Encoder(),
+		datastore:       datastore,
+		logger:          logger.NewNoopLogger(),
+		encoder:         encoder.NewBase64Encoder(),
+		tokenSerializer: encoder.NewStringContinuationTokenSerializer(),
 	}
 
 	for _, opt := range opts {
@@ -76,7 +84,12 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 	opts := storage.ReadPageOptions{
 		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
 	}
-	tuples, contToken, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), opts)
+	tuples, contUlid, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), opts)
+	if err != nil {
+		return nil, serverErrors.HandleError("", err)
+	}
+
+	contToken, err := q.tokenSerializer.Serialize(contUlid, "")
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read_authzmodels.go
+++ b/pkg/server/commands/read_authzmodels.go
@@ -58,7 +58,7 @@ func (q *ReadAuthorizationModelsQuery) Execute(ctx context.Context, req *openfga
 		return nil, serverErrors.HandleError("", err)
 	}
 
-	encodedContToken, err := q.encoder.Encode(contToken)
+	encodedContToken, err := q.encoder.Encode([]byte(contToken))
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)
 	}

--- a/pkg/server/commands/read_changes.go
+++ b/pkg/server/commands/read_changes.go
@@ -76,33 +76,40 @@ func (q *ReadChangesQuery) Execute(ctx context.Context, req *openfgav1.ReadChang
 	}
 	token := string(decodedContToken)
 
+	var fromUlid string
+
 	var startTime time.Time
 	if req.GetStartTime() != nil {
 		startTime = req.GetStartTime().AsTime()
 	}
-	if token == "" && !startTime.IsZero() {
+	if token != "" {
+		var objType string
+		fromUlid, objType, err = q.tokenSerializer.Deserialize(token)
+		if err != nil {
+			return nil, serverErrors.InvalidContinuationToken
+		}
+		if objType != req.GetType() {
+			return nil, serverErrors.MismatchObjectType
+		}
+	} else if !startTime.IsZero() {
 		tokenUlid, ulidErr := ulid.New(ulid.Timestamp(startTime), nil)
 		if ulidErr != nil {
 			return nil, serverErrors.HandleError(ulidErr.Error(), storage.ErrInvalidStartTime)
 		}
-		if ulidBytes, err := q.tokenSerializer.Serialize(tokenUlid.String(), req.GetType()); err == nil {
-			token = string(ulidBytes)
-		} else {
-			return nil, serverErrors.HandleError("", err)
-		}
+		fromUlid = tokenUlid.String()
 	}
 
 	opts := storage.ReadChangesOptions{
 		Pagination: storage.NewPaginationOptions(
 			req.GetPageSize().GetValue(),
-			token,
+			fromUlid,
 		),
 	}
 	filter := storage.ReadChangesFilter{
 		ObjectType:    req.GetType(),
 		HorizonOffset: q.horizonOffset,
 	}
-	changes, contToken, err := q.backend.ReadChanges(ctx, req.GetStoreId(), filter, opts)
+	changes, contUlid, err := q.backend.ReadChanges(ctx, req.GetStoreId(), filter, opts)
 	if err != nil {
 		if errors.Is(err, storage.ErrNotFound) {
 			return &openfgav1.ReadChangesResponse{
@@ -110,6 +117,14 @@ func (q *ReadChangesQuery) Execute(ctx context.Context, req *openfgav1.ReadChang
 			}, nil
 		}
 		return nil, serverErrors.HandleError("", err)
+	}
+
+	var contToken []byte
+	if contUlid != "" {
+		contToken, err = q.tokenSerializer.Serialize(contUlid, req.GetType())
+		if err != nil {
+			return nil, serverErrors.HandleError("", err)
+		}
 	}
 
 	encodedContToken, err := q.encoder.Encode(contToken)

--- a/pkg/server/commands/read_changes_test.go
+++ b/pkg/server/commands/read_changes_test.go
@@ -115,31 +115,27 @@ func TestReadChangesQuery(t *testing.T) {
 
 		startTime, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
 		reqToken := ""
-		startTimeToken := "startTimeToken"
 		respToken := "responsetoken"
 
 		mockEncoder := mocks.NewMockEncoder(mockController)
 		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
 		mockEncoder.EXPECT().Encode(gomock.Any()).Return(respToken, nil).Times(1)
 
+		expectedUlid := ulid.MustNew(ulid.Timestamp(startTime), nil).String()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		opts := storage.ReadChangesOptions{
+
+		expectedOpts := storage.ReadChangesOptions{
 			Pagination: storage.PaginationOptions{
 				PageSize: storage.DefaultPageSize,
-				From:     startTimeToken,
+				From:     expectedUlid,
 			},
 		}
-		expectedUlid := ulid.MustNew(ulid.Timestamp(startTime), ulid.DefaultEntropy()).String()
 
 		filter := storage.ReadChangesFilter{}
 
 		mockTokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
-		mockTokenSerializer.EXPECT().Serialize(gomock.Cond(func(actualUlid string) bool {
-			// Check if the ulid is valid - first 10 characters of ulid should match
-			assert.Equal(t, expectedUlid[:10], actualUlid[:10])
-			return true
-		}), "").Return([]byte(startTimeToken), nil).Times(1)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, opts).Times(1)
+		mockTokenSerializer.EXPECT().Serialize(gomock.Any(), "").Times(0)
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, expectedOpts).Times(1)
 
 		cmd := NewReadChangesQuery(
 			mockDatastore,
@@ -157,6 +153,40 @@ func TestReadChangesQuery(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Empty(t, resp.GetChanges())
 		require.Equal(t, respToken, resp.GetContinuationToken())
+	})
+
+	t.Run("start_time_is_invalid", func(t *testing.T) {
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		storeID := ulid.Make().String()
+		reqStore := storeID
+
+		startTime := ulid.Time(ulid.MaxTime() + 999_999_999)
+		reqToken := ""
+
+		mockEncoder := mocks.NewMockEncoder(mockController)
+		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
+
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+		mockTokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
+
+		cmd := NewReadChangesQuery(
+			mockDatastore,
+			WithReadChangesQueryEncoder(mockEncoder),
+			WithContinuationTokenSerializer(mockTokenSerializer),
+		)
+
+		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
+			StoreId:           reqStore,
+			ContinuationToken: reqToken,
+			StartTime:         timestamppb.New(startTime),
+		})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Invalid start time")
+		require.Nil(t, resp)
 	})
 
 	t.Run("uses_continuation_time_as_token_over_start_time", func(t *testing.T) {
@@ -185,10 +215,15 @@ func TestReadChangesQuery(t *testing.T) {
 		filter := storage.ReadChangesFilter{}
 
 		mockTokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
-		mockTokenSerializer.EXPECT().Serialize(gomock.Any(), "").Times(0)
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, opts).Times(1)
+		mockTokenSerializer.EXPECT().Deserialize(reqToken).Return(reqToken, "", nil).Times(1)
+		mockTokenSerializer.EXPECT().Serialize(gomock.Any(), "").Times(1)
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, opts).
+			Return([]*openfgav1.TupleChange{}, reqToken, nil).Times(1)
 
-		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
+		cmd := NewReadChangesQuery(mockDatastore,
+			WithReadChangesQueryEncoder(mockEncoder),
+			WithContinuationTokenSerializer(mockTokenSerializer),
+		)
 
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
 			StoreId:           reqStore,
@@ -202,7 +237,7 @@ func TestReadChangesQuery(t *testing.T) {
 		require.Equal(t, respToken, resp.GetContinuationToken())
 	})
 
-	t.Run("throws_error_if_get_continuation_token_fails", func(t *testing.T) {
+	t.Run("throws_error_if_continuation_token_deserialize_fails", func(t *testing.T) {
 		mockController := gomock.NewController(t)
 		defer mockController.Finish()
 
@@ -210,22 +245,20 @@ func TestReadChangesQuery(t *testing.T) {
 		reqStore := storeID
 
 		startTime, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
-		reqToken := ""
+		reqToken := "bad_token"
 
 		mockEncoder := mocks.NewMockEncoder(mockController)
-		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
+		mockEncoder.EXPECT().Decode(reqToken).Return([]byte(reqToken), nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		expectedUlid := ulid.MustNew(ulid.Timestamp(startTime), ulid.DefaultEntropy()).String()
 
 		mockTokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
-		mockTokenSerializer.EXPECT().Serialize(gomock.Cond(func(actualUlid string) bool {
-			// Check if the ulid is valid - first 10 characters of ulid should match
-			assert.Equal(t, expectedUlid[:10], actualUlid[:10])
-			return true
-		}), "").Return(nil, errors.New("continuation token error")).Times(1)
+		mockTokenSerializer.EXPECT().Deserialize(gomock.Any()).Return("", "", errors.New("")).Times(1)
 
-		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder), WithContinuationTokenSerializer(mockTokenSerializer))
+		cmd := NewReadChangesQuery(mockDatastore,
+			WithReadChangesQueryEncoder(mockEncoder),
+			WithContinuationTokenSerializer(mockTokenSerializer),
+		)
 
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
 			StoreId:           reqStore,
@@ -234,7 +267,42 @@ func TestReadChangesQuery(t *testing.T) {
 		})
 
 		require.Error(t, err)
-		require.ErrorContains(t, err, "Internal Server Error")
+		require.ErrorContains(t, err, "Invalid continuation token")
+		require.Nil(t, resp)
+	})
+
+	t.Run("throws_error_if_continuation_token_type_mismatch", func(t *testing.T) {
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		storeID := ulid.Make().String()
+		reqStore := storeID
+
+		startTime, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
+		reqToken := "bad_token"
+
+		mockEncoder := mocks.NewMockEncoder(mockController)
+		mockEncoder.EXPECT().Decode(reqToken).Return([]byte(reqToken), nil).Times(1)
+
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+		mockTokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
+		mockTokenSerializer.EXPECT().Deserialize(gomock.Any()).Return("some-value", "bad-type", nil).Times(1)
+
+		cmd := NewReadChangesQuery(mockDatastore,
+			WithReadChangesQueryEncoder(mockEncoder),
+			WithContinuationTokenSerializer(mockTokenSerializer),
+		)
+
+		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{
+			StoreId:           reqStore,
+			ContinuationToken: reqToken,
+			StartTime:         timestamppb.New(startTime),
+			Type:              "good-type",
+		})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "continuation token don't match")
 		require.Nil(t, resp)
 	})
 
@@ -277,7 +345,7 @@ func TestReadChangesQuery(t *testing.T) {
 
 		filter := storage.ReadChangesFilter{}
 
-		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, opts).Times(1).Return(nil, []byte{}, storage.ErrNotFound)
+		mockDatastore.EXPECT().ReadChanges(gomock.Any(), reqStore, filter, opts).Times(1).Return(nil, "", storage.ErrNotFound)
 
 		cmd := NewReadChangesQuery(mockDatastore, WithReadChangesQueryEncoder(mockEncoder))
 		resp, err := cmd.Execute(context.Background(), &openfgav1.ReadChangesRequest{

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -128,8 +128,6 @@ func HandleError(public string, err error) error {
 		return InvalidContinuationToken
 	case errors.Is(err, storage.ErrInvalidStartTime):
 		return InvalidStartTime
-	case errors.Is(err, storage.ErrMismatchObjectType):
-		return MismatchObjectType
 	case errors.Is(err, context.Canceled):
 		// cancel by a client is not an "internal server error"
 		return RequestCancelled

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -60,10 +60,6 @@ func TestHandleErrors(t *testing.T) {
 			storageErr:              storage.ErrInvalidContinuationToken,
 			expectedTranslatedError: InvalidContinuationToken,
 		},
-		`invalid_token_for_read_changes_api`: {
-			storageErr:              storage.ErrMismatchObjectType,
-			expectedTranslatedError: MismatchObjectType,
-		},
 		`context_cancelled`: {
 			storageErr:              context.Canceled,
 			expectedTranslatedError: RequestCancelled,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -669,6 +669,8 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		listUsersDispatchThrottlingFrequency:    serverconfig.DefaultListUsersDispatchThrottlingFrequency,
 		listUsersDispatchDefaultThreshold:       serverconfig.DefaultListUsersDispatchThrottlingDefaultThreshold,
 		listUsersDispatchThrottlingMaxThreshold: serverconfig.DefaultListUsersDispatchThrottlingMaxThreshold,
+
+		tokenSerializer: encoder.NewStringContinuationTokenSerializer(),
 	}
 
 	for _, opt := range opts {
@@ -1042,6 +1044,7 @@ func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfga
 	q := commands.NewReadQuery(s.datastore,
 		commands.WithReadQueryLogger(s.logger),
 		commands.WithReadQueryEncoder(s.encoder),
+		commands.WithReadQueryTokenSerializer(s.tokenSerializer),
 	)
 	return q.Execute(ctx, &openfgav1.ReadRequest{
 		StoreId:           req.GetStoreId(),

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -19,10 +19,6 @@ var (
 	// ErrInvalidStartTime is returned when start time param for ReadChanges API is invalid.
 	ErrInvalidStartTime = errors.New("invalid start time")
 
-	// ErrMismatchObjectType is returned when there is a type discrepancy between the requested
-	// object in the ReadChanges API and the type indicated by the continuation token.
-	ErrMismatchObjectType = errors.New("mismatched types in request and continuation token")
-
 	// ErrInvalidWriteInput is returned when the tuple to be written
 	// already existed or the tuple to be deleted did not exist.
 	ErrInvalidWriteInput = errors.New("invalid write input")

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -16,6 +16,7 @@ var (
 	// ErrInvalidContinuationToken is returned when the continuation token is invalid.
 	ErrInvalidContinuationToken = errors.New("invalid continuation token")
 
+	// ErrInvalidStartTime is returned when start time param for ReadChanges API is invalid.
 	ErrInvalidStartTime = errors.New("invalid start time")
 
 	// ErrMismatchObjectType is returned when there is a type discrepancy between the requested

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -13,23 +13,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/openfga/openfga/pkg/encoder"
 	"github.com/openfga/openfga/pkg/storage"
-	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	"github.com/openfga/openfga/pkg/storage/test"
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
 func TestMemdbStorage(t *testing.T) {
-	tokenSerializer := encoder.NewStringContinuationTokenSerializer()
-	ds := New(WithContinuationTokenSerializer(tokenSerializer))
-	test.RunAllTests(t, ds, tokenSerializer)
-}
-
-func TestMemdbStorageWithSqlTokenSerializer(t *testing.T) {
-	tokenSerializer := sqlcommon.NewSQLContinuationTokenSerializer()
-	ds := New(WithContinuationTokenSerializer(tokenSerializer))
-	t.Run("TestReadChanges", func(t *testing.T) { test.ReadChangesTest(t, ds, tokenSerializer) })
+	ds := New()
+	test.RunAllTests(t, ds)
 }
 
 func TestStaticTupleIterator(t *testing.T) {

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openfga/openfga/pkg/encoder"
-
 	sq "github.com/Masterminds/squirrel"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"
@@ -42,7 +40,6 @@ type Datastore struct {
 	dbInfo                 *sqlcommon.DBInfo
 	logger                 logger.Logger
 	dbStatsCollector       prometheus.Collector
-	tokenSerializer        encoder.ContinuationTokenSerializer
 	maxTuplesPerWriteField int
 	maxTypesPerModelField  int
 }
@@ -66,10 +63,6 @@ func New(uri string, cfg *sqlcommon.Config) (*Datastore, error) {
 		}
 
 		uri = dsnCfg.FormatDSN()
-	}
-
-	if cfg.TokenSerializer == nil {
-		cfg.TokenSerializer = sqlcommon.NewSQLContinuationTokenSerializer()
 	}
 
 	db, err := sql.Open("mysql", uri)
@@ -129,7 +122,6 @@ func NewWithDB(db *sql.DB, cfg *sqlcommon.Config) (*Datastore, error) {
 		db:                     db,
 		dbInfo:                 dbInfo,
 		logger:                 cfg.Logger,
-		tokenSerializer:        cfg.TokenSerializer,
 		dbStatsCollector:       collector,
 		maxTuplesPerWriteField: cfg.MaxTuplesPerWriteField,
 		maxTypesPerModelField:  cfg.MaxTypesPerModelField,
@@ -158,18 +150,13 @@ func (s *Datastore) Read(
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
-func (s *Datastore) ReadPage(
-	ctx context.Context,
-	store string,
-	tupleKey *openfgav1.TupleKey,
-	options storage.ReadPageOptions,
-) ([]*openfgav1.Tuple, []byte, error) {
+func (s *Datastore) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	ctx, span := startTrace(ctx, "ReadPage")
 	defer span.End()
 
 	iter, err := s.read(ctx, store, tupleKey, &options)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", err
 	}
 	defer iter.Stop()
 
@@ -206,10 +193,7 @@ func (s *Datastore) read(ctx context.Context, store string, tupleKey *openfgav1.
 		sb = sb.Where(sq.Eq{"_user": tupleKey.GetUser()})
 	}
 	if options != nil && options.Pagination.From != "" {
-		token, _, err := s.tokenSerializer.Deserialize(options.Pagination.From)
-		if err != nil {
-			return nil, err
-		}
+		token := options.Pagination.From
 		sb = sb.Where(sq.GtOrEq{"ulid": token})
 	}
 	if options != nil && options.Pagination.PageSize != 0 {
@@ -409,11 +393,7 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
-func (s *Datastore) ReadAuthorizationModels(
-	ctx context.Context,
-	store string,
-	options storage.ReadAuthorizationModelsOptions,
-) ([]*openfgav1.AuthorizationModel, []byte, error) {
+func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
 	ctx, span := startTrace(ctx, "ReadAuthorizationModels")
 	defer span.End()
 
@@ -425,10 +405,7 @@ func (s *Datastore) ReadAuthorizationModels(
 		OrderBy("authorization_model_id desc")
 
 	if options.Pagination.From != "" {
-		token, _, err := s.tokenSerializer.Deserialize(options.Pagination.From)
-		if err != nil {
-			return nil, nil, err
-		}
+		token := options.Pagination.From
 		sb = sb.Where(sq.LtOrEq{"authorization_model_id": token})
 	}
 	if options.Pagination.PageSize > 0 {
@@ -437,7 +414,7 @@ func (s *Datastore) ReadAuthorizationModels(
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, nil, HandleSQLError(err)
+		return nil, "", HandleSQLError(err)
 	}
 	defer rows.Close()
 
@@ -447,24 +424,21 @@ func (s *Datastore) ReadAuthorizationModels(
 	for rows.Next() {
 		err = rows.Scan(&modelID)
 		if err != nil {
-			return nil, nil, HandleSQLError(err)
+			return nil, "", HandleSQLError(err)
 		}
 
 		modelIDs = append(modelIDs, modelID)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, nil, HandleSQLError(err)
+		return nil, "", HandleSQLError(err)
 	}
 
-	var token []byte
+	var token string
 	numModelIDs := len(modelIDs)
 	if len(modelIDs) > options.Pagination.PageSize {
 		numModelIDs = options.Pagination.PageSize
-		token, err = s.tokenSerializer.Serialize(modelID, "")
-		if err != nil {
-			return nil, nil, err
-		}
+		token = modelID
 	}
 
 	// TODO: make this concurrent with a maximum of 5 goroutines. This may be helpful:
@@ -474,7 +448,7 @@ func (s *Datastore) ReadAuthorizationModels(
 	for i := 0; i < numModelIDs; i++ {
 		model, err := s.ReadAuthorizationModel(ctx, store, modelIDs[i])
 		if err != nil {
-			return nil, nil, err
+			return nil, "", err
 		}
 		models = append(models, model)
 	}
@@ -592,7 +566,7 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 }
 
 // ListStores provides a paginated list of all stores present in the storage.
-func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, []byte, error) {
+func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
 	ctx, span := startTrace(ctx, "ListStores")
 	defer span.End()
 
@@ -613,11 +587,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		OrderBy("id")
 
 	if options.Pagination.From != "" {
-		token, _, err := s.tokenSerializer.Deserialize(options.Pagination.From)
-		if err != nil {
-			return nil, nil, err
-		}
-		sb = sb.Where(sq.GtOrEq{"id": token})
+		sb = sb.Where(sq.GtOrEq{"id": options.Pagination.From})
 	}
 	if options.Pagination.PageSize > 0 {
 		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
@@ -625,7 +595,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, nil, HandleSQLError(err)
+		return nil, "", HandleSQLError(err)
 	}
 	defer rows.Close()
 
@@ -636,7 +606,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		var createdAt, updatedAt time.Time
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
-			return nil, nil, HandleSQLError(err)
+			return nil, "", HandleSQLError(err)
 		}
 
 		stores = append(stores, &openfgav1.Store{
@@ -648,18 +618,14 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, nil, HandleSQLError(err)
+		return nil, "", HandleSQLError(err)
 	}
 
 	if len(stores) > options.Pagination.PageSize {
-		contToken, err := s.tokenSerializer.Serialize(id, "")
-		if err != nil {
-			return nil, nil, err
-		}
-		return stores[:options.Pagination.PageSize], contToken, nil
+		return stores[:options.Pagination.PageSize], id, nil
 	}
 
-	return stores, nil, nil
+	return stores, "", nil
 }
 
 // DeleteStore removes a store from storage.
@@ -734,12 +700,7 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 }
 
 // ReadChanges see [storage.ChangelogBackend].ReadChanges.
-func (s *Datastore) ReadChanges(
-	ctx context.Context,
-	store string,
-	filter storage.ReadChangesFilter,
-	options storage.ReadChangesOptions,
-) ([]*openfgav1.TupleChange, []byte, error) {
+func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
 	ctx, span := startTrace(ctx, "ReadChanges")
 	defer span.End()
 
@@ -767,15 +728,7 @@ func (s *Datastore) ReadChanges(
 		sb = sb.Where(sq.Eq{"object_type": objectTypeFilter})
 	}
 	if options.Pagination.From != "" {
-		token, objectType, err := s.tokenSerializer.Deserialize(options.Pagination.From)
-		if err != nil {
-			return nil, nil, err
-		}
-		if objectType != objectTypeFilter {
-			return nil, nil, storage.ErrMismatchObjectType
-		}
-
-		sb = sqlcommon.AddFromUlid(sb, token, options.SortDesc)
+		sb = sqlcommon.AddFromUlid(sb, options.Pagination.From, options.SortDesc)
 	}
 	if options.Pagination.PageSize > 0 {
 		sb = sb.Limit(uint64(options.Pagination.PageSize)) // + 1 is NOT used here as we always return a continuation token.
@@ -783,7 +736,7 @@ func (s *Datastore) ReadChanges(
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, nil, HandleSQLError(err)
+		return nil, "", HandleSQLError(err)
 	}
 	defer rows.Close()
 
@@ -808,14 +761,14 @@ func (s *Datastore) ReadChanges(
 			&insertedAt,
 		)
 		if err != nil {
-			return nil, nil, HandleSQLError(err)
+			return nil, "", HandleSQLError(err)
 		}
 
 		var conditionContextStruct structpb.Struct
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-					return nil, nil, err
+					return nil, "", err
 				}
 			}
 		}
@@ -836,15 +789,10 @@ func (s *Datastore) ReadChanges(
 	}
 
 	if len(changes) == 0 {
-		return nil, nil, storage.ErrNotFound
+		return nil, "", storage.ErrNotFound
 	}
 
-	contToken, err := s.tokenSerializer.Serialize(ulid, objectTypeFilter)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return changes, contToken, nil
+	return changes, ulid, nil
 }
 
 // IsReady see [sqlcommon.IsReady].

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -34,7 +34,7 @@ func TestMySQLDatastore(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 
-	test.RunAllTests(t, ds, sqlcommon.NewSQLContinuationTokenSerializer())
+	test.RunAllTests(t, ds)
 }
 
 func TestMySQLDatastoreAfterCloseIsNotReady(t *testing.T) {
@@ -584,12 +584,11 @@ func TestNew(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "TokenSerializer_nil",
+			name: "bad_uri",
 			args: args{
 				uri: "my;uri?bad=true",
 				cfg: &sqlcommon.Config{
-					Logger:          logger.NewNoopLogger(),
-					TokenSerializer: nil,
+					Logger: logger.NewNoopLogger(),
 				},
 			},
 			want:    nil,

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -29,7 +29,7 @@ func TestPostgresDatastore(t *testing.T) {
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
-	test.RunAllTests(t, ds, sqlcommon.NewSQLContinuationTokenSerializer())
+	test.RunAllTests(t, ds)
 }
 
 func TestPostgresDatastoreAfterCloseIsNotReady(t *testing.T) {

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -32,8 +32,6 @@ type Config struct {
 	Logger                 logger.Logger
 	MaxTuplesPerWriteField int
 	MaxTypesPerModelField  int
-	// for serializing the read changes token
-	TokenSerializer encoder.ContinuationTokenSerializer
 
 	MaxOpenConns    int
 	MaxIdleConns    int
@@ -65,13 +63,6 @@ func WithPassword(password string) DatastoreOption {
 func WithLogger(l logger.Logger) DatastoreOption {
 	return func(cfg *Config) {
 		cfg.Logger = l
-	}
-}
-
-// WithContinuationTokenSerializer returns a DatastoreOption that sets the TokenSerializer in the Config.
-func WithContinuationTokenSerializer(tokenSerializer encoder.ContinuationTokenSerializer) DatastoreOption {
-	return func(cfg *Config) {
-		cfg.TokenSerializer = tokenSerializer
 	}
 }
 
@@ -144,10 +135,6 @@ func NewConfig(opts ...DatastoreOption) *Config {
 		cfg.Logger = logger.NewNoopLogger()
 	}
 
-	if cfg.TokenSerializer == nil {
-		cfg.TokenSerializer = NewSQLContinuationTokenSerializer()
-	}
-
 	if cfg.MaxTuplesPerWriteField == 0 {
 		cfg.MaxTuplesPerWriteField = storage.DefaultMaxTuplesPerWrite
 	}
@@ -175,19 +162,6 @@ func NewContToken(ulid, objectType string) *ContToken {
 }
 
 // MarshallContToken takes a ContToken struct and attempts to marshal it into a string.
-func MarshallContToken(from *ContToken) ([]byte, error) {
-	return json.Marshal(from)
-}
-
-// UnmarshallContToken takes a string representation of a continuation
-// token and attempts to unmarshal it into a ContToken struct.
-func UnmarshallContToken(from string) (*ContToken, error) {
-	var token ContToken
-	if err := json.Unmarshal([]byte(from), &token); err != nil {
-		return nil, storage.ErrInvalidContinuationToken
-	}
-	return &token, nil
-}
 
 func NewSQLContinuationTokenSerializer() encoder.ContinuationTokenSerializer {
 	return &SQLContinuationTokenSerializer{}
@@ -196,13 +170,13 @@ func NewSQLContinuationTokenSerializer() encoder.ContinuationTokenSerializer {
 type SQLContinuationTokenSerializer struct{}
 
 func (s *SQLContinuationTokenSerializer) Serialize(ulid string, objType string) ([]byte, error) {
-	return MarshallContToken(NewContToken(ulid, objType))
+	return json.Marshal(NewContToken(ulid, objType))
 }
 
 func (s *SQLContinuationTokenSerializer) Deserialize(continuationToken string) (ulid string, objType string, err error) {
-	token, err := UnmarshallContToken(continuationToken)
-	if err != nil {
-		return "", "", err
+	var token ContToken
+	if err := json.Unmarshal([]byte(continuationToken), &token); err != nil {
+		return "", "", storage.ErrInvalidContinuationToken
 	}
 	return token.Ulid, token.ObjectType, nil
 }
@@ -353,15 +327,15 @@ func (t *SQLTupleIterator) head() (*storage.TupleRecord, error) {
 // If the continuation token exists it is the ulid of the last element of the returned array.
 func (t *SQLTupleIterator) ToArray(
 	opts storage.PaginationOptions,
-) ([]*openfgav1.Tuple, []byte, error) {
+) ([]*openfgav1.Tuple, string, error) {
 	var res []*openfgav1.Tuple
 	for i := 0; i < opts.PageSize; i++ {
 		tupleRecord, err := t.next()
 		if err != nil {
-			if err == storage.ErrIteratorDone {
-				return res, nil, nil
+			if errors.Is(err, storage.ErrIteratorDone) {
+				return res, "", nil
 			}
-			return nil, nil, err
+			return nil, "", err
 		}
 		res = append(res, tupleRecord.AsTuple())
 	}
@@ -372,17 +346,12 @@ func (t *SQLTupleIterator) ToArray(
 	tupleRecord, err := t.next()
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
-			return res, nil, nil
+			return res, "", nil
 		}
-		return nil, nil, err
+		return nil, "", err
 	}
 
-	contToken, err := json.Marshal(NewContToken(tupleRecord.Ulid, ""))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return res, contToken, nil
+	return res, tupleRecord.Ulid, nil
 }
 
 // Next will return the next available item.

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -22,7 +22,7 @@ func TestSQLiteDatastore(t *testing.T) {
 	ds, err := New(uri, sqlcommon.NewConfig())
 	require.NoError(t, err)
 	defer ds.Close()
-	test.RunAllTests(t, ds, sqlcommon.NewSQLContinuationTokenSerializer())
+	test.RunAllTests(t, ds)
 }
 
 func TestSQLiteDatastoreAfterCloseIsNotReady(t *testing.T) {

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"sync"
 
@@ -12,7 +11,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/openfga/openfga/pkg/storage"
-	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 )
 
 // SQLTupleIterator is a struct that implements the storage.TupleIterator
@@ -165,15 +163,15 @@ func (t *SQLTupleIterator) head() (*storage.TupleRecord, error) {
 // If the continuation token exists it is the ulid of the last element of the returned array.
 func (t *SQLTupleIterator) ToArray(
 	opts storage.PaginationOptions,
-) ([]*openfgav1.Tuple, []byte, error) {
+) ([]*openfgav1.Tuple, string, error) {
 	var res []*openfgav1.Tuple
 	for i := 0; i < opts.PageSize; i++ {
 		tupleRecord, err := t.next()
 		if err != nil {
 			if err == storage.ErrIteratorDone {
-				return res, nil, nil
+				return res, "", nil
 			}
-			return nil, nil, err
+			return nil, "", err
 		}
 		res = append(res, tupleRecord.AsTuple())
 	}
@@ -184,17 +182,12 @@ func (t *SQLTupleIterator) ToArray(
 	tupleRecord, err := t.next()
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
-			return res, nil, nil
+			return res, "", nil
 		}
-		return nil, nil, err
+		return nil, "", err
 	}
 
-	contToken, err := json.Marshal(sqlcommon.NewContToken(tupleRecord.Ulid, ""))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return res, contToken, nil
+	return res, tupleRecord.Ulid, nil
 }
 
 // Next will return the next available item.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -56,7 +56,7 @@ func RelationshipTupleReaderFromContext(ctx context.Context) (RelationshipTupleR
 // PaginationOptions should not be instantiated directly. Use NewPaginationOptions.
 type PaginationOptions struct {
 	PageSize int
-	// From is an ulid that can be used to retrieve the next page of results
+	// From is a continuation token that can be used to retrieve the next page of results. Its contents will depend on the API.
 	From string
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -255,6 +255,7 @@ type AuthorizationModelReadBackend interface {
 	ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgav1.AuthorizationModel, error)
 
 	// ReadAuthorizationModels reads all models for the supplied store and returns them in descending order of ULID (from newest to oldest).
+	// In addition to the models, it returns a continuation token that can be used to fetch the next page of results.
 	ReadAuthorizationModels(ctx context.Context, store string, options ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error)
 
 	// FindLatestAuthorizationModel returns the last model for the store.
@@ -283,6 +284,10 @@ type StoresBackend interface {
 	CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error)
 	DeleteStore(ctx context.Context, id string) error
 	GetStore(ctx context.Context, id string) (*openfgav1.Store, error)
+
+	// ListStores returns a list of stores that match the provided options.
+	// In addition to the stores, it returns a continuation token that can be used to fetch the next page of results.
+	// If no stores are found, it is expected to return an empty list and an empty continuation token.
 	ListStores(ctx context.Context, options ListStoresOptions) ([]*openfgav1.Store, string, error)
 }
 
@@ -307,9 +312,9 @@ type ChangelogBackend interface {
 	// in the order that they occurred.
 	// You can optionally provide a filter to filter out changes for objects of a specific type.
 	// The horizonOffset should be specified using a unit no more granular than a millisecond.
-	// It should always return a non-empty continuation token so readers can continue reading later, except the case where
+	// It should always return a ULID as a continuation token so readers can continue reading later, except the case where
 	// if no changes are found, it should return storage.ErrNotFound and an empty continuation token.
-	// It the objectType and the type in the continuation token don't match, it should return ErrMismatchObjectType.
+	// It's important that the continuation token is a ULID, so it could be generated from timestamp.
 	ReadChanges(ctx context.Context, store string, filter ReadChangesFilter, options ReadChangesOptions) ([]*openfgav1.TupleChange, string, error)
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -56,8 +56,7 @@ func RelationshipTupleReaderFromContext(ctx context.Context) (RelationshipTupleR
 // PaginationOptions should not be instantiated directly. Use NewPaginationOptions.
 type PaginationOptions struct {
 	PageSize int
-	// From is a continuation token that can be used to retrieve the next page of results. It may be also overloaded
-	// to represent a starting time for the first page of results.
+	// From is an ulid that can be used to retrieve the next page of results
 	From string
 }
 
@@ -163,12 +162,7 @@ type RelationshipTupleReader interface {
 	// mandatory ReadPageOptions options. PageSize will always be greater than zero.
 	// It returns a slice of tuples along with a continuation token. This token can be used for retrieving subsequent pages of data.
 	// There is NO guarantee on the order of the tuples in one page.
-	ReadPage(
-		ctx context.Context,
-		store string,
-		tupleKey *openfgav1.TupleKey,
-		options ReadPageOptions,
-	) ([]*openfgav1.Tuple, []byte, error)
+	ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options ReadPageOptions) ([]*openfgav1.Tuple, string, error)
 
 	// ReadUserTuple tries to return one tuple that matches the provided key exactly.
 	// If none is found, it must return [ErrNotFound].
@@ -261,7 +255,7 @@ type AuthorizationModelReadBackend interface {
 	ReadAuthorizationModel(ctx context.Context, store string, id string) (*openfgav1.AuthorizationModel, error)
 
 	// ReadAuthorizationModels reads all models for the supplied store and returns them in descending order of ULID (from newest to oldest).
-	ReadAuthorizationModels(ctx context.Context, store string, options ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, []byte, error)
+	ReadAuthorizationModels(ctx context.Context, store string, options ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error)
 
 	// FindLatestAuthorizationModel returns the last model for the store.
 	// If none were ever written, it must return ErrNotFound.
@@ -289,7 +283,7 @@ type StoresBackend interface {
 	CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error)
 	DeleteStore(ctx context.Context, id string) error
 	GetStore(ctx context.Context, id string) (*openfgav1.Store, error)
-	ListStores(ctx context.Context, options ListStoresOptions) ([]*openfgav1.Store, []byte, error)
+	ListStores(ctx context.Context, options ListStoresOptions) ([]*openfgav1.Store, string, error)
 }
 
 // AssertionsBackend is an interface that defines the set of methods for reading and writing assertions.
@@ -316,7 +310,7 @@ type ChangelogBackend interface {
 	// It should always return a non-empty continuation token so readers can continue reading later, except the case where
 	// if no changes are found, it should return storage.ErrNotFound and an empty continuation token.
 	// It the objectType and the type in the continuation token don't match, it should return ErrMismatchObjectType.
-	ReadChanges(ctx context.Context, store string, filter ReadChangesFilter, options ReadChangesOptions) ([]*openfgav1.TupleChange, []byte, error)
+	ReadChanges(ctx context.Context, store string, filter ReadChangesFilter, options ReadChangesOptions) ([]*openfgav1.TupleChange, string, error)
 }
 
 // OpenFGADatastore is an interface that defines a set of methods for interacting

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -66,7 +66,7 @@ func (c *CombinedTupleReader) Read(
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *CombinedTupleReader) ReadPage(ctx context.Context, store string, tk *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (c *CombinedTupleReader) ReadPage(ctx context.Context, store string, tk *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	// No reading from contextual tuples.
 	return c.RelationshipTupleReader.ReadPage(ctx, store, tk, options)
 }

--- a/pkg/storage/storagewrappers/combinedtuplereader_test.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader_test.go
@@ -235,7 +235,7 @@ func Test_combinedTupleReader_ReadPage(t *testing.T) {
 
 	mockRelationshipTupleReader.EXPECT().
 		ReadPage(context.Background(), "1", testTuples["group:1#member@user:11"].GetKey(), storage.ReadPageOptions{}).
-		Return([]*openfgav1.Tuple{testTuples["group:1#member@user:11"]}, nil, nil)
+		Return([]*openfgav1.Tuple{testTuples["group:1#member@user:11"]}, "", nil)
 
 	got, _, err := c.ReadPage(context.Background(), "1", testTuples["group:1#member@user:11"].GetKey(), storage.ReadPageOptions{})
 	require.NoError(t, err)

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -45,7 +45,7 @@ func (c *ContextTracerWrapper) Read(ctx context.Context, store string, tupleKey 
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (c *ContextTracerWrapper) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	queryCtx := queryContext(ctx)
 
 	return c.OpenFGADatastore.ReadPage(queryCtx, store, tupleKey, options)

--- a/pkg/storage/storagewrappers/instrumented.go
+++ b/pkg/storage/storagewrappers/instrumented.go
@@ -48,7 +48,7 @@ func (m *InstrumentedOpenFGAStorage) Read(ctx context.Context, store string, tup
 }
 
 // ReadPage see [storage.RelationshipTupleReader.ReadPage].
-func (m *InstrumentedOpenFGAStorage) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, []byte, error) {
+func (m *InstrumentedOpenFGAStorage) ReadPage(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
 	m.increaseReads()
 
 	return m.RelationshipTupleReader.ReadPage(ctx, store, tupleKey, options)

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -99,7 +99,7 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 	}
 
 	opts = storage.ReadAuthorizationModelsOptions{
-		Pagination: storage.NewPaginationOptions(2, string(continuationToken)),
+		Pagination: storage.NewPaginationOptions(2, continuationToken),
 	}
 	models, continuationToken, err = datastore.ReadAuthorizationModels(ctx, store, opts)
 	require.NoError(t, err)

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/openfga/openfga/pkg/encoder"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/oklog/ulid/v2"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -28,7 +26,7 @@ var (
 	}
 )
 
-func RunAllTests(t *testing.T, ds storage.OpenFGADatastore, tokenSerializer encoder.ContinuationTokenSerializer) {
+func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestDatastoreIsReady", func(t *testing.T) {
 		status, err := ds.IsReady(context.Background())
 		require.NoError(t, err)
@@ -37,7 +35,7 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore, tokenSerializer enco
 
 	// Tuples.
 	t.Run("TestTupleWriteAndRead", func(t *testing.T) { TupleWritingAndReadingTest(t, ds) })
-	t.Run("TestReadChanges", func(t *testing.T) { ReadChangesTest(t, ds, tokenSerializer) })
+	t.Run("TestReadChanges", func(t *testing.T) { ReadChangesTest(t, ds) })
 	t.Run("TestReadStartingWithUser", func(t *testing.T) { ReadStartingWithUserTest(t, ds) })
 	t.Run("TestReadAndReadPages", func(t *testing.T) { ReadAndReadPageTest(t, ds) })
 

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -49,7 +49,7 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		require.NotEmpty(t, ct)
 
 		opts = storage.ListStoresOptions{
-			Pagination: storage.NewPaginationOptions(100, string(ct)),
+			Pagination: storage.NewPaginationOptions(100, ct),
 		}
 		_, ct, err = datastore.ListStores(ctx, opts)
 		require.NoError(t, err)

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/openfga/openfga/pkg/storage"
 
-	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -519,18 +517,30 @@ func GRPCWriteTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 	}
 }
 
-func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
-
+func writeTuples(client openfgav1.OpenFGAServiceClient, storeID string, modelID string, count int, user string) (*openfgav1.WriteResponse, error) {
+	tupleKeys := make([]*openfgav1.TupleKey, count)
+	for i := 0; i < count; i++ {
+		tupleKeys[i] = tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", user)
+	}
+	return client.Write(context.Background(), &openfgav1.WriteRequest{
+		StoreId: storeID,
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys: tupleKeys,
+		},
+		AuthorizationModelId: modelID,
+	})
 }
 
-func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
+func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 	storeResponse, err := client.CreateStore(context.Background(), &openfgav1.CreateStoreRequest{
 		Name: "GRPCReadChangesTest",
 	})
 	require.NoError(t, err)
 
+	storeID := storeResponse.GetId()
+
 	modelResponse, err := client.WriteAuthorizationModel(context.Background(), &openfgav1.WriteAuthorizationModelRequest{
-		StoreId: storeResponse.GetId(),
+		StoreId: storeID,
 		TypeDefinitions: []*openfgav1.TypeDefinition{
 			{
 				Type: "user",
@@ -556,20 +566,178 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 	})
 	require.NoError(t, err)
 
+	const pageSize = 20
+
+	modelID := modelResponse.GetAuthorizationModelId()
+
+	// one page of tuples with user:1st
+	_, err = writeTuples(client, storeID, modelID, pageSize, "user:1st")
+	require.NoError(t, err)
+
+	// one page of tuples with user:2nd - after continuation token is captured
+	_, err = writeTuples(client, storeID, modelID, pageSize, "user:2nd")
+	require.NoError(t, err)
+
+	// find the continuation token for the 3rd page from the start
+	require.NoError(t, err)
+	firstPage, err := client.Read(context.Background(), &openfgav1.ReadRequest{
+		StoreId:  storeID,
+		PageSize: wrapperspb.Int32(pageSize),
+	})
+	require.NoError(t, err)
+
+	continuationToken := firstPage.GetContinuationToken()
+
+	tests := []struct {
+		name     string
+		input    *openfgav1.ReadRequest
+		validate func(*testing.T, *openfgav1.ReadResponse)
+		err      error
+	}{
+		{
+			"empty_request",
+			&openfgav1.ReadRequest{
+				StoreId:  storeID,
+				PageSize: wrapperspb.Int32(pageSize),
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				require.Len(t, response.GetTuples(), pageSize)
+				require.NotEmpty(t, response.GetContinuationToken())
+				for _, tpl := range response.GetTuples() {
+					require.NotNil(t, tpl.GetKey())
+					require.Equal(t, "user:1st", tpl.GetKey().GetUser())
+				}
+			},
+			nil,
+		},
+		{
+			"with_tuple_key_single_document",
+			&openfgav1.ReadRequest{
+				StoreId: storeID,
+				TupleKey: &openfgav1.ReadRequestTupleKey{
+					User:     "user:1st",
+					Relation: "viewer",
+					Object:   "document:1",
+				},
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				require.Len(t, response.GetTuples(), 1)
+				require.NotEmpty(t, response.GetContinuationToken())
+				for _, tpl := range response.GetTuples() {
+					require.NotNil(t, tpl.GetKey())
+					require.Equal(t, "user:1st", tpl.GetKey().GetUser())
+				}
+			},
+			nil,
+		},
+		{
+			"with_tuple_key_by_user1",
+			&openfgav1.ReadRequest{
+				StoreId: storeID,
+				TupleKey: &openfgav1.ReadRequestTupleKey{
+					Relation: "viewer",
+					Object:   "document:1",
+				},
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				require.Len(t, response.GetTuples(), 2)
+				require.NotEmpty(t, response.GetContinuationToken())
+				for _, tpl := range response.GetTuples() {
+					require.NotNil(t, tpl.GetKey())
+					require.Equal(t, "document:1", tpl.GetKey().GetObject())
+				}
+				assert.ElementsMatch(t, []string{"user:1st", "user:2nd"},
+					[]string{
+						response.GetTuples()[0].GetKey().GetUser(),
+						response.GetTuples()[1].GetKey().GetUser(),
+					})
+			},
+			nil,
+		},
+		{
+			"with_continuation_token",
+			&openfgav1.ReadRequest{
+				StoreId:           storeID,
+				ContinuationToken: continuationToken,
+				PageSize:          wrapperspb.Int32(pageSize),
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				require.Len(t, response.GetTuples(), pageSize)
+				require.NotEmpty(t, response.GetContinuationToken())
+				for _, tpl := range response.GetTuples() {
+					require.NotNil(t, tpl.GetKey())
+					require.Equal(t, "user:2nd", tpl.GetKey().GetUser())
+				}
+			},
+			nil,
+		},
+		{
+			"with_invalid_continuation_token",
+			&openfgav1.ReadRequest{
+				StoreId:           storeID,
+				ContinuationToken: "invalid-token",
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				// do nothing
+			},
+			status.Error(2007, "Invalid continuation token"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			response, err := client.Read(context.Background(), test.input)
+			if test.err != nil {
+				require.Error(t, err)
+				assert.Equal(t, test.err, err)
+			} else {
+				require.NoError(t, err)
+				test.validate(t, response)
+			}
+		})
+	}
+}
+
+func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
+	storeResponse, err := client.CreateStore(context.Background(), &openfgav1.CreateStoreRequest{
+		Name: "GRPCReadChangesTest",
+	})
+	require.NoError(t, err)
+
+	storeID := storeResponse.GetId()
+	modelResponse, err := client.WriteAuthorizationModel(context.Background(), &openfgav1.WriteAuthorizationModelRequest{
+		StoreId: storeID,
+		TypeDefinitions: []*openfgav1.TypeDefinition{
+			{
+				Type: "user",
+			},
+			{
+				Type: "document",
+				Relations: map[string]*openfgav1.Userset{
+					"viewer": typesystem.This(),
+				},
+				Metadata: &openfgav1.Metadata{
+					Relations: map[string]*openfgav1.RelationMetadata{
+						"viewer": {
+							DirectlyRelatedUserTypes: []*openfgav1.RelationReference{
+								typesystem.DirectRelationReference("user", ""),
+								typesystem.WildcardRelationReference("user"),
+							},
+						},
+					},
+				},
+			},
+		},
+		SchemaVersion: "1.1",
+	})
+	require.NoError(t, err)
+
+	modelID := modelResponse.GetAuthorizationModelId()
+
 	const pageSize = storage.DefaultPageSize
 
 	// one page of tuples with user:before - before start_time is captured
-	tupleKeysBefore := make([]*openfgav1.TupleKey, pageSize)
-	for i := 0; i < pageSize; i++ {
-		tupleKeysBefore[i] = tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:before")
-	}
-	_, err = client.Write(context.Background(), &openfgav1.WriteRequest{
-		StoreId: storeResponse.GetId(),
-		Writes: &openfgav1.WriteRequestWrites{
-			TupleKeys: tupleKeysBefore,
-		},
-		AuthorizationModelId: modelResponse.GetAuthorizationModelId(),
-	})
+	_, err = writeTuples(client, storeID, modelID, pageSize, "user:before")
 	require.NoError(t, err)
 
 	// wait for the tuples to be written
@@ -580,43 +748,22 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 	time.Sleep(1 * time.Millisecond)
 
 	// one page of tuples with user:after - after start_time is captured
-	tupleKeysAfter := make([]*openfgav1.TupleKey, pageSize)
-	for i := 0; i < pageSize; i++ {
-		tupleKeysAfter[i] = tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:after")
-	}
-	_, err = client.Write(context.Background(), &openfgav1.WriteRequest{
-		StoreId: storeResponse.GetId(),
-		Writes: &openfgav1.WriteRequestWrites{
-			TupleKeys: tupleKeysAfter,
-		},
-		AuthorizationModelId: modelResponse.GetAuthorizationModelId(),
-	})
+	_, err = writeTuples(client, storeID, modelID, pageSize, "user:after")
 	require.NoError(t, err)
 
 	// one page of tuples with user:3rd - one page after the start_time is captured
-	tupleKeys3rd := make([]*openfgav1.TupleKey, pageSize)
-	for i := 0; i < pageSize; i++ {
-		tupleKeys3rd[i] = tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:3rd")
-	}
-	_, err = client.Write(context.Background(), &openfgav1.WriteRequest{
-		StoreId: storeResponse.GetId(),
-		Writes: &openfgav1.WriteRequestWrites{
-			TupleKeys: tupleKeys3rd,
-		},
-		AuthorizationModelId: modelResponse.GetAuthorizationModelId(),
-	})
+	_, err = writeTuples(client, storeID, modelID, pageSize, "user:3rd")
 	require.NoError(t, err)
 
 	// find the continuation token for the 3rd page from the start
-	pages100, err := runtime.Int32Value("100")
 	require.NoError(t, err)
-	changes100, err := client.ReadChanges(context.Background(), &openfgav1.ReadChangesRequest{
-		StoreId:  storeResponse.GetId(),
-		PageSize: pages100,
+	twoPages, err := client.ReadChanges(context.Background(), &openfgav1.ReadChangesRequest{
+		StoreId:  storeID,
+		PageSize: wrapperspb.Int32(pageSize * 2),
 	})
 	require.NoError(t, err)
 
-	continuationToken := changes100.GetContinuationToken()
+	continuationToken := twoPages.GetContinuationToken()
 
 	tests := []struct {
 		name     string
@@ -627,7 +774,7 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 		{
 			"empty_request",
 			&openfgav1.ReadChangesRequest{
-				StoreId: storeResponse.GetId(),
+				StoreId: storeID,
 			},
 			func(t *testing.T, response *openfgav1.ReadChangesResponse) {
 				require.Len(t, response.GetChanges(), pageSize)
@@ -642,7 +789,7 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 		{
 			"with_continuation_token",
 			&openfgav1.ReadChangesRequest{
-				StoreId:           storeResponse.GetId(),
+				StoreId:           storeID,
 				ContinuationToken: continuationToken,
 			},
 			func(t *testing.T, response *openfgav1.ReadChangesResponse) {
@@ -658,7 +805,7 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 		{
 			"with_start_time",
 			&openfgav1.ReadChangesRequest{
-				StoreId:   storeResponse.GetId(),
+				StoreId:   storeID,
 				StartTime: timestamppb.New(startTime),
 			},
 			func(t *testing.T, response *openfgav1.ReadChangesResponse) {
@@ -674,7 +821,7 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 		{
 			"with_start_time_and_token",
 			&openfgav1.ReadChangesRequest{
-				StoreId:           storeResponse.GetId(),
+				StoreId:           storeID,
 				StartTime:         timestamppb.New(startTime),
 				ContinuationToken: continuationToken,
 			},
@@ -691,7 +838,7 @@ func GRPCReadChangesTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 		{
 			"with_invalid_start_time",
 			&openfgav1.ReadChangesRequest{
-				StoreId: storeResponse.GetId(),
+				StoreId: storeID,
 				StartTime: timestamppb.New(startTime.
 					Add(-1 * startTime.Sub(startTime)). // until the beginning of time
 					Add(-1_000_000 * time.Hour),        // and then minus a million hours


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

Refactoring: remove token serialization from datastore

## Description
<!-- Provide a detailed description of the changes -->

Due to changes made in #2020 and introduced `ContinuationTokenSerializer` we can move token serialization to business layer, and keep database integration more simple and reduce number of dependencies.

The scope of this PR is to remove token serialization from the datastore and move it to the business layer.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
