### PR TITLE
test: add loop break optimization for test fixtures

### DIFF
--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -61,11 +61,13 @@ func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestCo
 	require.NoError(t, err)
 
 	foundMysqlImage := false
+
+AllImages:
 	for _, image := range allImages {
 		for _, tag := range image.RepoTags {
 			if strings.Contains(tag, mySQLImage) {
 				foundMysqlImage = true
-				break
+				break AllImages
 			}
 		}
 	}

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -61,11 +61,13 @@ func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) Datastore
 	require.NoError(t, err)
 
 	foundPostgresImage := false
+
+AllImages:
 	for _, image := range allImages {
 		for _, tag := range image.RepoTags {
 			if strings.Contains(tag, postgresImage) {
 				foundPostgresImage = true
-				break
+				break AllImages
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Speed up the process of starting a test fixture container for `mysql` and `postgres`.

## Description
When searching local docker images for a `mysql` or `postgres` image, the code currently iterates through all images, even after the desired image is found. This is a tiny optimization to ensure that the `break` statement actually breaks out of the outer loop and not the inner loop.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

