### PR TITLE
feat: add `storage.ErrTransactionThrottled` and associated server error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Added
 - Added `PassthroughError` type to proxy errors through OpenFGA. [#2303](https://github.com/openfga/openfga/pull/2303).
+- Added `storage.ErrTransactionThrottled` for throttling errors applied at the datastore level. [#2304](https://github.com/openfga/openfga/pull/2304).
 
 ### Removed
 - Removed recently-added `tuples_iterator_cache_invalid_hit_count` metric. The `cachecontroller_cache_invalidation_count` from 1.8.6 better accomplishes the same goal. [#2296)[https://github.com/openfga/openfga/pull/2296/]

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -30,6 +30,9 @@ var (
 	ErrRequestCancelled                       = status.Error(codes.Code(openfgav1.ErrorCode_cancelled), "Request Cancelled")
 	ErrRequestDeadlineExceeded                = status.Error(codes.Code(openfgav1.InternalErrorCode_deadline_exceeded), "Request Deadline Exceeded")
 	ErrThrottledTimeout                       = status.Error(codes.Code(openfgav1.UnprocessableContentErrorCode_throttled_timeout_error), "timeout due to throttling on complex request")
+
+	// ErrTransactionThrottled can apply when a limit is hit at the database level
+	ErrTransactionThrottled = status.Error(codes.ResourceExhausted, "transaction was throttled by the datastore")
 )
 
 type InternalError struct {
@@ -163,6 +166,8 @@ func InvalidAuthorizationModelInput(err error) error {
 // Use `public` if you want to return a useful error message to the user.
 func HandleError(public string, err error) error {
 	switch {
+	case errors.Is(err, storage.ErrTransactionThrottled):
+		return ErrTransactionThrottled
 	case errors.Is(err, ErrPassthrough):
 		return err
 	case errors.Is(err, context.Canceled):

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -31,7 +31,7 @@ var (
 	ErrRequestDeadlineExceeded                = status.Error(codes.Code(openfgav1.InternalErrorCode_deadline_exceeded), "Request Deadline Exceeded")
 	ErrThrottledTimeout                       = status.Error(codes.Code(openfgav1.UnprocessableContentErrorCode_throttled_timeout_error), "timeout due to throttling on complex request")
 
-	// ErrTransactionThrottled can apply when a limit is hit at the database level
+	// ErrTransactionThrottled can apply when a limit is hit at the database level.
 	ErrTransactionThrottled = status.Error(codes.ResourceExhausted, "transaction was throttled by the datastore")
 )
 

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -123,15 +123,15 @@ func HandleError(public string, err error) error {
 	switch {
 	case errors.Is(err, storage.ErrTransactionThrottled):
 		return ErrTransactionThrottled
-	case errors.Is(err, storage.ErrInvalidContinuationToken):
-		return ErrInvalidContinuationToken
-	case errors.Is(err, storage.ErrInvalidStartTime):
-		return ErrInvalidStartTime
 	case errors.Is(err, context.Canceled):
 		// cancel by a client is not an "internal server error"
 		return ErrRequestCancelled
 	case errors.Is(err, context.DeadlineExceeded):
 		return ErrRequestDeadlineExceeded
+	case errors.Is(err, storage.ErrInvalidStartTime):
+		return ErrInvalidStartTime
+	case errors.Is(err, storage.ErrInvalidContinuationToken):
+		return ErrInvalidContinuationToken
 	default:
 		return NewInternalError(public, err)
 	}

--- a/pkg/server/errors/errors_test.go
+++ b/pkg/server/errors/errors_test.go
@@ -72,6 +72,10 @@ func TestHandleErrors(t *testing.T) {
 			storageErr:              NewPassthroughError(NewEncodedError(1, "oh no")),
 			expectedTranslatedError: ErrPassthrough,
 		},
+		`throttling_error`: {
+			storageErr:              storage.ErrTransactionThrottled,
+			expectedTranslatedError: ErrTransactionThrottled,
+		},
 	}
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -26,6 +26,9 @@ var (
 	// ErrTransactionalWriteFailed is returned when two writes attempt to write the same tuple at the same time.
 	ErrTransactionalWriteFailed = errors.New("transactional write failed due to conflict")
 
+	// ErrTransactionThrottled is returned when throttling is applied at the datastore level.
+	ErrTransactionThrottled = errors.New("transaction throttled")
+
 	// ErrNotFound is returned when the object does not exist.
 	ErrNotFound = errors.New("not found")
 )


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR adds new storage error `ErrTransactionThrottled` to our existing set of potential errors, and adjusts for it in our centralized `HandleError` helper function. This PR also reorders some of the cases in `HandleError` so that it evaluates the most-frequent cases first.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

