### PR TITLE
fix: always return ErrUnauthorizedResponse for access control failures, but log the corresponding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Improve `Check` performance in the case that the query involves types that cannot be reached from the source. Enable via experimental flag `enable-check-optimizations`. [#2104](https://github.com/openfga/openfga/pull/2104)
 - Fix regression introduced in #2091: error message for invalid Writes. [#2110](https://github.com/openfga/openfga/pull/2110)
 - Ensure `/read` and `/list-objects` respect the received `Consistency` values [#2113](https://github.com/openfga/openfga/pull/2113)
+- Fix `access-control` to always return unauthorized errors, and add logging for authorization failures [2129](https://github.com/openfga/openfga/pull/2129)
 
 ## [1.8.0] - 2024-11-08
 [Full changelog](https://github.com/openfga/openfga/compare/v1.7.0...v1.8.0)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -906,7 +906,7 @@ func (s *Server) checkAuthz(ctx context.Context, storeID, apiMethod string, modu
 
 	err := s.authorizer.Authorize(ctx, storeID, apiMethod, modules...)
 	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
+		s.logger.Info("authorization failed", zap.Error(err))
 		return authz.ErrUnauthorizedResponse
 	}
 
@@ -921,7 +921,7 @@ func (s *Server) checkCreateStoreAuthz(ctx context.Context) error {
 
 	err := s.authorizer.AuthorizeCreateStore(ctx)
 	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
+		s.logger.Info("authorization failed", zap.Error(err))
 		return authz.ErrUnauthorizedResponse
 	}
 
@@ -937,13 +937,13 @@ func (s *Server) getAccessibleStores(ctx context.Context) ([]string, error) {
 
 	err := s.authorizer.AuthorizeListStores(ctx)
 	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
+		s.logger.Info("authorization failed", zap.Error(err))
 		return nil, authz.ErrUnauthorizedResponse
 	}
 
 	stores, err := s.authorizer.ListAuthorizedStores(ctx)
 	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
+		s.logger.Info("authorization failed", zap.Error(err))
 		return nil, authz.ErrUnauthorizedResponse
 	}
 
@@ -958,7 +958,7 @@ func (s *Server) checkWriteAuthz(ctx context.Context, req *openfgav1.WriteReques
 
 	modules, err := s.authorizer.GetModulesForWriteRequest(req, typesys)
 	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
+		s.logger.Info("authorization failed", zap.Error(err))
 		return authz.ErrUnauthorizedResponse
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -904,7 +904,13 @@ func (s *Server) checkAuthz(ctx context.Context, storeID, apiMethod string, modu
 		return nil
 	}
 
-	return s.authorizer.Authorize(ctx, storeID, apiMethod, modules...)
+	err := s.authorizer.Authorize(ctx, storeID, apiMethod, modules...)
+	if err != nil {
+		s.logger.Error("authorization failed", zap.Error(err))
+		return authz.ErrUnauthorizedResponse
+	}
+
+	return nil
 }
 
 // checkCreateStoreAuthz checks the authorization for creating a store.
@@ -913,7 +919,13 @@ func (s *Server) checkCreateStoreAuthz(ctx context.Context) error {
 		return nil
 	}
 
-	return s.authorizer.AuthorizeCreateStore(ctx)
+	err := s.authorizer.AuthorizeCreateStore(ctx)
+	if err != nil {
+		s.logger.Error("authorization failed", zap.Error(err))
+		return authz.ErrUnauthorizedResponse
+	}
+
+	return nil
 }
 
 // getAccessibleStores checks whether the caller has permission to list stores and if so,
@@ -925,10 +937,17 @@ func (s *Server) getAccessibleStores(ctx context.Context) ([]string, error) {
 
 	err := s.authorizer.AuthorizeListStores(ctx)
 	if err != nil {
-		return nil, err
+		s.logger.Error("authorization failed", zap.Error(err))
+		return nil, authz.ErrUnauthorizedResponse
 	}
 
-	return s.authorizer.ListAuthorizedStores(ctx)
+	stores, err := s.authorizer.ListAuthorizedStores(ctx)
+	if err != nil {
+		s.logger.Error("authorization failed", zap.Error(err))
+		return nil, authz.ErrUnauthorizedResponse
+	}
+
+	return stores, nil
 }
 
 // checkWriteAuthz checks the authorization for modules if they exist, otherwise the store on write requests.
@@ -939,8 +958,15 @@ func (s *Server) checkWriteAuthz(ctx context.Context, req *openfgav1.WriteReques
 
 	modules, err := s.authorizer.GetModulesForWriteRequest(req, typesys)
 	if err != nil {
-		return err
+		s.logger.Error("authorization failed", zap.Error(err))
+		return authz.ErrUnauthorizedResponse
 	}
 
-	return s.checkAuthz(ctx, req.GetStoreId(), authz.Write, modules...)
+	err = s.authorizer.Authorize(ctx, req.GetStoreId(), authz.Write, modules...)
+	if err != nil {
+		s.logger.Error("authorization failed", zap.Error(err))
+		return authz.ErrUnauthorizedResponse
+	}
+
+	return nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -962,11 +962,5 @@ func (s *Server) checkWriteAuthz(ctx context.Context, req *openfgav1.WriteReques
 		return authz.ErrUnauthorizedResponse
 	}
 
-	err = s.authorizer.Authorize(ctx, req.GetStoreId(), authz.Write, modules...)
-	if err != nil {
-		s.logger.Error("authorization failed", zap.Error(err))
-		return authz.ErrUnauthorizedResponse
-	}
-
-	return nil
+	return s.checkAuthz(ctx, req.GetStoreId(), authz.Write, modules...)
 }

--- a/pkg/server/server_authz_test.go
+++ b/pkg/server/server_authz_test.go
@@ -580,7 +580,7 @@ func TestWrite(t *testing.T) {
 				},
 			})
 
-			require.Equal(t, err, fmt.Errorf("%v (modules in request: %v)", authz.ErrBadRequestMaxModulesInRequestExceeded, len(tuples)), err)
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 
 			tuplesInDelete := []*openfgav1.TupleKeyWithoutCondition{}
 			for _, tuple := range tuples {
@@ -599,7 +599,7 @@ func TestWrite(t *testing.T) {
 				},
 			})
 
-			require.Equal(t, err, fmt.Errorf("%v (modules in request: %v)", authz.ErrBadRequestMaxModulesInRequestExceeded, len(tuplesInDelete)), err)
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("success_when_sending_more_than_max_modules_with_store_level_write_permission", func(t *testing.T) {
@@ -683,14 +683,14 @@ func TestCheckCreateStoreAuthz(t *testing.T) {
 		t.Run("error_with_no_client_id_found", func(t *testing.T) {
 			err := openfga.checkCreateStoreAuthz(context.Background())
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_with_empty_client_id", func(t *testing.T) {
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: ""})
 			err := openfga.checkCreateStoreAuthz(ctx)
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_check_when_not_authorized", func(t *testing.T) {
@@ -750,21 +750,21 @@ func TestCheckAuthz(t *testing.T) {
 		t.Run("error_with_no_client_id_found", func(t *testing.T) {
 			err := openfga.checkAuthz(context.Background(), settings.testData.id, authz.Check)
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_with_empty_client_id", func(t *testing.T) {
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: ""})
 			err := openfga.checkAuthz(ctx, settings.testData.id, authz.Check)
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_when_authorized_errors", func(t *testing.T) {
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: "ID"})
 			err := openfga.checkAuthz(ctx, settings.testData.id, "invalid api method")
 
-			require.ErrorIs(t, err, authz.ErrUnknownAPIMethod)
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_check_when_not_authorized", func(t *testing.T) {
@@ -822,14 +822,14 @@ func TestGetAccessibleStores(t *testing.T) {
 		t.Run("error_with_no_client_id_found", func(t *testing.T) {
 			_, err := openfga.getAccessibleStores(context.Background())
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_with_empty_client_id", func(t *testing.T) {
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: ""})
 			_, err := openfga.getAccessibleStores(ctx)
 
-			require.EqualError(t, err, errInvalidClientID.Error())
+			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 		})
 
 		t.Run("error_when_AuthorizeListStores_errors", func(t *testing.T) {

--- a/pkg/server/server_authz_test.go
+++ b/pkg/server/server_authz_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -22,8 +21,6 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
-
-var errInvalidClientID = errors.New("rpc error: code = InvalidArgument desc = client ID not found in context")
 
 type storeAndModel struct {
 	id      string


### PR DESCRIPTION
## Description
For any access control error we want to return unauthorized, but we do want to log the corresponding error for users to debug.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
