### PR TITLE
docs: make note that shadow resolver is a temporary feature

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -659,6 +659,7 @@ func WithMaxChecksPerBatchCheck(maxChecks uint32) OpenFGAServiceV1Option {
 }
 
 // WithShadowCheckResolverEnabled turns of shadow check resolver to allow result comparison.
+// Note that ShadowCheckResolver is a temporary feature and may be removed in future release.
 func WithShadowCheckResolverEnabled(enabled bool) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.shadowCheckResolverEnabled = enabled
@@ -680,13 +681,14 @@ func WithShadowCheckResolverSamplePercentage(rate int) OpenFGAServiceV1Option {
 }
 
 // WithShadowListObjectsCheckResolverEnabled turns on shadow check resolver to allow result comparison.
+// Note that ShadowListObjectsCheckResolver is a temporary feature and may be removed in future release.
 func WithShadowListObjectsCheckResolverEnabled(enabled bool) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.shadowListObjectsCheckResolverEnabled = enabled
 	}
 }
 
-// WithShadowCheckResolverTimeout is the amount of time to wait for the shadow Check evaluation response.
+// WithShadowListObjectsCheckResolverTimeout is the amount of time to wait for the shadow Check evaluation response.
 func WithShadowListObjectsCheckResolverTimeout(threshold time.Duration) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.shadowListObjectsCheckResolverTimeout = threshold


### PR DESCRIPTION


## Description
Add comments to denote that shadow resolver is a temporary feature and may be removed in future release.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

