### PR TITLE
fix: storage context wrapper preserve context without cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Performance improve for SQL based datastore by reducing connection usage during IsReady check. [#2483](https://github.com/openfga/openfga/pull/2483)
 - SQL drivers now respect zero value for MaxOpenConns, ConnMaxIdleTime, ConnMaxLifetime. [#2484](https://github.com/openfga/openfga/pull/2484)
 - When `enable-check-optimizations` experiment flag is enabled, incorrect check for model with recursion and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491)
+- Correlate storage context with caller's context. [#2292](https://github.com/openfga/openfga/pull/2292)
 
 ## [1.8.13] - 2025-05-22
 ### Added

--- a/pkg/storage/storagewrappers/context.go
+++ b/pkg/storage/storagewrappers/context.go
@@ -3,8 +3,6 @@ package storagewrappers
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/trace"
-
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"github.com/openfga/openfga/pkg/storage"
@@ -27,10 +25,9 @@ func NewContextWrapper(inner storage.OpenFGADatastore) *ContextTracerWrapper {
 }
 
 // queryContext generates a new context that is independent of the provided
-// context and its timeout with the exception of the trace context.
+// context timeout.
 func queryContext(ctx context.Context) context.Context {
-	span := trace.SpanFromContext(ctx)
-	return trace.ContextWithSpan(context.Background(), span)
+	return context.WithoutCancel(ctx)
 }
 
 // Close ensures proper cleanup and closure of resources associated with the OpenFGADatastore.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Our storage implementation needs access to context elements that are not currently propagated.

As I understand it, the need for the new context was to avoid the cancel propagation (or, more precisely, the timeout).

It is possible to use directly [context.WithoutCancel](https://pkg.go.dev/context#WithoutCancel) (available since go 1.21) which preserve everything else.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

