### PR TITLE
perf: Replace `fmt.Sprintf` with efficient string operations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,9 @@ linters-settings:
       - default # Default section: contains all imports that could not be matched to another section type.
       - prefix(github.com/openfga)  # Custom section: groups all imports with the specified Prefix.
       - localmodule
+  perfsprint:
+    errorf: false
+    err-error: false
 
 issues:
   exclude-use-default: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Fixed incorrect invalidation by cache controller on cache iterator. [#2190](https://github.com/openfga/openfga/pull/2190), [#2216](https://github.com/openfga/openfga/pull/2216)
 - Fixed incorrect types in configuration JSON schema [#2217](https://github.com/openfga/openfga/pull/2217), [#2228](https://github.com/openfga/openfga/pull/2228).
 
+### Changed
+- Performance optimizations for string operations and memory allocations across the codebase [#2241](https://github.com/openfga/openfga/pull/2241)
+
 ## [1.8.4] - 2025-01-13
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.3...v1.8.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added metrics to track invalid cache hits: `check_cache_invalid_hit_count` and `tuples_iterator_cache_invalid_hit_count` [#2222](https://github.com/openfga/openfga/pull/2222).
 - Move Check performance optimizations out of experimental mode: shortcutting based on path, recursive userset fast path, and recursive TTU fast path. [#2236](https://github.com/openfga/openfga/pull/2236)
 
+### Changed
+- Performance optimizations for string operations and memory allocations across the codebase [#2238](https://github.com/openfga/openfga/pull/2238) and [#2241](https://github.com/openfga/openfga/pull/2241)
+
 ### Fixed
 - Fixed incorrect invalidation by cache controller on cache iterator. [#2190](https://github.com/openfga/openfga/pull/2190), [#2216](https://github.com/openfga/openfga/pull/2216)
 - Fixed incorrect types in configuration JSON schema [#2217](https://github.com/openfga/openfga/pull/2217), [#2228](https://github.com/openfga/openfga/pull/2228).
-
-### Changed
-- Performance optimizations for string operations and memory allocations across the codebase [#2241](https://github.com/openfga/openfga/pull/2241)
 
 ## [1.8.4] - 2025-01-13
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.3...v1.8.4)

--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -327,7 +327,7 @@ func (a *Authorizer) ListAuthorizedStores(ctx context.Context) ([]string, error)
 	}
 
 	storeIDs := make([]string, len(resp.GetObjects()))
-	storePrefix := fmt.Sprintf("%s:", StoreType)
+	storePrefix := StoreType + ":"
 	for i, store := range resp.GetObjects() {
 		storeIDs[i] = strings.TrimPrefix(store, storePrefix)
 	}

--- a/internal/mocks/mock_oidc_server.go
+++ b/internal/mocks/mock_oidc_server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log"
 	"math/big"
 	"net/http"
@@ -67,7 +66,7 @@ func createHTTPServer(issuerURL string, publicKey *rsa.PublicKey) *http.Server {
 	mockHandler.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		err := json.NewEncoder(w).Encode(map[string]string{
 			"issuer":   issuerURL,
-			"jwks_uri": fmt.Sprintf("%s/jwks.json", issuerURL),
+			"jwks_uri": issuerURL + "/jwks.json",
 		})
 		if err != nil {
 			log.Fatalf("failed to json encode the openid configurations: %v", err)

--- a/pkg/server/commands/batch_check_command.go
+++ b/pkg/server/commands/batch_check_command.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -116,7 +115,7 @@ func NewBatchCheckCommand(datastore storage.RelationshipTupleReader, checkResolv
 func (bq *BatchCheckQuery) Execute(ctx context.Context, params *BatchCheckCommandParams) (map[CorrelationID]*BatchCheckOutcome, *BatchCheckMetadata, error) {
 	if len(params.Checks) > int(bq.maxChecksAllowed) {
 		return nil, nil, &BatchCheckValidationError{
-			Message: fmt.Sprintf("batchCheck received %d checks, the maximum allowed is %d ", len(params.Checks), bq.maxChecksAllowed),
+			Message: "batchCheck received " + strconv.Itoa(len(params.Checks)) + " checks, the maximum allowed is " + strconv.Itoa(int(bq.maxChecksAllowed)),
 		}
 	}
 
@@ -222,14 +221,14 @@ func validateCorrelationIDs(checks []*openfgav1.BatchCheckItem) error {
 	for _, check := range checks {
 		if check.GetCorrelationId() == "" {
 			return &BatchCheckValidationError{
-				Message: fmt.Sprintf("received empty correlation id for tuple: %s", check.GetTupleKey()),
+				Message: "received empty correlation id for tuple: " + check.GetTupleKey().String(),
 			}
 		}
 
 		_, ok := seen[check.GetCorrelationId()]
 		if ok {
 			return &BatchCheckValidationError{
-				Message: fmt.Sprintf("received duplicate correlation id: %s", check.GetCorrelationId()),
+				Message: "received duplicate correlation id: " + check.GetCorrelationId(),
 			}
 		}
 

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -164,7 +164,7 @@ var ErrUnexpectedStructValue = errors.New("unexpected structpb value encountered
 func writeValue(w io.StringWriter, v *structpb.Value) (err error) {
 	switch val := v.GetKind().(type) {
 	case *structpb.Value_BoolValue:
-		_, err = w.WriteString(fmt.Sprintf("%v", val.BoolValue))
+		_, err = w.WriteString(strconv.FormatBool(val.BoolValue))
 	case *structpb.Value_NullValue:
 		_, err = w.WriteString("null")
 	case *structpb.Value_StringValue:

--- a/pkg/storage/storagewrappers/check_caching.go
+++ b/pkg/storage/storagewrappers/check_caching.go
@@ -3,7 +3,6 @@ package storagewrappers
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -163,7 +162,7 @@ func (c *CachedDatastore) ReadStartingWithUser(
 	for _, objectRel := range filter.UserFilter {
 		subject := tuple.ToObjectRelationString(objectRel.GetObject(), objectRel.GetRelation())
 		subjects = append(subjects, subject)
-		b.WriteString(fmt.Sprintf("/%s", subject))
+		b.WriteString("/" + subject)
 	}
 
 	if filter.ObjectIDs != nil {
@@ -174,7 +173,7 @@ func (c *CachedDatastore) ReadStartingWithUser(
 			}
 		}
 
-		b.WriteString(fmt.Sprintf("/%s", strconv.FormatUint(hasher.Sum64(), 10)))
+		b.WriteString("/" + strconv.FormatUint(hasher.Sum64(), 10))
 	}
 
 	return c.newCachedIteratorByUserObjectType(ctx, "ReadStartingWithUser", store, iter, b.String(), subjects, filter.ObjectType)
@@ -212,10 +211,10 @@ func (c *CachedDatastore) ReadUsersetTuples(
 
 	for _, userset := range filter.AllowedUserTypeRestrictions {
 		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Relation); ok {
-			rb.WriteString(fmt.Sprintf("/%s#%s", userset.GetType(), userset.GetRelation()))
+			rb.WriteString("/" + userset.GetType() + "#" + userset.GetRelation())
 		}
 		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Wildcard); ok {
-			wb.WriteString(fmt.Sprintf("/%s:*", userset.GetType()))
+			wb.WriteString("/" + userset.GetType() + ":*")
 		}
 	}
 

--- a/pkg/storage/storagewrappers/model_caching.go
+++ b/pkg/storage/storagewrappers/model_caching.go
@@ -57,7 +57,7 @@ func (c *cachedOpenFGADatastore) ReadAuthorizationModel(ctx context.Context, sto
 
 // FindLatestAuthorizationModel see [storage.AuthorizationModelReadBackend].FindLatestAuthorizationModel.
 func (c *cachedOpenFGADatastore) FindLatestAuthorizationModel(ctx context.Context, storeID string) (*openfgav1.AuthorizationModel, error) {
-	v, err, _ := c.lookupGroup.Do(fmt.Sprintf("FindLatestAuthorizationModel:%s", storeID), func() (interface{}, error) {
+	v, err, _ := c.lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (interface{}, error) {
 		return c.OpenFGADatastore.FindLatestAuthorizationModel(ctx, storeID)
 	})
 	if err != nil {

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"strings"
@@ -97,7 +96,7 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 		Tmpfs:           map[string]string{"/var/lib/mysql": ""},
 	}
 
-	name := fmt.Sprintf("mysql-%s", ulid.Make().String())
+	name := "mysql-" + ulid.Make().String()
 
 	cont, err := dockerClient.ContainerCreate(context.Background(), &containerCfg, &hostCfg, nil, nil, name)
 	require.NoError(t, err, "failed to create mysql docker container")
@@ -125,12 +124,12 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	}
 
 	mySQLTestContainer := &mySQLTestContainer{
-		addr:     fmt.Sprintf("localhost:%s", p[0].HostPort),
+		addr:     "localhost:" + p[0].HostPort,
 		username: "root",
 		password: "secret",
 	}
 
-	uri := fmt.Sprintf("%s:%s@tcp(%s)/defaultdb?parseTime=true", mySQLTestContainer.username, mySQLTestContainer.password, mySQLTestContainer.addr)
+	uri := mySQLTestContainer.username + ":" + mySQLTestContainer.password + "@tcp(" + mySQLTestContainer.addr + ")/defaultdb?parseTime=true"
 
 	err = mysql.SetLogger(log.New(io.Discard, "", 0))
 	require.NoError(t, err)
@@ -166,15 +165,10 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 func (m *mySQLTestContainer) GetConnectionURI(includeCredentials bool) string {
 	creds := ""
 	if includeCredentials {
-		creds = fmt.Sprintf("%s:%s@", m.username, m.password)
+		creds = m.username + ":" + m.password + "@"
 	}
 
-	return fmt.Sprintf(
-		"%stcp(%s)/%s?parseTime=true",
-		creds,
-		m.addr,
-		"defaultdb",
-	)
+	return creds + "tcp(" + m.addr + ")/defaultdb?parseTime=true"
 }
 
 func (m *mySQLTestContainer) GetUsername() string {

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -96,7 +96,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 		Tmpfs:           map[string]string{"/var/lib/postgresql/data": ""},
 	}
 
-	name := fmt.Sprintf("postgres-%s", ulid.Make().String())
+	name := "postgres-" + ulid.Make().String()
 
 	cont, err := dockerClient.ContainerCreate(context.Background(), &containerCfg, &hostCfg, nil, nil, name)
 	require.NoError(t, err, "failed to create postgres docker container")
@@ -125,7 +125,7 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 	}
 
 	pgTestContainer := &postgresTestContainer{
-		addr:     fmt.Sprintf("localhost:%s", m[0].HostPort),
+		addr:     "localhost:" + m[0].HostPort,
 		username: "postgres",
 		password: "secret",
 	}

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -235,13 +235,13 @@ type UserString = string
 func UserProtoToString(obj *openfgav1.User) UserString {
 	switch obj.GetUser().(type) {
 	case *openfgav1.User_Wildcard:
-		return fmt.Sprintf("%s:*", obj.GetWildcard().GetType())
+		return obj.GetWildcard().GetType() + ":*"
 	case *openfgav1.User_Userset:
 		us := obj.GetUser().(*openfgav1.User_Userset)
-		return fmt.Sprintf("%s:%s#%s", us.Userset.GetType(), us.Userset.GetId(), us.Userset.GetRelation())
+		return us.Userset.GetType() + ":" + us.Userset.GetId() + "#" + us.Userset.GetRelation()
 	case *openfgav1.User_Object:
 		us := obj.GetUser().(*openfgav1.User_Object)
-		return fmt.Sprintf("%s:%s", us.Object.GetType(), us.Object.GetId())
+		return us.Object.GetType() + ":" + us.Object.GetId()
 	default:
 		panic("unsupported type")
 	}
@@ -289,13 +289,13 @@ func SplitObject(object string) (string, string) {
 }
 
 func BuildObject(objectType, objectID string) string {
-	return fmt.Sprintf("%s:%s", objectType, objectID)
+	return objectType + ":" + objectID
 }
 
 // GetObjectRelationAsString returns a string like "object#relation". If there is no relation it returns "object".
 func GetObjectRelationAsString(objectRelation *openfgav1.ObjectRelation) string {
 	if objectRelation.GetRelation() != "" {
-		return fmt.Sprintf("%s#%s", objectRelation.GetObject(), objectRelation.GetRelation())
+		return objectRelation.GetObject() + "#" + objectRelation.GetRelation()
 	}
 	return objectRelation.GetObject()
 }
@@ -335,7 +335,7 @@ func IsObjectRelation(userset string) bool {
 // ToObjectRelationString formats an object/relation pair as an object#relation string. This is the inverse of
 // SplitObjectRelation.
 func ToObjectRelationString(object, relation string) string {
-	return fmt.Sprintf("%s#%s", object, relation)
+	return object + "#" + relation
 }
 
 // GetUserTypeFromUser returns the type of user (userset or user).
@@ -362,7 +362,7 @@ func TupleKeyWithConditionToString(tk TupleWithCondition) string {
 	var sb strings.Builder
 	sb.WriteString(TupleKeyToString(tk))
 	if tk.GetCondition() != nil {
-		sb.WriteString(fmt.Sprintf(" (condition %s)", tk.GetCondition().GetName()))
+		sb.WriteString(" (condition " + tk.GetCondition().GetName() + ")")
 	}
 	return sb.String()
 }
@@ -480,10 +480,10 @@ func ToUserParts(user string) (string, string, string) {
 func FromUserParts(userObjectType, userObjectID, userRelation string) string {
 	user := userObjectID
 	if userObjectType != "" {
-		user = fmt.Sprintf("%s:%s", userObjectType, userObjectID)
+		user = userObjectType + ":" + userObjectID
 	}
 	if userRelation != "" {
-		user = fmt.Sprintf("%s#%s", user, userRelation)
+		user = user + "#" + userRelation
 	}
 	return user
 }

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -60,7 +60,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		var model *openfgav1.AuthorizationModel
 		var key string
 		if modelID == "" {
-			v, err, _ := lookupGroup.Do(fmt.Sprintf("FindLatestAuthorizationModel:%s", storeID), func() (interface{}, error) {
+			v, err, _ := lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (interface{}, error) {
 				return datastore.FindLatestAuthorizationModel(ctx, storeID)
 			})
 			if err != nil {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -682,7 +682,7 @@ func (t *TypeSystem) TTUCanFastPathWeight2(objectType, relation, userType string
 			// exceed weight 2
 			if edge.GetEdgeType() == graph.TTUEdge &&
 				edge.GetConditionedOn() == tuplesetRelationKey &&
-				strings.HasSuffix(edge.GetTo().GetUniqueLabel(), fmt.Sprintf("#%s", computedRelation)) {
+				strings.HasSuffix(edge.GetTo().GetUniqueLabel(), "#"+computedRelation) {
 				if len(edge.GetWildcards()) != 0 {
 					return false
 				}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR improves performance by optimizing string operations across the codebase.

Changes:
- Replace `fmt.Sprintf` with direct string concatenation using + operator
- Use `strconv.FormatBool` for boolean to string conversion
- Optimize `strings.Builder` usage in tuple operations
- Clean up imports in affected files

Performance impact:

These changes reduce allocations and CPU overhead by using more efficient string operations instead of fmt.Sprintf formatting.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

address [this comment](https://github.com/openfga/openfga/pull/2238#pullrequestreview-2573629219) 😄 

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

