### PR TITLE
fix: current_iterator_cache_count account for iter stop more than once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Handle case where iterator is stopped more than once for `current_iterator_cache_count`. [#2409](https://github.com/openfga/openfga/pull/2409)
 
 ## [1.8.11] - 2025-04-29
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.10...v1.8.11)

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -493,11 +493,9 @@ func (c *cachedIterator) Stop() {
 
 	newStop := !c.stopped
 	c.stopped = true
-	defer func() {
-		if newStop {
-			currentIteratorCacheCount.WithLabelValues("false").Dec()
-		}
-	}()
+	if newStop {
+		currentIteratorCacheCount.WithLabelValues("false").Dec()
+	}
 
 	swapped := c.closing.CompareAndSwap(false, true)
 	if !swapped {

--- a/pkg/storage/storagewrappers/cached_iterators.go
+++ b/pkg/storage/storagewrappers/cached_iterators.go
@@ -39,12 +39,10 @@ func (c *cachedTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error
 func (c *cachedTupleIterator) Stop() {
 	newStop := !c.stopped
 	c.stopped = true
-	defer func() {
-		if newStop {
-			currentIteratorCacheCount.WithLabelValues("true").Dec()
-		}
-	}()
 	c.iter.Stop()
+	if newStop {
+		currentIteratorCacheCount.WithLabelValues("true").Dec()
+	}
 }
 
 // Head will return the first minimal cached tuple of the iterator as

--- a/pkg/storage/storagewrappers/cached_iterators.go
+++ b/pkg/storage/storagewrappers/cached_iterators.go
@@ -19,6 +19,7 @@ type cachedTupleIterator struct {
 	relation   string
 	userType   string
 	iter       storage.Iterator[*storage.TupleRecord]
+	stopped    bool
 }
 
 var _ storage.TupleIterator = (*cachedTupleIterator)(nil)
@@ -36,7 +37,13 @@ func (c *cachedTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error
 
 // Stop see [storage.Iterator].Stop.
 func (c *cachedTupleIterator) Stop() {
-	defer currentIteratorCacheCount.Dec()
+	newStop := !c.stopped
+	c.stopped = true
+	defer func() {
+		if newStop {
+			currentIteratorCacheCount.WithLabelValues("true").Dec()
+		}
+	}()
 	c.iter.Stop()
 }
 


### PR DESCRIPTION
## Description
Update logic for `current_iterator_cache_count` so that it handles case where iterator stop more than once correctly.  Otherwise, the gauge counter can go into negative when the same iterator is stopped more than once.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

