### PR TITLE
fix: add goroutine concurrency limit for iterator processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - The serverconfig was moved from internal to pkg to make it available to external users of this package. [#2382](https://github.com/openfga/openfga/pull/2382)
 
+### Fixed
+- Add limit to goroutine concurrency when processing iterator [#2386](https://github.com/openfga/openfga/pull/2386)
+
 ## [1.8.9] - 2025-04-01
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.8...v1.8.9)
 

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -528,7 +528,13 @@ ConsumerLoop:
 	return res, lastErr
 }
 
-func constructLeftChannels(ctx context.Context, req *ResolveCheckRequest, relationReferences []*openfgav1.RelationReference, relationFunc checkutil.V2RelationFunc, concurrencyLimit uint32) ([]chan *iterator.Msg, error) {
+func constructLeftChannels(
+	ctx context.Context,
+	req *ResolveCheckRequest,
+	relationReferences []*openfgav1.RelationReference,
+	relationFunc checkutil.V2RelationFunc,
+	concurrencyLimit int,
+) ([]chan *iterator.Msg, error) {
 	typesys, _ := typesystem.TypesystemFromContext(ctx)
 
 	leftChans := make([]chan *iterator.Msg, 0, len(relationReferences))
@@ -614,7 +620,7 @@ func (c *LocalChecker) checkTTUFastPathV2(ctx context.Context, req *ResolveCheck
 }
 
 // NOTE: Can we make this generic and move it to concurrency pkg?
-func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg, concurrencyLimit uint32) chan *iterator.Msg {
+func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg, concurrencyLimit int) chan *iterator.Msg {
 	limit := len(chans)
 
 	out := make(chan *iterator.Msg, limit)
@@ -626,7 +632,7 @@ func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg, conc
 
 	// It is ok if the limit is < concurrencyLimit because that
 	// is the pool's max limit.
-	pool := concurrency.NewPool(ctx, int(concurrencyLimit))
+	pool := concurrency.NewPool(ctx, concurrencyLimit)
 
 	for _, c := range chans {
 		pool.Go(func(ctx context.Context) error {

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -433,7 +433,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans []chan *it
 	))
 	defer span.End()
 	cancellableCtx, cancel := context.WithCancel(ctx)
-	leftChan := fanInIteratorChannels(cancellableCtx, leftChans)
+	leftChan := fanInIteratorChannels(cancellableCtx, leftChans, c.concurrencyLimit)
 	rightChan := streamedLookupUsersetFromIterator(cancellableCtx, iter)
 	rightOpen := true
 	leftOpen := true
@@ -528,10 +528,7 @@ ConsumerLoop:
 	return res, lastErr
 }
 
-func constructLeftChannels(ctx context.Context,
-	req *ResolveCheckRequest,
-	relationReferences []*openfgav1.RelationReference,
-	relationFunc checkutil.V2RelationFunc) ([]chan *iterator.Msg, error) {
+func constructLeftChannels(ctx context.Context, req *ResolveCheckRequest, relationReferences []*openfgav1.RelationReference, relationFunc checkutil.V2RelationFunc, concurrencyLimit uint32) ([]chan *iterator.Msg, error) {
 	typesys, _ := typesystem.TypesystemFromContext(ctx)
 
 	leftChans := make([]chan *iterator.Msg, 0, len(relationReferences))
@@ -552,7 +549,7 @@ func constructLeftChannels(ctx context.Context,
 		if err != nil {
 			// if the resolver already started it needs to be drained
 			if len(leftChans) > 0 {
-				go drainIteratorChannel(fanInIteratorChannels(ctx, leftChans))
+				go drainIteratorChannel(fanInIteratorChannels(ctx, leftChans, concurrencyLimit))
 			}
 			return nil, err
 		}
@@ -572,7 +569,7 @@ func (c *LocalChecker) checkUsersetFastPathV2(ctx context.Context, req *ResolveC
 	defer cancel()
 	directlyRelatedUsersetTypes, _ := typesys.DirectlyRelatedUsersets(objectType, req.GetTupleKey().GetRelation())
 
-	leftChans, err := constructLeftChannels(cancellableCtx, req, directlyRelatedUsersetTypes, checkutil.BuildUsersetV2RelationFunc())
+	leftChans, err := constructLeftChannels(cancellableCtx, req, directlyRelatedUsersetTypes, checkutil.BuildUsersetV2RelationFunc(), c.concurrencyLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +599,7 @@ func (c *LocalChecker) checkTTUFastPathV2(ctx context.Context, req *ResolveCheck
 	cancellableCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	leftChans, err := constructLeftChannels(cancellableCtx, req, possibleParents, checkutil.BuildTTUV2RelationFunc(computedRelation))
+	leftChans, err := constructLeftChannels(cancellableCtx, req, possibleParents, checkutil.BuildTTUV2RelationFunc(computedRelation), c.concurrencyLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -617,7 +614,7 @@ func (c *LocalChecker) checkTTUFastPathV2(ctx context.Context, req *ResolveCheck
 }
 
 // NOTE: Can we make this generic and move it to concurrency pkg?
-func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg) chan *iterator.Msg {
+func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg, concurrencyLimit uint32) chan *iterator.Msg {
 	limit := len(chans)
 
 	out := make(chan *iterator.Msg, limit)
@@ -626,7 +623,10 @@ func fanInIteratorChannels(ctx context.Context, chans []chan *iterator.Msg) chan
 		close(out)
 		return out
 	}
-	pool := concurrency.NewPool(ctx, limit)
+
+	// It is ok if the limit is < concurrencyLimit because that
+	// is the pool's max limit.
+	pool := concurrency.NewPool(ctx, int(concurrencyLimit))
 
 	for _, c := range chans {
 		pool.Go(func(ctx context.Context) error {
@@ -709,7 +709,7 @@ func (c *LocalChecker) breadthFirstRecursiveMatch(ctx context.Context, req *Reso
 		close(c)
 		chans = append(chans, c)
 	}
-	leftChan := fanInIteratorChannels(ctx, chans)
+	leftChan := fanInIteratorChannels(ctx, chans, c.concurrencyLimit)
 	leftOpen := true
 	defer func() {
 		if leftOpen {
@@ -926,7 +926,7 @@ func (c *LocalChecker) recursiveTTUFastPathV2(ctx context.Context, req *ResolveC
 
 	ttu := rewrite.GetTupleToUserset()
 
-	objectProvider := newRecursiveTTUObjectProvider(typesys, ttu)
+	objectProvider := newRecursiveTTUObjectProvider(typesys, ttu, c.concurrencyLimit)
 
 	return c.recursiveFastPath(ctx, req, rightIter, &recursiveMapping{
 		kind:             storage.TTUKind,
@@ -957,7 +957,7 @@ func (c *LocalChecker) recursiveUsersetFastPathV2(ctx context.Context, req *Reso
 	typesys, _ := typesystem.TypesystemFromContext(ctx)
 
 	directlyRelatedUsersetTypes, _ := typesys.DirectlyRelatedUsersets(tuple.GetType(req.GetTupleKey().GetObject()), req.GetTupleKey().GetRelation())
-	objectProvider := newRecursiveUsersetObjectProvider(typesys)
+	objectProvider := newRecursiveUsersetObjectProvider(typesys, c.concurrencyLimit)
 
 	return c.recursiveFastPath(ctx, req, rightIter, &recursiveMapping{
 		kind:                        storage.UsersetKind,

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -130,7 +130,7 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 	ctx := context.Background()
 
-	concurrencyLimit := uint32(10)
+	concurrencyLimit := 10
 
 	t.Run("requires_exactly_two_handlers", func(t *testing.T) {
 		_, err := exclusion(ctx, concurrencyLimit)
@@ -469,7 +469,7 @@ func TestIntersectionCheckFuncReducer(t *testing.T) {
 
 	ctx := context.Background()
 
-	concurrencyLimit := uint32(10)
+	concurrencyLimit := 10
 
 	t.Run("no_handlers_return_false", func(t *testing.T) {
 		resp, err := intersection(ctx, concurrencyLimit)
@@ -1353,7 +1353,7 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 
 	ctx := context.Background()
 
-	concurrencyLimit := uint32(10)
+	concurrencyLimit := 10
 
 	falseHandler := func(context.Context) (*ResolveCheckResponse, error) {
 		return &ResolveCheckResponse{
@@ -3233,7 +3233,7 @@ func TestProcessDispatch(t *testing.T) {
 				dispatchMsgChan <- dispatchMsg
 			}
 
-			outcomeChan := checker.processDispatches(ctx, uint32(tt.poolSize), dispatchMsgChan)
+			outcomeChan := checker.processDispatches(ctx, tt.poolSize, dispatchMsgChan)
 
 			// now, close the channel to simulate everything is sent
 			close(dispatchMsgChan)
@@ -3255,7 +3255,7 @@ func TestProcessDispatch(t *testing.T) {
 		checker.SetDelegate(mockResolver)
 
 		dispatchChan := make(chan dispatchMsg, 1)
-		outcomeChan := checker.processDispatches(ctx, uint32(1), dispatchChan)
+		outcomeChan := checker.processDispatches(ctx, 1, dispatchChan)
 		dispatchChan <- dispatchMsg{
 			dispatchParams: &dispatchParams{
 				parentReq: nil, // This will cause a panic when accessed in `dispatch`
@@ -3280,7 +3280,7 @@ func TestConsumeDispatch(t *testing.T) {
 	}
 	tests := []struct {
 		name                   string
-		limit                  uint32
+		limit                  int
 		ctxCancelled           bool
 		dispatchMsgs           []dispatchMsg
 		mockedDispatchResponse []*ResolveCheckResponse

--- a/internal/graph/object_providers.go
+++ b/internal/graph/object_providers.go
@@ -64,10 +64,10 @@ type recursiveTTUObjectProvider struct {
 	computedRelation string
 	cancel           context.CancelFunc
 	pool             *pool.ContextPool
-	concurrencyLimit uint32
+	concurrencyLimit int
 }
 
-func newRecursiveTTUObjectProvider(ts *typesystem.TypeSystem, ttu *openfgav1.TupleToUserset, concurrencyLimit uint32) *recursiveTTUObjectProvider {
+func newRecursiveTTUObjectProvider(ts *typesystem.TypeSystem, ttu *openfgav1.TupleToUserset, concurrencyLimit int) *recursiveTTUObjectProvider {
 	tuplesetRelation := ttu.GetTupleset().GetRelation()
 	computedRelation := ttu.GetComputedUserset().GetRelation()
 	return &recursiveTTUObjectProvider{ts: ts, tuplesetRelation: tuplesetRelation, computedRelation: computedRelation, concurrencyLimit: concurrencyLimit}
@@ -111,10 +111,10 @@ type recursiveUsersetObjectProvider struct {
 	ts               *typesystem.TypeSystem
 	cancel           context.CancelFunc
 	pool             *pool.ContextPool
-	concurrencyLimit uint32
+	concurrencyLimit int
 }
 
-func newRecursiveUsersetObjectProvider(ts *typesystem.TypeSystem, concurrencyLimit uint32) *recursiveUsersetObjectProvider {
+func newRecursiveUsersetObjectProvider(ts *typesystem.TypeSystem, concurrencyLimit int) *recursiveUsersetObjectProvider {
 	return &recursiveUsersetObjectProvider{ts: ts, concurrencyLimit: concurrencyLimit}
 }
 

--- a/internal/graph/object_providers.go
+++ b/internal/graph/object_providers.go
@@ -64,12 +64,13 @@ type recursiveTTUObjectProvider struct {
 	computedRelation string
 	cancel           context.CancelFunc
 	pool             *pool.ContextPool
+	concurrencyLimit uint32
 }
 
-func newRecursiveTTUObjectProvider(ts *typesystem.TypeSystem, ttu *openfgav1.TupleToUserset) *recursiveTTUObjectProvider {
+func newRecursiveTTUObjectProvider(ts *typesystem.TypeSystem, ttu *openfgav1.TupleToUserset, concurrencyLimit uint32) *recursiveTTUObjectProvider {
 	tuplesetRelation := ttu.GetTupleset().GetRelation()
 	computedRelation := ttu.GetComputedUserset().GetRelation()
-	return &recursiveTTUObjectProvider{ts: ts, tuplesetRelation: tuplesetRelation, computedRelation: computedRelation}
+	return &recursiveTTUObjectProvider{ts: ts, tuplesetRelation: tuplesetRelation, computedRelation: computedRelation, concurrencyLimit: concurrencyLimit}
 }
 
 var _ objectProvider = (*recursiveTTUObjectProvider)(nil)
@@ -91,12 +92,12 @@ func (c *recursiveTTUObjectProvider) Begin(ctx context.Context, req *ResolveChec
 		return nil, err
 	}
 
-	leftChannels, err := constructLeftChannels(ctx, req, possibleParents, checkutil.BuildTTUV2RelationFunc(c.computedRelation))
+	leftChannels, err := constructLeftChannels(ctx, req, possibleParents, checkutil.BuildTTUV2RelationFunc(c.computedRelation), c.concurrencyLimit)
 	if err != nil {
 		return nil, err
 	}
 	outChannel := make(chan usersetMessage, len(leftChannels))
-	leftChannel := fanInIteratorChannels(ctx, leftChannels)
+	leftChannel := fanInIteratorChannels(ctx, leftChannels, c.concurrencyLimit)
 	poolCtx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
 
@@ -107,13 +108,14 @@ func (c *recursiveTTUObjectProvider) Begin(ctx context.Context, req *ResolveChec
 }
 
 type recursiveUsersetObjectProvider struct {
-	ts     *typesystem.TypeSystem
-	cancel context.CancelFunc
-	pool   *pool.ContextPool
+	ts               *typesystem.TypeSystem
+	cancel           context.CancelFunc
+	pool             *pool.ContextPool
+	concurrencyLimit uint32
 }
 
-func newRecursiveUsersetObjectProvider(ts *typesystem.TypeSystem) *recursiveUsersetObjectProvider {
-	return &recursiveUsersetObjectProvider{ts: ts}
+func newRecursiveUsersetObjectProvider(ts *typesystem.TypeSystem, concurrencyLimit uint32) *recursiveUsersetObjectProvider {
+	return &recursiveUsersetObjectProvider{ts: ts, concurrencyLimit: concurrencyLimit}
 }
 
 var _ objectProvider = (*recursiveUsersetObjectProvider)(nil)
@@ -130,12 +132,12 @@ func (c *recursiveUsersetObjectProvider) End() {
 func (c *recursiveUsersetObjectProvider) Begin(ctx context.Context, req *ResolveCheckRequest) (chan usersetMessage, error) {
 	objectType := tuple.GetType(req.GetTupleKey().GetObject())
 	reference := []*openfgav1.RelationReference{{Type: objectType, RelationOrWildcard: &openfgav1.RelationReference_Relation{Relation: req.GetTupleKey().GetRelation()}}}
-	leftChans, err := constructLeftChannels(ctx, req, reference, checkutil.BuildUsersetV2RelationFunc())
+	leftChans, err := constructLeftChannels(ctx, req, reference, checkutil.BuildUsersetV2RelationFunc(), c.concurrencyLimit)
 	if err != nil {
 		return nil, err
 	}
 	outChannel := make(chan usersetMessage, len(leftChans))
-	leftChannel := fanInIteratorChannels(ctx, leftChans)
+	leftChannel := fanInIteratorChannels(ctx, leftChans, c.concurrencyLimit)
 	poolCtx, cancel := context.WithCancel(ctx)
 	c.cancel = cancel
 	c.pool = concurrency.NewPool(poolCtx, 1)

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
+const concurrencyLimit = 50
+
 func TestRecursiveObjectProvider(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
@@ -156,7 +158,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("when_invalid_req", func(t *testing.T) {
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				invalidReq, err := NewResolveCheckRequest(ResolveCheckRequestParams{
@@ -178,7 +180,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -203,7 +205,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -228,7 +230,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 					Times(1).
 					Return(nil, mockError)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -247,7 +249,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						return iterator, nil
 					})
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -272,7 +274,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(ts, ttu, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx, cancel := context.WithCancel(setRequestContext(context.Background(), ts, mockDatastore, nil))
@@ -333,7 +335,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(ts, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -358,7 +360,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(ts, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -382,7 +384,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 					Times(1).
 					Return(nil, fmt.Errorf("error"))
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(ts, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -401,7 +403,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						return iterator, nil
 					})
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(ts, concurrencyLimit)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -426,7 +428,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "parent", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(ts, concurrencyLimit)
 
 				t.Cleanup(c.End)
 


### PR DESCRIPTION
## Description

Add limit on goroutine concurrency limit when processing iterator.
This avoids high number of goroutine usage and avoids saturation
in datastore usage when the number of tuple iterators processed for
a check / list objects / list users request is high.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

