### PR TITLE
Surface partial metrics on check resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added "dispatch_count" histogram metric to batch-check requests.
 - Added "request.throttled" boolean to the context tags for check and batch-check
 - Added "throttled_requests_count" metric to batch-check requests.
+- Surface partial metrics on check resolutions [#2371](https://github.com/openfga/openfga/pull/2371)
 
 ## [1.8.9] - 2025-04-01
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.8...v1.8.9)

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -121,18 +121,30 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 	ctx = storage.ContextWithRelationshipTupleReader(ctx, datastoreWithTupleCache)
 
 	startTime := time.Now()
-
 	resp, err := c.checkResolver.ResolveCheck(ctx, resolveCheckRequest)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) && resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
-			return nil, resolveCheckRequest.GetRequestMetadata(), &ThrottledError{Cause: err}
-		}
+	endTime := time.Since(startTime)
 
-		return nil, resolveCheckRequest.GetRequestMetadata(), err
+	// ResolveCheck might fail half way throughout (e.g. due to a timeout) and return a nil response.
+	// Partial resolution metadata is still useful for obsevability.
+	// From here on, we can assume that request metadata and response are not nil even if
+	// there is an error present.
+	if resp == nil {
+		resp = &graph.ResolveCheckResponse{
+			Allowed:            false,
+			ResolutionMetadata: graph.ResolveCheckResponseMetadata{},
+		}
 	}
 
-	resp.ResolutionMetadata.Duration = time.Since(startTime)
+	resp.ResolutionMetadata.Duration = endTime
 	resp.ResolutionMetadata.DatastoreQueryCount = datastoreWithTupleCache.GetMetrics().DatastoreQueryCount
+
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) && resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
+			return resp, resolveCheckRequest.GetRequestMetadata(), &ThrottledError{Cause: err}
+		}
+
+		return resp, resolveCheckRequest.GetRequestMetadata(), err
+	}
 
 	return resp, resolveCheckRequest.GetRequestMetadata(), nil
 }

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -125,10 +125,10 @@ func (c *CheckQuery) Execute(ctx context.Context, params *CheckCommandParams) (*
 	resp, err := c.checkResolver.ResolveCheck(ctx, resolveCheckRequest)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) && resolveCheckRequest.GetRequestMetadata().WasThrottled.Load() {
-			return nil, nil, &ThrottledError{Cause: err}
+			return nil, resolveCheckRequest.GetRequestMetadata(), &ThrottledError{Cause: err}
 		}
 
-		return nil, nil, err
+		return nil, resolveCheckRequest.GetRequestMetadata(), err
 	}
 
 	resp.ResolutionMetadata.Duration = time.Since(startTime)

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -243,7 +243,7 @@ type doc
 		require.Equal(t, uint32(1), checkResp.GetResolutionMetadata().DatastoreQueryCount)
 		require.Equal(t, uint32(1), checkRequestMetadata.Depth)
 		require.Equal(t, uint32(1), checkRequestMetadata.DispatchCounter.Load())
-		require.Equal(t, true, checkRequestMetadata.WasThrottled.Load())
+		require.True(t, checkRequestMetadata.WasThrottled.Load())
 	})
 }
 


### PR DESCRIPTION
## Description
Capture dispatch count, datastore query count, and if the request was throttled even when an error exists and/or the context deadline is exceeded.

For example, given a complex query and dispatch throttling enabled, the log line for `grpc_req_complete`:

**Before**

```
{"grpc_service": "openfga.v1.OpenFGAService", "grpc_method": "Check", "grpc_type": "unary", "trace_id": "29a1aa6b34009d3b4ece15baadaa4a8b", "user_agent": "openfga-cli/dev", "raw_request": {"store_id":"01JRE4QDT4X4JB95TD482GCAQN","tuple_key":{"user":"user:maria","relation":"viewer_complex","object":"folder:x"},"contextual_tuples":{"tuple_keys":[]},"authorization_model_id":"","trace":false,"context":{},"consistency":"UNSPECIFIED"}, "raw_response": {"code":"throttled_timeout_error","message":"timeout due to throttling on complex request"}, "query_duration_ms": "3004", "peer.address": "127.0.0.1:35370", "request_id": "29a1aa6b34009d3b4ece15baadaa4a8b", "store_id": "01JRE4QDT4X4JB95TD482GCAQN", "authorization_model_id": "01JRE4QNAS43GS833BCMD7FD52", "grpc_code": 3500, "error": "rpc error: code = Code(3500) desc = timeout due to throttling on complex request"}
```

**After**

```
{"grpc_service": "openfga.v1.OpenFGAService", "grpc_method": "Check", "grpc_type": "unary", "trace_id": "c1a48c52a4e7da9e76138a6eaf9f4ce9", "user_agent": "openfga-cli/dev", "raw_request": {"store_id":"01JRE4QDT4X4JB95TD482GCAQN","tuple_key":{"user":"user:maria","relation":"viewer_complex","object":"folder:x"},"contextual_tuples":{"tuple_keys":[]},"authorization_model_id":"","trace":false,"context":{},"consistency":"UNSPECIFIED"}, "raw_response": {"code":"throttled_timeout_error","message":"timeout due to throttling on complex request"}, "query_duration_ms": "3004", "request_id": "c1a48c52a4e7da9e76138a6eaf9f4ce9", "store_id": "01JRE4QDT4X4JB95TD482GCAQN", "authorization_model_id": "01JRE4QNAS43GS833BCMD7FD52", "dispatch_count": 159, "datastore_query_count": 119, "request.throttled": true, "peer.address": "127.0.0.1:39340", "grpc_code": 3500, "error": "rpc error: code = Code(3500) desc = timeout due to throttling on complex request"}
```

Notice 

> "dispatch_count": 159, "datastore_query_count": 119, "request.throttled": true,

⚠️ the same behavior is likely present in other APIs like ListObjects

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

