### PR TITLE
fix: respect consistency preference in `read` and `listObjects`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Improve `Check` performance in the case that the query involves types that cannot be reached from the source. Enable via experimental flag `enable-check-optimizations`. [#2104](https://github.com/openfga/openfga/pull/2104)
 - Fix regression introduced in #2091: error message for invalid Writes. [#2110](https://github.com/openfga/openfga/pull/2110)
+- Ensure `/read` and `/list-objects` respect the received `Consistency` values [#2113](https://github.com/openfga/openfga/pull/2113)
 
 ## [1.8.0] - 2024-11-08
 [Full changelog](https://github.com/openfga/openfga/compare/v1.7.0...v1.8.0)

--- a/pkg/server/commands/read.go
+++ b/pkg/server/commands/read.go
@@ -90,8 +90,10 @@ func (q *ReadQuery) Execute(ctx context.Context, req *openfgav1.ReadRequest) (*o
 	}
 
 	opts := storage.ReadPageOptions{
-		Pagination: storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+		Pagination:  storage.NewPaginationOptions(req.GetPageSize().GetValue(), string(decodedContToken)),
+		Consistency: storage.ConsistencyOptions{Preference: req.GetConsistency()},
 	}
+
 	tuples, contUlid, err := q.datastore.ReadPage(ctx, store, tupleUtils.ConvertReadRequestTupleKeyToTupleKey(tk), opts)
 	if err != nil {
 		return nil, serverErrors.HandleError("", err)

--- a/pkg/server/commands/read_test.go
+++ b/pkg/server/commands/read_test.go
@@ -91,6 +91,7 @@ func TestReadCommand(t *testing.T) {
 				PageSize: storage.DefaultPageSize,
 				From:     "",
 			},
+			Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 		}
 		mockDatastore.EXPECT().ReadPage(gomock.Any(), storeID, tupleKey, opts).Times(1)
 
@@ -100,6 +101,7 @@ func TestReadCommand(t *testing.T) {
 			TupleKey:          &openfgav1.ReadRequestTupleKey{Object: "document:1", Relation: "reader", User: "user:maria"},
 			PageSize:          nil,
 			ContinuationToken: "",
+			Consistency:       openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 		})
 		require.NoError(t, err)
 	})

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -339,6 +339,7 @@ LoopOnEdges:
 			ContextualTuples: req.ContextualTuples,
 			Context:          req.Context,
 			edge:             innerLoopEdge,
+			Consistency:      req.Consistency,
 		}
 		switch innerLoopEdge.Type {
 		case graph.DirectEdge:

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -567,6 +567,7 @@ LoopOnIterator:
 				ContextualTuples: req.ContextualTuples,
 				Context:          req.Context,
 				edge:             req.edge,
+				Consistency:      req.Consistency,
 			}, resultChan, intersectionOrExclusionInPreviousEdges, resolutionMetadata)
 		})
 	}

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -753,3 +753,79 @@ func TestReverseExpandDispatchCount(t *testing.T) {
 		})
 	}
 }
+
+func TestReverseExpandHonorsConsistency(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	store := ulid.Make().String()
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+
+		type user
+		type document
+			relations
+				define viewer: [user]`)
+
+	typeSystem, err := typesystem.New(model)
+	require.NoError(t, err)
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := context.Background()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	// run once with no consistency specified
+	unspecifiedConsistency := storage.ReadStartingWithUserOptions{
+		Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+	}
+	mockDatastore.EXPECT().
+		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), unspecifiedConsistency).
+		Times(1)
+
+	request := &ReverseExpandRequest{
+		StoreID:    store,
+		ObjectType: "document",
+		Relation:   "viewer",
+		User: &UserRefObject{
+			Object: &openfgav1.Object{
+				Type: "user",
+				Id:   "maria",
+			},
+		},
+		ContextualTuples: []*openfgav1.TupleKey{},
+	}
+
+	reverseExpandQuery := NewReverseExpandQuery(mockDatastore, typeSystem)
+	resultChan := make(chan *ReverseExpandResult)
+
+	err = reverseExpandQuery.Execute(ctx, request, resultChan, NewResolutionMetadata())
+	require.NoError(t, err)
+
+	// now do it again with specified consistency
+	highConsistency := storage.ReadStartingWithUserOptions{
+		Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
+	}
+
+	request.Consistency = openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
+	mockDatastore.EXPECT().
+		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), highConsistency).
+		Times(1)
+
+	resultChanTwo := make(chan *ReverseExpandResult)
+	err = reverseExpandQuery.Execute(ctx, request, resultChanTwo, NewResolutionMetadata())
+	require.NoError(t, err)
+
+	// Make sure we didn't leave channels open
+	select {
+	case _, open := <-resultChan:
+		if open {
+			require.FailNow(t, "results channels should be closed")
+		}
+	case _, open := <-resultChanTwo:
+		if open {
+			require.FailNow(t, "results channels should be closed")
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The `/read` and `/list-objects` endpoints were dropping the received `consistency` preference during evaluation. This PR passes it through.

This PR also adds assertions for `/expand` and `/list-users`. They were handling consistency correctly but didn't have test coverage for it.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
