### PR TITLE
test: shuffle order of tuples when writing them, and shuffle ctx tuples

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openfga/openfga/pkg/tuple"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/go-retryablehttp"
@@ -31,6 +29,7 @@ import (
 	parser "github.com/openfga/language/pkg/go/transformer"
 
 	serverconfig "github.com/openfga/openfga/internal/server/config"
+	"github.com/openfga/openfga/pkg/tuple"
 )
 
 const (

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -88,6 +88,13 @@ func ConvertTuplesToTupleKeys(input []*openfgav1.Tuple) []*openfgav1.TupleKey {
 	return converted
 }
 
+func Shuffle(arr []*openfgav1.TupleKey) []*openfgav1.TupleKey {
+	rand.Shuffle(len(arr), func(i, j int) {
+		arr[i], arr[j] = arr[j], arr[i]
+	})
+	return arr
+}
+
 func CreateRandomString(n int) string {
 	b := make([]byte, n)
 	for i := range b {

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -88,6 +88,7 @@ func ConvertTuplesToTupleKeys(input []*openfgav1.Tuple) []*openfgav1.TupleKey {
 	return converted
 }
 
+// Shuffle returns the input but with order of elements randomized.
 func Shuffle(arr []*openfgav1.TupleKey) []*openfgav1.TupleKey {
 	rand.Shuffle(len(arr), func(i, j int) {
 		arr[i], arr[j] = arr[j], arr[i]

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -139,14 +139,13 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 				})
 				require.NoError(t, err)
 
-				tuples := stage.Tuples
+				tuples := testutils.Shuffle(stage.Tuples)
 				tuplesLength := len(tuples)
 				// arrange: write tuples
 				if tuplesLength > 0 && !contextTupleTest {
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
-						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: writeModelResponse.GetAuthorizationModelId(),
@@ -165,9 +164,8 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					t.Run(fmt.Sprintf("assertion_%d", assertionNumber), func(t *testing.T) {
 						detailedInfo := fmt.Sprintf("Check request: %s. Model: %s. Tuples: %s. Contextual tuples: %s", assertion.Tuple, stage.Model, stage.Tuples, assertion.ContextualTuples)
 
-						ctxTuples := assertion.ContextualTuples
+						ctxTuples := testutils.Shuffle(assertion.ContextualTuples)
 						if contextTupleTest {
-							testutils.Shuffle(ctxTuples)
 							ctxTuples = append(ctxTuples, stage.Tuples...)
 						}
 
@@ -1221,13 +1219,12 @@ condition xcond(x: string) {
 				require.NoError(t, err)
 				modelID := writeModelResponse.GetAuthorizationModelId()
 
-				tuples := stage.Tuples
+				tuples := testutils.Shuffle(stage.Tuples)
 				tuplesLength := len(tuples)
 				if tuplesLength > 0 {
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
-						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: modelID,

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -124,9 +124,9 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 
 		for stageNumber, stage := range test.Stages {
 			t.Run(fmt.Sprintf("stage_%d", stageNumber), func(t *testing.T) {
-				if contextTupleTest && len(stage.Tuples) > 20 {
-					// https://github.com/openfga/api/blob/05de9d8be3ee12fa4e796b92dbdd4bbbf87107f2/openfga/v1/openfga.proto#L151
-					t.Skipf("cannot send more than 20 contextual tuples in one request")
+				if contextTupleTest && len(stage.Tuples) > 100 {
+					// https://github.com/openfga/api/blob/6e048d8023f434cb7a1d3943f41bdc3937d4a1bf/openfga/v1/openfga.proto#L222
+					t.Skipf("cannot send more than 100 contextual tuples in one request")
 				}
 				// arrange: write model
 				model := testutils.MustTransformDSLToProtoWithID(stage.Model)
@@ -146,6 +146,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
+						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: writeModelResponse.GetAuthorizationModelId(),
@@ -166,6 +167,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 
 						ctxTuples := assertion.ContextualTuples
 						if contextTupleTest {
+							testutils.Shuffle(ctxTuples)
 							ctxTuples = append(ctxTuples, stage.Tuples...)
 						}
 
@@ -1225,6 +1227,7 @@ condition xcond(x: string) {
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
+						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: modelID,

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -120,9 +120,9 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 
 		for stageNumber, stage := range test.Stages {
 			t.Run(fmt.Sprintf("stage_%d", stageNumber), func(t *testing.T) {
-				if contextTupleTest && len(stage.Tuples) > 20 {
+				if contextTupleTest && len(stage.Tuples) > 100 {
 					// https://github.com/openfga/api/blob/05de9d8be3ee12fa4e796b92dbdd4bbbf87107f2/openfga/v1/openfga.proto#L151
-					t.Skipf("cannot send more than 20 contextual tuples in one request")
+					t.Skipf("cannot send more than 100 contextual tuples in one request")
 				}
 				// arrange: write model
 				model := testutils.MustTransformDSLToProtoWithID(stage.Model)
@@ -142,6 +142,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
+						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: writeModelResponse.GetAuthorizationModelId(),
@@ -163,6 +164,7 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 
 						ctxTuples := assertion.ContextualTuples
 						if contextTupleTest {
+							testutils.Shuffle(ctxTuples)
 							ctxTuples = append(ctxTuples, stage.Tuples...)
 						}
 

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -135,14 +135,13 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 				})
 				require.NoError(t, err)
 
-				tuples := stage.Tuples
+				tuples := testutils.Shuffle(stage.Tuples)
 				tuplesLength := len(tuples)
 				// arrange: write tuples
 				if tuplesLength > 0 && !contextTupleTest {
 					for i := 0; i < tuplesLength; i += writeMaxChunkSize {
 						end := int(math.Min(float64(i+writeMaxChunkSize), float64(tuplesLength)))
 						writeChunk := (tuples)[i:end]
-						testutils.Shuffle(writeChunk)
 						_, err = client.Write(ctx, &openfgav1.WriteRequest{
 							StoreId:              storeID,
 							AuthorizationModelId: writeModelResponse.GetAuthorizationModelId(),
@@ -162,9 +161,8 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 					t.Run(fmt.Sprintf("assertion_%d", assertionNumber), func(t *testing.T) {
 						detailedInfo := fmt.Sprintf("ListObject request: %s. Model: %s. Tuples: %s. Contextual tuples: %s", assertion.Request, stage.Model, stage.Tuples, assertion.ContextualTuples)
 
-						ctxTuples := assertion.ContextualTuples
+						ctxTuples := testutils.Shuffle(assertion.ContextualTuples)
 						if contextTupleTest {
-							testutils.Shuffle(ctxTuples)
 							ctxTuples = append(ctxTuples, stage.Tuples...)
 						}
 


### PR DESCRIPTION
## Description

- shuffle order of tuples when writing them, and shuffle ctx tuples
- update maximum allowed number of contextual tuples per request.

Motivation:
- Prevent bugs related to the code assuming that the input tuples have the "right" order.
- https://github.com/openfga/openfga/pull/2150


