### PR TITLE
fix: enforce order by object id for ReadStartingWithUser

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -545,6 +545,10 @@ func (s *MemoryBackend) ReadStartingWithUser(
 			matches = append(matches, t)
 		}
 	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].ObjectID < matches[j].ObjectID
+	})
+
 	return &staticIterator{records: matches}, nil
 }
 

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -362,7 +362,7 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 			"_user":       targetUsersArg,
-		})
+		}).OrderBy("object_id")
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -376,7 +376,7 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 			"_user":       targetUsersArg,
-		})
+		}).OrderBy("object_id")
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -553,7 +553,7 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 		}).
-		Where(targetUsersArg)
+		Where(targetUsersArg).OrderBy("object_id")
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -201,7 +201,7 @@ type RelationshipTupleReader interface {
 	// ReadStartingWithUser for ['user:jon', 'group:eng#member'] filtered by 'document#viewer'
 	// and 'document:doc1, document:doc2' would
 	// return ['document:doc1#viewer@user:jon', 'document:doc2#viewer@group:eng#member'].
-	// There is NO guarantee on the order returned on the iterator.
+	// The result is sorted by object ID.
 	ReadStartingWithUser(
 		ctx context.Context,
 		store string,

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1457,6 +1457,47 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		_, objectID := tuple.SplitObject(tuples[0].GetObject())
 		require.Equal(t, "doc1", objectID)
 	})
+	t.Run("enforce_order_of_tuples", func(t *testing.T) {
+		storeID := ulid.Make().String()
+
+		var tupleInReverseOrder = []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:doc7", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:doc6", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:doc5", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:doc4", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:doc3", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:doc2", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:doc1", "viewer", "user:bob"),
+			tuple.NewTupleKey("folder:folder1", "viewer", "user:bob"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tupleInReverseOrder)
+		require.NoError(t, err)
+
+		tupleIterator, err := datastore.ReadStartingWithUser(
+			ctx,
+			storeID,
+			storage.ReadStartingWithUserFilter{
+				ObjectType: "document",
+				Relation:   "viewer",
+				UserFilter: []*openfgav1.ObjectRelation{
+					{
+						Object: "user:bob",
+					},
+				},
+			},
+			storage.ReadStartingWithUserOptions{},
+		)
+		require.NoError(t, err)
+
+		tuples := iterateThroughAllTuples(t, tupleIterator)
+		var actualObjectIDs []string
+		for _, item := range tuples {
+			_, objectID := tuple.SplitObject(item.GetObject())
+			actualObjectIDs = append(actualObjectIDs, objectID)
+		}
+		require.Equal(t, []string{"doc1", "doc3", "doc4", "doc5", "doc6", "doc7"}, actualObjectIDs)
+	})
 }
 
 func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {


### PR DESCRIPTION


## Description
The optimized check function checkUsersetFastPathV2 expects ReadStartingWithUser to be sorted by object IDs.  Update various datastore ReadStartingWithUser to reflect this.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

