### PR TITLE
test: adding matrix test for recursive userset and TTUs with condition

### DIFF
--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1100,6 +1100,7 @@ type directs-user
     define tuple_cycle2: [user, usersets-user#tuple_cycle2, employee]  
     define tuple_cycle3: [user, complexity3#cycle_nested]
     define compute_tuple_cycle3: tuple_cycle3
+	define mixed_use: or_computed_no_cond
 type directs-employee
   relations
     define direct: [employee]
@@ -1124,6 +1125,7 @@ type usersets-user
     define butnot_computed: computed but not direct_4
     define direct_wild: [user:*]
     define alg_combined: butnot_computed but not direct_4
+    define alg_cond_combined: [user with xcond] or alg_combined
     define userset: [directs-user#direct, directs-employee#direct]
     define userset_alg: [directs-user#alg_combined, directs-employee#alg_combined]
     define userset_to_computed: [directs-user#computed, directs-employee#computed]
@@ -1145,6 +1147,7 @@ type usersets-user
     define userset_recursive_public_alg: [user, user:*, usersets-user#userset_recursive_public_alg] or alg_combined or direct_wild
     define userset_recursive_public_only: [user:*, usersets-user#userset_recursive_public_only]
     define userset_recursive_public_only_alg: [user, user:*, usersets-user#userset_recursive_public_only_alg] or direct_wild
+    define userset_recursive_public_alg_cond: [user with xcond, user:*, usersets-user#userset_recursive_public_alg_cond with xcond] or alg_cond_combined or direct_wild
     define userset_recursive_mixed_direct_assignment: [user, usersets-user#userset_recursive_mixed_direct_assignment, usersets-user#userset]
     define or_userset: userset or userset_to_computed_cond
     define and_userset: userset_to_computed_cond and userset_to_computed_wild
@@ -1169,10 +1172,13 @@ type ttus
     define butnot_computed: computed but not direct_4
     define direct_wild: [directs-user:*]
     define alg_combined: butnot_computed but not direct_4
+    define alg_combined_cond: [user with xcond] or alg_combined
     define direct_parent: [directs-user]
     define ttu_parent: [ttus]
+    define ttu_parent_cond: [ttus with xcond]
     define mult_parent_types: [directs-user, directs-employee]
     define mult_parent_types_cond: [directs-user with xcond, directs-employee with xcond]
+    define mixed_ttu_parent: [ttus, directs-user]
     define direct_cond_parent: [directs-user with xcond]
     define userset_parent: [usersets-user]
     define userset_cond_parent: [usersets-user with xcond]
@@ -1200,6 +1206,8 @@ type ttus
     define recursive_ttu_alg: [directs-user] or recursive_ttu_alg from ttu_parent or alg_combined
     define recursive_ttu_public: [directs-user, directs-user:*] or recursive_ttu_public from ttu_parent
     define recursive_ttu_public_alg: [directs-user, directs-user:*] or recursive_ttu_public_alg from ttu_parent or direct_wild
+    define recursive_ttu_alg_cond: [directs-user with xcond] or recursive_ttu_alg_cond from ttu_parent_cond or alg_combined_cond
+	define mixed_use: [directs-user] or mixed_use from mixed_ttu_parent
 
 type complexity3
   relations

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -1100,7 +1100,7 @@ type directs-user
     define tuple_cycle2: [user, usersets-user#tuple_cycle2, employee]  
     define tuple_cycle3: [user, complexity3#cycle_nested]
     define compute_tuple_cycle3: tuple_cycle3
-	define mixed_use: or_computed_no_cond
+    define mixed_use: or_computed_no_cond
 type directs-employee
   relations
     define direct: [employee]
@@ -1207,7 +1207,7 @@ type ttus
     define recursive_ttu_public: [directs-user, directs-user:*] or recursive_ttu_public from ttu_parent
     define recursive_ttu_public_alg: [directs-user, directs-user:*] or recursive_ttu_public_alg from ttu_parent or direct_wild
     define recursive_ttu_alg_cond: [directs-user with xcond] or recursive_ttu_alg_cond from ttu_parent_cond or alg_combined_cond
-	define mixed_use: [directs-user] or mixed_use from mixed_ttu_parent
+    define mixed_use: [directs-user] or mixed_use from mixed_ttu_parent
 
 type complexity3
   relations

--- a/tests/check/check_ttu.go
+++ b/tests/check/check_ttu.go
@@ -1081,4 +1081,137 @@ var ttuCompleteTestingModelTest = []*stage{
 			},
 		},
 	},
+	{
+		Name: "recursive_ttu_alg_cond",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_direct_assign", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_1", Relation: "ttu_parent_cond", User: "ttus:ttus_recursive_ttu_alg_cond_direct_assign", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_2", Relation: "ttu_parent_cond", User: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_1", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_3", Relation: "ttu_parent_cond", User: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_2", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_4", Relation: "ttu_parent_cond", User: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_3", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "ttus:ttus_recursive_ttu_alg_cond_alg", Relation: "alg_combined_cond", User: "user:ttus_recursive_ttu_alg_cond_alg", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "recursive_ttu_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_direct_assign", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "recursive_ttu_direct_user_not_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_direct_assign", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_not_assigned"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_direct_obj_not_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:other", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_direct_assigned_false_cond",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_direct_assign", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_level_1",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_1", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "recursive_ttu_level_1_cond_not_met",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_1", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_level_1_not_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_1", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_other"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_level_4",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_4", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "recursive_ttu_level_4_cond_not_met",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_4", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_direct_assign"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_level_4_not_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_parent_case_1_4", Relation: "recursive_ttu_alg_cond", User: "directs-user:ttus_recursive_ttu_alg_cond_other"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_direct_alg",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_alg", Relation: "recursive_ttu_alg_cond", User: "user:ttus_recursive_ttu_alg_cond_alg"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "recursive_ttu_direct_alg_bad_cond",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_recursive_ttu_alg_cond_alg", Relation: "recursive_ttu_alg_cond", User: "user:ttus_recursive_ttu_alg_cond_alg"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+		},
+	},
+	{
+		Name: "mixed_use",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "ttus:ttus_mixed_use_direct_assign", Relation: "mixed_use", User: "directs-user:ttus_mixed_use_direct_assign"},
+			{Object: "ttus:ttus_mixed_use_direct_assign_level_1", Relation: "mixed_ttu_parent", User: "ttus:ttus_mixed_use_direct_assign"},
+			{Object: "ttus:ttus_mixed_use_direct_assign_level_2", Relation: "mixed_ttu_parent", User: "ttus:ttus_mixed_use_direct_assign_level_1"},
+			{Object: "ttus:ttus_mixed_use_direct_assign_level_3", Relation: "mixed_ttu_parent", User: "ttus:ttus_mixed_use_direct_assign_level_2"},
+			// note that there is no direct connection from user:ttus_mixed_use_direct_assign_should_not_connect to directs-user:ttus_mixed_use_direct_assign with mixed_use relation
+			{Object: "directs-user:ttus_mixed_use_direct_assign", Relation: "direct", User: "user:ttus_mixed_use_direct_assign_should_not_connect"},
+			// tests for the user#mixed_use side
+			{Object: "directs-user:ttus_mixed_use_mixed_use", Relation: "direct", User: "user:ttus_mixed_use_mixed_use_side"},
+			{Object: "ttus:ttus_mixed_use_mixed_use", Relation: "mixed_ttu_parent", User: "directs-user:ttus_mixed_use_mixed_use"},
+			{Object: "ttus:ttus_mixed_use_mixed_use_level_1", Relation: "mixed_ttu_parent", User: "ttus:ttus_mixed_use_mixed_use"},
+			{Object: "ttus:ttus_mixed_use_mixed_use_level_2", Relation: "mixed_ttu_parent", User: "ttus:ttus_mixed_use_mixed_use_level_1"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "recursive_ttu_direct_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_direct_assign", Relation: "mixed_use", User: "directs-user:ttus_mixed_use_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "recursive_ttu_direct_user_not_assigned",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_direct_assign", Relation: "mixed_use", User: "directs-user:ttus_mixed_use_direct_assign_user_not_assigned"},
+				Expectation: false,
+			},
+			{
+				Name:        "recursive_ttu_direct_assigned_recursive_parent",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_direct_assign_level_3", Relation: "mixed_use", User: "directs-user:ttus_mixed_use_direct_assign"},
+				Expectation: true,
+			},
+			{
+				Name:        "mixed_use_should_not_connect",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_direct_assign_level_3", Relation: "mixed_use", User: "user:ttus_mixed_use_direct_assign_should_not_connect"},
+				Expectation: false,
+			},
+			{
+				Name:        "mixed_use_mixed_use_side",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_mixed_use", Relation: "mixed_use", User: "user:ttus_mixed_use_mixed_use_side"},
+				Expectation: true,
+			},
+			{
+				Name:        "mixed_use_mixed_use_side_level_2",
+				Tuple:       &openfgav1.TupleKey{Object: "ttus:ttus_mixed_use_mixed_use_level_2", Relation: "mixed_use", User: "user:ttus_mixed_use_mixed_use_side"},
+				Expectation: true,
+			},
+		},
+	},
 }

--- a/tests/check/check_userset.go
+++ b/tests/check/check_userset.go
@@ -1091,6 +1091,88 @@ var usersetCompleteTestingModelTest = []*stage{
 		},
 	},
 	{
+		Name: "usersets_userset_recursive_public_cond",
+		Tuples: []*openfgav1.TupleKey{
+			// the following are for the directly assignable part
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_1#userset_recursive_public_alg_cond", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_1", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_2#userset_recursive_public_alg_cond", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_2", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_3#userset_recursive_public_alg_cond", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_3", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_4#userset_recursive_public_alg_cond", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_4", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_1", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			// The following case are for the algebraic part
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_4", Relation: "alg_cond_combined", User: "user:userset_recursive_public_alg_cond_alg", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_4", Relation: "direct", User: "user:userset_recursive_public_alg_cond_alg_direct"},
+		},
+		CheckAssertions: []*checktest.Assertion{
+			{
+				Name:        "invalid_object",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_only_alg_invalid_object", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_1"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_user",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_invalid"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: false,
+			},
+			{
+				Name:        "valid_recursion",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_1"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_recursive_userset_single_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_1#userset_recursive_public_alg_cond"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "valid_recursive_userset_multi_level",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_3#userset_recursive_public_alg_cond"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Expectation: true,
+			},
+			{
+				Name:        "fail_due_to_cond",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_1"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_recursive_userset_single_level_due_to_cond",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_1#userset_recursive_public_alg_cond"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "invalid_recursive_userset_multi_level_due_to_cond",
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "usersets-user:userset_recursive_public_alg_cond_1_multi_level_3#userset_recursive_public_alg_cond"},
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Expectation: false,
+			},
+			{
+				Name:        "alg_match",
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_alg"},
+				Expectation: true,
+			},
+			{
+				Name:        "alg_match_cond_not_match",
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("2")}},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_alg"},
+				Expectation: false,
+			},
+			{
+				Name:        "alg_match_direct",
+				Context:     &structpb.Struct{Fields: map[string]*structpb.Value{"x": structpb.NewStringValue("1")}},
+				Tuple:       &openfgav1.TupleKey{Object: "usersets-user:userset_recursive_public_alg_cond_1_multi_level", Relation: "userset_recursive_public_alg_cond", User: "user:userset_recursive_public_alg_cond_alg_direct"},
+				Expectation: true,
+			},
+		},
+	},
+	{
 		Name: "userset_recursive_mixed_direct_assignment_mixed_direct_assignment",
 		Tuples: []*openfgav1.TupleKey{
 			{Object: "usersets-user:userset_recursive_mixed_direct_assignment_1", Relation: "userset_recursive_mixed_direct_assignment", User: "user:userset_recursive_mixed_direct_assignment_user_1"},


### PR DESCRIPTION
## Description
Updating matrix tests for the following cases:
1. recursive userset with condition
2. recursive TTU with condition
3. mixture of parents in recursive TTU

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

