### PR TITLE
chore: remove experimental flag from check shortcut and fast_path_v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Improve `Check` performance for sub-problems when caching is enabled [#2193](https://github.com/openfga/openfga/pull/2193).
 - Improve `Check` performance for relations involving public wildcard. Enable via experimental flag `enable-check-optimizations`.  [#2180](https://github.com/openfga/openfga/pull/2180).
 - Improve Check API performance when experimental flag `enable-check-optimizations` is turned on and contextual tuples are involved. [#2150](https://github.com/openfga/openfga/pull/2150)
+- Move Check performance optimizations out of experimental mode: shortcutting based on path and recursive userset fast path. [#2236](https://github.com/openfga/openfga/pull/2236)
 
 ### Fixed
 - Fixed incorrect invalidation by cache controller on cache iterator. [#2190](https://github.com/openfga/openfga/pull/2190), [#2216](https://github.com/openfga/openfga/pull/2216)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Improve `Check` performance for relations involving public wildcard. Enable via experimental flag `enable-check-optimizations`.  [#2180](https://github.com/openfga/openfga/pull/2180).
 - Improve Check API performance when experimental flag `enable-check-optimizations` is turned on and contextual tuples are involved. [#2150](https://github.com/openfga/openfga/pull/2150)
 - Added metrics to track invalid cache hits: `check_cache_invalid_hit_count` and `tuples_iterator_cache_invalid_hit_count` [#2222](https://github.com/openfga/openfga/pull/2222).
-- Move Check performance optimizations out of experimental mode: shortcutting based on path and recursive userset fast path. [#2236](https://github.com/openfga/openfga/pull/2236)
+- Move Check performance optimizations out of experimental mode: shortcutting based on path, recursive userset fast path, and recursive TTU fast path. [#2236](https://github.com/openfga/openfga/pull/2236)
 
 ### Fixed
 - Fixed incorrect invalidation by cache controller on cache iterator. [#2190](https://github.com/openfga/openfga/pull/2190), [#2216](https://github.com/openfga/openfga/pull/2216)

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -478,16 +478,14 @@ func (c *LocalChecker) ResolveCheck(
 		return nil, fmt.Errorf("relation '%s' undefined for object type '%s'", relation, objectType)
 	}
 
-	if c.optimizationsEnabled {
-		hasPath, err := typesys.PathExists(tupleKey.GetUser(), relation, objectType)
-		if err != nil {
-			return nil, err
-		}
-		if !hasPath {
-			return &ResolveCheckResponse{
-				Allowed: false,
-			}, nil
-		}
+	hasPath, err := typesys.PathExists(tupleKey.GetUser(), relation, objectType)
+	if err != nil {
+		return nil, err
+	}
+	if !hasPath {
+		return &ResolveCheckResponse{
+			Allowed: false,
+		}, nil
 	}
 
 	resp, err := c.checkRewrite(ctx, req, rel.GetRewrite())(ctx)
@@ -1170,13 +1168,13 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 				if typesys.UsersetCanFastPath(directlyRelatedUsersetTypes) {
 					resolver = c.checkUsersetFastPath
 					span.SetAttributes(attribute.String("resolver", "fastpathv1"))
-				} else if c.optimizationsEnabled {
+				} else {
 					userType := tuple.GetType(reqTupleKey.GetUser())
 					if typesys.RecursiveUsersetCanFastPath(
 						tuple.ToObjectRelationString(tuple.GetType(reqTupleKey.GetObject()), reqTupleKey.GetRelation()), userType) {
 						resolver = c.recursiveUsersetFastPath
 						span.SetAttributes(attribute.String("resolver", "recursivefastpathv1"))
-					} else if typesys.UsersetCanFastPathWeight2(objectType, relation, userType, directlyRelatedUsersetTypes) {
+					} else if c.optimizationsEnabled && typesys.UsersetCanFastPathWeight2(objectType, relation, userType, directlyRelatedUsersetTypes) {
 						resolver = c.checkUsersetFastPathV2
 						span.SetAttributes(attribute.String("resolver", "fastpathv2"))
 					}
@@ -1410,14 +1408,12 @@ func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequ
 			}
 		}
 
-		if c.optimizationsEnabled {
-			if typesys.RecursiveTTUCanFastPath(objectTypeRelation, userType) {
-				resolver = c.recursiveTTUFastPath
-				span.SetAttributes(attribute.String("resolver", "recursivefastpathv1"))
-			} else if typesys.TTUCanFastPathWeight2(objectType, relation, userType, rewrite.GetTupleToUserset()) {
-				resolver = c.checkTTUFastPathV2
-				span.SetAttributes(attribute.String("resolver", "fastpathv2"))
-			}
+		if typesys.RecursiveTTUCanFastPath(objectTypeRelation, userType) {
+			resolver = c.recursiveTTUFastPath
+			span.SetAttributes(attribute.String("resolver", "recursivefastpathv1"))
+		} else if c.optimizationsEnabled && typesys.TTUCanFastPathWeight2(objectType, relation, userType, rewrite.GetTupleToUserset()) {
+			resolver = c.checkTTUFastPathV2
+			span.SetAttributes(attribute.String("resolver", "fastpathv2"))
 		}
 		return resolver(ctx, req, rewrite, filteredIter)
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR removes the `optimizationsEnabled` gate from two check optimizations, [shortcutting based on path](https://github.com/openfga/openfga/pull/2104/files) and [recursive userset fast path](https://github.com/openfga/openfga/blob/main/internal/graph/check_fast_path.go#L1003)

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

