### PR TITLE
fix: fastpath v2 tuples not iterated correctly for intersection and exclusion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Labels of metrics that went past the `max` histogram bucket are now labelled "+Inf" instead of ">max". [#2146](https://github.com/openfga/openfga/pull/2146)
 - Prevent possible data races by waiting for in-flight cached iterator goroutines during server shutdown [#2145](https://github.com/openfga/openfga/pull/2145)
+- Correct incorrect check result returned when system is configured with experimental flag enable-check-optimizations and model has intersection or exclusion. [#2157](https://github.com/openfga/openfga/pull/2157)
 
 ## [1.8.1] - 2024-12-05
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.0...v1.8.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Labels of metrics that went past the `max` histogram bucket are now labelled "+Inf" instead of ">max". [#2146](https://github.com/openfga/openfga/pull/2146)
 - Prevent possible data races by waiting for in-flight cached iterator goroutines during server shutdown [#2145](https://github.com/openfga/openfga/pull/2145)
-- Correct incorrect check result returned when system is configured with experimental flag enable-check-optimizations and model has intersection or exclusion. [#2157](https://github.com/openfga/openfga/pull/2157)
+- Correct incorrect check result returned when using experimental flag `enable-check-optimizations` and model has intersection or exclusion within a TTU or Userset. [#2157](https://github.com/openfga/openfga/pull/2157)
 
 ## [1.8.1] - 2024-12-05
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.0...v1.8.1)

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -315,7 +315,9 @@ func fastPathIntersection(ctx context.Context, streams *iteratorStreams, outChan
 			}
 			tmpKey := t.GetObject()
 			for tmpKey < maxObject {
-				t, err := stream.buffer.Next(ctx)
+				_, _ = stream.buffer.Next(ctx)
+
+				t, err := stream.buffer.Head(ctx)
 				if err != nil {
 					if storage.IterIsDoneOrCancelled(err) {
 						stream.buffer.Stop()
@@ -425,7 +427,9 @@ func fastPathDifference(ctx context.Context, streams *iteratorStreams, outChan c
 
 		// diff < base, then move the diff to catch up with base
 		for diff < base {
-			t, err := iterStreams[DifferenceIndex].buffer.Next(ctx)
+			_, _ = iterStreams[DifferenceIndex].buffer.Next(ctx)
+			t, err := iterStreams[DifferenceIndex].buffer.Head(ctx)
+
 			if err != nil {
 				if storage.IterIsDoneOrCancelled(err) {
 					iterStreams[DifferenceIndex].buffer.Stop()

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -316,7 +316,6 @@ func fastPathIntersection(ctx context.Context, streams *iteratorStreams, outChan
 			tmpKey := t.GetObject()
 			for tmpKey < maxObject {
 				_, _ = stream.buffer.Next(ctx)
-
 				t, err := stream.buffer.Head(ctx)
 				if err != nil {
 					if storage.IterIsDoneOrCancelled(err) {


### PR DESCRIPTION

## Description
Bug fix where incorrect check result is returned where system is configured with experimental flag `enable-check-optimizations` and model has intersection or exclusion.  

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

