### PR TITLE
test: fix order-dependent assertion in expand test

### DIFF
--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -15,164 +15,135 @@ import (
 )
 
 func TestExpand(t *testing.T) {
-	tests := []struct {
-		name             string
-		modelStr         string
-		tuples           []string
-		contextualTuples []*openfgav1.TupleKey
-		expandTupleKey   *openfgav1.ExpandRequestTupleKey
-		expected         *openfgav1.UsersetTree_Node
-		expectedErr      error
-	}{
-		{
-			name: "invalid_contextual_tuple_fails_validation",
-			modelStr: `
-				model
-					schema 1.1
-				type user
+	modelStr := `
+		model
+			schema 1.1
+		type user
 
-				type document
-					relations
-						define viewer: [user]
-						define can_view: viewer`,
-			tuples: []string{},
-			contextualTuples: []*openfgav1.TupleKey{
-				{
-					Object:   "document:1",
+		type document
+			relations
+				define viewer: [user]
+				define can_view: viewer
+	`
+
+	var tuples []string
+	t.Run("invalid_contextual_tuple_fails_validation", func(t *testing.T) {
+		contextualTuples := []*openfgav1.TupleKey{
+			{Object: "document:1", Relation: "invalid_relation", User: "user:bob"},
+		}
+		expandTupleKey := &openfgav1.ExpandRequestTupleKey{
+			Object:   "document:1",
+			Relation: "can_view",
+		}
+		expectedErr := serverErrors.HandleTupleValidateError(
+			&tuple.InvalidTupleError{
+				Cause: &tuple.RelationNotFoundError{
 					Relation: "invalid_relation",
+					TypeName: "document",
+				},
+				TupleKey: &openfgav1.TupleKey{
 					User:     "user:bob",
-				},
-			},
-			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
-				Object:   "document:1",
-				Relation: "can_view",
-			},
-			expectedErr: serverErrors.HandleTupleValidateError(
-				&tuple.InvalidTupleError{
-					Cause: &tuple.RelationNotFoundError{
-						Relation: "invalid_relation",
-						TypeName: "document",
-					},
-					TupleKey: &openfgav1.TupleKey{
-						User:     "user:bob",
-						Relation: "invalid_relation",
-						Object:   "document:1",
-					}}),
-		},
-		{
-			name: "expand_with_only_contextual_tuples",
-			modelStr: `
-				model
-					schema 1.1
-
-				type user
-
-				type document
-					relations
-						define viewer: [user]
-						define can_view: viewer
-			`,
-			tuples: []string{},
-			contextualTuples: []*openfgav1.TupleKey{
-				{
+					Relation: "invalid_relation",
 					Object:   "document:1",
-					Relation: "viewer",
-					User:     "user:bob",
 				},
 			},
-			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
-				Object:   "document:1",
-				Relation: "viewer",
+		)
+
+		ds := memory.New()
+		t.Cleanup(ds.Close)
+		storeID, model := storagetest.BootstrapFGAStore(t, ds, modelStr, tuples)
+		ctx := context.Background()
+		ts, err := typesystem.NewAndValidate(
+			ctx,
+			model,
+		)
+		ctx = typesystem.ContextWithTypesystem(ctx, ts)
+		require.NoError(t, err)
+
+		expandQuery := NewExpandQuery(ds)
+
+		_, err = expandQuery.Execute(ctx, &openfgav1.ExpandRequest{
+			StoreId:  storeID,
+			TupleKey: expandTupleKey,
+			ContextualTuples: &openfgav1.ContextualTupleKeys{
+				TupleKeys: contextualTuples,
 			},
-			expected: &openfgav1.UsersetTree_Node{
-				Name: "document:1#viewer",
-				Value: &openfgav1.UsersetTree_Node_Leaf{
-					Leaf: &openfgav1.UsersetTree_Leaf{
-						Value: &openfgav1.UsersetTree_Leaf_Users{
-							Users: &openfgav1.UsersetTree_Users{
-								Users: []string{"user:bob"},
-							},
-						},
-					},
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "multiple_contextual_tuples_expand_correctly",
-			modelStr: `
-					model
-						schema 1.1
-					type user
-
-					type document
-					relations
-						define viewer: [user]
-						define can_view: viewer`,
-			tuples: []string{},
-			contextualTuples: []*openfgav1.TupleKey{
-				{
-					Object:   "document:1",
-					Relation: "viewer",
-					User:     "user:bob",
-				},
-				{
-					Object:   "document:1",
-					Relation: "viewer",
-					User:     "user:alice",
-				},
-			},
-			expandTupleKey: &openfgav1.ExpandRequestTupleKey{
-				Object:   "document:1",
-				Relation: "viewer",
-			},
-			expected: &openfgav1.UsersetTree_Node{
-				Name: "document:1#viewer",
-				Value: &openfgav1.UsersetTree_Node_Leaf{
-					Leaf: &openfgav1.UsersetTree_Leaf{
-						Value: &openfgav1.UsersetTree_Leaf_Users{
-							Users: &openfgav1.UsersetTree_Users{
-								Users: []string{"user:bob", "user:alice"},
-							},
-						},
-					},
-				},
-			},
-			expectedErr: nil,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ds := memory.New()
-			t.Cleanup(ds.Close)
-			storeID, model := storagetest.BootstrapFGAStore(t, ds, tc.modelStr, tc.tuples)
-			ctx := context.Background()
-			ts, err := typesystem.NewAndValidate(
-				ctx,
-				model,
-			)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
-			require.NoError(t, err)
-
-			expandQuery := NewExpandQuery(ds)
-
-			resp, err := expandQuery.Execute(ctx, &openfgav1.ExpandRequest{
-				StoreId:  storeID,
-				TupleKey: tc.expandTupleKey,
-				ContextualTuples: &openfgav1.ContextualTupleKeys{
-					TupleKeys: tc.contextualTuples,
-				},
-			})
-
-			if tc.expectedErr != nil {
-				require.ErrorIs(t, err, tc.expectedErr)
-				return
-			}
-
-			require.NoError(t, err)
-			require.NotNil(t, resp)
-			require.Equal(t, tc.expected, resp.GetTree().GetRoot())
 		})
-	}
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("expand_with_only_contextual_tuples", func(t *testing.T) {
+		contextualTuples := []*openfgav1.TupleKey{{Object: "document:1", Relation: "viewer", User: "user:bob"}}
+		expandTupleKey := &openfgav1.ExpandRequestTupleKey{
+			Object: "document:1", Relation: "viewer",
+		}
+
+		ds := memory.New()
+		t.Cleanup(ds.Close)
+		storeID, model := storagetest.BootstrapFGAStore(t, ds, modelStr, tuples)
+		ctx := context.Background()
+		ts, err := typesystem.NewAndValidate(
+			ctx,
+			model,
+		)
+		ctx = typesystem.ContextWithTypesystem(ctx, ts)
+		require.NoError(t, err)
+
+		expandQuery := NewExpandQuery(ds)
+
+		resp, err := expandQuery.Execute(ctx, &openfgav1.ExpandRequest{
+			StoreId:  storeID,
+			TupleKey: expandTupleKey,
+			ContextualTuples: &openfgav1.ContextualTupleKeys{
+				TupleKeys: contextualTuples,
+			},
+		})
+
+		require.NoError(t, err)
+		root := resp.GetTree().GetRoot()
+		require.Equal(t, "document:1#viewer", root.GetName())
+
+		finalUsers := root.GetLeaf().GetUsers().GetUsers()
+		require.Equal(t, []string{"user:bob"}, finalUsers)
+	})
+
+	t.Run("multiple_contextual_tuples_expand_correctly", func(t *testing.T) {
+		contextualTuples := []*openfgav1.TupleKey{
+			{Object: "document:1", Relation: "viewer", User: "user:bob"},
+			{Object: "document:1", Relation: "viewer", User: "user:alice"},
+		}
+		expandTupleKey := &openfgav1.ExpandRequestTupleKey{
+			Object:   "document:1",
+			Relation: "viewer",
+		}
+
+		ds := memory.New()
+		t.Cleanup(ds.Close)
+		storeID, model := storagetest.BootstrapFGAStore(t, ds, modelStr, tuples)
+		ctx := context.Background()
+		ts, err := typesystem.NewAndValidate(
+			ctx,
+			model,
+		)
+		ctx = typesystem.ContextWithTypesystem(ctx, ts)
+		require.NoError(t, err)
+
+		expandQuery := NewExpandQuery(ds)
+
+		resp, err := expandQuery.Execute(ctx, &openfgav1.ExpandRequest{
+			StoreId:  storeID,
+			TupleKey: expandTupleKey,
+			ContextualTuples: &openfgav1.ContextualTupleKeys{
+				TupleKeys: contextualTuples,
+			},
+		})
+
+		require.NoError(t, err)
+
+		root := resp.GetTree().GetRoot()
+		require.Equal(t, "document:1#viewer", root.GetName())
+
+		finalUsers := root.GetLeaf().GetUsers().GetUsers()
+		require.ElementsMatch(t, finalUsers, []string{"user:bob", "user:alice"})
+	})
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The new Expand tests have a race condition built into them. I've seen it in CI and if you run `go clean -testcache && go test -v ./pkg/server/... -run TestExpand` enough times you will see the following:

![image](https://github.com/user-attachments/assets/48bcee4a-9ec8-4d6b-bb2b-800114472eed)

The code is working properly but the assertion is order-dependent so depending on which comes back first the test sometimes fails. It's an artifact of using `require.Equal` on a deeply nested expectation which contains a slice.

This PR changes the Expand test from table-driven to individual test assertions to allow for more granular assertion targeting. E.g. now it uses `require.ElementsMatch` on the specific leaf node, instead of trying to `require.Equal` on a big object which contains a slice.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->
#2045 

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
