### PR TITLE
perf: use `strings.builder` when generating check cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Add metrics `cachecontroller_find_changes_and_invalidate_histogram` on latency for cache controller in finding changes and invalidating.  [#2135](https://github.com/openfga/openfga/pull/2135)
 - Improve `Check` performance when cache controller is enabled by invalidating iterator and sub-problem cache asynchronously when read changes API indicates there are recent writes/deletes for the store.  [#2124](https://github.com/openfga/openfga/pull/2124)
+- Improve check cache key generation via `strings.Builder` [#2161](https://github.com/openfga/openfga/pull/2161).
 
 ### Fixed
 - Labels of metrics that went past the `max` histogram bucket are now labelled "+Inf" instead of ">max". [#2146](https://github.com/openfga/openfga/pull/2146)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Add metrics `cachecontroller_find_changes_and_invalidate_histogram` on latency for cache controller in finding changes and invalidating.  [#2135](https://github.com/openfga/openfga/pull/2135)
 - Improve `Check` performance when cache controller is enabled by invalidating iterator and sub-problem cache asynchronously when read changes API indicates there are recent writes/deletes for the store.  [#2124](https://github.com/openfga/openfga/pull/2124)
-- Improve check cache key generation via `strings.Builder` [#2161](https://github.com/openfga/openfga/pull/2161).
+- Improve check cache key generation performance via `strings.Builder` [#2161](https://github.com/openfga/openfga/pull/2161).
 
 ### Fixed
 - Labels of metrics that went past the `max` histogram bucket are now labelled "+Inf" instead of ">max". [#2146](https://github.com/openfga/openfga/pull/2146)

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -162,16 +163,19 @@ type CheckCacheKeyParams struct {
 func GetCheckCacheKey(params *CheckCacheKeyParams) (string, error) {
 	hasher := keys.NewCacheKeyHasher(xxhash.New())
 
-	key := fmt.Sprintf("%s%s/%s/%s#%s@%s",
-		SubproblemCachePrefix,
-		params.StoreID,
-		params.AuthorizationModelID,
-		params.TupleKey.GetObject(),
-		params.TupleKey.GetRelation(),
-		params.TupleKey.GetUser(),
-	)
+	key := strings.Builder{}
+	key.WriteString(SubproblemCachePrefix)
+	key.WriteString(params.StoreID)
+	key.WriteString("/")
+	key.WriteString(params.AuthorizationModelID)
+	key.WriteString("/")
+	key.WriteString(params.TupleKey.GetObject())
+	key.WriteString("#")
+	key.WriteString(params.TupleKey.GetRelation())
+	key.WriteString("@")
+	key.WriteString(params.TupleKey.GetUser())
 
-	if err := hasher.WriteString(key); err != nil {
+	if err := hasher.WriteString(key.String()); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This is a low-hanging performance optimization I stumbled across while doing work on #2160.

<img width="1302" alt="image" src="https://github.com/user-attachments/assets/7d3de691-e9b8-4f46-a075-00f476a3582d" />


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

