### PR TITLE
test: add error test cases to the hasher Write* functions in the keys package

### DIFF
--- a/internal/keys/hasher.go
+++ b/internal/keys/hasher.go
@@ -16,8 +16,13 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
+// ErrUnexpectedStructValue is an error used to indicate that
+// an unexpected structpb.Value kind was encountered.
 var ErrUnexpectedStructValue = errors.New("unexpected structpb value encountered")
 
+// WriteValue writes value v to the writer w. An error
+// is returned only when the underlying writer returns
+// an error or an unexpected value kind is encountered.
 func WriteValue(w io.StringWriter, v *structpb.Value) (err error) {
 	switch val := v.GetKind().(type) {
 	case *structpb.Value_BoolValue:
@@ -50,6 +55,10 @@ func WriteValue(w io.StringWriter, v *structpb.Value) (err error) {
 	return
 }
 
+// WriteStruct writes Struct value s to writer w. When s is nil, a
+// nil error is returned. An error is returned only when the underlying
+// writer returns an error. The struct fields are written in the sorted
+// order of their names. A comma separates fields.
 func WriteStruct(w io.StringWriter, s *structpb.Struct) (err error) {
 	if s == nil {
 		return
@@ -75,6 +84,11 @@ func WriteStruct(w io.StringWriter, s *structpb.Struct) (err error) {
 	return
 }
 
+// WriteTuples writes the set of tuples to writer w in ascending sorted order.
+// The intention of this function is to write the tuples as a unique string.
+// Tuples are separated by commas, and when present, conditions are included
+// in the tuple string representation. WriteTuples returns an error only when
+// the underlying writer returns an error.
 func WriteTuples(w io.StringWriter, tuples ...*openfgav1.TupleKey) (err error) {
 	sortedTuples := tuple.TupleKeys(tuples)
 

--- a/internal/keys/hasher_test.go
+++ b/internal/keys/hasher_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
+// MustNewStruct returns a new *structpb.Struct or panics
+// on error. The new *structpb.Struct value is built from
+// the map m.
 func MustNewStruct(m map[string]any) *structpb.Struct {
 	s, err := structpb.NewStruct(m)
 	if err == nil {
@@ -25,28 +28,51 @@ func MustNewStruct(m map[string]any) *structpb.Struct {
 	panic(err)
 }
 
+// ResetableStringWriter is an interface that groups the
+// io.StringWriter and fmt.Stringer interfaces with a
+// Reset method.
 type ResetableStringWriter interface {
 	io.StringWriter
 	fmt.Stringer
 	Reset()
 }
 
+// ErrWriteString is an error used exclusively for testing
+// Write functions.
 var ErrWriteString = errors.New("test error")
 
-type ErrorStringWriter struct{}
-
-func (e *ErrorStringWriter) WriteString(s string) (int, error) {
-	return 0, ErrWriteString
+// An ErrorStringWriter counts the calls made to its WriteString
+// method and returns an error when the number of calls is
+// greater than or equal to TriggerAt.
+type ErrorStringWriter struct {
+	TriggerAt int // number of calls to WriteString before returning an error
+	current   int // the number of calls to WriteString up to this point
 }
 
-func (e *ErrorStringWriter) Reset() {}
+// WriteString ignores string s and returns the length of string s
+// in bytes with a nil error. When the number of calls to WriteString
+// is greater than or equal to TriggerAt WriteString will return
+// 0 bytes and an error.
+func (e *ErrorStringWriter) WriteString(s string) (int, error) {
+	e.current++
+	if e.current >= e.TriggerAt {
+		return 0, ErrWriteString
+	}
+	return len([]byte(s)), nil
+}
 
+// Reset sets the number of calls made to WriteString up to this
+// point, to 0.
+func (e *ErrorStringWriter) Reset() {
+	e.current = 0
+}
+
+// String always returns an empty string value.
 func (e *ErrorStringWriter) String() string {
 	return ""
 }
 
-var errorWriter ErrorStringWriter
-var validWriter strings.Builder
+var validWriter strings.Builder // A global string builder intended for reuse across tests
 
 func TestWriteValue(t *testing.T) {
 	var cases = map[string]struct {
@@ -70,8 +96,8 @@ func TestWriteValue(t *testing.T) {
 			}),
 			output: "A,null,true,1111111111,'key:'value,",
 		},
-		"list_error": {
-			writer: &errorWriter,
+		"list_write_value_error": {
+			writer: &ErrorStringWriter{},
 			value: structpb.NewListValue(&structpb.ListValue{
 				Values: []*structpb.Value{
 					structpb.NewStringValue("A"),
@@ -81,6 +107,18 @@ func TestWriteValue(t *testing.T) {
 					structpb.NewStructValue(MustNewStruct(map[string]any{
 						"key": "value",
 					})),
+				},
+			}),
+			error: true,
+		},
+		"list_write_comma_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 2,
+			},
+			value: structpb.NewListValue(&structpb.ListValue{
+				Values: []*structpb.Value{
+					structpb.NewNullValue(),
+					structpb.NewNullValue(),
 				},
 			}),
 			error: true,
@@ -121,8 +159,28 @@ func TestWriteStruct(t *testing.T) {
 			}),
 			output: "'keyA:'valueA,'keyB:'valueB,",
 		},
-		"general_error": {
-			writer: &errorWriter,
+		"fields_write_key_error": {
+			writer: &ErrorStringWriter{},
+			value: MustNewStruct(map[string]any{
+				"keyA": "valueA",
+				"keyB": "valueB",
+			}),
+			error: true,
+		},
+		"fields_write_value_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 2,
+			},
+			value: MustNewStruct(map[string]any{
+				"keyA": "valueA",
+				"keyB": "valueB",
+			}),
+			error: true,
+		},
+		"fields_write_comma_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 3,
+			},
 			value: MustNewStruct(map[string]any{
 				"keyA": "valueA",
 				"keyB": "valueB",
@@ -135,7 +193,7 @@ func TestWriteStruct(t *testing.T) {
 			output: "",
 		},
 		"nil_error": {
-			writer: &errorWriter,
+			writer: &ErrorStringWriter{},
 			value:  nil,
 			output: "",
 		},
@@ -171,10 +229,36 @@ func TestWriteTuples(t *testing.T) {
 			},
 			output: "/document:A#relationA@user:A,document:B#relationB@user:B,document:C#relationC@user:C",
 		},
-		"sans_condition_error": {
-			writer: &errorWriter,
+		"write_forward_slash_error": {
+			writer: &ErrorStringWriter{},
 			tuples: []*openfgav1.TupleKey{
-				tuple.NewTupleKey("document:C", "relationC", "user:C"),
+				tuple.NewTupleKey("document:A", "relationA", "user:A"),
+			},
+			error: true,
+		},
+		"write_object_relation_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 2,
+			},
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:A", "relationA", "user:A"),
+			},
+			error: true,
+		},
+		"write_user_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 3,
+			},
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:A", "relationA", "user:A"),
+			},
+			error: true,
+		},
+		"write_comma_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 3,
+			},
+			tuples: []*openfgav1.TupleKey{
 				tuple.NewTupleKey("document:A", "relationA", "user:A"),
 				tuple.NewTupleKey("document:B", "relationB", "user:B"),
 			},
@@ -204,8 +288,62 @@ func TestWriteTuples(t *testing.T) {
 			},
 			output: "/document:A#relationA with A 'key:'value,@user:A,document:A#relationA with B 'key:'value,@user:A",
 		},
-		"with_condition_error": {
-			writer: &errorWriter,
+		"with_condition_write_with_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 3,
+			},
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKeyWithCondition(
+					"document:A",
+					"relationA",
+					"user:A",
+					"B",
+					MustNewStruct(map[string]any{
+						"key": "value",
+					}),
+				),
+				tuple.NewTupleKeyWithCondition(
+					"document:A",
+					"relationA",
+					"user:A",
+					"A",
+					MustNewStruct(map[string]any{
+						"key": "value",
+					}),
+				),
+			},
+			error: true,
+		},
+		"with_condition_write_space_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 4,
+			},
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKeyWithCondition(
+					"document:A",
+					"relationA",
+					"user:A",
+					"B",
+					MustNewStruct(map[string]any{
+						"key": "value",
+					}),
+				),
+				tuple.NewTupleKeyWithCondition(
+					"document:A",
+					"relationA",
+					"user:A",
+					"A",
+					MustNewStruct(map[string]any{
+						"key": "value",
+					}),
+				),
+			},
+			error: true,
+		},
+		"with_condition_write_context_error": {
+			writer: &ErrorStringWriter{
+				TriggerAt: 5,
+			},
 			tuples: []*openfgav1.TupleKey{
 				tuple.NewTupleKeyWithCondition(
 					"document:A",

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -13,10 +13,20 @@ import (
 
 type TupleKeys []*openfgav1.TupleKey
 
+// Len is a method that is required to implement the
+// sort.Interface interface. Len returns the number
+// of elements in the slice.
 func (tk TupleKeys) Len() int {
 	return len(tk)
 }
 
+// Less is a method that is required to implement the
+// sort.Interface interface. Less returns true when the
+// value at index i is less than the value at index j.
+// Tuples are compared first by their object, then their
+// relation, then their user, and finally their condition.
+// If Less(i, j) returns false and Less(j, i) returns false,
+// then the tuples are equal.
 func (tk TupleKeys) Less(i, j int) bool {
 	if tk[i].GetObject() != tk[j].GetObject() {
 		return tk[i].GetObject() < tk[j].GetObject()
@@ -40,6 +50,9 @@ func (tk TupleKeys) Less(i, j int) bool {
 	return true
 }
 
+// Swap is a method that is required to implement the
+// sort.Interface interface. Swap exchanges the values
+// at slice indexes i and j.
 func (tk TupleKeys) Swap(i, j int) {
 	tk[i], tk[j] = tk[j], tk[i]
 }

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -9,6 +9,9 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 )
 
+// MustNewStruct returns a new *structpb.Struct or panics
+// on error. The new *structpb.Struct value is built from
+// the map m.
 func MustNewStruct(m map[string]any) *structpb.Struct {
 	s, err := structpb.NewStruct(m)
 	if err == nil {


### PR DESCRIPTION
Additional tests have been included for the recently introduced hasher `Write*` functions in the `keys` package.

Many of these new tests will error on the first call to `WriteString` in the unit under test. There are other locations in the code that could error on a call to `WriteString`, but are more challenging to reach due to the prior call to `WriteString` having already returned an error.

-- Edit:
I've altered some test helpers to allow deeper error cases to be covered.
Also, comments have been added to the new functions and text helpers.
