### PR TITLE
docs(v1.8.8): add v1.8.8 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Added a new CheckResolver (`ShadowResolver`) to allow comparing changes across different CheckResolvers. [#2308](https://github.com/openfga/openfga/pull/2308).
 
+### Changed
+- Extend object_id VARCHAR in MySQL to 255 characters. [#2230](https://github.com/openfga/openfga/pull/2230).
+
 ## [1.8.7] - 2025-03-07
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.6...v1.8.7)
 


### PR DESCRIPTION

## Description
Add v1.8.8 release details to the CHANGELOG.  Note that originally the changelog has v1.8.8 but it is not released.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

