### PR TITLE
fix: increase discard count on `.Next()`

### DIFF
--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -483,6 +483,7 @@ func (c *cachedIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	if c.tuples != nil {
 		c.tuples = append(c.tuples, t)
 		if len(c.tuples) >= c.maxResultSize {
+			tuplesCacheDiscardCounter.WithLabelValues(c.operation).Inc()
 			c.tuples = nil // don't store results that are incomplete
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Previous to this change, the `openfga_tuples_cache_discard_count` metric was only incremented when discarding tuples as part of draining an iterator when calling `.Stop()`. Tuples buffered for caching during `.Next()` can also be discarded after the maximum result size is reached.

This pull request introduces a minor enhancement to the `cachedIterator` implementation in `pkg/storage/storagewrappers/cached_datastore.go`. It adds a metric to track discarded tuples when the maximum result size is reached.

Metrics improvement:

* [`pkg/storage/storagewrappers/cached_datastore.go`](diffhunk://#diff-82cf5bfde2c5cec1b2ded64b56724a635b979199401e0ce5303b093473d89443R486): Incremented the `tuplesCacheDiscardCounter` metric with the operation label whenever the tuple cache is discarded due to exceeding the maximum result size.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

