### PR TITLE
tests: consolidate matrix test infrastucture

### DIFF
--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -52,32 +52,11 @@ func runMatrixWithEngine(t *testing.T, engine string) {
 		goleak.VerifyNone(t)
 	})
 
-	clientWithExperimentals := buildClientInterface(t, engine, true)
+	clientWithExperimentals := tests.BuildClientInterface(t, engine, []string{"enable-check-optimizations"})
 	RunMatrixTests(t, engine, true, clientWithExperimentals)
 
-	clientWithoutExperimentals := buildClientInterface(t, engine, false)
+	clientWithoutExperimentals := tests.BuildClientInterface(t, engine, []string{})
 	RunMatrixTests(t, engine, false, clientWithoutExperimentals)
-}
-
-func buildClientInterface(t *testing.T, engine string, experimentalsEnabled bool) ClientInterface {
-	cfg := config.MustDefaultConfig()
-	if experimentalsEnabled {
-		cfg.Experimentals = append(cfg.Experimentals, "enable-check-optimizations")
-	}
-	cfg.Log.Level = "error"
-	cfg.Datastore.Engine = engine
-	cfg.ListUsersDeadline = 0   // no deadline
-	cfg.ListObjectsDeadline = 0 // no deadline
-	// extend the timeout for the tests, coverage makes them slower
-	cfg.RequestTimeout = 10 * time.Second
-
-	cfg.CheckIteratorCache.Enabled = true
-	cfg.ContextPropagationToDatastore = true
-
-	tests.StartServer(t, cfg)
-
-	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
-	return openfgav1.NewOpenFGAServiceClient(conn)
 }
 
 func TestCheckMemory(t *testing.T) {

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
-	"github.com/openfga/openfga/tests/check"
+	"github.com/openfga/openfga/tests"
 )
 
 var writeMaxChunkSize = 40 // chunk write requests into a chunks of this max size
@@ -37,7 +37,7 @@ type listObjectTests struct {
 
 type testParams struct {
 	schemaVersion string
-	client        ClientInterface
+	client        tests.ClientInterface
 }
 
 // stage is a stage of a test. All stages will be run in a single store.
@@ -47,15 +47,8 @@ type stage struct {
 	ListObjectAssertions []*listobjectstest.Assertion `json:"listObjectsAssertions"`
 }
 
-// ClientInterface defines interface for running ListObjects and StreamedListObjects tests.
-type ClientInterface interface {
-	check.ClientInterface
-	ListObjects(ctx context.Context, in *openfgav1.ListObjectsRequest, opts ...grpc.CallOption) (*openfgav1.ListObjectsResponse, error)
-	StreamedListObjects(ctx context.Context, in *openfgav1.StreamedListObjectsRequest, opts ...grpc.CallOption) (openfgav1.OpenFGAService_StreamedListObjectsClient, error)
-}
-
 // RunAllTests will invoke all list objects tests.
-func RunAllTests(t *testing.T, client ClientInterface) {
+func RunAllTests(t *testing.T, client tests.ClientInterface) {
 	t.Run("RunAll", func(t *testing.T) {
 		t.Run("ListObjects", func(t *testing.T) {
 			t.Parallel()

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"sigs.k8s.io/yaml"
 
@@ -20,7 +19,7 @@ import (
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
-	"github.com/openfga/openfga/tests/check"
+	"github.com/openfga/openfga/tests"
 )
 
 var writeMaxChunkSize = 40 // chunk write requests into a chunks of this max size
@@ -40,13 +39,8 @@ type stage struct {
 	ListUsersAssertions []*listuserstest.Assertion `json:"listUsersAssertions"`
 }
 
-type ClientInterface interface {
-	check.ClientInterface
-	ListUsers(ctx context.Context, in *openfgav1.ListUsersRequest, opts ...grpc.CallOption) (*openfgav1.ListUsersResponse, error)
-}
-
 // RunAllTests will invoke all ListUsers tests.
-func RunAllTests(t *testing.T, client ClientInterface) {
+func RunAllTests(t *testing.T, client tests.ClientInterface) {
 	t.Run("RunAll", func(t *testing.T) {
 		t.Run("ListUsers", func(t *testing.T) {
 			t.Parallel()
@@ -79,7 +73,7 @@ func RunAllTests(t *testing.T, client ClientInterface) {
 	})
 }
 
-func runTest(t *testing.T, test individualTest, client ClientInterface, contextTupleTest bool) {
+func runTest(t *testing.T, test individualTest, client tests.ClientInterface, contextTupleTest bool) {
 	ctx := context.Background()
 	name := test.Name
 


### PR DESCRIPTION

## Description
Consolidate matrix test infrastructure so that list objects matrix test can also use some of the check matrix infra.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

