### PR TITLE
test: fix benchmark alarm firing due to randomness

### DIFF
--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -369,8 +369,8 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 		err = ds.WriteAuthorizationModel(context.Background(), storeID, model)
 		require.NoError(b, err)
 
-		// create and write necessary tuples in random order
-		tuples := testutils.Shuffle(bm.tupleGenerator())
+		// create and write necessary tuples in deterministic order (to make runs comparable)
+		tuples := bm.tupleGenerator()
 		for i := 0; i < len(tuples); {
 			var tuplesToWrite []*openfgav1.TupleKey
 			for j := 0; j < ds.MaxTuplesPerWrite(); j++ {
@@ -441,8 +441,6 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	// one userset gets access to document:budget
 	tuples = append(tuples, &openfgav1.TupleKey{Object: "document:budget", Relation: "viewer", User: "group:999#member"})
-
-	tuples = testutils.Shuffle(tuples)
 
 	// now actually write the tuples
 	for i := 0; i < len(tuples); {


### PR DESCRIPTION
## Description
Recently i've seen an uptick in failures in Check benchmark comparisons (not the runs themselves, just the comparison with `main`). I have a strong suspicion  this is because I recently added randomness to the order the tuples are written, which will mean that one run of the benchmark may be "lucky" in finding a response quickly, while other runs may not.

## References
E.g. https://github.com/openfga/openfga/actions/runs/13003063201/job/36265167139?pr=2241



```
threshold 2
Error: # :warning: **Performance Alert** :warning:

Possible performance regression was detected for benchmark.
Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.

| Benchmark suite | Current: 2e5a5a04db13a5a739697b84da1141c7cb1f3e50 | Previous: b20e5580b80a0ea4579ad31d7e23175dd255fdc7 | Ratio |
|-|-|-|-|
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu` | `1976808` ns/op	  253245 B/op	    3831 allocs/op | `379249` ns/op	   68821 B/op	    1002 allocs/op | `5.21` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - ns/op` | `1976808` ns/op | `379249` ns/op | `5.21` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - B/op` | `253245` B/op | `68821` B/op | `3.68` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - allocs/op` | `3831` allocs/op | `1002` allocs/op | `3.82` |



```

https://github.com/openfga/openfga/actions/runs/12988273014/job/36218891855?pr=2242

```
Possible performance regression was detected for benchmark.
Benchmark result of this commit is worse than the previous benchmark result exceeding threshold `2`.

| Benchmark suite | Current: 66cbf20766f8616838ba1fa24ea0ee13cba81c49 | Previous: deb5dc253e17fe8e302ef2818b3a92553d9ae221 | Ratio |
|-|-|-|-|
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_complex_ttu` | `47498618` ns/op	 9284055 B/op	  123513 allocs/op | `17509190` ns/op	 3513987 B/op	   46735 allocs/op | `2.71` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_complex_ttu - ns/op` | `47498618` ns/op | `17509190` ns/op | `2.71` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_complex_ttu - B/op` | `9284055` B/op | `3513987` B/op | `2.64` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_complex_ttu - allocs/op` | `123513` allocs/op | `46735` allocs/op | `2.64` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu` | `4735577` ns/op	  416333 B/op	    7539 allocs/op | `521991` ns/op	  106735 B/op	    1757 allocs/op | `9.07` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - ns/op` | `4735577` ns/op | `521991` ns/op | `9.07` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - B/op` | `416333` B/op | `106735` B/op | `3.90` |
| `BenchmarkOpenFGAServer/BenchmarkMemoryDatastore/BenchmarkCheck/with_simple_ttu - allocs/op` | `7539` allocs/op | `1757` allocs/op | `4.29` |
| `BenchmarkOpenFGAServer/BenchmarkMySQLDatastore/BenchmarkCheck/race_between_direct_and_userset` | `5800817` ns/op	  115089 B/op	    1688 allocs/op | `2032483` ns/op	  101690 B/op	    1484 allocs/op | `2.85` |
| `BenchmarkOpenFGAServer/BenchmarkMySQLDatastore/BenchmarkCheck/race_between_direct_and_userset - ns/op` | `5800817` ns/op | `2032483` ns/op | `2.85` |
```