### PR TITLE
fix: wait for cached iters on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 - Labels of metrics that went past the `max` histogram bucket are now labelled "+Inf" instead of ">max". [#2146](https://github.com/openfga/openfga/pull/2146)
+- Prevent possible data races by waiting for in-flight cached iterator goroutines during server shutdown [#2145](https://github.com/openfga/openfga/pull/2145)
 
 ## [1.8.1] - 2024-12-05
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.0...v1.8.1)

--- a/internal/graph/storagewrapper.go
+++ b/internal/graph/storagewrapper.go
@@ -73,6 +73,8 @@ type CachedDatastore struct {
 	// across multiple requests.
 	sf *singleflight.Group
 
+	// wg is used to synchronize inflight goroutines from underlying
+	// cached iterators.
 	wg *sync.WaitGroup
 }
 
@@ -391,7 +393,8 @@ type cachedIterator struct {
 	// mu is used to synchronize access to the iterator.
 	mu sync.Mutex
 
-	// wg is used purely for testing and is an internal detail.
+	// wg is used to synchronize inflight goroutines spawned
+	// when stopping the iterator.
 	wg *sync.WaitGroup
 }
 

--- a/internal/graph/storagewrapper_test.go
+++ b/internal/graph/storagewrapper_test.go
@@ -762,34 +762,6 @@ func TestRead(t *testing.T) {
 	})
 }
 
-// func TestCloseDatastore(t *testing.T) {
-// 	ctx := context.Background()
-// 	t.Cleanup(func() {
-// 		goleak.VerifyNone(t)
-// 	})
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
-
-// 	mockCache := mocks.NewMockInMemoryCache[any](mockController)
-// 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-
-// 	maxSize := 10
-// 	ttl := 5 * time.Hour
-// 	ds := NewCachedDatastore(ctx, mockDatastore, mockCache, maxSize, ttl)
-// 	ds.Close()
-
-// 	doneCh := make(chan struct{})
-// 	go func() {
-// 		ds.wg.Wait()
-// 		close(doneCh)
-// 	}()
-// 	select {
-// 	case <-doneCh:
-// 	case <-time.After(1 * time.Millisecond):
-// 		t.Fatalf("timeout waiting for waitgroup")
-// 	}
-// }
-
 func TestDatastoreIteratorError(t *testing.T) {
 	ctx := context.Background()
 	t.Cleanup(func() {

--- a/internal/graph/storagewrapper_test.go
+++ b/internal/graph/storagewrapper_test.go
@@ -776,12 +776,21 @@ func TestCloseDatastore(t *testing.T) {
 	mockCache := mocks.NewMockInMemoryCache[any](mockController)
 	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 
-	mockDatastore.EXPECT().Close().Times(1).Return()
-
 	maxSize := 10
 	ttl := 5 * time.Hour
 	ds := NewCachedDatastore(ctx, mockDatastore, mockCache, maxSize, ttl)
 	ds.Close()
+
+	doneCh := make(chan struct{})
+	go func() {
+		ds.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-doneCh:
+	case <-time.After(1 * time.Millisecond):
+		t.Fatalf("timeout waiting for waitgroup")
+	}
 }
 
 func TestDatastoreIteratorError(t *testing.T) {
@@ -878,6 +887,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -917,6 +927,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -950,6 +961,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1005,6 +1017,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1041,6 +1054,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1102,6 +1116,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1144,6 +1159,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1198,6 +1214,7 @@ func TestCachedIterator(t *testing.T) {
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
 			objectType:        "",
 			objectID:          "",
 			relation:          "",
@@ -1253,6 +1270,7 @@ func TestCachedIterator(t *testing.T) {
 				maxResultSize:     maxCacheSize,
 				ttl:               ttl,
 				sf:                sf,
+				wg:                &sync.WaitGroup{},
 				objectType:        "",
 				objectID:          "",
 				relation:          "",
@@ -1274,6 +1292,7 @@ func TestCachedIterator(t *testing.T) {
 				maxResultSize:     maxCacheSize,
 				ttl:               ttl,
 				sf:                sf,
+				wg:                &sync.WaitGroup{},
 				objectType:        "",
 				objectID:          "",
 				relation:          "",

--- a/pkg/server/batch_check.go
+++ b/pkg/server/batch_check.go
@@ -21,17 +21,11 @@ import (
 	"github.com/openfga/openfga/pkg/telemetry"
 )
 
-func (s *Server) BatchCheck(
-	ctx context.Context,
-	req *openfgav1.BatchCheckRequest,
-) (*openfgav1.BatchCheckResponse, error) {
+func (s *Server) BatchCheck(ctx context.Context, req *openfgav1.BatchCheckRequest) (*openfgav1.BatchCheckResponse, error) {
 	ctx, span := tracer.Start(ctx, authz.BatchCheck, trace.WithAttributes(
 		attribute.KeyValue{Key: "store_id", Value: attribute.StringValue(req.GetStoreId())},
 		attribute.KeyValue{Key: "batch_size", Value: attribute.IntValue(len(req.GetChecks()))},
-		attribute.KeyValue{
-			Key:   "consistency",
-			Value: attribute.StringValue(req.GetConsistency().String()),
-		},
+		attribute.KeyValue{Key: "consistency", Value: attribute.StringValue(req.GetConsistency().String())},
 	))
 	defer span.End()
 
@@ -118,9 +112,7 @@ func (s *Server) BatchCheck(
 
 // transformCheckResultToProto transforms the internal BatchCheckOutcome into the external-facing
 // BatchCheckSingleResult struct for transmission back via the api.
-func transformCheckResultToProto(
-	outcome *commands.BatchCheckOutcome,
-) *openfgav1.BatchCheckSingleResult {
+func transformCheckResultToProto(outcome *commands.BatchCheckOutcome) *openfgav1.BatchCheckSingleResult {
 	singleResult := &openfgav1.BatchCheckSingleResult{}
 
 	if outcome.Err != nil {
@@ -146,31 +138,19 @@ func transformCheckCommandErrorToBatchCheckError(cmdErr error) *openfgav1.CheckE
 	// switch to map the possible errors to their specific GRPC codes in the proto definition
 	switch {
 	case errors.As(cmdErr, &invalidRelationError):
-		err.Code = &openfgav1.CheckError_InputError{
-			InputError: openfgav1.ErrorCode_validation_error,
-		}
+		err.Code = &openfgav1.CheckError_InputError{InputError: openfgav1.ErrorCode_validation_error}
 	case errors.As(cmdErr, &invalidTupleError):
 		err.Code = &openfgav1.CheckError_InputError{InputError: openfgav1.ErrorCode_invalid_tuple}
 	case errors.Is(cmdErr, graph.ErrResolutionDepthExceeded):
-		err.Code = &openfgav1.CheckError_InputError{
-			InputError: openfgav1.ErrorCode_authorization_model_resolution_too_complex,
-		}
+		err.Code = &openfgav1.CheckError_InputError{InputError: openfgav1.ErrorCode_authorization_model_resolution_too_complex}
 	case errors.Is(cmdErr, condition.ErrEvaluationFailed):
-		err.Code = &openfgav1.CheckError_InputError{
-			InputError: openfgav1.ErrorCode_validation_error,
-		}
+		err.Code = &openfgav1.CheckError_InputError{InputError: openfgav1.ErrorCode_validation_error}
 	case errors.As(cmdErr, &throttledError):
-		err.Code = &openfgav1.CheckError_InputError{
-			InputError: openfgav1.ErrorCode_validation_error,
-		}
+		err.Code = &openfgav1.CheckError_InputError{InputError: openfgav1.ErrorCode_validation_error}
 	case errors.Is(cmdErr, context.DeadlineExceeded):
-		err.Code = &openfgav1.CheckError_InternalError{
-			InternalError: openfgav1.InternalErrorCode_deadline_exceeded,
-		}
+		err.Code = &openfgav1.CheckError_InternalError{InternalError: openfgav1.InternalErrorCode_deadline_exceeded}
 	default:
-		err.Code = &openfgav1.CheckError_InternalError{
-			InternalError: openfgav1.InternalErrorCode_internal_error,
-		}
+		err.Code = &openfgav1.CheckError_InternalError{InternalError: openfgav1.InternalErrorCode_internal_error}
 	}
 
 	return err

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -23,10 +23,7 @@ import (
 	"github.com/openfga/openfga/pkg/telemetry"
 )
 
-func (s *Server) Check(
-	ctx context.Context,
-	req *openfgav1.CheckRequest,
-) (*openfgav1.CheckResponse, error) {
+func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openfgav1.CheckResponse, error) {
 	start := time.Now()
 
 	tk := req.GetTupleKey()
@@ -35,10 +32,7 @@ func (s *Server) Check(
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},
 		attribute.KeyValue{Key: "user", Value: attribute.StringValue(tk.GetUser())},
-		attribute.KeyValue{
-			Key:   "consistency",
-			Value: attribute.StringValue(req.GetConsistency().String()),
-		},
+		attribute.KeyValue{Key: "consistency", Value: attribute.StringValue(req.GetConsistency().String())},
 	))
 	defer span.End()
 
@@ -131,8 +125,7 @@ func (s *Server) Check(
 		Allowed: resp.Allowed,
 	}
 
-	checkResultCounter.With(prometheus.Labels{allowedLabel: strconv.FormatBool(resp.GetAllowed())}).
-		Inc()
+	checkResultCounter.With(prometheus.Labels{allowedLabel: strconv.FormatBool(resp.GetAllowed())}).Inc()
 
 	requestDurationHistogram.WithLabelValues(
 		s.serviceName,
@@ -145,10 +138,7 @@ func (s *Server) Check(
 	if s.authorizer.AccessControlStoreID() == req.GetStoreId() {
 		accessControlStoreCheckDurationHistogram.WithLabelValues(
 			utils.Bucketize(uint(queryCount), s.requestDurationByQueryHistogramBuckets),
-			utils.Bucketize(
-				uint(rawDispatchCount),
-				s.requestDurationByDispatchCountHistogramBuckets,
-			),
+			utils.Bucketize(uint(rawDispatchCount), s.requestDurationByDispatchCountHistogramBuckets),
 			req.GetConsistency().String(),
 		).Observe(float64(time.Since(start).Milliseconds()))
 	}

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -96,12 +96,7 @@ func WithCheckCommandCache(
 }
 
 // TODO accept CheckCommandParams so we can build the datastore object right away.
-func NewCheckCommand(
-	datastore storage.RelationshipTupleReader,
-	checkResolver graph.CheckResolver,
-	typesys *typesystem.TypeSystem,
-	opts ...CheckQueryOption,
-) *CheckQuery {
+func NewCheckCommand(datastore storage.RelationshipTupleReader, checkResolver graph.CheckResolver, typesys *typesystem.TypeSystem, opts ...CheckQueryOption) *CheckQuery {
 	cmd := &CheckQuery{
 		logger:               logger.NewNoopLogger(),
 		datastore:            datastore,
@@ -120,10 +115,7 @@ func NewCheckCommand(
 	return cmd
 }
 
-func (c *CheckQuery) Execute(
-	ctx context.Context,
-	params *CheckCommandParams,
-) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
+func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*graph.ResolveCheckResponse, *graph.ResolveCheckRequestMetadata, error) {
 	err := validateCheckRequest(c.typesys, params.TupleKey, params.ContextualTuples)
 	if err != nil {
 		return nil, nil, err
@@ -167,8 +159,7 @@ func (c *CheckQuery) Execute(
 	startTime := time.Now()
 	resp, err := c.checkResolver.ResolveCheck(ctx, &resolveCheckRequest)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) &&
-			resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
+		if errors.Is(err, context.DeadlineExceeded) && resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
 			return nil, nil, &ThrottledError{Cause: err}
 		}
 
@@ -181,11 +172,7 @@ func (c *CheckQuery) Execute(
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }
 
-func validateCheckRequest(
-	typesys *typesystem.TypeSystem,
-	tupleKey *openfgav1.CheckRequestTupleKey,
-	contextualTuples *openfgav1.ContextualTupleKeys,
-) error {
+func validateCheckRequest(typesys *typesystem.TypeSystem, tupleKey *openfgav1.CheckRequestTupleKey, contextualTuples *openfgav1.ContextualTupleKeys) error {
 	// The input tuple Key should be validated loosely.
 	if err := validation.ValidateUserObjectRelation(typesys, tuple.ConvertCheckRequestTupleKeyToTupleKey(tupleKey)); err != nil {
 		return &InvalidRelationError{Cause: err}

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -106,11 +106,7 @@ type doc
 				},
 			},
 		})
-		require.ErrorContains(
-			t,
-			err,
-			"type 'user' is not an allowed type restriction for 'doc#viewer_computed'",
-		)
+		require.ErrorContains(t, err, "type 'user' is not an allowed type restriction for 'doc#viewer_computed'")
 	})
 
 	t.Run("no_validation_error_and_call_to_resolver_goes_through", func(t *testing.T) {
@@ -165,10 +161,7 @@ type doc
 
 	t.Run("no_validation_error_but_call_to_resolver_fails", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		mockCheckResolver.EXPECT().
-			ResolveCheck(gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(nil, ofga_errors.ErrUnknown)
+		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).Return(nil, ofga_errors.ErrUnknown)
 		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  ulid.Make().String(),
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
@@ -178,13 +171,10 @@ type doc
 
 	t.Run("ignores_cache_controller_with_high_consistency", func(t *testing.T) {
 		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts)
-		mockCheckResolver.EXPECT().
-			ResolveCheck(gomock.Any(), gomock.Any()).
-			Times(1).
-			DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest) (*graph.ResolveCheckResponse, error) {
-				require.Zero(t, req.GetLastCacheInvalidationTime())
-				return &graph.ResolveCheckResponse{}, nil
-			})
+		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest) (*graph.ResolveCheckResponse, error) {
+			require.Zero(t, req.GetLastCacheInvalidationTime())
+			return &graph.ResolveCheckResponse{}, nil
+		})
 		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:     ulid.Make().String(),
 			TupleKey:    tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
@@ -197,22 +187,12 @@ type doc
 		storeID := ulid.Make().String()
 		invalidationTime := time.Now().UTC()
 		cacheController := mockstorage.NewMockCacheController(mockController)
-		cmd := NewCheckCommand(
-			mockDatastore,
-			mockCheckResolver,
-			ts,
-			WithCheckCommandCache(context.TODO(), cacheController, false, nil, nil, nil, 0, 0),
-		)
-		mockCheckResolver.EXPECT().
-			ResolveCheck(gomock.Any(), gomock.Any()).
-			Times(1).
-			DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest) (*graph.ResolveCheckResponse, error) {
-				require.Equal(t, req.GetLastCacheInvalidationTime(), invalidationTime)
-				return &graph.ResolveCheckResponse{}, nil
-			})
-		cacheController.EXPECT().
-			DetermineInvalidation(gomock.Any(), storeID).
-			Return(invalidationTime)
+		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts, WithCheckCommandCache(context.TODO(), cacheController, false, nil, nil, nil, 0, 0))
+		mockCheckResolver.EXPECT().ResolveCheck(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest) (*graph.ResolveCheckResponse, error) {
+			require.Equal(t, req.GetLastCacheInvalidationTime(), invalidationTime)
+			return &graph.ResolveCheckResponse{}, nil
+		})
+		cacheController.EXPECT().DetermineInvalidation(gomock.Any(), storeID).Return(invalidationTime)
 		_, _, err := cmd.Execute(context.Background(), &CheckCommandParams{
 			StoreID:  storeID,
 			TupleKey: tuple.NewCheckRequestTupleKey("doc:1", "viewer", "user:1"),
@@ -251,10 +231,8 @@ func TestCheckCommandErrorToServerError(t *testing.T) {
 			),
 		},
 		`6`: {
-			inputError: &InvalidRelationError{Cause: errors.New("oh no")},
-			expectedError: serverErrors.ValidationError(
-				&InvalidRelationError{Cause: errors.New("oh no")},
-			),
+			inputError:    &InvalidRelationError{Cause: errors.New("oh no")},
+			expectedError: serverErrors.ValidationError(&InvalidRelationError{Cause: errors.New("oh no")}),
 		},
 		`7`: {
 			inputError:    ofga_errors.ErrUnknown,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -844,9 +844,14 @@ func (s *Server) Close() {
 		s.listUsersDispatchThrottler.Close()
 	}
 
+	if s.checkCache != nil && s.checkIteratorCacheEnabled {
+		s.checkDatastore.Close()
+	}
+
 	if s.checkCache != nil {
 		s.checkCache.Stop()
 	}
+
 	s.datastore.Close()
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -845,9 +845,9 @@ func (s *Server) Close() {
 		s.listUsersDispatchThrottler.Close()
 	}
 
-	if s.checkIteratorCacheWaitGroup != nil {
-		s.checkIteratorCacheWaitGroup.Wait()
-	}
+	// wait for any cached iterator goroutines still in flight before
+	// closing the cache instance to avoid data races
+	s.checkIteratorCacheWaitGroup.Wait()
 
 	if s.checkCache != nil {
 		s.checkCache.Stop()

--- a/pkg/storage/storagewrappers/request.go
+++ b/pkg/storage/storagewrappers/request.go
@@ -56,11 +56,7 @@ func NewRequestStorageWrapperForCheckAPI(
 }
 
 // NewRequestStorageWrapperForListAPIs can be used for ListObjects or ListUsers.
-func NewRequestStorageWrapperForListAPIs(
-	ds storage.RelationshipTupleReader,
-	requestContextualTuples []*openfgav1.TupleKey,
-	maxConcurrentReads uint32,
-) *RequestStorageWrapper {
+func NewRequestStorageWrapperForListAPIs(ds storage.RelationshipTupleReader, requestContextualTuples []*openfgav1.TupleKey, maxConcurrentReads uint32) *RequestStorageWrapper {
 	a := NewBoundedConcurrencyTupleReader(ds, maxConcurrentReads) // to rate-limit reads
 	b := NewInstrumentedOpenFGAStorage(a)                         // to capture metrics
 	c := NewCombinedTupleReader(b, requestContextualTuples)       // to read the contextual tuples

--- a/pkg/storage/storagewrappers/request_test.go
+++ b/pkg/storage/storagewrappers/request_test.go
@@ -112,11 +112,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 			tuple.NewTupleKey("doc:1", "viewer", "user:maria"),
 		}
 
-		br := NewRequestStorageWrapperForListAPIs(
-			mockDatastore,
-			requestContextualTuples,
-			maxConcurrentReads,
-		)
+		br := NewRequestStorageWrapperForListAPIs(mockDatastore, requestContextualTuples, maxConcurrentReads)
 		require.NotNil(t, br)
 
 		// assert on the chain


### PR DESCRIPTION
## Description

Use a wait group per instance of a `CachedDatastore` to help synchronize any cached iterator goroutines still in flight during when server is shutting down. This should eliminate potential data races by allowing us to close the inmem cache instance once we're sure there's no further access to it.

```
==================
WARNING: DATA RACE
Read at 0x00c0008085a0 by goroutine 85819:
  github.com/Yiling-J/theine-go/internal.(*Shard[go.shape.string,go.shape.interface {}]).get()
      /home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:80 +0xd8
  github.com/Yiling-J/theine-go/internal.(*Store[go.shape.string,go.shape.interface {}]).getFromShard()
      /home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:212 +0x8b
  github.com/Yiling-J/theine-go/internal.(*Store[go.shape.string,go.shape.interface {}]).Get()
      /home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:268 +0x1c4
  github.com/Yiling-J/theine-go.(*Cache[go.shape.string,go.shape.interface {}]).Get()
      /home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/cache.go:47 +0xea
  github.com/openfga/openfga/pkg/storage.InMemoryLRUCache[go.shape.interface {}].Get()
      /home/runner/work/openfga/openfga/pkg/storage/cache.go:72 +0x8e
  github.com/openfga/openfga/pkg/storage.(*InMemoryLRUCache[interface {}]).Get()
      <autogenerated>:1 +0x74
  github.com/openfga/openfga/internal/graph.(*cachedIterator).Stop.func1()
      /home/runner/work/openfga/openfga/internal/graph/storagewrapper.go:448 +0x1e7

Previous write at 0x00c0008085a0 by goroutine 85794:
  github.com/Yiling-J/theine-go/internal.(*Store[go.shape.string,go.shape.interface {}]).Close()
      /home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:745 +0xf5
github.com/Yiling-J/theine-go/internal.(*Shard[...]).set(0x291bb80, {0xc000ea8080, 0x4e}, 0xc000914360)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:70 +0x87
github.com/Yiling-J/theine-go/internal.(*Store[...]).setEntry(0x29532a0, 0xed92923813064fe, 0xc0008085a0, 0x1, 0xc000914360, 0x0)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:316 +0x96
github.com/Yiling-J/theine-go/internal.(*Store[...]).setShard(0x29532a0, 0xc0008085a0, 0xed92923813064fe, {0xc000ea8080, 0x4e}, {0x2280a80, 0xc000ebc030}, 0x1, 0xdf8adf203, 0x0)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:383 +0x6d0
github.com/Yiling-J/theine-go/internal.(*Store[...]).setInternal(0x29532a0, {0xc000ea8080, 0x4e}, {0x2280a80, 0xc000ebc030}, 0x1, 0xdf8adf203, 0x0)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:393 +0x255
github.com/Yiling-J/theine-go/internal.(*Store[...]).Set(0x29532a0, {0xc000ea8080, 0x4e}, {0x2280a80, 0xc000ebc030}, 0x1, 0xdf8475800)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/internal/store.go:408 +0x17b
github.com/Yiling-J/theine-go.(*Cache[...]).SetWithTTL(...)
	/home/runner/go/pkg/mod/github.com/!yiling-!j/theine-go@v0.6.0/cache.go:53
github.com/openfga/openfga/pkg/storage.InMemoryLRUCache[...].Set(0x29198a0?, {0xc000ea8080?, 0x4e?}, {0x2280a80, 0xc000ebc030}, 0xdf8475800)
	/home/runner/work/openfga/openfga/pkg/storage/cache.go:82 +0x146
github.com/openfga/openfga/internal/graph.(*cachedIterator).flush(0xc000c5c240)
	/home/runner/work/openfga/openfga/internal/graph/storagewrapper.go:567 +0x32c
github.com/openfga/openfga/internal/graph.(*cachedIterator).Stop.func1()
	/home/runner/work/openfga/openfga/internal/graph/storagewrapper.go:462 +0x4ec
created by github.com/openfga/openfga/internal/graph.(*cachedIterator).Stop in goroutine 85821
	/home/runner/work/openfga/openfga/internal/graph/storagewrapper.go:443 +0x245
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

