### PR TITLE
test: add ListObjects weight one directs multiple types test case

### DIFF
--- a/tests/listobjects/matrix.go
+++ b/tests/listobjects/matrix.go
@@ -10,7 +10,6 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 
-	listobjectstest "github.com/openfga/openfga/internal/test/listobjects"
 	"github.com/openfga/openfga/pkg/testutils"
 )
 
@@ -160,35 +159,8 @@ type complexity4
 condition xcond(x: string) {
   x == '1'
 }`,
-	Tests: []matrixTest{
-		{
-			Name: "direct_assignment",
-			Tuples: []*openfgav1.TupleKey{
-				{Object: "directs:direct_1_1", Relation: "direct", User: "user:direct_1"},
-				{Object: "directs:direct_1_2", Relation: "direct", User: "user:direct_1"},
-			},
-			ListObjectAssertions: []*listobjectstest.Assertion{
-				{
-					Request: &openfgav1.ListObjectsRequest{
-						User:     "user:direct_1",
-						Type:     "directs",
-						Relation: "direct",
-					},
 
-					Expectation: []string{"directs:direct_1_1", "directs:direct_1_2"},
-				},
-				{
-					Request: &openfgav1.ListObjectsRequest{
-						User:     "user:direct_no_such_user",
-						Type:     "directs",
-						Relation: "direct",
-					},
-
-					Expectation: []string{},
-				},
-			},
-		},
-	},
+	Tests: directs,
 }
 
 func runTestMatrix(t *testing.T, params testParams) {

--- a/tests/listobjects/matrix.go
+++ b/tests/listobjects/matrix.go
@@ -6,12 +6,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 
 	"github.com/openfga/openfga/pkg/testutils"
 )
+
+// MustNewStruct returns a new *structpb.Struct or panics
+// on error. The new *structpb.Struct value is built from
+// the map m.
+func MustNewStruct(m map[string]any) *structpb.Struct {
+	s, err := structpb.NewStruct(m)
+	if err == nil {
+		return s
+	}
+	panic(err)
+}
 
 var matrix = matrixTests{
 	Name: "matrix_test",
@@ -160,7 +172,7 @@ condition xcond(x: string) {
   x == '1'
 }`,
 
-	Tests: directs,
+	Tests: directs, // TODO: to be extended by upcoming tests
 }
 
 func runTestMatrix(t *testing.T, params testParams) {

--- a/tests/listobjects/matrix_directs.go
+++ b/tests/listobjects/matrix_directs.go
@@ -50,13 +50,27 @@ var directs = []matrixTest{
 					Relation: "direct_comb",
 				},
 				Context: MustNewStruct(map[string]any{
-					"x": "1",
+					"x": "1", // passes condition
 				}),
 				Expectation: []string{
 					"directs:wildcard_and_condition_1",
 					"directs:wildcard_and_condition_2",
 					"directs:wildcard_and_condition_3",
 					"directs:wildcard_and_condition_4",
+				},
+			},
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "user:direct_comb_1",
+					Type:     "directs",
+					Relation: "direct_comb",
+				},
+				Context: MustNewStruct(map[string]any{
+					"x": "9", // fails condition
+				}),
+				Expectation: []string{
+					"directs:wildcard_and_condition_1",
+					"directs:wildcard_and_condition_2",
 				},
 			},
 		},

--- a/tests/listobjects/matrix_directs.go
+++ b/tests/listobjects/matrix_directs.go
@@ -1,0 +1,36 @@
+package listobjects
+
+import (
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	listobjectstest "github.com/openfga/openfga/internal/test/listobjects"
+)
+
+var directs = []matrixTest{
+	{
+		Name: "directs_direct_assignment",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "directs:direct_1_1", Relation: "direct", User: "user:direct_1"},
+			{Object: "directs:direct_1_2", Relation: "direct", User: "user:direct_1"},
+		},
+		ListObjectAssertions: []*listobjectstest.Assertion{
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "user:direct_1",
+					Type:     "directs",
+					Relation: "direct",
+				},
+
+				Expectation: []string{"directs:direct_1_1", "directs:direct_1_2"},
+			},
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "user:direct_no_such_user",
+					Type:     "directs",
+					Relation: "direct",
+				},
+
+				Expectation: []string{},
+			},
+		},
+	},
+}

--- a/tests/listobjects/matrix_directs.go
+++ b/tests/listobjects/matrix_directs.go
@@ -2,6 +2,7 @@ package listobjects
 
 import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
 	listobjectstest "github.com/openfga/openfga/internal/test/listobjects"
 )
 
@@ -30,6 +31,33 @@ var directs = []matrixTest{
 				},
 
 				Expectation: []string{},
+			},
+		},
+	},
+	{
+		Name: "directs_one_terminal_type_wildcard_and_conditions",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "directs:wildcard_and_condition_1", Relation: "direct_comb", User: "user:direct_comb_1"},
+			{Object: "directs:wildcard_and_condition_2", Relation: "direct_comb", User: "user:*"},
+			{Object: "directs:wildcard_and_condition_3", Relation: "direct_comb", User: "user:direct_comb_1", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+			{Object: "directs:wildcard_and_condition_4", Relation: "direct_comb", User: "user:*", Condition: &openfgav1.RelationshipCondition{Name: "xcond"}},
+		},
+		ListObjectAssertions: []*listobjectstest.Assertion{
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "user:direct_comb_1",
+					Type:     "directs",
+					Relation: "direct_comb",
+				},
+				Context: MustNewStruct(map[string]any{
+					"x": "1",
+				}),
+				Expectation: []string{
+					"directs:wildcard_and_condition_1",
+					"directs:wildcard_and_condition_2",
+					"directs:wildcard_and_condition_3",
+					"directs:wildcard_and_condition_4",
+				},
 			},
 		},
 	},

--- a/tests/listobjects/matrix_directs.go
+++ b/tests/listobjects/matrix_directs.go
@@ -75,4 +75,37 @@ var directs = []matrixTest{
 			},
 		},
 	},
+	{
+		Name: "directs_multiple_terminal_types",
+		Tuples: []*openfgav1.TupleKey{
+			{Object: "directs:mult_types_1", Relation: "direct_mult_types", User: "employee:mult_types_1"},
+			{Object: "directs:mult_types_2", Relation: "direct_mult_types", User: "employee:*"},
+			{Object: "directs:mult_types_3", Relation: "direct_mult_types", User: "user:mult_types_1"},
+			{Object: "directs:mult_types_4", Relation: "direct_mult_types", User: "user:*"},
+		},
+		ListObjectAssertions: []*listobjectstest.Assertion{
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "user:mult_types_1",
+					Type:     "directs",
+					Relation: "direct_mult_types",
+				},
+				Expectation: []string{
+					"directs:mult_types_3",
+					"directs:mult_types_4",
+				},
+			},
+			{
+				Request: &openfgav1.ListObjectsRequest{
+					User:     "employee:mult_types_1",
+					Type:     "directs",
+					Relation: "direct_mult_types",
+				},
+				Expectation: []string{
+					"directs:mult_types_1",
+					"directs:mult_types_2",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
More ListObjects matrix testing, branched off of #2327 

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

