### PR TITLE
chore: move cache key logic to separate file

### DIFF
--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -3,13 +3,10 @@ package storagewrappers
 import (
 	"context"
 	"errors"
-	"strconv"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -143,10 +140,10 @@ func (c *CachedDatastore) ReadStartingWithUser(
 		return iter(ctx)
 	}
 
-	var b strings.Builder
-	b.WriteString(
-		storage.GetReadStartingWithUserCacheKeyPrefix(store, filter.ObjectType, filter.Relation),
-	)
+	cacheKey, err := readStartingWithUserKey(store, filter)
+	if err != nil {
+		return nil, err
+	}
 
 	// NOTE: There is no need to limit the length of this
 	// since at most it will have 2 entries (user and wildcard if possible)
@@ -157,21 +154,9 @@ func (c *CachedDatastore) ReadStartingWithUser(
 			subject = tuple.ToObjectRelationString(objectRel.GetObject(), objectRel.GetRelation())
 		}
 		subjects = append(subjects, subject)
-		b.WriteString("/" + subject)
 	}
 
-	if filter.ObjectIDs != nil {
-		hasher := xxhash.New()
-		for _, oid := range filter.ObjectIDs.Values() {
-			if _, err := hasher.WriteString(oid); err != nil {
-				return nil, err
-			}
-		}
-
-		b.WriteString("/" + strconv.FormatUint(hasher.Sum64(), 10))
-	}
-
-	return c.newCachedIteratorByUserObjectType(ctx, "ReadStartingWithUser", store, iter, b.String(), subjects, filter.ObjectType)
+	return c.newCachedIteratorByUserObjectType(ctx, "ReadStartingWithUser", store, iter, cacheKey, subjects, filter.ObjectType)
 }
 
 // ReadUsersetTuples see [storage.RelationshipTupleReader].ReadUsersetTuples.
@@ -196,33 +181,13 @@ func (c *CachedDatastore) ReadUsersetTuples(
 		return iter(ctx)
 	}
 
-	var b strings.Builder
-	b.WriteString(
-		storage.GetReadUsersetTuplesCacheKeyPrefix(store, filter.Object, filter.Relation),
-	)
-
-	var rb strings.Builder
-	var wb strings.Builder
-
-	for _, userset := range filter.AllowedUserTypeRestrictions {
-		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Relation); ok {
-			rb.WriteString("/" + userset.GetType() + "#" + userset.GetRelation())
-		}
-		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Wildcard); ok {
-			wb.WriteString("/" + userset.GetType() + ":*")
-		}
-	}
-
-	// wildcard should have precedence
-	if wb.Len() > 0 {
-		b.WriteString(wb.String())
-	}
-
-	if rb.Len() > 0 {
-		b.WriteString(rb.String())
-	}
-
-	return c.newCachedIteratorByObjectRelation(ctx, "ReadUsersetTuples", store, iter, b.String(), filter.Object, filter.Relation)
+	return c.newCachedIteratorByObjectRelation(ctx,
+		"ReadUsersetTuples",
+		store,
+		iter,
+		readUsersetTuplesKey(store, filter),
+		filter.Object,
+		filter.Relation)
 }
 
 // Read see [storage.RelationshipTupleReader].Read.
@@ -252,11 +217,13 @@ func (c *CachedDatastore) Read(
 		return iter(ctx)
 	}
 
-	var b strings.Builder
-	b.WriteString(
-		storage.GetReadCacheKey(store, tuple.TupleKeyToString(tupleKey)),
-	)
-	return c.newCachedIteratorByObjectRelation(ctx, "Read", store, iter, b.String(), tupleKey.GetObject(), tupleKey.GetRelation())
+	return c.newCachedIteratorByObjectRelation(ctx,
+		"Read",
+		store,
+		iter,
+		readKey(store, tupleKey),
+		tupleKey.GetObject(),
+		tupleKey.GetRelation())
 }
 
 // findInCache tries to find a key in the cache.

--- a/pkg/storage/storagewrappers/key_utils.go
+++ b/pkg/storage/storagewrappers/key_utils.go
@@ -1,0 +1,82 @@
+package storagewrappers
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cespare/xxhash/v2"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/tuple"
+)
+
+func readStartingWithUserKey(
+	store string,
+	filter storage.ReadStartingWithUserFilter,
+) (string, error) {
+	var b strings.Builder
+	b.WriteString(
+		storage.GetReadStartingWithUserCacheKeyPrefix(store, filter.ObjectType, filter.Relation),
+	)
+
+	// NOTE: There is no need to limit the length of this
+	// since at most it will have 2 entries (user and wildcard if possible)
+	for _, objectRel := range filter.UserFilter {
+		subject := objectRel.GetObject()
+		if objectRel.GetRelation() != "" {
+			subject = tuple.ToObjectRelationString(objectRel.GetObject(), objectRel.GetRelation())
+		}
+		b.WriteString("/" + subject)
+	}
+
+	if filter.ObjectIDs != nil {
+		hasher := xxhash.New()
+		for _, oid := range filter.ObjectIDs.Values() {
+			if _, err := hasher.WriteString(oid); err != nil {
+				return "", err
+			}
+		}
+
+		b.WriteString("/" + strconv.FormatUint(hasher.Sum64(), 10))
+	}
+	return b.String(), nil
+}
+
+func readUsersetTuplesKey(store string, filter storage.ReadUsersetTuplesFilter) string {
+	var b strings.Builder
+	b.WriteString(
+		storage.GetReadUsersetTuplesCacheKeyPrefix(store, filter.Object, filter.Relation),
+	)
+
+	var rb strings.Builder
+	var wb strings.Builder
+
+	for _, userset := range filter.AllowedUserTypeRestrictions {
+		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Relation); ok {
+			rb.WriteString("/" + userset.GetType() + "#" + userset.GetRelation())
+		}
+		if _, ok := userset.GetRelationOrWildcard().(*openfgav1.RelationReference_Wildcard); ok {
+			wb.WriteString("/" + userset.GetType() + ":*")
+		}
+	}
+
+	// wildcard should have precedence
+	if wb.Len() > 0 {
+		b.WriteString(wb.String())
+	}
+
+	if rb.Len() > 0 {
+		b.WriteString(rb.String())
+	}
+	return b.String()
+}
+
+func readKey(store string, tupleKey *openfgav1.TupleKey) string {
+	var b strings.Builder
+	b.WriteString(
+		storage.GetReadCacheKey(store, tuple.TupleKeyToString(tupleKey)),
+	)
+	return b.String()
+}


### PR DESCRIPTION
## Description
Chore of moving cache key to separate file in preparation that the key generation logic can be used in different storage wrapper.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

