### PR TITLE
test: shuffle order of tuples when writing them

### DIFF
--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -369,8 +369,8 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 		err = ds.WriteAuthorizationModel(context.Background(), storeID, model)
 		require.NoError(b, err)
 
-		// create and write necessary tuples
-		tuples := bm.tupleGenerator()
+		// create and write necessary tuples in random order
+		tuples := testutils.Shuffle(bm.tupleGenerator())
 		for i := 0; i < len(tuples); {
 			var tuplesToWrite []*openfgav1.TupleKey
 			for j := 0; j < ds.MaxTuplesPerWrite(); j++ {
@@ -441,6 +441,8 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	// one userset gets access to document:budget
 	tuples = append(tuples, &openfgav1.TupleKey{Object: "document:budget", Relation: "viewer", User: "group:999#member"})
+
+	tuples = testutils.Shuffle(tuples)
 
 	// now actually write the tuples
 	for i := 0; i < len(tuples); {

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -481,7 +481,8 @@ func TestListObjects(t *testing.T, ds storage.OpenFGADatastore) {
 			err := ds.WriteAuthorizationModel(ctx, storeID, model)
 			require.NoError(t, err)
 
-			// arrange: write tuples
+			// arrange: write tuples in random order
+			test.tuples = testutils.Shuffle(test.tuples)
 			err = ds.Write(context.Background(), storeID, nil, test.tuples)
 			require.NoError(t, err)
 
@@ -628,6 +629,8 @@ func setupListObjectsBenchmark(b *testing.B, ds storage.OpenFGADatastore, storeI
 
 			numberObjectsAccesible++
 		}
+
+		tuples = testutils.Shuffle(tuples)
 
 		err := ds.Write(context.Background(), storeID, nil, tuples)
 		require.NoError(b, err)

--- a/pkg/server/test/list_users.go
+++ b/pkg/server/test/list_users.go
@@ -162,7 +162,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 		err = ds.WriteAuthorizationModel(context.Background(), storeID, model)
 		require.NoError(b, err)
 
-		// arrange: write tuples
+		// arrange: write tuples in random order
 		tuples := bm.tupleGenerator()
 		for i := 0; i < len(tuples); {
 			var tuplesToWrite []*openfgav1.TupleKey
@@ -173,6 +173,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				tuplesToWrite = append(tuplesToWrite, tuples[i])
 				i++
 			}
+			tuplesToWrite = testutils.Shuffle(tuplesToWrite)
 			err = ds.Write(context.Background(), storeID, nil, tuplesToWrite)
 			require.NoError(b, err)
 		}

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -67,7 +67,7 @@ func BootstrapFGAStore(
 	require.NoError(t, err)
 
 	tuples := tuple.MustParseTupleStrings(tupleStrs...)
-
+	tuples = testutils.Shuffle(tuples)
 	batchSize := ds.MaxTuplesPerWrite()
 	for batch := 0; batch < len(tuples); batch += batchSize {
 		batchEnd := min(batch+batchSize, len(tuples))


### PR DESCRIPTION
This PR is a continuation of https://github.com/openfga/openfga/pull/2175. Adding randomness so that we can expose bugs caused by code that incorrectly relies on a particular order of tuples.