### PR TITLE
feat: add tests.BuildServer to use for integration testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added "dispatch_count" histogram metric to batch-check requests.
 - Added "request.throttled" boolean to the context tags for check and batch-check
 - Added "throttled_requests_count" metric to batch-check requests.
+- Added tests.BuildServer to start a FGA server and return the HTTP addr for use with SDK client based tests.
 
 ## [1.8.9] - 2025-04-01
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.8...v1.8.9)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -73,8 +73,7 @@ func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *r
 	testutils.EnsureServiceHealthy(t, cfg.GRPC.Addr, cfg.HTTP.Addr, nil)
 }
 
-// BuildClientInterface sets up test client interface to be used for matrix test.
-func BuildClientInterface(t *testing.T, engine string, experimentals []string) ClientInterface {
+func buildAndStartServer(t *testing.T, engine string, experimentals []string) *serverconfig.Config {
 	cfg := serverconfig.MustDefaultConfig()
 	if len(experimentals) > 0 {
 		cfg.Experimentals = append(cfg.Experimentals, experimentals...)
@@ -90,7 +89,18 @@ func BuildClientInterface(t *testing.T, engine string, experimentals []string) C
 	cfg.ContextPropagationToDatastore = true
 
 	StartServer(t, cfg)
+	return cfg
+}
 
+// BuildClientInterface sets up test client interface to be used for matrix test.
+func BuildClientInterface(t *testing.T, engine string, experimentals []string) ClientInterface {
+	cfg := buildAndStartServer(t, engine, experimentals)
 	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)
 	return openfgav1.NewOpenFGAServiceClient(conn)
+}
+
+// BuildServer sets up a server to use for tests that use the SDK client.
+func BuildServer(t *testing.T, engine string, experimentals []string) string {
+	cfg := buildAndStartServer(t, engine, experimentals)
+	return cfg.HTTP.Addr
 }


### PR DESCRIPTION
## Description
I have a k8s microservice that talks to my OpenFGA service. I have some integration tests for the microservice that now need a OpenFGA service to talk to. Instead of using docker to setup the OpneFGA server, I'd like to just bring up an instance in my tests and connect to it directly. This enables me to do so.

## References
None

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

