### PR TITLE
perf: remove fmt.sprintf and just add strings

### DIFF
--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -349,7 +349,11 @@ func GetUserTypeFromUser(user string) UserType {
 // TupleKeyToString converts a tuple key into its string representation. It assumes the tupleKey is valid
 // (i.e. no forbidden characters).
 func TupleKeyToString(tk TupleWithoutCondition) string {
-	return fmt.Sprintf("%s#%s@%s", tk.GetObject(), tk.GetRelation(), tk.GetUser())
+	return tk.GetObject() +
+		"#" +
+		tk.GetRelation() +
+		"@" +
+		tk.GetUser()
 }
 
 // TupleKeyWithConditionToString converts a tuple key with condition into its string representation. It assumes the tupleKey is valid


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Came across a `fmt.sprintf` in the `tuple` package which we can make faster while maintaining readability by just concatenating strings.

I did a quick benchmark comparison:
```
func BenchmarkTupleStringifiers(b *testing.B) {
	tupleKey := &openfgav1.TupleKey{
		User:     "user:justin",
		Relation: "viewer",
		Object:   "doc:1",
	}

	b.Run("new_version", func(b *testing.B) {
		for i := 0; i < b.N; i++ {
			_ = TupleKeyToString(tupleKey)
		}
	})
}
```

Old:
<img width="969" alt="image" src="https://github.com/user-attachments/assets/bd9f3ffb-af01-4b83-b03f-9362233909b1" />

New
<img width="969" alt="image" src="https://github.com/user-attachments/assets/7761b35c-5e0f-4c14-9c3c-9f620752b221" />

Percentage-wise it's quite a bit faster, but we're talking nanoseconds here so 🤷 

We can actually make it significantly faster still (and remove all memory usage) if we specify an explicit type for this function to accept, rather than an interface, but that requires a refactor in other places and doesn't seem worth it for such small gains.

With explicit type:
<img width="921" alt="image" src="https://github.com/user-attachments/assets/b91f1586-d011-4457-864c-54b1cb2349ca" />


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

