### PR TITLE
chore: add perfsprint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,34 +6,35 @@ run:
     - docker
 
 linters:
-  enable:
+  enable: # please keep in sorted order
+    - bodyclose
+    - errcheck
     - errname
+    - gci
+    - gocritic
+    - gocyclo
+    - godot
     - gofmt
     - goimports
-    - gci
-    - stylecheck
-    - importas
-    - errcheck
     - gosimple
     - govet
+    - importas
     - ineffassign
     - mirror
     - misspell
+    - perfsprint
+    - protogetter
+    - revive
     - staticcheck
+    - stylecheck
     - tagalign
     - testifylint
     - typecheck
-    - unused
     - unconvert
     - unparam
+    - unused
     - wastedassign
     - whitespace
-    - protogetter
-    - revive
-    - godot
-    - bodyclose
-    - gocritic
-    - gocyclo
     #- gosec Too many different issues. Needs to be tackled in a separate PR.
 
 linters-settings:
@@ -76,6 +77,7 @@ issues:
     - path: "(.+)_test.go"
       linters:
         - bodyclose
+        - perfsprint
   exclude:
     - "should have a package comment" # stylecheck | revive
     - "exported (.+) should have comment" # revive

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -623,7 +622,7 @@ func setupListObjectsBenchmark(b *testing.B, ds storage.OpenFGADatastore, storeI
 		var tuples []*openfgav1.TupleKey
 
 		for j := 0; j < ds.MaxTuplesPerWrite(); j++ {
-			obj := fmt.Sprintf("document:%s", strconv.Itoa(numberObjectsAccesible))
+			obj := "document:" + strconv.Itoa(numberObjectsAccesible)
 
 			tuples = append(tuples, tuple.NewTupleKey(obj, "viewer", "user:maria"))
 

--- a/pkg/server/test/list_users.go
+++ b/pkg/server/test/list_users.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -44,7 +43,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				// same as the next benchmark, so that later we can compare times.
 				var tuples []*openfgav1.TupleKey
 				for j := 0; j < 1000; j++ {
-					user := fmt.Sprintf("user:%s", ulid.Make().String())
+					user := "user:" + ulid.Make().String()
 					// one document accessible by many users
 					tuples = append(tuples, tuple.NewTupleKey("document:1", "viewer", user))
 				}
@@ -75,8 +74,8 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				// same as the previous benchmark, so that later we can compare times.
 				var tuples []*openfgav1.TupleKey
 				for j := 0; j < 1000; j++ {
-					user := fmt.Sprintf("user:%s", ulid.Make().String())
-					folder := fmt.Sprintf("folder:%s", ulid.Make().String())
+					user := "user:" + ulid.Make().String()
+					folder := "folder:" + ulid.Make().String()
 					// one document accessible by many users, but this benchmark will incur more reads, so it should take longer and result in less iterations
 					tuples = append(tuples, tuple.NewTupleKey(folder, "viewer", user))
 					tuples = append(tuples, tuple.NewTupleKey("document:1", "parent", folder))
@@ -113,7 +112,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				var tuples []*openfgav1.TupleKey
 				for j := 0; j < 1000; j++ {
 					// one document accessible by many users
-					user := fmt.Sprintf("user:%s", ulid.Make().String())
+					user := "user:" + ulid.Make().String()
 					tuples = append(tuples, tuple.NewTupleKeyWithCondition("document:1", "viewer", user, "condTrue", nil))
 				}
 				return tuples

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1207,7 +1207,7 @@ condition xcond(x: string) {
 		stages = append(stages, complexityFourTestingModelTest...)
 		stages = append(stages, usersetCompleteTestingModelTest...)
 		for _, stage := range stages {
-			t.Run(fmt.Sprintf("stage_%s", stage.Name), func(t *testing.T) {
+			t.Run("stage_"+stage.Name, func(t *testing.T) {
 				resp, err := client.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: name})
 				require.NoError(t, err)
 				storeID := resp.GetId()
@@ -1242,13 +1242,13 @@ condition xcond(x: string) {
 					t.Skipf("no check assertions defined")
 				}
 				for _, assertion := range stage.CheckAssertions {
-					t.Run(fmt.Sprintf("assertion_check_%s", assertion.Name), func(t *testing.T) {
+					t.Run("assertion_check_"+assertion.Name, func(t *testing.T) {
 						assertCheck(ctx, t, assertion, stage, client, storeID, modelID)
 					})
-					t.Run(fmt.Sprintf("assertion_list_objects_%s", assertion.Name), func(t *testing.T) {
+					t.Run("assertion_list_objects_"+assertion.Name, func(t *testing.T) {
 						assertListObjects(ctx, t, assertion, stage, client, storeID, modelID)
 					})
-					t.Run(fmt.Sprintf("assertion_list_users_%s", assertion.Name), func(t *testing.T) {
+					t.Run("assertion_list_users_"+assertion.Name, func(t *testing.T) {
 						assertListUsers(ctx, t, assertion, client, storeID, modelID)
 					})
 				}


### PR DESCRIPTION

## Description
In https://github.com/openfga/openfga/pull/2241 I forgot to comment that `perfsprint` needs to be added to `.golangci.yaml` 😅 

## References
Part of https://github.com/openfga/openfga/issues/598

