### PR TITLE
Add support for disabling telemetry exporter

### DIFF
--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -176,7 +176,7 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Bool("trace-enabled", defaultConfig.Trace.Enabled, "enable tracing")
 
-	flags.String("trace-otlp-endpoint", defaultConfig.Trace.OTLP.Endpoint, "the endpoint of the trace collector")
+	flags.String("trace-otlp-endpoint", defaultConfig.Trace.OTLP.Endpoint, "the endpoint of the trace collector. 'none' for disabling the exporter")
 
 	flags.Bool("trace-otlp-tls-enabled", defaultConfig.Trace.OTLP.TLS.Enabled, "use TLS connection for trace collector")
 


### PR DESCRIPTION
## Description
This PR adds support for disabling OpenTelemetry GRPC exporter when tracing is enabled.
This is useful for logging trace IDs but not wanting them to export to OTEL collector.

PR to documentation: https://github.com/openfga/openfga.dev/pull/897

## References
https://github.com/openfga/openfga/issues/2120

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
