### PR TITLE
refactor: rename sharedCheckResources -> sharedDatastoreResources

### DIFF
--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -12,19 +12,19 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 )
 
-// SharedCheckResourcesOpt defines an option that can be used to change the behavior of SharedCheckResources
+// SharedDatastoreResourcesOpt defines an option that can be used to change the behavior of SharedDatastoreResources
 // instance.
-type SharedCheckResourcesOpt func(*SharedCheckResources)
+type SharedDatastoreResourcesOpt func(*SharedDatastoreResources)
 
 // WithLogger sets the logger for CachedDatastore.
-func WithLogger(logger logger.Logger) SharedCheckResourcesOpt {
-	return func(scr *SharedCheckResources) {
+func WithLogger(logger logger.Logger) SharedDatastoreResourcesOpt {
+	return func(scr *SharedDatastoreResources) {
 		scr.Logger = logger
 	}
 }
 
-// SharedCheckResources contains resources that can be shared across Check requests.
-type SharedCheckResources struct {
+// SharedDatastoreResources contains resources that can be shared across Check requests.
+type SharedDatastoreResources struct {
 	SingleflightGroup *singleflight.Group
 	WaitGroup         *sync.WaitGroup
 	ServerCtx         context.Context
@@ -33,8 +33,14 @@ type SharedCheckResources struct {
 	Logger            logger.Logger
 }
 
-func NewSharedCheckResources(sharedCtx context.Context, sharedSf *singleflight.Group, ds storage.OpenFGADatastore, settings serverconfig.CacheSettings, opts ...SharedCheckResourcesOpt) (*SharedCheckResources, error) {
-	s := &SharedCheckResources{
+func NewSharedDatastoreResources(
+	sharedCtx context.Context,
+	sharedSf *singleflight.Group,
+	ds storage.OpenFGADatastore,
+	settings serverconfig.CacheSettings,
+	opts ...SharedDatastoreResourcesOpt,
+) (*SharedDatastoreResources, error) {
+	s := &SharedDatastoreResources{
 		WaitGroup:         &sync.WaitGroup{},
 		SingleflightGroup: sharedSf,
 		ServerCtx:         sharedCtx,
@@ -63,7 +69,7 @@ func NewSharedCheckResources(sharedCtx context.Context, sharedSf *singleflight.G
 	return s, nil
 }
 
-func (s *SharedCheckResources) Close() {
+func (s *SharedDatastoreResources) Close() {
 	// wait for any goroutines still in flight before
 	// closing the cache instance to avoid data races
 	s.WaitGroup.Wait()

--- a/internal/shared/shared_test.go
+++ b/internal/shared/shared_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openfga/openfga/pkg/server/config"
 )
 
-func TestSharedCheckResources(t *testing.T) {
+func TestSharedDatastoreResources(t *testing.T) {
 	sharedCtx := context.Background()
 	sharedSf := &singleflight.Group{}
 	mockController := gomock.NewController(t)
@@ -23,7 +23,7 @@ func TestSharedCheckResources(t *testing.T) {
 
 	t.Run("without", func(t *testing.T) {
 		settings := config.CacheSettings{}
-		s, err := NewSharedCheckResources(sharedCtx, sharedSf, mockDatastore, settings)
+		s, err := NewSharedDatastoreResources(sharedCtx, sharedSf, mockDatastore, settings)
 		require.NoError(t, err)
 		t.Cleanup(s.Close)
 
@@ -42,7 +42,7 @@ func TestSharedCheckResources(t *testing.T) {
 			CheckIteratorCacheEnabled: true,
 		}
 
-		s, err := NewSharedCheckResources(sharedCtx, sharedSf, mockDatastore, settings)
+		s, err := NewSharedDatastoreResources(sharedCtx, sharedSf, mockDatastore, settings)
 		require.NoError(t, err)
 		t.Cleanup(s.Close)
 
@@ -56,7 +56,7 @@ func TestSharedCheckResources(t *testing.T) {
 			CacheControllerEnabled:    true,
 		}
 
-		s, err := NewSharedCheckResources(sharedCtx, sharedSf, mockDatastore, settings)
+		s, err := NewSharedDatastoreResources(sharedCtx, sharedSf, mockDatastore, settings)
 		require.NoError(t, err)
 		t.Cleanup(s.Close)
 

--- a/pkg/server/commands/batch_check_command.go
+++ b/pkg/server/commands/batch_check_command.go
@@ -22,7 +22,7 @@ import (
 )
 
 type BatchCheckQuery struct {
-	sharedCheckResources *shared.SharedCheckResources
+	sharedCheckResources *shared.SharedDatastoreResources
 	cacheSettings        config.CacheSettings
 	checkResolver        graph.CheckResolver
 	datastore            storage.RelationshipTupleReader
@@ -69,7 +69,7 @@ type checkAndCorrelationIDs struct {
 
 type BatchCheckQueryOption func(*BatchCheckQuery)
 
-func WithBatchCheckCacheOptions(sharedCheckResources *shared.SharedCheckResources, cacheSettings config.CacheSettings) BatchCheckQueryOption {
+func WithBatchCheckCacheOptions(sharedCheckResources *shared.SharedDatastoreResources, cacheSettings config.CacheSettings) BatchCheckQueryOption {
 	return func(c *BatchCheckQuery) {
 		c.sharedCheckResources = sharedCheckResources
 		c.cacheSettings = cacheSettings
@@ -103,7 +103,7 @@ func NewBatchCheckCommand(datastore storage.RelationshipTupleReader, checkResolv
 		maxChecksAllowed:    config.DefaultMaxChecksPerBatchCheck,
 		maxConcurrentChecks: config.DefaultMaxConcurrentChecksPerBatchCheck,
 		cacheSettings:       config.NewDefaultCacheSettings(),
-		sharedCheckResources: &shared.SharedCheckResources{
+		sharedCheckResources: &shared.SharedDatastoreResources{
 			CacheController: cachecontroller.NewNoopCacheController(),
 		},
 	}

--- a/pkg/server/commands/check_command.go
+++ b/pkg/server/commands/check_command.go
@@ -31,7 +31,7 @@ type CheckQuery struct {
 	checkResolver        graph.CheckResolver
 	typesys              *typesystem.TypeSystem
 	datastore            storage.RelationshipTupleReader
-	sharedCheckResources *shared.SharedCheckResources
+	sharedCheckResources *shared.SharedDatastoreResources
 	cacheSettings        config.CacheSettings
 	maxConcurrentReads   uint32
 	shouldCacheIterators bool
@@ -59,7 +59,7 @@ func WithCheckCommandLogger(l logger.Logger) CheckQueryOption {
 	}
 }
 
-func WithCheckCommandCache(sharedCheckResources *shared.SharedCheckResources, cacheSettings config.CacheSettings) CheckQueryOption {
+func WithCheckCommandCache(sharedCheckResources *shared.SharedDatastoreResources, cacheSettings config.CacheSettings) CheckQueryOption {
 	return func(c *CheckQuery) {
 		c.sharedCheckResources = sharedCheckResources
 		c.cacheSettings = cacheSettings
@@ -76,7 +76,7 @@ func NewCheckCommand(datastore storage.RelationshipTupleReader, checkResolver gr
 		maxConcurrentReads:   defaultMaxConcurrentReadsForCheck,
 		shouldCacheIterators: false,
 		cacheSettings:        config.NewDefaultCacheSettings(),
-		sharedCheckResources: &shared.SharedCheckResources{
+		sharedCheckResources: &shared.SharedDatastoreResources{
 			CacheController: cachecontroller.NewNoopCacheController(),
 		},
 	}

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -190,7 +190,7 @@ type doc
 		storeID := ulid.Make().String()
 		invalidationTime := time.Now().UTC()
 		cacheController := mockstorage.NewMockCacheController(mockController)
-		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts, WithCheckCommandCache(&shared.SharedCheckResources{
+		cmd := NewCheckCommand(mockDatastore, mockCheckResolver, ts, WithCheckCommandCache(&shared.SharedDatastoreResources{
 			CacheController: cacheController,
 			Logger:          logger.NewNoopLogger(),
 		}, config.CacheSettings{}))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -175,7 +175,7 @@ type Server struct {
 	// cacheSettings are given by the user
 	cacheSettings serverconfig.CacheSettings
 	// sharedCheckResources are created by the server
-	sharedCheckResources *shared.SharedCheckResources
+	sharedCheckResources *shared.SharedDatastoreResources
 
 	checkResolver       graph.CheckResolver
 	checkResolverCloser func()
@@ -825,7 +825,7 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		return nil, err
 	}
 
-	s.sharedCheckResources, err = shared.NewSharedCheckResources(s.ctx, s.singleflightGroup, s.datastore, s.cacheSettings, []shared.SharedCheckResourcesOpt{shared.WithLogger(s.logger)}...)
+	s.sharedCheckResources, err = shared.NewSharedDatastoreResources(s.ctx, s.singleflightGroup, s.datastore, s.cacheSettings, []shared.SharedDatastoreResourcesOpt{shared.WithLogger(s.logger)}...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/storagewrappers/request.go
+++ b/pkg/storage/storagewrappers/request.go
@@ -23,7 +23,7 @@ func NewRequestStorageWrapper(
 	ds storage.RelationshipTupleReader,
 	requestContextualTuples []*openfgav1.TupleKey,
 	maxConcurrentReads uint32,
-	resources *shared.SharedCheckResources,
+	resources *shared.SharedDatastoreResources,
 	cacheSettings config.CacheSettings,
 	logger logger.Logger,
 ) *RequestStorageWrapper {

--- a/pkg/storage/storagewrappers/request_test.go
+++ b/pkg/storage/storagewrappers/request_test.go
@@ -29,7 +29,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 		}
 
 		br := NewRequestStorageWrapper(mockDatastore, requestContextualTuples, maxConcurrentReads,
-			&shared.SharedCheckResources{
+			&shared.SharedDatastoreResources{
 				CheckCache: mockCache,
 				Logger:     logger.NewNoopLogger(),
 			}, config.CacheSettings{
@@ -66,7 +66,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 			tuple.NewTupleKey("doc:1", "viewer", "user:maria"),
 		}
 
-		br := NewRequestStorageWrapper(mockDatastore, requestContextualTuples, maxConcurrentReads, &shared.SharedCheckResources{Logger: logger.NewNoopLogger()}, config.CacheSettings{}, logger.NewNoopLogger())
+		br := NewRequestStorageWrapper(mockDatastore, requestContextualTuples, maxConcurrentReads, &shared.SharedDatastoreResources{Logger: logger.NewNoopLogger()}, config.CacheSettings{}, logger.NewNoopLogger())
 		require.NotNil(t, br)
 
 		// assert on the chain


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
We're currently working on adding the iterator cache into the ListObjects flow, and it will also be reusing these resources. I pulled the renaming diff into its own PR so it doesn't complicate the ListObjects caching PR which is coming soon.

No change in behavior here, just a rename.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

