### PR TITLE
avoid mutating reference input

### DIFF
--- a/internal/keys/hasher.go
+++ b/internal/keys/hasher.go
@@ -90,7 +90,10 @@ func WriteStruct(w io.StringWriter, s *structpb.Struct) (err error) {
 // in the tuple string representation. WriteTuples returns an error only when
 // the underlying writer returns an error.
 func WriteTuples(w io.StringWriter, tuples ...*openfgav1.TupleKey) (err error) {
-	sortedTuples := tuple.TupleKeys(tuples)
+	sortedTuples := make(tuple.TupleKeys, len(tuples))
+
+	// copy tuples slice to avoid mutating the original slice during sorting.
+	copy(sortedTuples, tuples)
 
 	// sort tulpes for a deterministic write
 	sort.Sort(sortedTuples)


### PR DESCRIPTION
In function `hasher.WriteTuples`, instead of mutating the input slice of tuples, copy the input slice.

The intent or responsibility of this function is not to sort the input slice and it is a side-effect that is observable outside of the function that really shouldn't exist.

For performance reasons, I could argue that the caller should pass a copy of the slice when necessary. However, I see the mutation side-effect as surprising in a negative way.