### PR TITLE
fix: resolve Sqlite test database locking issue

### DIFF
--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -1393,15 +1393,14 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 				}
 			}
 			return fmt.Errorf("%w: %s does not appear as a relation in any of the directly related user types %s", ErrRelationUndefined, computedUserset, userTypes)
-		} else {
-			// For 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model.
-			for typeName := range t.relations {
-				if _, err := t.GetRelation(typeName, computedUserset); err == nil {
-					return nil
-				}
-			}
-			return &RelationUndefinedError{ObjectType: "", Relation: computedUserset, Err: ErrRelationUndefined}
 		}
+		// For 1.0 models, relation `computedUserset` has to be defined _somewhere_ in the model.
+		for typeName := range t.relations {
+			if _, err := t.GetRelation(typeName, computedUserset); err == nil {
+				return nil
+			}
+		}
+		return &RelationUndefinedError{ObjectType: "", Relation: computedUserset, Err: ErrRelationUndefined}
 	case *openfgav1.Userset_Union:
 		for _, child := range r.Union.GetChild() {
 			err := t.isUsersetRewriteValid(objectType, relation, child)

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -336,7 +336,10 @@ func testRunAll(t *testing.T, engine string) {
 	cfg.RequestTimeout = 10 * time.Second
 
 	cfg.CheckIteratorCache.Enabled = true
-	cfg.ContextPropagationToDatastore = true
+
+	if engine == "mysql" {
+		cfg.ContextPropagationToDatastore = true
+	}
 
 	// Some tests/stages are sensitive to the cache TTL,
 	// so we set it to a very low value to still exercise


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
In #2259 we introduced a config change to our `check_test` suite to resolve some goroutine leaks in test. That PR resulted in issues causing a lock of the SQLite DB in the same test suite. This PR makes the config change _specific_ to only mysql tests while we investigate why this caused an issue with SQLite.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

