### PR TITLE
refactor: iterators

### DIFF
--- a/pkg/storage/iterators.go
+++ b/pkg/storage/iterators.go
@@ -8,7 +8,6 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
 
-// ErrIteratorDone is returned when the iterator has finished iterating through all the items.
 var ErrIteratorDone = errors.New("iterator done")
 
 // Iterator is a generic interface defining methods for
@@ -19,42 +18,40 @@ type Iterator[T any] interface {
 	// items are available.
 	Next(ctx context.Context) (T, error)
 
-	// Stop terminates iteration over
-	// the underlying iterator.
+	// Stop terminates iteration. Any subsequent calls to Next must return ErrIteratorDone.
 	Stop()
 
-	// Head will return the first item or ErrIteratorDone if the iterator
-	// is empty.
+	// Head will return the first item or ErrIteratorDone if the iterator is finished or empty.
 	// It's possible for this method to advance the iterator internally, but a subsequent call to Next will not miss any results.
 	// Calling Head() continuously without calling Next() will yield the same result (the first one) over and over.
 	Head(ctx context.Context) (T, error)
 }
 
-// TupleIterator is an iterator for [*openfgav1.Tuple](s).
-// It is closed by explicitly calling [Iterator.Stop] or by calling
-// [Iterator.Next] until it returns an [ErrIteratorDone] error.
 type TupleIterator = Iterator[*openfgav1.Tuple]
 
-// TupleKeyIterator is an iterator for [*openfgav1.TupleKey](s). It is closed by
-// explicitly calling [Iterator.Stop] or by calling [Iterator.Next] until it
-// returns an [ErrIteratorDone] error.
 type TupleKeyIterator = Iterator[*openfgav1.TupleKey]
 
+// combinedIterator is a thread-safe iterator that merges multiple iterators.
+// Duplicates can be returned.
 type combinedIterator[T any] struct {
 	mu      *sync.Mutex
 	once    *sync.Once
-	pending []Iterator[T]
+	pending []Iterator[T] // GUARDED_BY(mu)
 }
+
+var _ Iterator[any] = (*combinedIterator[any])(nil)
 
 // Next see [Iterator.Next].
 func (c *combinedIterator[T]) Next(ctx context.Context) (T, error) {
+	c.mu.Lock() // no defer of Unlock because of the recursive call
+
 	if len(c.pending) == 0 {
 		// All iterators ended.
 		var val T
+		c.mu.Unlock()
 		return val, ErrIteratorDone
 	}
 
-	c.mu.Lock()
 	iter := c.pending[0]
 	val, err := iter.Next(ctx)
 	if err != nil {
@@ -76,22 +73,24 @@ func (c *combinedIterator[T]) Next(ctx context.Context) (T, error) {
 func (c *combinedIterator[T]) Stop() {
 	c.once.Do(func() {
 		c.mu.Lock()
+		defer c.mu.Unlock()
 		for _, iter := range c.pending {
 			iter.Stop()
 		}
-		c.mu.Unlock()
 	})
 }
 
 // Head see [Iterator.Head].
 func (c *combinedIterator[T]) Head(ctx context.Context) (T, error) {
+	c.mu.Lock() // no defer of Unlock because of the recursive call
+
 	if len(c.pending) == 0 {
 		// All iterators ended.
 		var val T
+		c.mu.Unlock()
 		return val, ErrIteratorDone
 	}
 
-	c.mu.Lock()
 	iter := c.pending[0]
 	val, err := iter.Head(ctx)
 	if err != nil {
@@ -108,7 +107,7 @@ func (c *combinedIterator[T]) Head(ctx context.Context) (T, error) {
 	return val, nil
 }
 
-// NewCombinedIterator takes generic iterators of a given type T
+// NewCombinedIterator is a thread-safe iterator that takes generic iterators of a given type T
 // and combines them into a single iterator that yields all the
 // values from all iterators. Duplicates can be returned.
 func NewCombinedIterator[T any](iters ...Iterator[T]) Iterator[T] {
@@ -125,6 +124,7 @@ func NewCombinedIterator[T any](iters ...Iterator[T]) Iterator[T] {
 func NewStaticTupleIterator(tuples []*openfgav1.Tuple) TupleIterator {
 	iter := &StaticIterator[*openfgav1.Tuple]{
 		items: tuples,
+		mu:    &sync.Mutex{},
 	}
 
 	return iter
@@ -134,6 +134,7 @@ func NewStaticTupleIterator(tuples []*openfgav1.Tuple) TupleIterator {
 func NewStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey) TupleKeyIterator {
 	iter := &StaticIterator[*openfgav1.TupleKey]{
 		items: tupleKeys,
+		mu:    &sync.Mutex{},
 	}
 
 	return iter
@@ -178,8 +179,11 @@ func NewTupleKeyIteratorFromTupleIterator(iter TupleIterator) TupleKeyIterator {
 }
 
 type StaticIterator[T any] struct {
-	items []T
+	items []T // GUARDED_BY(mu)
+	mu    *sync.Mutex
 }
+
+var _ Iterator[any] = (*StaticIterator[any])(nil)
 
 // Next see [Iterator.Next].
 func (s *StaticIterator[T]) Next(ctx context.Context) (T, error) {
@@ -188,6 +192,9 @@ func (s *StaticIterator[T]) Next(ctx context.Context) (T, error) {
 	if ctx.Err() != nil {
 		return val, ctx.Err()
 	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	if len(s.items) == 0 {
 		return val, ErrIteratorDone
@@ -200,7 +207,11 @@ func (s *StaticIterator[T]) Next(ctx context.Context) (T, error) {
 }
 
 // Stop see [Iterator.Stop].
-func (s *StaticIterator[T]) Stop() {}
+func (s *StaticIterator[T]) Stop() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.items = nil
+}
 
 // Head see [Iterator.Head].
 func (s *StaticIterator[T]) Head(ctx context.Context) (T, error) {
@@ -210,6 +221,9 @@ func (s *StaticIterator[T]) Head(ctx context.Context) (T, error) {
 		return val, ctx.Err()
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	if len(s.items) == 0 {
 		return val, ErrIteratorDone
 	}
@@ -218,7 +232,7 @@ func (s *StaticIterator[T]) Head(ctx context.Context) (T, error) {
 }
 
 func NewStaticIterator[T any](items []T) Iterator[T] {
-	return &StaticIterator[T]{items: items}
+	return &StaticIterator[T]{items: items, mu: &sync.Mutex{}}
 }
 
 // TupleKeyFilterFunc is a filter function that is used to filter out
@@ -259,7 +273,7 @@ func (f *filteredTupleKeyIterator) Stop() {
 
 // Head returns the next most tuple in the underlying iterator that meets
 // the filter function this iterator was constructed with.
-// Note: the underlying iterator for unmatched filter may advance until filter is satisfied.
+// Note: the underlying iterator will advance until the filter is satisfied.
 func (f *filteredTupleKeyIterator) Head(ctx context.Context) (*openfgav1.TupleKey, error) {
 	for {
 		tuple, err := f.iter.Head(ctx)


### PR DESCRIPTION
While working on https://github.com/openfga/openfga/pull/2150 I looked at our existing iterators and found a couple of minor issues:

- there is no locking of the mutex before checking `len(c.pending)`, fixed it
- made `StaticIterator` thread safe