### PR TITLE
feat: add a field in log entries when authz calls were made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - New flag `OPENFGA_CHECK_ITERATOR_TTL`. Please see the flag description (`./openfga run --help`) for more details. [#2082](https://github.com/openfga/openfga/pull/2082)
 - New flag `OPENFGA_CHECK_CACHE_LIMIT`. Please see the flag description (`./openfga run --help`) for more details. [#2082](https://github.com/openfga/openfga/pull/2082)
 - Improve `Check` performance for TTU relationships that include set operations. Enable via experimental flag `enable-check-optimizations`. [#2075](https://github.com/openfga/openfga/pull/2075)
+- Add a field in log entries when authz calls were made. [#2130](https://github.com/openfga/openfga/pull/2130)
 
 ### Changed
 - OIDC token validation will now exclusively throw error code 1004 for invalid tokens. [#1999](https://github.com/openfga/openfga/pull/1999)

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -610,6 +610,7 @@ func TestGetModulesForWriteRequest(t *testing.T) {
 
 	t.Run("error_when_write_tuples_errors", func(t *testing.T) {
 		modules, err := authorizer.GetModulesForWriteRequest(
+			context.Background(),
 			&openfgav1.WriteRequest{
 				StoreId: "store-id",
 				Writes: &openfgav1.WriteRequestWrites{
@@ -626,6 +627,7 @@ func TestGetModulesForWriteRequest(t *testing.T) {
 
 	t.Run("error_when_delete_tuples_errors", func(t *testing.T) {
 		modules, err := authorizer.GetModulesForWriteRequest(
+			context.Background(),
 			&openfgav1.WriteRequest{
 				StoreId: "store-id",
 				Deletes: &openfgav1.WriteRequestDeletes{
@@ -642,6 +644,7 @@ func TestGetModulesForWriteRequest(t *testing.T) {
 
 	t.Run("return_empty_when_a_write_tuple_has_no_modules", func(t *testing.T) {
 		modules, err := authorizer.GetModulesForWriteRequest(
+			context.Background(),
 			&openfgav1.WriteRequest{
 				StoreId: "store-id",
 				Writes: &openfgav1.WriteRequestWrites{
@@ -659,6 +662,7 @@ func TestGetModulesForWriteRequest(t *testing.T) {
 
 	t.Run("return_empty_when_a_delete_tuple_has_no_modules", func(t *testing.T) {
 		modules, err := authorizer.GetModulesForWriteRequest(
+			context.Background(),
 			&openfgav1.WriteRequest{
 				StoreId: "store-id",
 				Deletes: &openfgav1.WriteRequestDeletes{
@@ -676,6 +680,7 @@ func TestGetModulesForWriteRequest(t *testing.T) {
 
 	t.Run("return_modules", func(t *testing.T) {
 		modules, err := authorizer.GetModulesForWriteRequest(
+			context.Background(),
 			&openfgav1.WriteRequest{
 				StoreId: "store-id",
 				Writes: &openfgav1.WriteRequestWrites{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,6 +42,7 @@ type ExperimentalFeatureFlag string
 const (
 	AuthorizationModelIDHeader = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey    = "authorization_model_id"
+	accessControlKey           = "access_control"
 
 	ExperimentalCheckOptimizations  ExperimentalFeatureFlag = "enable-check-optimizations"
 	ExperimentalAccessControlParams ExperimentalFeatureFlag = "enable-access-control"
@@ -904,6 +905,8 @@ func (s *Server) checkAuthz(ctx context.Context, storeID, apiMethod string, modu
 		return nil
 	}
 
+	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkAuthz")
+
 	return s.authorizer.Authorize(ctx, storeID, apiMethod, modules...)
 }
 
@@ -912,6 +915,8 @@ func (s *Server) checkCreateStoreAuthz(ctx context.Context) error {
 	if authclaims.SkipAuthzCheckFromContext(ctx) {
 		return nil
 	}
+
+	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkCreateStoreAuthz")
 
 	return s.authorizer.AuthorizeCreateStore(ctx)
 }
@@ -922,6 +927,8 @@ func (s *Server) getAccessibleStores(ctx context.Context) ([]string, error) {
 	if authclaims.SkipAuthzCheckFromContext(ctx) {
 		return nil, nil
 	}
+
+	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "getAccessibleStores")
 
 	err := s.authorizer.AuthorizeListStores(ctx)
 	if err != nil {
@@ -936,6 +943,8 @@ func (s *Server) checkWriteAuthz(ctx context.Context, req *openfgav1.WriteReques
 	if authclaims.SkipAuthzCheckFromContext(ctx) {
 		return nil
 	}
+
+	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkWriteAuthz")
 
 	modules, err := s.authorizer.GetModulesForWriteRequest(req, typesys)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -42,7 +42,6 @@ type ExperimentalFeatureFlag string
 const (
 	AuthorizationModelIDHeader = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey    = "authorization_model_id"
-	accessControlKey           = "access_control"
 
 	ExperimentalCheckOptimizations  ExperimentalFeatureFlag = "enable-check-optimizations"
 	ExperimentalAccessControlParams ExperimentalFeatureFlag = "enable-access-control"
@@ -905,8 +904,6 @@ func (s *Server) checkAuthz(ctx context.Context, storeID, apiMethod string, modu
 		return nil
 	}
 
-	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkAuthz")
-
 	return s.authorizer.Authorize(ctx, storeID, apiMethod, modules...)
 }
 
@@ -915,8 +912,6 @@ func (s *Server) checkCreateStoreAuthz(ctx context.Context) error {
 	if authclaims.SkipAuthzCheckFromContext(ctx) {
 		return nil
 	}
-
-	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkCreateStoreAuthz")
 
 	return s.authorizer.AuthorizeCreateStore(ctx)
 }
@@ -927,8 +922,6 @@ func (s *Server) getAccessibleStores(ctx context.Context) ([]string, error) {
 	if authclaims.SkipAuthzCheckFromContext(ctx) {
 		return nil, nil
 	}
-
-	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "getAccessibleStores")
 
 	err := s.authorizer.AuthorizeListStores(ctx)
 	if err != nil {
@@ -944,9 +937,7 @@ func (s *Server) checkWriteAuthz(ctx context.Context, req *openfgav1.WriteReques
 		return nil
 	}
 
-	grpc_ctxtags.Extract(ctx).Set(accessControlKey, "checkWriteAuthz")
-
-	modules, err := s.authorizer.GetModulesForWriteRequest(req, typesys)
+	modules, err := s.authorizer.GetModulesForWriteRequest(ctx, req, typesys)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Add GRPC tags to be able to detect when calls go through authz.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
