### PR TITLE
docs(v1.8.9): add v1.8.9 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.8.9] - 2025-04-01
+[Full changelog](https://github.com/openfga/openfga/compare/v1.8.8...v1.8.9)
+
 ### Added
 - Updated grpc logs for the healthcheck service to log at the Debug level instead of at the Info level. [#2340](https://github.com/openfga/openfga/pull/2340)
 - Separate out experimental list objects optimization flag (`enable-list-objects-optimizations`) from experimental check optimization flag (`enable-check-optimizations`) to allow individual optimization. [#2341](https://github.com/openfga/openfga/pull/2341).
@@ -1241,7 +1245,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.8...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.9...HEAD
+[1.8.9]: https://github.com/openfga/openfga/compare/v1.8.8...v1.8.9
 [1.8.8]: https://github.com/openfga/openfga/compare/v1.8.7...v1.8.8
 [1.8.7]: https://github.com/openfga/openfga/compare/v1.8.6...v1.8.7
 [1.8.6]: https://github.com/openfga/openfga/compare/v1.8.5...v1.8.6


### PR DESCRIPTION
## Description

Add v1.8.9 release notes to CHANGELOG

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

