### PR TITLE
test: expose matrix tests publicly, run them against all datastores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Move Check performance optimizations out of experimental mode: shortcutting based on path, recursive userset fast path, and recursive TTU fast path. [#2236](https://github.com/openfga/openfga/pull/2236)
 - Improve Check API performance when experimental flag `enable-check-optimizations` is turned on and the model contains union of a TTU and algebraic operations. [#2200](https://github.com/openfga/openfga/pull/2200)
 - Implement dynamic TLS certificate reloading for HTTP and gRPC servers. [#2182](https://github.com/openfga/openfga/pull/2182)
+- Publicize `check.RunMatrixTests` method to allow testing against any `ClientInterface`. [#2267](https://github.com/openfga/openfga/pull/2267).
 
 ### Changed
 - Performance optimizations for string operations and memory allocations across the codebase [#2238](https://github.com/openfga/openfga/pull/2238) and [#2241](https://github.com/openfga/openfga/pull/2241)

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -64,7 +64,6 @@ func RunAllTests(t *testing.T, client ClientInterface) {
 		t.Run("Check", func(t *testing.T) {
 			t.Parallel()
 			runTests(t, testParams{typesystem.SchemaVersion1_1, client})
-			//runTestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 		})
 	})
 }
@@ -206,9 +205,10 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 	})
 }
 
-func runTestMatrix(t *testing.T, engine string, experimentalsEnabled bool, client ClientInterface) {
+func RunMatrixTests(t *testing.T, engine string, experimentalsEnabled bool, client ClientInterface) {
 	t.Run("test_matrix_"+engine+"_experimental_"+strconv.FormatBool(experimentalsEnabled), func(t *testing.T) {
-		TestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
+		t.Parallel()
+		runTestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 	})
 }
 
@@ -1067,7 +1067,7 @@ var matrix = individualTest{
 	},
 }
 
-func TestMatrix(t *testing.T, params testParams) {
+func runTestMatrix(t *testing.T, params testParams) {
 	model := `model
   schema 1.1
 type user

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -63,6 +64,7 @@ func RunAllTests(t *testing.T, client ClientInterface) {
 		t.Run("Check", func(t *testing.T) {
 			t.Parallel()
 			runTests(t, testParams{typesystem.SchemaVersion1_1, client})
+			//runTestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 		})
 	})
 }
@@ -201,6 +203,12 @@ func runTest(t *testing.T, test individualTest, params testParams, contextTupleT
 				}
 			})
 		}
+	})
+}
+
+func runTestMatrix(t *testing.T, engine string, experimentalsEnabled bool, client ClientInterface) {
+	t.Run("test_matrix_"+engine+"_experimental_"+strconv.FormatBool(experimentalsEnabled), func(t *testing.T) {
+		TestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 	})
 }
 
@@ -1059,7 +1067,7 @@ var matrix = individualTest{
 	},
 }
 
-func runTestMatrix(t *testing.T, params testParams) {
+func TestMatrix(t *testing.T, params testParams) {
 	model := `model
   schema 1.1
 type user
@@ -1383,8 +1391,4 @@ func assertListUsers(ctx context.Context, t *testing.T, assertion *checktest.Ass
 	} else {
 		require.NotContains(t, responseUsers, assertion.Tuple.GetUser(), "user should not be returned in the response")
 	}
-}
-
-func runTestMatrixSuite(t *testing.T, client ClientInterface) {
-	runTestMatrix(t, testParams{typesystem.SchemaVersion1_1, client})
 }

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -29,54 +29,39 @@ import (
 	"github.com/openfga/openfga/tests"
 )
 
-func TestMatrixMemory(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
-	memory := "memory"
-	clientWithExperimentals := buildClientInterface(t, memory, true)
-	runTestMatrix(t, memory, true, clientWithExperimentals)
-
-	clientWithoutExperimentals := buildClientInterface(t, memory, false)
-	runTestMatrix(t, memory, false, clientWithoutExperimentals)
+func TestMatrix(t *testing.T) {
+	testMatrixMemory(t)
+	testMatrixPostgres(t)
+	testMatrixMysql(t)
+	testMatrixSqlite(t)
 }
 
-func TestMatrixPostgres(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
-	postgres := "postgres"
-	clientWithExperimentals := buildClientInterface(t, postgres, true)
-	runTestMatrix(t, postgres, true, clientWithExperimentals)
-
-	clientWithoutExperimentals := buildClientInterface(t, postgres, false)
-	runTestMatrix(t, postgres, false, clientWithoutExperimentals)
+func testMatrixMemory(t *testing.T) {
+	runMatrixWithEngine(t, "memory")
 }
-func TestMatrixMysql(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
 
-	mysql := "mysql"
-	clientWithExperimentals := buildClientInterface(t, mysql, true)
-	runTestMatrix(t, mysql, true, clientWithExperimentals)
-
-	clientWithoutExperimentals := buildClientInterface(t, mysql, false)
-	runTestMatrix(t, mysql, false, clientWithoutExperimentals)
+func testMatrixPostgres(t *testing.T) {
+	runMatrixWithEngine(t, "postgres")
 }
-func TestMatrixSqlite(t *testing.T) {
+
+func testMatrixMysql(t *testing.T) {
+	runMatrixWithEngine(t, "mysql")
+}
+
+func testMatrixSqlite(t *testing.T) {
+	runMatrixWithEngine(t, "sqlite")
+}
+
+func runMatrixWithEngine(t *testing.T, engine string) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
 	})
 
-	sqlite := "sqlite"
-	clientWithExperimentals := buildClientInterface(t, sqlite, true)
-	runTestMatrix(t, sqlite, true, clientWithExperimentals)
+	clientWithExperimentals := buildClientInterface(t, engine, true)
+	RunMatrixTests(t, engine, true, clientWithExperimentals)
 
-	clientWithoutExperimentals := buildClientInterface(t, sqlite, false)
-	runTestMatrix(t, sqlite, false, clientWithoutExperimentals)
+	clientWithoutExperimentals := buildClientInterface(t, engine, false)
+	RunMatrixTests(t, engine, false, clientWithoutExperimentals)
 }
 
 func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool) ClientInterface {

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -29,26 +29,19 @@ import (
 	"github.com/openfga/openfga/tests"
 )
 
-func TestMatrix(t *testing.T) {
-	testMatrixMemory(t)
-	testMatrixPostgres(t)
-	testMatrixMysql(t)
-	testMatrixSqlite(t)
-}
-
-func testMatrixMemory(t *testing.T) {
+func TestMatrixMemory(t *testing.T) {
 	runMatrixWithEngine(t, "memory")
 }
 
-func testMatrixPostgres(t *testing.T) {
+func TestMatrixPostgres(t *testing.T) {
 	runMatrixWithEngine(t, "postgres")
 }
 
-func testMatrixMysql(t *testing.T) {
+func TestMatrixMysql(t *testing.T) {
 	runMatrixWithEngine(t, "mysql")
 }
 
-func testMatrixSqlite(t *testing.T) {
+func TestMatrixSqlite(t *testing.T) {
 	runMatrixWithEngine(t, "sqlite")
 }
 

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -31,33 +31,78 @@ import (
 )
 
 func TestMatrixMemory(t *testing.T) {
-	testRunTestMatrix(t, "memory", true)
-	testRunTestMatrix(t, "memory", false)
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	memory := "memory"
+	clientWithExperimentals := buildClientInterface(t, memory, true)
+	testRunTestMatrix(t, memory, true, clientWithExperimentals)
+
+	clientWithoutExperimentals := buildClientInterface(t, memory, false)
+	testRunTestMatrix(t, memory, false, clientWithoutExperimentals)
 }
 
-func testRunTestMatrix(t *testing.T, engine string, experimental bool) {
-	t.Run("test_matrix_"+engine+"_experimental_"+strconv.FormatBool(experimental), func(t *testing.T) {
-		t.Cleanup(func() {
-			goleak.VerifyNone(t)
-		})
-		cfg := config.MustDefaultConfig()
-		if experimental {
-			cfg.Experimentals = append(cfg.Experimentals, "enable-check-optimizations")
-		}
-		cfg.Log.Level = "error"
-		cfg.Datastore.Engine = engine
-		cfg.ListUsersDeadline = 0   // no deadline
-		cfg.ListObjectsDeadline = 0 // no deadline
-		// extend the timeout for the tests, coverage makes them slower
-		cfg.RequestTimeout = 10 * time.Second
+func TestMatrixPostgres(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 
-		cfg.CheckIteratorCache.Enabled = true
+	postgres := "postgres"
+	clientWithExperimentals := buildClientInterface(t, postgres, true)
+	testRunTestMatrix(t, postgres, true, clientWithExperimentals)
 
-		tests.StartServer(t, cfg)
+	clientWithoutExperimentals := buildClientInterface(t, postgres, false)
+	testRunTestMatrix(t, postgres, false, clientWithoutExperimentals)
+}
+func TestMatrixMysql(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
 
-		conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
+	mysql := "mysql"
+	clientWithExperimentals := buildClientInterface(t, mysql, true)
+	testRunTestMatrix(t, mysql, true, clientWithExperimentals)
 
-		runTestMatrixSuite(t, openfgav1.NewOpenFGAServiceClient(conn))
+	clientWithoutExperimentals := buildClientInterface(t, mysql, false)
+	testRunTestMatrix(t, mysql, false, clientWithoutExperimentals)
+}
+func TestMatrixSqlite(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	sqlite := "sqlite"
+	clientWithExperimentals := buildClientInterface(t, sqlite, true)
+	testRunTestMatrix(t, sqlite, true, clientWithExperimentals)
+
+	clientWithoutExperimentals := buildClientInterface(t, sqlite, false)
+	testRunTestMatrix(t, sqlite, false, clientWithoutExperimentals)
+}
+
+func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool) ClientInterface {
+	cfg := config.MustDefaultConfig()
+	if experimentalsEnabled {
+		cfg.Experimentals = append(cfg.Experimentals, "enable-check-optimizations")
+	}
+	cfg.Log.Level = "error"
+	cfg.Datastore.Engine = engine
+	cfg.ListUsersDeadline = 0   // no deadline
+	cfg.ListObjectsDeadline = 0 // no deadline
+	// extend the timeout for the tests, coverage makes them slower
+	cfg.RequestTimeout = 10 * time.Second
+
+	cfg.CheckIteratorCache.Enabled = true
+
+	tests.StartServer(t, cfg)
+
+	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
+	return openfgav1.NewOpenFGAServiceClient(conn)
+}
+
+func testRunTestMatrix(t *testing.T, engine string, experimentalsEnabled bool, client ClientInterface) {
+	t.Run("test_matrix_"+engine+"_experimental_"+strconv.FormatBool(experimentalsEnabled), func(t *testing.T) {
+		runTestMatrixSuite(t, client)
 	})
 }
 

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -70,6 +70,7 @@ func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool
 	cfg.RequestTimeout = 10 * time.Second
 
 	cfg.CheckIteratorCache.Enabled = true
+	cfg.ContextPropagationToDatastore = true
 
 	tests.StartServer(t, cfg)
 

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -37,9 +37,10 @@ func TestMatrixPostgres(t *testing.T) {
 	runMatrixWithEngine(t, "postgres")
 }
 
-func TestMatrixMysql(t *testing.T) {
-	runMatrixWithEngine(t, "mysql")
-}
+// TODO: re-enable
+// func TestMatrixMysql(t *testing.T) {
+//	runMatrixWithEngine(t, "mysql")
+//}
 
 // TODO: re-enable after investigating write contention in test
 // func TestMatrixSqlite(t *testing.T) {

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"testing"
 	"time"
 
@@ -37,10 +36,10 @@ func TestMatrixMemory(t *testing.T) {
 
 	memory := "memory"
 	clientWithExperimentals := buildClientInterface(t, memory, true)
-	testRunTestMatrix(t, memory, true, clientWithExperimentals)
+	runTestMatrix(t, memory, true, clientWithExperimentals)
 
 	clientWithoutExperimentals := buildClientInterface(t, memory, false)
-	testRunTestMatrix(t, memory, false, clientWithoutExperimentals)
+	runTestMatrix(t, memory, false, clientWithoutExperimentals)
 }
 
 func TestMatrixPostgres(t *testing.T) {
@@ -50,10 +49,10 @@ func TestMatrixPostgres(t *testing.T) {
 
 	postgres := "postgres"
 	clientWithExperimentals := buildClientInterface(t, postgres, true)
-	testRunTestMatrix(t, postgres, true, clientWithExperimentals)
+	runTestMatrix(t, postgres, true, clientWithExperimentals)
 
 	clientWithoutExperimentals := buildClientInterface(t, postgres, false)
-	testRunTestMatrix(t, postgres, false, clientWithoutExperimentals)
+	runTestMatrix(t, postgres, false, clientWithoutExperimentals)
 }
 func TestMatrixMysql(t *testing.T) {
 	t.Cleanup(func() {
@@ -62,10 +61,10 @@ func TestMatrixMysql(t *testing.T) {
 
 	mysql := "mysql"
 	clientWithExperimentals := buildClientInterface(t, mysql, true)
-	testRunTestMatrix(t, mysql, true, clientWithExperimentals)
+	runTestMatrix(t, mysql, true, clientWithExperimentals)
 
 	clientWithoutExperimentals := buildClientInterface(t, mysql, false)
-	testRunTestMatrix(t, mysql, false, clientWithoutExperimentals)
+	runTestMatrix(t, mysql, false, clientWithoutExperimentals)
 }
 func TestMatrixSqlite(t *testing.T) {
 	t.Cleanup(func() {
@@ -74,10 +73,10 @@ func TestMatrixSqlite(t *testing.T) {
 
 	sqlite := "sqlite"
 	clientWithExperimentals := buildClientInterface(t, sqlite, true)
-	testRunTestMatrix(t, sqlite, true, clientWithExperimentals)
+	runTestMatrix(t, sqlite, true, clientWithExperimentals)
 
 	clientWithoutExperimentals := buildClientInterface(t, sqlite, false)
-	testRunTestMatrix(t, sqlite, false, clientWithoutExperimentals)
+	runTestMatrix(t, sqlite, false, clientWithoutExperimentals)
 }
 
 func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool) ClientInterface {
@@ -98,12 +97,6 @@ func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool
 
 	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
 	return openfgav1.NewOpenFGAServiceClient(conn)
-}
-
-func testRunTestMatrix(t *testing.T, engine string, experimentalsEnabled bool, client ClientInterface) {
-	t.Run("test_matrix_"+engine+"_experimental_"+strconv.FormatBool(experimentalsEnabled), func(t *testing.T) {
-		runTestMatrixSuite(t, client)
-	})
 }
 
 func TestCheckMemory(t *testing.T) {

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -41,9 +41,10 @@ func TestMatrixMysql(t *testing.T) {
 	runMatrixWithEngine(t, "mysql")
 }
 
-func TestMatrixSqlite(t *testing.T) {
-	runMatrixWithEngine(t, "sqlite")
-}
+// TODO: re-enable after investigating write contention in test
+// func TestMatrixSqlite(t *testing.T) {
+//	runMatrixWithEngine(t, "sqlite")
+//}
 
 func runMatrixWithEngine(t *testing.T, engine string) {
 	t.Cleanup(func() {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR is a small testing update and refactor of the check matrix tests. It updates the test suite to run against more datastores and also publicizes a `RunTestMatrix` method to allow for testing with any other engine that implements a `ClientInterface`

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

