### PR TITLE
docs(v1.8.5): add v1.8.5 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.8.5] - 2025-02-19
+[Full changelog](https://github.com/openfga/openfga/compare/v1.8.4...v1.8.5)
+
 ### Added
 - Improve `Check` performance for sub-problems when caching is enabled [#2193](https://github.com/openfga/openfga/pull/2193).
 - Improve `Check` performance for relations involving public wildcard. Enable via experimental flag `enable-check-optimizations`.  [#2180](https://github.com/openfga/openfga/pull/2180).
@@ -1207,7 +1211,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.4...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.5...HEAD
+[1.8.5]: https://github.com/openfga/openfga/compare/v1.8.4...v1.8.5
 [1.8.4]: https://github.com/openfga/openfga/compare/v1.8.3...v1.8.4
 [1.8.3]: https://github.com/openfga/openfga/compare/v1.8.2...v1.8.3
 [1.8.2]: https://github.com/openfga/openfga/compare/v1.8.1...v1.8.2


### PR DESCRIPTION

## Description
Add `v1.8.5` release details to the CHANGELOG.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

