### PR TITLE
rework cache key hash generation

### DIFF
--- a/internal/keys/hasher.go
+++ b/internal/keys/hasher.go
@@ -12,13 +12,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
 var ErrUnexpectedStructValue = errors.New("unexpected structpb value encountered")
 
 func WriteStructValue(w io.StringWriter, v *structpb.Value) (err error) {
-	switch val := v.Kind.(type) {
+	switch val := v.GetKind().(type) {
 	case *structpb.Value_BoolValue:
 		_, err = w.WriteString(fmt.Sprintf("%v", val.BoolValue))
 	case *structpb.Value_NullValue:

--- a/internal/keys/hasher.go
+++ b/internal/keys/hasher.go
@@ -1,7 +1,9 @@
 package keys
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 	"strings"
@@ -10,7 +12,123 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/openfga/openfga/pkg/tuple"
 )
+
+var ErrUnexpectedStructValue = errors.New("unexpected structpb value encountered")
+
+func WriteStructValue(w io.StringWriter, v *structpb.Value) (err error) {
+	switch val := v.Kind.(type) {
+	case *structpb.Value_BoolValue:
+		_, err = w.WriteString(fmt.Sprintf("%v", val.BoolValue))
+	case *structpb.Value_NullValue:
+		_, err = w.WriteString("null")
+	case *structpb.Value_StringValue:
+		_, err = w.WriteString(val.StringValue)
+	case *structpb.Value_NumberValue:
+		_, err = w.WriteString(strconv.FormatFloat(val.NumberValue, 'f', -1, 64)) // -1 precision ensures we represent the 64-bit value with the maximum precision needed to represent it, see strconv#FormatFloat for more info.
+	case *structpb.Value_ListValue:
+		values := val.ListValue.GetValues()
+
+		for n, vv := range values {
+			if err = WriteStructValue(w, vv); err != nil {
+				return
+			}
+
+			if n < len(values)-1 {
+				if _, err = w.WriteString(","); err != nil {
+					return
+				}
+			}
+		}
+	case *structpb.Value_StructValue:
+		err = WriteStruct(w, val.StructValue)
+	default:
+		err = ErrUnexpectedStructValue
+	}
+	return
+}
+
+func WriteStruct(w io.StringWriter, s *structpb.Struct) (err error) {
+	if s == nil {
+		return
+	}
+
+	fields := s.GetFields()
+	keys := maps.Keys(fields)
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if _, err = w.WriteString(fmt.Sprintf("'%s:'", key)); err != nil {
+			return
+		}
+
+		if err = WriteStructValue(w, fields[key]); err != nil {
+			return
+		}
+
+		if _, err = w.WriteString(","); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func WriteTuples(w io.StringWriter, tuples ...*openfgav1.TupleKey) (err error) {
+	sortedTuples := tuple.TupleKeys(tuples)
+
+	// sort tulpes for a deterministic write
+	sort.Sort(sortedTuples)
+
+	// prefix to avoid overlap with previous strings written
+	_, err = w.WriteString("/")
+	if err != nil {
+		return
+	}
+
+	for n, tupleKey := range sortedTuples {
+		_, err = w.WriteString(tupleKey.GetObject() + "#" + tupleKey.GetRelation())
+		if err != nil {
+			return
+		}
+
+		cond := tupleKey.GetCondition()
+		if cond != nil {
+			// " with " is separated by spaces as those are invalid in relation names
+			// and we need to ensure this cache key is unique
+			// resultant cache key format is "object:object_id#relation with {condition} {context}@user:user_id"
+			_, err = w.WriteString(" with " + cond.GetName())
+			if err != nil {
+				return
+			}
+
+			// if the condition also has context, we need an additional separator
+			// which cannot be present in condition names
+			if cond.GetContext() != nil {
+				_, err = w.WriteString(" ")
+				if err != nil {
+					return
+				}
+			}
+
+			// now write context to hash. Is a noop if context is nil.
+			if err = WriteStruct(w, cond.GetContext()); err != nil {
+				return
+			}
+		}
+
+		if _, err = w.WriteString("@" + tupleKey.GetUser()); err != nil {
+			return
+		}
+
+		if n < len(tuples)-1 {
+			if _, err = w.WriteString(","); err != nil {
+				return
+			}
+		}
+	}
+	return
+}
 
 type hasher interface {
 	WriteString(value string) error

--- a/internal/keys/hasher.go
+++ b/internal/keys/hasher.go
@@ -18,7 +18,7 @@ import (
 
 var ErrUnexpectedStructValue = errors.New("unexpected structpb value encountered")
 
-func WriteStructValue(w io.StringWriter, v *structpb.Value) (err error) {
+func WriteValue(w io.StringWriter, v *structpb.Value) (err error) {
 	switch val := v.GetKind().(type) {
 	case *structpb.Value_BoolValue:
 		_, err = w.WriteString(fmt.Sprintf("%v", val.BoolValue))
@@ -32,7 +32,7 @@ func WriteStructValue(w io.StringWriter, v *structpb.Value) (err error) {
 		values := val.ListValue.GetValues()
 
 		for n, vv := range values {
-			if err = WriteStructValue(w, vv); err != nil {
+			if err = WriteValue(w, vv); err != nil {
 				return
 			}
 
@@ -64,7 +64,7 @@ func WriteStruct(w io.StringWriter, s *structpb.Struct) (err error) {
 			return
 		}
 
-		if err = WriteStructValue(w, fields[key]); err != nil {
+		if err = WriteValue(w, fields[key]); err != nil {
 			return
 		}
 

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -5,7 +5,6 @@ package storage
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -161,37 +160,35 @@ type CheckCacheKeyParams struct {
 // should produce the same cache key. Contextual tuple order and context parameter order is ignored,
 // only the contents are compared.
 func GetCheckCacheKey(params *CheckCacheKeyParams) (string, error) {
-	hasher := keys.NewCacheKeyHasher(xxhash.New())
+	hasher := xxhash.New()
 
-	key := strings.Builder{}
-	key.WriteString(SubproblemCachePrefix)
-	key.WriteString(params.StoreID)
-	key.WriteString("/")
-	key.WriteString(params.AuthorizationModelID)
-	key.WriteString("/")
-	key.WriteString(params.TupleKey.GetObject())
-	key.WriteString("#")
-	key.WriteString(params.TupleKey.GetRelation())
-	key.WriteString("@")
-	key.WriteString(params.TupleKey.GetUser())
-
-	if err := hasher.WriteString(key.String()); err != nil {
+	_, err := hasher.WriteString(
+		SubproblemCachePrefix +
+			params.StoreID +
+			"/" +
+			params.AuthorizationModelID +
+			"/" +
+			params.TupleKey.GetObject() +
+			"#" +
+			params.TupleKey.GetRelation() +
+			"@" +
+			params.TupleKey.GetUser(),
+	)
+	if err != nil {
 		return "", err
 	}
 
 	// here, and for context below, avoid hashing if we don't need to
 	if len(params.ContextualTuples) > 0 {
-		if err := keys.NewTupleKeysHasher(params.ContextualTuples...).Append(hasher); err != nil {
+		if err = keys.WriteTuples(hasher, params.ContextualTuples...); err != nil {
 			return "", err
 		}
 	}
 
 	if params.Context != nil {
-		err := keys.NewContextHasher(params.Context).Append(hasher)
-		if err != nil {
+		if err = keys.WriteStruct(hasher, params.Context); err != nil {
 			return "", err
 		}
 	}
-
-	return strconv.FormatUint(hasher.Key().ToUInt64(), 10), nil
+	return strconv.FormatUint(hasher.Sum64(), 10), nil
 }

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -11,6 +11,39 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
 
+type TupleKeys []*openfgav1.TupleKey
+
+func (tk TupleKeys) Len() int {
+	return len(tk)
+}
+
+func (tk TupleKeys) Less(i, j int) bool {
+	if tk[i].GetObject() != tk[j].GetObject() {
+		return tk[i].GetObject() < tk[j].GetObject()
+	}
+
+	if tk[i].GetRelation() != tk[j].GetRelation() {
+		return tk[i].GetRelation() < tk[j].GetRelation()
+	}
+
+	if tk[i].GetUser() != tk[j].GetUser() {
+		return tk[i].GetUser() < tk[j].GetUser()
+	}
+
+	cond1 := tk[i].GetCondition()
+	cond2 := tk[j].GetCondition()
+	if (cond1 != nil || cond2 != nil) && cond1.GetName() != cond2.GetName() {
+		return cond1.GetName() < cond2.GetName()
+	}
+	// Note: conditions also optionally have context structs, but we aren't sorting by context
+
+	return true
+}
+
+func (tk TupleKeys) Swap(i, j int) {
+	tk[i], tk[j] = tk[j], tk[i]
+}
+
 type TupleWithCondition interface {
 	TupleWithoutCondition
 	GetCondition() *openfgav1.RelationshipCondition

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -4,9 +4,110 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
+
+func MustNewStruct(m map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	if err == nil {
+		return s
+	}
+	panic(err)
+}
+
+func TestTupleKeys_Len(t *testing.T) {
+	tuples := TupleKeys{
+		NewTupleKey("document:A", "relationA", "user:A"),
+		NewTupleKey("document:B", "relationB", "user:B"),
+	}
+	require.Equal(t, 2, tuples.Len())
+}
+
+func TestTupleKeys_Swap(t *testing.T) {
+	tuples := TupleKeys{
+		NewTupleKey("document:A", "relationA", "user:A"),
+		NewTupleKey("document:B", "relationB", "user:B"),
+	}
+	tuples.Swap(0, 1)
+	require.Equal(t, "document:B", tuples[0].GetObject())
+	require.Equal(t, "document:A", tuples[1].GetObject())
+}
+
+func TestTupleKeys_Less(t *testing.T) {
+	var cases = map[string]struct {
+		value TupleKeys
+		i     int
+		j     int
+		ij    bool
+		ji    bool
+	}{
+		"object": {
+			value: TupleKeys{
+				NewTupleKey("document:A", "relationA", "user:A"),
+				NewTupleKey("document:B", "relationA", "user:A"),
+			},
+			i:  0,
+			j:  1,
+			ij: true,
+			ji: false,
+		},
+		"relation": {
+			value: TupleKeys{
+				NewTupleKey("document:A", "relationA", "user:A"),
+				NewTupleKey("document:A", "relationB", "user:A"),
+			},
+			i:  0,
+			j:  1,
+			ij: true,
+			ji: false,
+		},
+		"user": {
+			value: TupleKeys{
+				NewTupleKey("document:A", "relationA", "user:A"),
+				NewTupleKey("document:A", "relationA", "user:B"),
+			},
+			i:  0,
+			j:  1,
+			ij: true,
+			ji: false,
+		},
+		"condition": {
+			value: TupleKeys{
+				NewTupleKeyWithCondition("document:A", "relationA", "user:A", "testA", MustNewStruct(map[string]any{
+					"key": "value",
+				})),
+				NewTupleKeyWithCondition("document:A", "relationA", "user:A", "testB", MustNewStruct(map[string]any{
+					"key": "value",
+				})),
+			},
+			i:  0,
+			j:  1,
+			ij: true,
+			ji: false,
+		},
+		"nil_condition": {
+			value: TupleKeys{
+				NewTupleKey("document:A", "relationA", "user:A"),
+				NewTupleKeyWithCondition("document:A", "relationA", "user:A", "test", MustNewStruct(map[string]any{
+					"key": "value",
+				})),
+			},
+			i:  0,
+			j:  1,
+			ij: true,
+			ji: false,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.ij, test.value.Less(test.i, test.j))
+			require.Equal(t, test.ji, test.value.Less(test.j, test.i))
+		})
+	}
+}
 
 func TestSplitObjectId(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
- move logic out of structs and into functions
- accept an io.StringWriter instead of using separate string builders
- allow the hasher to build the string and eliminate need for other builders
- add sorting logic to TupleKeys type

Unit tests can easily be added for each of the new functions, but I'm not sure what all of the cases around contexts and conditions would look like.
