### PR TITLE
test: adding test on AllowedUserTypeRestrictions for ReadUsersetTuples

### DIFF
--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -957,6 +957,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		tks := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:*"),
 			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
 			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
@@ -1099,6 +1100,49 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		expected := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+		}
+		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_mix_references_for_same_type", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+				typesystem.WildcardRelationReference("group"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotOne, err := iter.Next(ctx)
+		require.NoError(t, err)
+		gotTwo, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
 		}
 		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
 			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)


### PR DESCRIPTION


## Description
Adding tests for ReadUsersetTuples that tests what happen for AllowedUserTypeRestrictions if there are wildcard as well as direct relation reference with same type.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

