### PR TITLE
test: use storage wrapper in Check unit tests

### DIFF
--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -93,6 +93,9 @@ func (s *iteratorStreams) getActiveStreams(ctx context.Context) ([]*iteratorStre
 	return s.streams, nil
 }
 
+// fastPathDirect assumes that req.Object + req.Relation is a directly assignable relation, e.g. define viewer: [user, user:*].
+// It returns a channel with one element, and then closes the channel.
+// The element is an iterator over all objects that are directly related to the user or the wildcard (if applicable).
 func (c *LocalChecker) fastPathDirect(ctx context.Context,
 	req *ResolveCheckRequest) (chan *iteratorMsg, error) {
 	typesys, _ := typesystem.TypesystemFromContext(ctx)
@@ -483,6 +486,9 @@ func fastPathDifference(ctx context.Context, streams *iteratorStreams, outChan c
 	}
 }
 
+// fastPathOperationSetup returns a channel with a number of elements that is >= the number of children.
+// Each element is an iterator.
+// The caller must wait until the channel is closed.
 func (c *LocalChecker) fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, op setOperatorType, children ...*openfgav1.Userset) (chan *iteratorMsg, error) {
 	iterStreams := make([]*iteratorStream, 0, len(children))
 	for idx, child := range children {
@@ -508,6 +514,8 @@ func (c *LocalChecker) fastPathOperationSetup(ctx context.Context, req *ResolveC
 	return outChan, nil
 }
 
+// fastPathRewrite returns a channel that will contain an unknown but finite number of elements.
+// The channel is closed at the end.
 func (c *LocalChecker) fastPathRewrite(
 	ctx context.Context,
 	req *ResolveCheckRequest,

--- a/internal/graph/check_fast_path_test.go
+++ b/internal/graph/check_fast_path_test.go
@@ -19,11 +19,24 @@ import (
 
 	"github.com/openfga/openfga/internal/concurrency"
 	"github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/internal/server/config"
 	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/storagewrappers"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
+
+// setRequestContext creates the correct storage wrappers in the request. NOTE: "ds" can be a mock.
+// TODO(miparnisari) pass contextual tuples parameter in a test.
+//
+//nolint:unparam
+func setRequestContext(ctx context.Context, ts *typesystem.TypeSystem, ds storage.RelationshipTupleReader, ctxTuples []*openfgav1.TupleKey) context.Context {
+	rsw := storagewrappers.NewRequestStorageWrapperForCheckAPI(ds, ctxTuples, config.DefaultMaxConcurrentReadsForCheck, nil, config.CacheSettings{}, nil)
+	ctx = storage.ContextWithRelationshipTupleReader(ctx, rsw)
+	ctx = typesystem.ContextWithTypesystem(ctx, ts)
+	return ctx
+}
 
 func TestIteratorStreams(t *testing.T) {
 	t.Run("getActiveStreams", func(t *testing.T) {
@@ -92,7 +105,7 @@ func TestFastPathDirect(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		mockDatastore := mocks.NewMockOpenFGADatastore(ctrl)
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "document",
 			Relation:   "admin",
@@ -103,8 +116,6 @@ func TestFastPathDirect(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
-		checker := NewLocalChecker()
-		ctx := context.Background()
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -118,9 +129,9 @@ func TestFastPathDirect(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, ts)
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
+		ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
 
+		checker := NewLocalChecker()
 		c, err := checker.fastPathDirect(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -141,7 +152,7 @@ func TestFastPathDirect(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		mockDatastore := mocks.NewMockOpenFGADatastore(ctrl)
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "document",
 			Relation:   "admin",
@@ -152,8 +163,6 @@ func TestFastPathDirect(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).MaxTimes(1).Return(nil, errors.New("boom"))
-		checker := NewLocalChecker()
-		ctx := context.Background()
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -167,9 +176,9 @@ func TestFastPathDirect(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, ts)
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
+		ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
 
+		checker := NewLocalChecker()
 		_, err = checker.fastPathDirect(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -200,7 +209,7 @@ func TestFastPathComputed(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, ts)
+		ctx = setRequestContext(ctx, ts, nil, nil)
 
 		_, err = checker.fastPathComputed(ctx, &ResolveCheckRequest{
 			StoreID:  ulid.Make().String(),
@@ -1047,12 +1056,12 @@ func TestBreadthFirstRecursiveMatch(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			ds := mocks.NewMockRelationshipTupleReader(ctrl)
 
 			storeID := ulid.Make().String()
 
+			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			for _, mock := range tt.readMocks {
-				ds.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(mock), nil)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(mock), nil)
 			}
 
 			model := parser.MustTransformDSLToProto(`
@@ -1075,8 +1084,7 @@ func TestBreadthFirstRecursiveMatch(t *testing.T) {
 			ts, err := typesystem.New(model)
 			require.NoError(t, err)
 			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx = setRequestContext(ctx, ts, mockDatastore, nil)
 
 			checker := NewLocalChecker()
 			mapping := &recursiveMapping{
@@ -1150,9 +1158,10 @@ func TestRecursiveTTUFastPath(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			ds := mocks.NewMockRelationshipTupleReader(ctrl)
 			storeID := ulid.Make().String()
-			ds.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
+
+			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 				ObjectType: "group",
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
@@ -1160,7 +1169,7 @@ func TestRecursiveTTUFastPath(t *testing.T) {
 			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples {
-				ds.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
 			}
 			ts, err := typesystem.New(model)
 			require.NoError(t, err)
@@ -1174,8 +1183,7 @@ func TestRecursiveTTUFastPath(t *testing.T) {
 				RequestMetadata:      NewCheckRequestMetadata(),
 			}
 			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx = setRequestContext(ctx, ts, mockDatastore, nil)
 			checker := NewLocalChecker()
 			result, err := checker.recursiveTTUFastPath(ctx, req, rel.GetRewrite(), storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{Object: "group:2", Relation: "parent", User: "group:1"}}))
 			require.Equal(t, tt.expectedError, err)
@@ -1305,11 +1313,9 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			storeID := ulid.Make().String()
-			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 
-			ds.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
+			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 				ObjectType: "group",
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
@@ -1317,7 +1323,7 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
-				ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
+				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
 			}
 			model := parser.MustTransformDSLToProto(`
 						model
@@ -1331,7 +1337,7 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 
 			ts, err := typesystem.New(model)
 			require.NoError(t, err)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
 
 			req := &ResolveCheckRequest{
 				StoreID:              storeID,
@@ -1364,12 +1370,8 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 		defer ctrl.Finish()
 
 		storeID := ulid.Make().String()
-		ds := mocks.NewMockRelationshipTupleReader(ctrl)
-
-		ctx := context.Background()
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
-
-		ds.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
 			storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 				{
 					Key: tuple.NewTupleKey("group:bad", "member", "user:maria"),
@@ -1377,7 +1379,7 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 			}), nil)
 
 		for i := 1; i < 26; i++ {
-			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
+			mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
 				storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					{
 						Key: tuple.NewTupleKey("group:"+strconv.Itoa(i+1), "member", "group:"+strconv.Itoa(i)+"#member"),
@@ -1397,7 +1399,7 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
-		ctx = typesystem.ContextWithTypesystem(ctx, ts)
+		ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
 
 		req := &ResolveCheckRequest{
 			StoreID:              storeID,
@@ -1416,14 +1418,10 @@ func TestRecursiveUsersetFastPath(t *testing.T) {
 }
 
 func TestBuildRecursiveMapper(t *testing.T) {
+	storeID := ulid.Make().String()
+
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
-
-	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-
-	storeID := ulid.Make().String()
-	ctx := context.Background()
-	ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
 
 	model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -1435,7 +1433,8 @@ func TestBuildRecursiveMapper(t *testing.T) {
 	ts, err := typesystem.New(model)
 	require.NoError(t, err)
 
-	ctx = typesystem.ContextWithTypesystem(ctx, ts)
+	mockDatastore := mocks.NewMockRelationshipTupleReader(mockController)
+	ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
 	checker := NewLocalChecker()
 
 	t.Run("recursive_userset", func(t *testing.T) {

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -789,12 +789,7 @@ func TestNonStratifiableCheckQueries(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 			StoreID:         storeID,
@@ -833,12 +828,7 @@ func TestNonStratifiableCheckQueries(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 			StoreID:         storeID,
@@ -894,12 +884,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 			StoreID:         storeID,
@@ -950,11 +935,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		for i := 0; i < 2000; i++ {
 			// subtract branch resolves to {allowed: true} even though the base branch
@@ -1000,11 +981,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		for i := 0; i < 2000; i++ {
 			// base should resolve to {allowed: false} even though the subtract branch
@@ -1062,11 +1039,7 @@ func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
 	ts, err := typesystem.New(model)
 	require.NoError(t, err)
 
-	ctx := typesystem.ContextWithTypesystem(
-		context.Background(),
-		ts,
-	)
-	ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+	ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 	resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 		StoreID:         storeID,
@@ -1133,8 +1106,7 @@ func TestCheckConditions(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	ctx := typesystem.ContextWithTypesystem(context.Background(), typesys)
-	ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+	ctx := setRequestContext(context.Background(), typesys, ds, nil)
 
 	conditionContext, err := structpb.NewStruct(map[string]interface{}{
 		"param1": "notok",
@@ -1174,7 +1146,6 @@ func TestCheckConditions(t *testing.T) {
 
 func TestCheckDispatchCount(t *testing.T) {
 	ds := memory.New()
-	ctx := storage.ContextWithRelationshipTupleReader(context.Background(), ds)
 
 	t.Run("dispatch_count_ttu", func(t *testing.T) {
 		storeID := ulid.Make().String()
@@ -1196,7 +1167,7 @@ func TestCheckDispatchCount(t *testing.T) {
 					define parent: [folder]
 			`)
 
-		err := ds.Write(ctx, storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
 			tuple.NewTupleKey("folder:C", "viewer", "user:jon"),
 			tuple.NewTupleKey("folder:B", "parent", "folder:C"),
 			tuple.NewTupleKey("folder:A", "parent", "folder:B"),
@@ -1212,7 +1183,7 @@ func TestCheckDispatchCount(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+		ctx := setRequestContext(context.Background(), typesys, ds, nil)
 
 		checkRequestMetadata := NewCheckRequestMetadata()
 
@@ -1262,7 +1233,7 @@ func TestCheckDispatchCount(t *testing.T) {
 					define viewer: [group#member]
 			`)
 
-		err := ds.Write(ctx, storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
 			tuple.NewTupleKey("group:1", "member", "user:jon"),
 			tuple.NewTupleKey("group:eng", "member", "group:1#member"),
 			tuple.NewTupleKey("group:eng", "member", "group:2#member"),
@@ -1279,7 +1250,7 @@ func TestCheckDispatchCount(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+		ctx := setRequestContext(context.Background(), typesys, ds, nil)
 		checkRequestMetadata := NewCheckRequestMetadata()
 
 		resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
@@ -1322,7 +1293,7 @@ func TestCheckDispatchCount(t *testing.T) {
 					define owner: [user]
 					define editor: [user] or owner`)
 
-		err := ds.Write(ctx, storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "owner", "user:jon"),
 			tuple.NewTupleKey("document:2", "editor", "user:will"),
 		})
@@ -1336,7 +1307,7 @@ func TestCheckDispatchCount(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+		ctx := setRequestContext(context.Background(), typesys, ds, nil)
 		checkRequestMetadata := NewCheckRequestMetadata()
 		resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
@@ -1718,7 +1689,7 @@ func TestCheckWithFastPathOptimization(t *testing.T) {
 	ts, err := typesystem.NewAndValidate(context.Background(), model)
 	require.NoError(t, err)
 
-	ctx := typesystem.ContextWithTypesystem(storage.ContextWithRelationshipTupleReader(context.Background(), ds), ts)
+	ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 	newL, _ := logger.NewLogger(logger.WithFormat("text"), logger.WithLevel("debug"))
 	checker := NewLocalChecker(WithUsersetBatchSize(usersetBatchSize), WithLocalCheckerLogger(newL), WithOptimizations(true), WithMaxResolutionDepth(20))
@@ -1828,12 +1799,7 @@ func TestCycleDetection(t *testing.T) {
 		ts, err := typesystem.New(model)
 		require.NoError(t, err)
 
-		ctx := typesystem.ContextWithTypesystem(
-			context.Background(),
-			ts,
-		)
-
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 		t.Run("disconnected_types_in_query", func(t *testing.T) {
 			resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
@@ -2351,9 +2317,7 @@ func TestCheckAssociatedObjects(t *testing.T) {
 
 			ts, err := typesystem.New(tt.model)
 			require.NoError(t, err)
-			ctx := context.Background()
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+			ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 			contextStruct, err := structpb.NewStruct(tt.context)
 			require.NoError(t, err)
@@ -2688,8 +2652,7 @@ func TestConsumeUsersets(t *testing.T) {
 				ctx, cancel = context.WithCancel(ctx)
 				cancel()
 			}
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
+			ctx = setRequestContext(ctx, ts, ds, nil)
 
 			usersetsChannelItems := usersetsChannelFromUsersetsChannelStruct(tt.usersetsChannelResult)
 
@@ -3745,8 +3708,6 @@ func TestStreamedLookupUsersetFromIterator(t *testing.T) {
 			defer ctrl.Finish()
 			storeID := ulid.Make().String()
 			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
 
 			model := parser.MustTransformDSLToProto(`
 					model
@@ -3760,7 +3721,8 @@ func TestStreamedLookupUsersetFromIterator(t *testing.T) {
 
 			ts, err := typesystem.New(model)
 			require.NoError(t, err)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+
+			ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 			restrictions, err := ts.DirectlyRelatedUsersets("group", "member")
 			require.NoError(t, err)
@@ -3954,8 +3916,7 @@ func TestCheckTTU(t *testing.T) {
 			RequestMetadata: NewCheckRequestMetadata(),
 		}
 
-		ctx := typesystem.ContextWithTypesystem(context.Background(), typesys)
-		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
+		ctx := setRequestContext(context.Background(), typesys, mockDatastore, nil)
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, tuple.NewTupleKey("group:1", "parent", ""), gomock.Any()).
 			Times(1).
@@ -4071,15 +4032,13 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			defer ctrl.Finish()
 			storeID := ulid.Make().String()
 			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
 
 			ds.EXPECT().ReadUserTuple(gomock.Any(), storeID, tt.reqTupleKey, gomock.Any()).Times(1).Return(tt.readUserTuple, tt.readUserTupleError)
 
 			ts, err := typesystem.New(tt.model)
 			require.NoError(t, err)
 
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx := setRequestContext(context.Background(), ts, ds, nil)
 
 			contextStruct, err := structpb.NewStruct(tt.context)
 			require.NoError(t, err)
@@ -4402,14 +4361,11 @@ func TestCheckPublicAssignable(t *testing.T) {
 
 			storeID := ulid.Make().String()
 			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ctx := context.Background()
-			ctx = storage.ContextWithRelationshipTupleReader(ctx, ds)
-
 			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
 
 			ts, err := typesystem.New(tt.model)
 			require.NoError(t, err)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx := setRequestContext(context.Background(), ts, ds, nil)
 			checker := NewLocalChecker()
 
 			contextStruct, err := structpb.NewStruct(tt.context)


### PR DESCRIPTION
## Description
This PR is meant to have unit tests of Check API mimic production code as much as possible. 

In production code, we are calling `NewRequestStorageWrapperForCheckAPI` on every Check API call: https://github.com/openfga/openfga/blob/f00569d20166aab9810ea1b6566cd0968abb4ecd/pkg/server/commands/check_command.go#L115-L118

therefore, the tests should do the same.

## References
To be able to write a complete integration test in https://github.com/openfga/openfga/pull/2150.

