### PR TITLE
feat: add counters on current number of iterator cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added "request.throttled" boolean to the context tags for check and batch-check
 - Added "throttled_requests_count" metric to batch-check requests.
 - Surface partial metrics on check resolutions [#2371](https://github.com/openfga/openfga/pull/2371)
+- Added "current_iterator_cache_count" gauge metric to current number of iterator cache. [#2397](https://github.com/openfga/openfga/pull/2397)
 
 ### Changed
 - The serverconfig was moved from internal to pkg to make it available to external users of this package. [#2382](https://github.com/openfga/openfga/pull/2382)

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -490,7 +490,7 @@ func (c *cachedIterator) Stop() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	currentIteratorCacheCount.Dec()
+	defer currentIteratorCacheCount.Dec()
 
 	swapped := c.closing.CompareAndSwap(false, true)
 	if !swapped {

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -59,9 +59,9 @@ var (
 		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"operation"})
 
-	currentCacheCount = promauto.NewGauge(prometheus.GaugeOpts{
+	currentIteratorCacheCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: build.ProjectName,
-		Name:      "current_cache_count",
+		Name:      "current_iterator_cache_count",
 		Help:      "The current number of items of cache iterator.",
 	})
 )
@@ -390,7 +390,7 @@ func (c *CachedDatastore) newCachedIterator(
 		span.SetAttributes(attribute.Bool("cached", true))
 
 		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cacheEntry.Tuples)
-		currentCacheCount.Inc()
+		currentIteratorCacheCount.Inc()
 
 		return &cachedTupleIterator{
 			objectID:   objectID,
@@ -406,7 +406,7 @@ func (c *CachedDatastore) newCachedIterator(
 		return nil, err
 	}
 
-	currentCacheCount.Inc()
+	currentIteratorCacheCount.Inc()
 	return &cachedIterator{
 		ctx:       c.ctx,
 		iter:      iter,
@@ -511,7 +511,7 @@ func (c *cachedIterator) Stop() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	currentCacheCount.Dec()
+	currentIteratorCacheCount.Dec()
 
 	swapped := c.closing.CompareAndSwap(false, true)
 	if !swapped {

--- a/pkg/storage/storagewrappers/cached_iterators.go
+++ b/pkg/storage/storagewrappers/cached_iterators.go
@@ -36,8 +36,8 @@ func (c *cachedTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error
 
 // Stop see [storage.Iterator].Stop.
 func (c *cachedTupleIterator) Stop() {
+	defer currentIteratorCacheCount.Dec()
 	c.iter.Stop()
-	currentIteratorCacheCount.Dec()
 }
 
 // Head will return the first minimal cached tuple of the iterator as

--- a/pkg/storage/storagewrappers/cached_iterators.go
+++ b/pkg/storage/storagewrappers/cached_iterators.go
@@ -37,6 +37,7 @@ func (c *cachedTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error
 // Stop see [storage.Iterator].Stop.
 func (c *cachedTupleIterator) Stop() {
 	c.iter.Stop()
+	currentIteratorCacheCount.Dec()
 }
 
 // Head will return the first minimal cached tuple of the iterator as


### PR DESCRIPTION
## Description
Add counters on current number of iterator cache as gauge.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

## Testing
![Screenshot 2025-04-25 at 3 43 23 PM](https://github.com/user-attachments/assets/9a03fc74-0673-45c8-a7dc-081f0474e8e4)
Purposely not calling Stop
![Screenshot 2025-04-25 at 3 15 50 PM](https://github.com/user-attachments/assets/a96c72c1-ceb2-4590-a17a-6f6579f68ce8)

