### PR TITLE
don't generate continuation token for empty result

### DIFF
--- a/pkg/encoder/token_serializer.go
+++ b/pkg/encoder/token_serializer.go
@@ -3,6 +3,7 @@
 package encoder
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -28,6 +29,9 @@ func NewStringContinuationTokenSerializer() ContinuationTokenSerializer {
 
 // Serialize serializes the continuation token into a string, as ulid & type concatenated by a pipe.
 func (ts *StringContinuationTokenSerializer) Serialize(ulid string, objType string) ([]byte, error) {
+	if ulid == "" {
+		return nil, errors.New("empty ulid provided for continuation token")
+	}
 	return []byte(fmt.Sprintf("%s|%s", ulid, objType)), nil
 }
 

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -97,6 +97,13 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 		return nil, serverErrors.HandleError("", err)
 	}
 
+	if len(contUlid) == 0 {
+		return &openfgav1.ReadResponse{
+			Tuples:            tuples,
+			ContinuationToken: "",
+		}, nil
+	}
+
 	contToken, err := q.tokenSerializer.Serialize(contUlid, "")
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)

--- a/pkg/server/commands/read_changes.go
+++ b/pkg/server/commands/read_changes.go
@@ -119,12 +119,16 @@ func (q *ReadChangesQuery) Execute(ctx context.Context, req *openfgav1.ReadChang
 		return nil, serverErrors.HandleError("", err)
 	}
 
-	var contToken []byte
-	if contUlid != "" {
-		contToken, err = q.tokenSerializer.Serialize(contUlid, req.GetType())
-		if err != nil {
-			return nil, serverErrors.HandleError("", err)
-		}
+	if len(contUlid) == 0 {
+		return &openfgav1.ReadChangesResponse{
+			Changes:           changes,
+			ContinuationToken: "",
+		}, nil
+	}
+
+	contToken, err := q.tokenSerializer.Serialize(contUlid, req.GetType())
+	if err != nil {
+		return nil, serverErrors.HandleError("", err)
 	}
 
 	encodedContToken, err := q.encoder.Encode(contToken)

--- a/pkg/server/commands/read_changes_test.go
+++ b/pkg/server/commands/read_changes_test.go
@@ -77,11 +77,9 @@ func TestReadChangesQuery(t *testing.T) {
 		storeID := ulid.Make().String()
 		reqStore := storeID
 		reqToken := "token"
-		respToken := "responsetoken"
 
 		mockEncoder := mocks.NewMockEncoder(mockController)
 		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
-		mockEncoder.EXPECT().Encode(gomock.Any()).Return(respToken, nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		opts := storage.ReadChangesOptions{
@@ -103,7 +101,7 @@ func TestReadChangesQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Empty(t, resp.GetChanges())
-		require.Equal(t, respToken, resp.GetContinuationToken())
+		require.Empty(t, resp.GetContinuationToken())
 	})
 
 	t.Run("uses_start_time_as_token", func(t *testing.T) {
@@ -115,11 +113,9 @@ func TestReadChangesQuery(t *testing.T) {
 
 		startTime, _ := time.Parse(time.RFC3339, "2021-01-01T00:00:00Z")
 		reqToken := ""
-		respToken := "responsetoken"
 
 		mockEncoder := mocks.NewMockEncoder(mockController)
 		mockEncoder.EXPECT().Decode(reqToken).Return([]byte{}, nil).Times(1)
-		mockEncoder.EXPECT().Encode(gomock.Any()).Return(respToken, nil).Times(1)
 
 		expectedUlid := ulid.MustNew(ulid.Timestamp(startTime), nil).String()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
@@ -152,7 +148,7 @@ func TestReadChangesQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Empty(t, resp.GetChanges())
-		require.Equal(t, respToken, resp.GetContinuationToken())
+		require.Empty(t, resp.GetContinuationToken())
 	})
 
 	t.Run("start_time_is_invalid", func(t *testing.T) {

--- a/pkg/server/commands/read_test.go
+++ b/pkg/server/commands/read_test.go
@@ -113,10 +113,8 @@ func TestReadCommand(t *testing.T) {
 
 		mockEncoder := mocks.NewMockEncoder(mockController)
 		mockEncoder.EXPECT().Decode(gomock.Any()).Return([]byte("decodedtoken"), nil).Times(1)
-		mockEncoder.EXPECT().Encode(gomock.Any()).Return("encodedtoken", nil).Times(1)
 
 		tokenSerializer := mocks.NewMockContinuationTokenSerializer(mockController)
-		tokenSerializer.EXPECT().Serialize(gomock.Any(), gomock.Any()).Return([]byte("serializedtoken"), nil).Times(1)
 		tokenSerializer.EXPECT().Deserialize("decodedtoken").Return("deserializedtoken", "", nil).Times(1)
 
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
@@ -140,7 +138,7 @@ func TestReadCommand(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Empty(t, resp.GetTuples())
-		require.Equal(t, "encodedtoken", resp.GetContinuationToken())
+		require.Empty(t, resp.GetContinuationToken())
 	})
 
 	t.Run("throws_error_if_continuation_token_is_invalid", func(t *testing.T) {

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -170,6 +170,9 @@ func NewSQLContinuationTokenSerializer() encoder.ContinuationTokenSerializer {
 type SQLContinuationTokenSerializer struct{}
 
 func (s *SQLContinuationTokenSerializer) Serialize(ulid string, objType string) ([]byte, error) {
+	if ulid == "" {
+		return nil, errors.New("empty ulid provided for continuation token")
+	}
 	return json.Marshal(NewContToken(ulid, objType))
 }
 

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -622,7 +622,7 @@ func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 			},
 			func(t *testing.T, response *openfgav1.ReadResponse) {
 				require.Len(t, response.GetTuples(), 1)
-				require.NotEmpty(t, response.GetContinuationToken())
+				require.Empty(t, response.GetContinuationToken())
 				for _, tpl := range response.GetTuples() {
 					require.NotNil(t, tpl.GetKey())
 					require.Equal(t, "user:1st", tpl.GetKey().GetUser())
@@ -631,7 +631,7 @@ func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 			nil,
 		},
 		{
-			"with_tuple_key_by_user1",
+			"with_tuple_key_by_document1",
 			&openfgav1.ReadRequest{
 				StoreId: storeID,
 				TupleKey: &openfgav1.ReadRequestTupleKey{
@@ -641,7 +641,7 @@ func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 			},
 			func(t *testing.T, response *openfgav1.ReadResponse) {
 				require.Len(t, response.GetTuples(), 2)
-				require.NotEmpty(t, response.GetContinuationToken())
+				require.Empty(t, response.GetContinuationToken())
 				for _, tpl := range response.GetTuples() {
 					require.NotNil(t, tpl.GetKey())
 					require.Equal(t, "document:1", tpl.GetKey().GetObject())
@@ -655,6 +655,30 @@ func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 			nil,
 		},
 		{
+			"with_tuple_key_by_document1_page_size1",
+			&openfgav1.ReadRequest{
+				StoreId: storeID,
+				TupleKey: &openfgav1.ReadRequestTupleKey{
+					Relation: "viewer",
+					Object:   "document:1",
+				},
+				PageSize: wrapperspb.Int32(1),
+			},
+			func(t *testing.T, response *openfgav1.ReadResponse) {
+				require.Len(t, response.GetTuples(), 1)
+				assert.NotEmpty(t, response.GetContinuationToken())
+				for _, tpl := range response.GetTuples() {
+					require.NotNil(t, tpl.GetKey())
+					require.Equal(t, "document:1", tpl.GetKey().GetObject())
+				}
+				assert.ElementsMatch(t, []string{"user:1st"},
+					[]string{
+						response.GetTuples()[0].GetKey().GetUser(),
+					})
+			},
+			nil,
+		},
+		{
 			"with_continuation_token",
 			&openfgav1.ReadRequest{
 				StoreId:           storeID,
@@ -663,7 +687,7 @@ func GRPCReadTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 			},
 			func(t *testing.T, response *openfgav1.ReadResponse) {
 				require.Len(t, response.GetTuples(), pageSize)
-				require.NotEmpty(t, response.GetContinuationToken())
+				require.Empty(t, response.GetContinuationToken())
 				for _, tpl := range response.GetTuples() {
 					require.NotNil(t, tpl.GetKey())
 					require.Equal(t, "user:2nd", tpl.GetKey().GetUser())


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Due to a non-empty `continuation_token` returned by the API which internally contains an emtpy `ulid` - pagination for `read` would go into an infinite loop.

This PR checks for `ulid` length before serializing it into a token and never again returns a continuation token with empty contents.

On top of that - extra validation added to the serializer checking the length of the input `ulid` and throwing an error in cases its empty.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
