### PR TITLE
chore: refactor check fastpath v2 left channels

### DIFF
--- a/internal/checkutil/checkutil.go
+++ b/internal/checkutil/checkutil.go
@@ -139,14 +139,14 @@ func buildUsersetDetails(typesys *typesystem.TypeSystem, objectType, relation st
 
 type V2LeftChannelRelationFunc func(*openfgav1.RelationReference) string
 
-// BuildUsersetV2LeftChannelRelationFunc returns the relation reference's relation.
+// BuildUsersetV2LeftChannelRelationFunc returns the reference's relation.
 func BuildUsersetV2LeftChannelRelationFunc() V2LeftChannelRelationFunc {
 	return func(ref *openfgav1.RelationReference) string {
 		return ref.GetRelation()
 	}
 }
 
-// BuildTTUV2LeftChannelRelationFunc will always return the computed regardless of the reference.
+// BuildTTUV2LeftChannelRelationFunc will always return the computedRelation regardless of the reference.
 func BuildTTUV2LeftChannelRelationFunc(computedRelation string) V2LeftChannelRelationFunc {
 	return func(_ *openfgav1.RelationReference) string {
 		return computedRelation

--- a/internal/checkutil/checkutil.go
+++ b/internal/checkutil/checkutil.go
@@ -137,6 +137,22 @@ func buildUsersetDetails(typesys *typesystem.TypeSystem, objectType, relation st
 	return tuple.ToObjectRelationString(objectType, cr), nil
 }
 
+type V2LeftChannelRelationFunc func(*openfgav1.RelationReference) string
+
+// BuildUsersetV2LeftChannelRelationFunc returns the relation reference's relation.
+func BuildUsersetV2LeftChannelRelationFunc() V2LeftChannelRelationFunc {
+	return func(ref *openfgav1.RelationReference) string {
+		return ref.GetRelation()
+	}
+}
+
+// BuildTTUV2LeftChannelRelationFunc will always return the computed regardless of the reference.
+func BuildTTUV2LeftChannelRelationFunc(computedRelation string) V2LeftChannelRelationFunc {
+	return func(_ *openfgav1.RelationReference) string {
+		return computedRelation
+	}
+}
+
 type UsersetDetailsFunc func(*openfgav1.TupleKey) (string, string, error)
 
 // BuildUsersetDetailsUserset given tuple doc:1#viewer@group:2#member will return group#member, 2, nil.

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -619,6 +619,36 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 	return res, ctx.Err()
 }
 
+func (c *LocalChecker) constructLeftChannels(ctx context.Context,
+	req *ResolveCheckRequest,
+	relationReferences []*openfgav1.RelationReference,
+	channelRelationFunc checkutil.V2LeftChannelRelationFunc) ([]chan *iteratorMsg, error) {
+	typesys, _ := typesystem.TypesystemFromContext(ctx)
+
+	leftChans := make([]chan *iteratorMsg, 0, len(relationReferences))
+	for _, parentType := range relationReferences {
+		r := req.clone()
+		r.TupleKey = &openfgav1.TupleKey{
+			Object: tuple.BuildObject(parentType.GetType(), "ignore"),
+			// depending on channelRelationFunc, it may either return the parentType's relation (in case of userset) or computedRelation (in case of TTU)
+			Relation: channelRelationFunc(parentType),
+			User:     r.GetTupleKey().GetUser(),
+		}
+		rel, err := typesys.GetRelation(parentType.GetType(), channelRelationFunc(parentType))
+		if err != nil {
+			// NOTE: is there a better way to check and filter rather than skipping?
+			// other paths can be reachable
+			continue
+		}
+		leftChan, err := c.fastPathRewrite(ctx, r, rel.GetRewrite())
+		if err != nil {
+			return nil, err
+		}
+		leftChans = append(leftChans, leftChan)
+	}
+	return leftChans, nil
+}
+
 func (c *LocalChecker) checkUsersetFastPathV2(ctx context.Context, req *ResolveCheckRequest, iter storage.TupleKeyIterator) (*ResolveCheckResponse, error) {
 	ctx, span := tracer.Start(ctx, "checkUsersetFastPathV2")
 	defer span.End()
@@ -630,25 +660,10 @@ func (c *LocalChecker) checkUsersetFastPathV2(ctx context.Context, req *ResolveC
 	defer cancel()
 	directlyRelatedUsersetTypes, _ := typesys.DirectlyRelatedUsersets(objectType, req.GetTupleKey().GetRelation())
 
-	leftChans := make([]chan *iteratorMsg, 0, len(directlyRelatedUsersetTypes))
-	for _, parentType := range directlyRelatedUsersetTypes {
-		r := req.clone()
-		r.TupleKey = &openfgav1.TupleKey{
-			Object:   tuple.BuildObject(parentType.GetType(), "ignore"),
-			Relation: parentType.GetRelation(),
-			User:     r.GetTupleKey().GetUser(),
-		}
-		rel, err := typesys.GetRelation(parentType.GetType(), parentType.GetRelation())
-		if err != nil {
-			// NOTE: is there a better way to check and filter rather than skipping?
-			// other paths can be reachable
-			continue
-		}
-		leftChan, err := c.fastPathRewrite(cancellableCtx, r, rel.GetRewrite())
-		if err != nil {
-			return nil, err
-		}
-		leftChans = append(leftChans, leftChan)
+	leftChans, err := c.constructLeftChannels(cancellableCtx, req, directlyRelatedUsersetTypes, checkutil.BuildUsersetV2LeftChannelRelationFunc())
+
+	if err != nil {
+		return nil, err
 	}
 
 	if len(leftChans) == 0 {
@@ -676,25 +691,10 @@ func (c *LocalChecker) checkTTUFastPathV2(ctx context.Context, req *ResolveCheck
 	cancellableCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	leftChans := make([]chan *iteratorMsg, 0, len(possibleParents))
-	for _, parentType := range possibleParents {
-		r := req.clone()
-		r.TupleKey = &openfgav1.TupleKey{
-			Object:   tuple.BuildObject(parentType.GetType(), "ignore"),
-			Relation: computedRelation,
-			User:     r.GetTupleKey().GetUser(),
-		}
-		rel, err := typesys.GetRelation(parentType.GetType(), computedRelation)
-		if err != nil {
-			// NOTE: is there a better way to check and filter rather than skipping?
-			// other paths can be reachable
-			continue
-		}
-		leftChan, err := c.fastPathRewrite(cancellableCtx, r, rel.GetRewrite())
-		if err != nil {
-			return nil, err
-		}
-		leftChans = append(leftChans, leftChan)
+	leftChans, err := c.constructLeftChannels(cancellableCtx, req, possibleParents, checkutil.BuildTTUV2LeftChannelRelationFunc(computedRelation))
+
+	if err != nil {
+		return nil, err
 	}
 
 	if len(leftChans) == 0 {


### PR DESCRIPTION
## Description
In preparation of improving performance by allowing public wildcard for v2 fastpath, refactor so that both TTU and userset shared construction of left channels.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

