### PR TITLE
feat: creates `PassthroughError` type to proxy errors through FGA

### DIFF
--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -68,6 +68,51 @@ func NewInternalError(public string, internal error) InternalError {
 	}
 }
 
+type ExternalError interface {
+	HTTPStatus() int
+	GRPCStatus() *status.Status
+	Error() string
+	Code() string
+}
+
+// PassthroughError is for external consumers of OpenFGA who want an explicit error status
+// returned from their service. OpenFGA heavily utilizes HandleError which contains a case
+// specifically looking for errors.Is(err, PassthroughError), which it returns unmodified.
+type PassthroughError struct {
+	external ExternalError
+}
+
+var ErrPassthrough = PassthroughError{}
+
+func (e PassthroughError) Error() string {
+	return e.external.Error()
+}
+
+func (e PassthroughError) Code() string {
+	return e.external.Code()
+}
+
+func (e PassthroughError) Unwrap() error {
+	return e.external
+}
+
+func (e PassthroughError) GRPCStatus() *status.Status {
+	return e.external.GRPCStatus()
+}
+
+func (e PassthroughError) HTTPStatus() int {
+	return e.external.HTTPStatus()
+}
+
+func (e PassthroughError) Is(target error) bool {
+	_, ok := target.(PassthroughError)
+	return ok
+}
+
+func NewPassthroughError(external ExternalError) PassthroughError {
+	return PassthroughError{external: external}
+}
+
 func ValidationError(cause error) error {
 	return status.Error(codes.Code(openfgav1.ErrorCode_validation_error), cause.Error())
 }
@@ -118,15 +163,17 @@ func InvalidAuthorizationModelInput(err error) error {
 // Use `public` if you want to return a useful error message to the user.
 func HandleError(public string, err error) error {
 	switch {
-	case errors.Is(err, storage.ErrInvalidContinuationToken):
-		return ErrInvalidContinuationToken
-	case errors.Is(err, storage.ErrInvalidStartTime):
-		return ErrInvalidStartTime
+	case errors.Is(err, ErrPassthrough):
+		return err
 	case errors.Is(err, context.Canceled):
 		// cancel by a client is not an "internal server error"
 		return ErrRequestCancelled
+	case errors.Is(err, storage.ErrInvalidStartTime):
+		return ErrInvalidStartTime
 	case errors.Is(err, context.DeadlineExceeded):
 		return ErrRequestDeadlineExceeded
+	case errors.Is(err, storage.ErrInvalidContinuationToken):
+		return ErrInvalidContinuationToken
 	default:
 		return NewInternalError(public, err)
 	}

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -68,6 +68,10 @@ func TestHandleErrors(t *testing.T) {
 			storageErr:              context.DeadlineExceeded,
 			expectedTranslatedError: ErrRequestDeadlineExceeded,
 		},
+		`passthrough_error`: {
+			storageErr:              NewPassthroughError(NewEncodedError(1, "oh no")),
+			expectedTranslatedError: ErrPassthrough,
+		},
 	}
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
The `HandleError` method in FGA is the central error handler and transformer for many of our APIs; everything except `Check`. `HandleError` assumes that any errors thrown by one of those operations will fall into its current set of switch cases, but that's not always true.

This PR creates a `PassthroughError` type in pkg `errors` to act as a proxy for other errors that consumers may want to surface via the API. If any of these operations returns a `PassthroughError`, `HandleError` will simply pass it through unmodified.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

