### PR TITLE
feat: measurement on root store check + write latency due to authz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Added
 * Added `start_time` parameter to `ReadChanges` API to allow filtering by specific time [#2020](https://github.com/openfga/openfga/pull/2020)
+* Added OTEL measurement for root store check latency and write latency due to authorization [#2069](https://github.com/openfga/openfga/pull/2069)
 
 ### Breaking changes
 * The storage adapter `ReadChanges`'s parameter ReadChangesOptions allows filtering by `StartTime` [#2020](https://github.com/openfga/openfga/pull/2020).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 * Added `start_time` parameter to `ReadChanges` API to allow filtering by specific time [#2020](https://github.com/openfga/openfga/pull/2020)
 * Added support for Contextual Tuples in the `Expand` API. [#2045](https://github.com/openfga/openfga/pull/2045)
-* Added OTEL measurement for root store check latency and write latency due to authorization [#2069](https://github.com/openfga/openfga/pull/2069)
+* Added OTEL measurement for access control store check latency and write latency due to authorization [#2069](https://github.com/openfga/openfga/pull/2069)
 
 ### Performance
 * Improve `Check` performance in the case that the query involves resolving nested userset with type bound public access. Enable via experimental flag `enable-check-optimizations`. [#2063](https://github.com/openfga/openfga/pull/2063)

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -108,7 +108,7 @@ type AuthorizerInterface interface {
 	AuthorizeListStores(ctx context.Context) error
 	ListAuthorizedStores(ctx context.Context) ([]string, error)
 	GetModulesForWriteRequest(req *openfgav1.WriteRequest, typesys *typesystem.TypeSystem) ([]string, error)
-	RootStoreID() string
+	AccessControlStoreID() string
 	IsNoop() bool
 }
 
@@ -138,7 +138,7 @@ func (a *NoopAuthorizer) GetModulesForWriteRequest(req *openfgav1.WriteRequest, 
 	return nil, nil
 }
 
-func (a *NoopAuthorizer) RootStoreID() string {
+func (a *NoopAuthorizer) AccessControlStoreID() string {
 	return ""
 }
 
@@ -209,7 +209,7 @@ func (a *Authorizer) getRelation(apiMethod string) (string, error) {
 	}
 }
 
-func (a *Authorizer) RootStoreID() string {
+func (a *Authorizer) AccessControlStoreID() string {
 	if a.config != nil {
 		return a.config.StoreID
 	}

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -108,6 +108,8 @@ type AuthorizerInterface interface {
 	AuthorizeListStores(ctx context.Context) error
 	ListAuthorizedStores(ctx context.Context) ([]string, error)
 	GetModulesForWriteRequest(req *openfgav1.WriteRequest, typesys *typesystem.TypeSystem) ([]string, error)
+	RootStoreID() string
+	IsNoop() bool
 }
 
 type NoopAuthorizer struct{}
@@ -134,6 +136,14 @@ func (a *NoopAuthorizer) ListAuthorizedStores(ctx context.Context) ([]string, er
 
 func (a *NoopAuthorizer) GetModulesForWriteRequest(req *openfgav1.WriteRequest, typesys *typesystem.TypeSystem) ([]string, error) {
 	return nil, nil
+}
+
+func (a *NoopAuthorizer) RootStoreID() string {
+	return ""
+}
+
+func (a *NoopAuthorizer) IsNoop() bool {
+	return true
 }
 
 type Authorizer struct {
@@ -197,6 +207,17 @@ func (a *Authorizer) getRelation(apiMethod string) (string, error) {
 	default:
 		return "", AuthorizationError{Err: ErrUnknownAPIMethod}.Err
 	}
+}
+
+func (a *Authorizer) RootStoreID() string {
+	if a.config != nil {
+		return a.config.StoreID
+	}
+	return ""
+}
+
+func (a *Authorizer) IsNoop() bool {
+	return false
 }
 
 // Authorize checks if the user has access to the resource.

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -63,6 +63,27 @@ func TestGetRelation(t *testing.T) {
 	}
 }
 
+func TestGetStoreID(t *testing.T) {
+	t.Run("has_store_ID", func(t *testing.T) {
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		mockServer := mocks.NewMockServerInterface(mockController)
+
+		authorizer := NewAuthorizer(&Config{StoreID: "test-store", ModelID: "test-model"}, mockServer, logger.NewNoopLogger())
+		require.Equal(t, "test-store", authorizer.RootStoreID())
+	})
+	t.Run("no_config", func(t *testing.T) {
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		mockServer := mocks.NewMockServerInterface(mockController)
+
+		authorizer := NewAuthorizer(nil, mockServer, logger.NewNoopLogger())
+		require.Equal(t, "", authorizer.RootStoreID())
+	})
+}
+
 func TestAuthorizeCreateStore(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -71,7 +71,7 @@ func TestGetStoreID(t *testing.T) {
 		mockServer := mocks.NewMockServerInterface(mockController)
 
 		authorizer := NewAuthorizer(&Config{StoreID: "test-store", ModelID: "test-model"}, mockServer, logger.NewNoopLogger())
-		require.Equal(t, "test-store", authorizer.RootStoreID())
+		require.Equal(t, "test-store", authorizer.AccessControlStoreID())
 	})
 	t.Run("no_config", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -80,7 +80,7 @@ func TestGetStoreID(t *testing.T) {
 		mockServer := mocks.NewMockServerInterface(mockController)
 
 		authorizer := NewAuthorizer(nil, mockServer, logger.NewNoopLogger())
-		require.Equal(t, "", authorizer.RootStoreID())
+		require.Equal(t, "", authorizer.AccessControlStoreID())
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -115,12 +115,12 @@ var (
 		Help:      "The total number of check requests by response result",
 	}, []string{allowedLabel})
 
-	rootStoreCheckDurationHistogramName = "root_store_check_request_duration_ms"
+	accessControlStoreCheckDurationHistogramName = "access_control_store_check_request_duration_ms"
 
-	rootStoreCheckDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	accessControlStoreCheckDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:                       build.ProjectName,
-		Name:                            rootStoreCheckDurationHistogramName,
-		Help:                            "The request duration (in ms) for root store's check duration labeled by method and buckets of datastore query counts and number of dispatches.",
+		Name:                            accessControlStoreCheckDurationHistogramName,
+		Help:                            "The request duration (in ms) for access control store's check duration labeled by method and buckets of datastore query counts and number of dispatches.",
 		Buckets:                         []float64{1, 5, 10, 25, 50, 80, 100, 150, 200, 300, 1000, 2000, 5000},
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,
@@ -1211,8 +1211,8 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		req.GetConsistency().String(),
 	).Observe(float64(time.Since(start).Milliseconds()))
 
-	if s.authorizer.RootStoreID() == req.GetStoreId() {
-		rootStoreCheckDurationHistogram.WithLabelValues(
+	if s.authorizer.AccessControlStoreID() == req.GetStoreId() {
+		accessControlStoreCheckDurationHistogram.WithLabelValues(
 			utils.Bucketize(uint(queryCount), s.requestDurationByQueryHistogramBuckets),
 			utils.Bucketize(uint(rawDispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
 			req.GetConsistency().String(),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -114,6 +114,29 @@ var (
 		Name:      checkResultCounterName,
 		Help:      "The total number of check requests by response result",
 	}, []string{allowedLabel})
+
+	rootStoreCheckDurationHistogramName = "root_store_check_request_duration_ms"
+
+	rootStoreCheckDurationHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       build.ProjectName,
+		Name:                            rootStoreCheckDurationHistogramName,
+		Help:                            "The request duration (in ms) for root store's check duration labeled by method and buckets of datastore query counts and number of dispatches.",
+		Buckets:                         []float64{1, 5, 10, 25, 50, 80, 100, 150, 200, 300, 1000, 2000, 5000},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	}, []string{"datastore_query_count", "dispatch_count", "consistency"})
+
+	writeDurationHistogramName = "write_duration_ms"
+	writeDurationHistogram     = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace:                       build.ProjectName,
+		Name:                            writeDurationHistogramName,
+		Help:                            "The request duration (in ms) for write duration labeled by whether whether authorizer check is required.",
+		Buckets:                         []float64{1, 5, 10, 25, 50, 80, 100, 150, 200, 300, 1000, 2000, 5000},
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: time.Hour,
+	}, []string{"require_authorize_check"})
 )
 
 // A Server implements the OpenFGA service backend as both
@@ -1030,6 +1053,8 @@ func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfga
 }
 
 func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openfgav1.WriteResponse, error) {
+	start := time.Now()
+
 	ctx, span := tracer.Start(ctx, authz.Write, trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
@@ -1067,12 +1092,20 @@ func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openf
 		s.datastore,
 		commands.WithWriteCmdLogger(s.logger),
 	)
-	return cmd.Execute(ctx, &openfgav1.WriteRequest{
+	resp, err := cmd.Execute(ctx, &openfgav1.WriteRequest{
 		StoreId:              storeID,
 		AuthorizationModelId: typesys.GetAuthorizationModelID(), // the resolved model id
 		Writes:               req.GetWrites(),
 		Deletes:              req.GetDeletes(),
 	})
+
+	// For now, we only measure the duration if it passes the authz step to make the comparison
+	// apple to apple.
+	writeDurationHistogram.WithLabelValues(
+		strconv.FormatBool(!s.authorizer.IsNoop() && !authclaims.SkipAuthzCheckFromContext(ctx)),
+	).Observe(float64(time.Since(start).Milliseconds()))
+
+	return resp, err
 }
 
 func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openfgav1.CheckResponse, error) {
@@ -1177,6 +1210,14 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		utils.Bucketize(uint(rawDispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
 		req.GetConsistency().String(),
 	).Observe(float64(time.Since(start).Milliseconds()))
+
+	if s.authorizer.RootStoreID() == req.GetStoreId() {
+		rootStoreCheckDurationHistogram.WithLabelValues(
+			utils.Bucketize(uint(queryCount), s.requestDurationByQueryHistogramBuckets),
+			utils.Bucketize(uint(rawDispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
+			req.GetConsistency().String(),
+		).Observe(float64(time.Since(start).Milliseconds()))
+	}
 
 	wasRequestThrottled := checkRequestMetadata.WasThrottled.Load()
 	if wasRequestThrottled {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -131,7 +131,7 @@ var (
 	writeDurationHistogram     = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace:                       build.ProjectName,
 		Name:                            writeDurationHistogramName,
-		Help:                            "The request duration (in ms) for write duration labeled by whether whether authorizer check is required.",
+		Help:                            "The request duration (in ms) for write duration labeled by whether an authorizer check is required or not.",
 		Buckets:                         []float64{1, 5, 10, 25, 50, 80, 100, 150, 200, 300, 1000, 2000, 5000},
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  100,


### PR DESCRIPTION


## Description
Adding OTEL measurement on latency for root store check.  In addition, adding OTEL measurement on write latency (with and without authz)
  
<img width="1920" alt="Screenshot 2024-11-04 at 2 57 01 PM" src="https://github.com/user-attachments/assets/cc606a7c-855a-4aed-8212-14400336f4dd">
<img width="1920" alt="Screenshot 2024-11-04 at 2 56 19 PM" src="https://github.com/user-attachments/assets/b15ac6e8-2541-45f7-8825-1282b5d392fa">


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
