### PR TITLE
test: fix goroutine leak in check tests

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -94,6 +94,7 @@ func TestServerLogs(t *testing.T) {
 	cfg.Trace.Enabled = true
 	cfg.Trace.OTLP.Endpoint = localOTLPServerURL
 	cfg.Datastore.Engine = "memory"
+	cfg.ContextPropagationToDatastore = true
 
 	observerLogger, logs := observer.New(zap.DebugLevel)
 	serverCtx := &run.ServerContext{

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -94,7 +94,6 @@ func TestServerLogs(t *testing.T) {
 	cfg.Trace.Enabled = true
 	cfg.Trace.OTLP.Endpoint = localOTLPServerURL
 	cfg.Datastore.Engine = "memory"
-	cfg.ContextPropagationToDatastore = true
 
 	observerLogger, logs := observer.New(zap.DebugLevel)
 	serverCtx := &run.ServerContext{
@@ -337,6 +336,7 @@ func testRunAll(t *testing.T, engine string) {
 	cfg.RequestTimeout = 10 * time.Second
 
 	cfg.CheckIteratorCache.Enabled = true
+	cfg.ContextPropagationToDatastore = true
 
 	// Some tests/stages are sensitive to the cache TTL,
 	// so we set it to a very low value to still exercise


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The `check_test` suite _sometimes_ has a goroutine leak on cleanup. The exact cause is still under investigation, but it is within [this code path](https://github.com/openfga/openfga/blob/main/pkg/storage/storagewrappers/context.go#L25) and related to how our iterator cache interacts with the DB during shutdown; that behavior is modified by the environment variable in this PR. I have a messy branch which reproduced the leak reliably [here](https://github.com/openfga/openfga/compare/main...data-race-debugging), but after making the change in this PR I have been unable to reproduce the leak again.



## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

