### PR TITLE
fix: prevent race condition of context cancellation

### DIFF
--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -561,7 +561,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 		return nil, ctx.Err()
 	case r, ok := <-rightChan:
 		if !ok {
-			return res, nil
+			return res, ctx.Err()
 		}
 		if r.err != nil {
 			return nil, r.err
@@ -577,7 +577,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 			if !ok {
 				leftOpen = false
 				if leftSet.Size() == 0 {
-					return res, nil
+					return res, ctx.Err()
 				}
 				break
 			}
@@ -596,7 +596,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 				if processUsersetMessage(t.GetObject(), leftSet, rightSet) {
 					msg.iter.Stop()
 					res.Allowed = true
-					return res, nil
+					return res, ctx.Err()
 				}
 			}
 		case msg, ok := <-rightChan:
@@ -613,7 +613,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 			}
 		}
 	}
-	return res, nil
+	return res, ctx.Err()
 }
 
 func (c *LocalChecker) checkTTUFastPathV2(ctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset, iter storage.TupleKeyIterator) (*ResolveCheckResponse, error) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

In the case the client/upstream cancels the context, it should yield an error rather than a `false` resolution.
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

If you haven't done so yet, we would appreciate it if you could star the [OpenFGA repository](https://github.com/openfga/openfga). :) 
