### PR TITLE
chore: replace sprintf in cache code

### DIFF
--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -123,9 +123,11 @@ func GetInvalidIteratorByObjectRelationCacheKeys(storeID, object, relation strin
 }
 
 func GetInvalidIteratorByUserObjectTypeCacheKeys(storeID string, users []string, objectType string) []string {
-	res := make([]string, 0, len(users))
+	res := make([]string, len(users))
+	var i int
 	for _, user := range users {
-		res = append(res, fmt.Sprintf("%s%s-otr/%s|%s", invalidIteratorCachePrefix, storeID, user, objectType))
+		res[i] = invalidIteratorCachePrefix + storeID + "-otr/" + user + "|" + objectType
+		i++
 	}
 	return res
 }

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -107,7 +107,7 @@ type ChangelogCacheEntry struct {
 }
 
 func GetChangelogCacheKey(storeID string) string {
-	return fmt.Sprintf("%s%s", changelogCachePrefix, storeID)
+	return changelogCachePrefix + storeID
 }
 
 type InvalidEntityCacheEntry struct {
@@ -115,11 +115,11 @@ type InvalidEntityCacheEntry struct {
 }
 
 func GetInvalidIteratorCacheKey(storeID string) string {
-	return fmt.Sprintf("%s%s", invalidIteratorCachePrefix, storeID)
+	return invalidIteratorCachePrefix + storeID
 }
 
 func GetInvalidIteratorByObjectRelationCacheKeys(storeID, object, relation string) []string {
-	return []string{fmt.Sprintf("%s%s-or/%s#%s", invalidIteratorCachePrefix, storeID, object, relation)}
+	return []string{invalidIteratorCachePrefix + storeID + "-or/" + object + "#" + relation}
 }
 
 func GetInvalidIteratorByUserObjectTypeCacheKeys(storeID string, users []string, objectType string) []string {
@@ -138,15 +138,15 @@ type TupleIteratorCacheEntry struct {
 }
 
 func GetReadUsersetTuplesCacheKeyPrefix(store, object, relation string) string {
-	return fmt.Sprintf("%srut/%s/%s#%s", iteratorCachePrefix, store, object, relation)
+	return iteratorCachePrefix + "rut/" + store + "/" + object + "#" + relation
 }
 
 func GetReadStartingWithUserCacheKeyPrefix(store, objectType, relation string) string {
-	return fmt.Sprintf("%srtwu/%s/%s#%s", iteratorCachePrefix, store, objectType, relation)
+	return iteratorCachePrefix + "rtwu/" + store + "/" + objectType + "#" + relation
 }
 
 func GetReadCacheKey(store, tuple string) string {
-	return fmt.Sprintf("%sr/%s/%s", iteratorCachePrefix, store, tuple)
+	return iteratorCachePrefix + "r/" + store + "/" + tuple
 }
 
 // ErrUnexpectedStructValue is an error used to indicate that

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -839,3 +839,40 @@ func BenchmarkCheckRequestCacheKeyWithContext(b *testing.B) {
 		require.NoError(b, err)
 	}
 }
+
+func BenchmarkGetInvalidIteratorByUserObjectTypeCacheKeys(b *testing.B) {
+	storeId := "abc123"
+	objectType := "document"
+	users := []string{
+		"a",
+		"b",
+		"c",
+		"d",
+		"e",
+		"f",
+		"g",
+		"h",
+		"i",
+		"j",
+		"k",
+		"l",
+		"m",
+		"n",
+		"o",
+		"p",
+		"q",
+		"r",
+		"s",
+		"t",
+		"u",
+		"v",
+		"w",
+		"x",
+		"y",
+		"z",
+	}
+
+	for n := 0; n < b.N; n++ {
+		_ = GetInvalidIteratorByUserObjectTypeCacheKeys(storeId, users, objectType)
+	}
+}

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -841,7 +841,7 @@ func BenchmarkCheckRequestCacheKeyWithContext(b *testing.B) {
 }
 
 func BenchmarkGetInvalidIteratorByUserObjectTypeCacheKeys(b *testing.B) {
-	storeId := "abc123"
+	storeID := "abc123"
 	objectType := "document"
 	users := []string{
 		"a",
@@ -873,6 +873,6 @@ func BenchmarkGetInvalidIteratorByUserObjectTypeCacheKeys(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		_ = GetInvalidIteratorByUserObjectTypeCacheKeys(storeId, users, objectType)
+		_ = GetInvalidIteratorByUserObjectTypeCacheKeys(storeID, users, objectType)
 	}
 }


### PR DESCRIPTION
replace simple uses of `fmt.Sprintf` with the concatenation operator `+`.

