### PR TITLE
chore: expose cache controller configuration to allow use as stand alone binary

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -523,6 +523,24 @@
                 }
             }
         },
+        "cacheController": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "description": "enabling dynamic invalidation of check query cache and check iterator cache based on whether there are recent tuple writes. If enabled, cache will be invalidated when either 1) there are tuples written to the store OR 2) the check query cache or check iterator cache TTL has expired.",
+                    "type": "bool",
+                    "default": "false",
+                    "x-env-variable": "OPENFGA_CACHE_CONTROLLER_ENABLED"
+                },
+                "ttl": {
+                    "description": "if cache controller is enabled, control how frequent read changes are invoked internally to query for recent tuple writes to the store.",
+                    "type": "string",
+                    "format": "duration",
+                    "default": "10s",
+                    "x-env-variable": "OPENFGA_CACHE_CONTROLLER_TTL"
+                }
+            }
+        },
         "checkDispatchThrottling": {
             "type": "object",
             "properties": {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -236,6 +236,10 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Duration("check-query-cache-ttl", defaultConfig.CheckQueryCache.TTL, "if check-query-cache-enabled, this is the TTL of each value")
 
+	flags.Bool("cache-controller-enabled", defaultConfig.CacheController.Enabled, "enabling dynamic invalidation of check query cache and check iterator cache based on whether there are recent tuple writes. If enabled, cache will be invalidated when either 1) there are tuples written to the store OR 2) the check query cache or check iterator cache TTL has expired.")
+
+	flags.Duration("cache-controller-ttl", defaultConfig.CacheController.TTL, "if cache controller is enabled, control how frequent read changes are invoked internally to query for recent tuple writes to the store.")
+
 	// Unfortunately UintSlice/IntSlice does not work well when used as environment variable, we need to stick with string slice and convert back to integer
 	flags.StringSlice("request-duration-datastore-query-count-buckets", defaultConfig.RequestDurationDatastoreQueryCountBuckets, "datastore query count buckets used in labelling request_duration_ms.")
 

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1184,6 +1184,14 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.CheckIteratorCache.TTL.String())
 
+	val = res.Get("properties.cacheController.properties.enabled.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.Bool(), cfg.CacheController.Enabled)
+
+	val = res.Get("properties.cacheController.properties.ttl.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.String(), cfg.CacheController.TTL.String())
+
 	val = res.Get("properties.requestDurationDatastoreQueryCountBuckets.default")
 	require.True(t, val.Exists())
 	require.Equal(t, len(val.Array()), len(cfg.RequestDurationDatastoreQueryCountBuckets))
@@ -1332,6 +1340,8 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 	t.Setenv("OPENFGA_CHECK_QUERY_CACHE_ENABLED", "true")
 	t.Setenv("OPENFGA_CHECK_CACHE_LIMIT", "33")
 	t.Setenv("OPENFGA_CHECK_QUERY_CACHE_TTL", "5s")
+	t.Setenv("OPENFGA_CACHE_CONTROLLER_ENABLED", "true")
+	t.Setenv("OPENFGA_CACHE_CONTROLLER_TTL", "4s")
 	t.Setenv("OPENFGA_REQUEST_DURATION_DATASTORE_QUERY_COUNT_BUCKETS", "33 44")
 	t.Setenv("OPENFGA_DISPATCH_THROTTLING_ENABLED", "true")
 	t.Setenv("OPENFGA_DISPATCH_THROTTLING_FREQUENCY", "1ms")
@@ -1351,6 +1361,8 @@ func TestRunCommandConfigIsMerged(t *testing.T) {
 		require.True(t, viper.GetBool("check-query-cache-enabled"))
 		require.Equal(t, uint32(33), viper.GetUint32("check-cache-limit"))
 		require.Equal(t, 5*time.Second, viper.GetDuration("check-query-cache-ttl"))
+		require.True(t, viper.GetBool("cache-controller-enabled"))
+		require.Equal(t, 4*time.Second, viper.GetDuration("cache-controller-ttl"))
 
 		require.Equal(t, []string{"33", "44"}, viper.GetStringSlice("request-duration-datastore-query-count-buckets"))
 		require.True(t, viper.GetBool("dispatch-throttling-enabled"))

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -323,6 +323,115 @@ func TestVerifyConfig(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("cache_query_cache", func(t *testing.T) {
+		t.Run("enable_but_ttl_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckQueryCache.Enabled = true
+			cfg.CheckQueryCache.TTL = 0
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+		t.Run("enable_but_ttl_negative", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckQueryCache.Enabled = true
+			cfg.CheckQueryCache.TTL = -2 * time.Second
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+		t.Run("enable_and_ttl_positive", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckQueryCache.Enabled = true
+			cfg.CheckQueryCache.TTL = 2 * time.Second
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+		t.Run("disable_and_ttl_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckQueryCache.Enabled = false
+			cfg.CheckQueryCache.TTL = 0
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("check_iterator_cache", func(t *testing.T) {
+		t.Run("enable_but_ttl_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckIteratorCache.Enabled = true
+			cfg.CheckIteratorCache.TTL = 0
+			cfg.CheckIteratorCache.MaxResults = 1000
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+
+		t.Run("enable_but_ttl_negative", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckIteratorCache.Enabled = true
+			cfg.CheckIteratorCache.TTL = -2 * time.Second
+			cfg.CheckIteratorCache.MaxResults = 1000
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+
+		t.Run("enable_but_max_results_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckIteratorCache.Enabled = true
+			cfg.CheckIteratorCache.TTL = 2 * time.Second
+			cfg.CheckIteratorCache.MaxResults = 0
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+
+		t.Run("disable_but_ttl_and_max_results_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckIteratorCache.Enabled = false
+			cfg.CheckIteratorCache.TTL = 0
+			cfg.CheckIteratorCache.MaxResults = 0
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+
+		t.Run("enable_and_ttl_and_max_results_positive", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CheckIteratorCache.Enabled = true
+			cfg.CheckIteratorCache.TTL = 10 * time.Second
+			cfg.CheckIteratorCache.MaxResults = 10000
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("cache_controller", func(t *testing.T) {
+		t.Run("enable_but_ttl_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheController.Enabled = true
+			cfg.CacheController.TTL = 0
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+		t.Run("enable_but_ttl_negative", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheController.Enabled = true
+			cfg.CacheController.TTL = -2 * time.Second
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+		t.Run("enable_and_ttl_positive", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheController.Enabled = true
+			cfg.CacheController.TTL = 2 * time.Second
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+		t.Run("disable_and_ttl_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheController.Enabled = false
+			cfg.CacheController.TTL = 0
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+	})
+
 	t.Run("prints_warning_when_log_level_is_none", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Log.Level = "none"


### PR DESCRIPTION

## Description
Expose cache controller configurations as environment variables to allow configuration when running as a standalone binary.

## References
Close https://github.com/openfga/openfga/issues/2148


## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

