### PR TITLE
fix: safeguard against nil and cancelled context in check_fast_path

### DIFF
--- a/internal/concurrency/concurrency.go
+++ b/internal/concurrency/concurrency.go
@@ -19,6 +19,9 @@ func NewPool(ctx context.Context, maxGoroutines int) *pool.ContextPool {
 // TrySendThroughChannel attempts to send an object through a channel.
 // If the context is canceled, it will not send the object.
 func TrySendThroughChannel[T any](ctx context.Context, msg T, channel chan<- T) bool {
+	if ctx.Err() != nil {
+		return false
+	}
 	select {
 	case <-ctx.Done():
 		return false

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/emirpasic/gods/sets/hashset"
@@ -372,7 +373,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 // fastPathOperationSetup returns a channel with a number of elements that is >= the number of children.
 // Each element is an iterator.
 // The caller must wait until the channel is closed.
-func fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, op setOperatorType, children ...*openfgav1.Userset) (chan *iterator.Msg, error) {
+func fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, resolver fastPathSetHandler, children ...*openfgav1.Userset) (chan *iterator.Msg, error) {
 	iterStreams := make([]*iterator.Stream, 0, len(children))
 	for idx, child := range children {
 		producerChan, err := fastPathRewrite(ctx, req, child)
@@ -381,25 +382,15 @@ func fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, op se
 		}
 		iterStreams = append(iterStreams, iterator.NewStream(idx, producerChan))
 	}
-	var resolver fastPathSetHandler
-	switch op {
-	case unionSetOperator:
-		resolver = fastPathUnion
-	case intersectionSetOperator:
-		resolver = fastPathIntersection
-	case exclusionSetOperator:
-		resolver = fastPathDifference
-	default:
-		return nil, ErrUnknownSetOperator
-	}
+
 	outChan := make(chan *iterator.Msg, len(children))
 	go func() {
-		recoverredError := panics.Try(func() {
+		recoveredError := panics.Try(func() {
 			resolver(ctx, iterator.NewStreams(iterStreams), outChan)
 		})
 
-		if recoverredError != nil {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Err: recoverredError.AsError()}, outChan)
+		if recoveredError != nil {
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Err: fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())}, outChan)
 		}
 	}()
 	return outChan, nil
@@ -418,11 +409,11 @@ func fastPathRewrite(
 	case *openfgav1.Userset_ComputedUserset:
 		return fastPathComputed(ctx, req, rewrite)
 	case *openfgav1.Userset_Union:
-		return fastPathOperationSetup(ctx, req, unionSetOperator, rw.Union.GetChild()...)
+		return fastPathOperationSetup(ctx, req, fastPathUnion, rw.Union.GetChild()...)
 	case *openfgav1.Userset_Intersection:
-		return fastPathOperationSetup(ctx, req, intersectionSetOperator, rw.Intersection.GetChild()...)
+		return fastPathOperationSetup(ctx, req, fastPathIntersection, rw.Intersection.GetChild()...)
 	case *openfgav1.Userset_Difference:
-		return fastPathOperationSetup(ctx, req, exclusionSetOperator, rw.Difference.GetBase(), rw.Difference.GetSubtract())
+		return fastPathOperationSetup(ctx, req, fastPathDifference, rw.Difference.GetBase(), rw.Difference.GetSubtract())
 	case *openfgav1.Userset_TupleToUserset:
 		return fastPathNoop(ctx, req)
 	default:

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -60,7 +60,7 @@ func TestRecursiveObjectProvider(t *testing.T) {
 			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 				Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
 
-			c := newRecursiveObjectProvider(ts, mockDatastore)
+			c := newRecursiveObjectProvider(&mocks.MockLogger{}, ts, mockDatastore)
 			t.Cleanup(c.End)
 
 			ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -83,7 +83,7 @@ func TestRecursiveObjectProvider(t *testing.T) {
 					{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 				}), nil)
 
-			c := newRecursiveObjectProvider(ts, mockDatastore)
+			c := newRecursiveObjectProvider(&mocks.MockLogger{}, ts, mockDatastore)
 			t.Cleanup(c.End)
 
 			ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -105,7 +105,7 @@ func TestRecursiveObjectProvider(t *testing.T) {
 				Times(1).
 				Return(nil, fmt.Errorf("error"))
 
-			c := newRecursiveObjectProvider(ts, mockDatastore)
+			c := newRecursiveObjectProvider(&mocks.MockLogger{}, ts, mockDatastore)
 			t.Cleanup(c.End)
 
 			ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -156,7 +156,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("when_invalid_req", func(t *testing.T) {
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				invalidReq, err := NewResolveCheckRequest(ResolveCheckRequestParams{
@@ -178,7 +178,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -203,7 +203,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -228,7 +228,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 					Times(1).
 					Return(nil, mockError)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -247,7 +247,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						return iterator, nil
 					})
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -272,7 +272,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveTTUObjectProvider(ts, ttu)
+				c := newRecursiveTTUObjectProvider(&mocks.MockLogger{}, ts, ttu)
 				t.Cleanup(c.End)
 
 				ctx, cancel := context.WithCancel(setRequestContext(context.Background(), ts, mockDatastore, nil))
@@ -333,7 +333,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(&mocks.MockLogger{}, ts)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -358,7 +358,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(&mocks.MockLogger{}, ts)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -382,7 +382,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 					Times(1).
 					Return(nil, fmt.Errorf("error"))
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(&mocks.MockLogger{}, ts)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -401,7 +401,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						return iterator, nil
 					})
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(&mocks.MockLogger{}, ts)
 				t.Cleanup(c.End)
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -426,7 +426,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "parent", "user:XYZ")},
 					}), nil)
 
-				c := newRecursiveUsersetObjectProvider(ts)
+				c := newRecursiveUsersetObjectProvider(&mocks.MockLogger{}, ts)
 
 				t.Cleanup(c.End)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

- Add safeguards around nil pointers
- Check if context Err value exists in `TrySendThroughChannel`
- Add comments in goroutines in `check_fast_path` that cannot easily include error handling for panics
  - When goroutines are spawned to handle draining channels, waiting on the channel to finish draining in order to handle potential panics may cause processes to slow down when there are no panics to handle.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

