### PR TITLE
test: fix nil pointer in benchmarks

### DIFF
--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -670,7 +670,8 @@ func BenchmarkListObjects(b *testing.B, ds storage.OpenFGADatastore) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			r, _ := listObjectsQuery.Execute(ctx, req)
+			r, err := listObjectsQuery.Execute(ctx, req)
+			require.NoError(b, err)
 			require.Len(b, r.Objects, 1)
 		}
 
@@ -687,7 +688,8 @@ func BenchmarkListObjects(b *testing.B, ds storage.OpenFGADatastore) {
 
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			r, _ := listObjectsQuery.Execute(ctx, req)
+			r, err := listObjectsQuery.Execute(ctx, req)
+			require.NoError(b, err)
 			totalObjects := len(r.Objects)
 			require.Equal(b, numberObjectsAccessible, totalObjects, "total number of records returned should match")
 		}


### PR DESCRIPTION
## Description
Seen in https://github.com/openfga/openfga/actions/runs/11719328473/job/32642347221?pr=2076

```
BenchmarkOpenFGAServer/BenchmarkMySQLDatastore/BenchmarkListObjects/oneResult                             	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x12756ba]

goroutine 12452829 [running]:
github.com/openfga/openfga/pkg/server/test.BenchmarkListObjects.func1(0xc000162a08)
	/home/runner/work/openfga/openfga/pkg/server/test/list_objects.go:674 +0x13a
testing.(*B).runN(0xc000162a08, 0xd1b)
	/opt/hostedtoolcache/go/1.22.7/x64/src/testing/benchmark.go:193 +0xf8
testing.(*B).launch(0xc000162a08)
	/opt/hostedtoolcache/go/1.22.7/x64/src/testing/benchmark.go:316 +0x1b1
created by testing.(*B).doBench in goroutine 12452716
	/opt/hostedtoolcache/go/1.22.7/x64/src/testing/benchmark.go:266 +0x65
exit status 2
FAIL	github.com/openfga/openfga/pkg/server	346.921s

```