### PR TITLE
fix: fanin draining across clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
-
 ### Fixed
 - Ensure `fanin.Stop` and `fanin.Drain` are called for all clients which may create blocking goroutines. [#2441](https://github.com/openfga/openfga/pull/2441)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+### Fixed
+- Ensure `fanin.Stop` and `fanin.Drain` are called for all clients which may create blocking goroutines. [#2441](https://github.com/openfga/openfga/pull/2441)
+
 ## [1.8.12] - 2025-05-12
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12)
 

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -441,6 +441,7 @@ func (c *LocalChecker) resolveFastPath(ctx context.Context, leftChans *iterator.
 		cancel()
 		iter.Stop()
 		leftChans.Stop()
+		iterator.Drain(leftChan)
 	}()
 
 	res := &ResolveCheckResponse{
@@ -658,6 +659,7 @@ ConsumerLoop:
 		case <-ctx.Done():
 			close(checkOutcomeChan)
 			leftChans.Stop()
+			iterator.Drain(out)
 			return
 		case msg, ok := <-out:
 			if !ok {
@@ -674,6 +676,7 @@ ConsumerLoop:
 					concurrency.TrySendThroughChannel(ctx, checkOutcome{err: err}, checkOutcomeChan)
 					close(checkOutcomeChan)
 					leftChans.Stop()
+					iterator.Drain(out)
 					return
 				}
 
@@ -682,6 +685,7 @@ ConsumerLoop:
 					concurrency.TrySendThroughChannel(ctx, checkOutcome{resp: &ResolveCheckResponse{Allowed: true}}, checkOutcomeChan)
 					close(checkOutcomeChan)
 					leftChans.Stop()
+					iterator.Drain(out)
 					return
 				}
 

--- a/internal/graph/check_fast_path_test.go
+++ b/internal/graph/check_fast_path_test.go
@@ -1642,7 +1642,7 @@ func TestRecursiveTTUFastPath(t *testing.T) {
 
 func TestRecursiveTTUFastPathV2(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/openfga/openfga/internal/iterator.drainOnExit(...)"))
+		goleak.VerifyNone(t)
 	})
 
 	model := parser.MustTransformDSLToProto(`
@@ -2115,7 +2115,7 @@ type group
 
 func TestRecursiveUsersetFastPath(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/openfga/openfga/internal/iterator.drainOnExit(...)"))
+		goleak.VerifyNone(t)
 	})
 	tests := []struct {
 		name                            string

--- a/internal/graph/object_providers.go
+++ b/internal/graph/object_providers.go
@@ -146,7 +146,7 @@ func (c *recursiveUsersetObjectProvider) Begin(ctx context.Context, req *Resolve
 func iteratorToUserset(src *iterator.FanIn, dst chan usersetMessage) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		defer func() {
-			src.Close()
+			src.Stop()
 			close(dst)
 		}()
 		select {

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -120,7 +120,7 @@ func TestRecursiveObjectProvider(t *testing.T) {
 
 func TestRecursiveTTUObjectProvider(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/openfga/openfga/internal/iterator.drainOnExit(...)"))
+		goleak.VerifyNone(t)
 	})
 
 	storeID := ulid.Make().String()
@@ -298,7 +298,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 
 func TestRecursiveUsersetObjectProvider(t *testing.T) {
 	t.Cleanup(func() {
-		goleak.VerifyNone(t, goleak.IgnoreTopFunction("github.com/openfga/openfga/internal/iterator.drainOnExit(...)"))
+		goleak.VerifyNone(t)
 	})
 
 	storeID := ulid.Make().String()

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -46,7 +46,7 @@ func (f *FanIn) cleaner() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, ch := range f.drainQueue {
-		Drain(ch)
+		Drain(ch).Wait()
 	}
 	f.wg.Done()
 }

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -114,15 +114,19 @@ func (f *FanIn) Add(ch chan *Msg) bool {
 	return concurrency.TrySendThroughChannel(f.ctx, ch, f.addCh)
 }
 
-func Drain(ch chan *Msg) {
+func Drain(ch chan *Msg) *sync.WaitGroup {
 	// sync drain
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
 	go func() {
 		for msg := range ch {
 			if msg.Iter != nil {
 				msg.Iter.Stop()
 			}
 		}
+		wg.Done()
 	}()
+	return wg
 }
 
 func (f *FanIn) Out() chan *Msg {

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -48,7 +48,7 @@ func (f *FanIn) cleaner() {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for _, ch := range f.drainQueue {
-		Drain(ch).Wait()
+		Drain(ch).Wait() // drain serially to prevent creating an explosion of concurrent routines
 	}
 	f.wg.Done()
 }

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -10,34 +10,45 @@ import (
 )
 
 type FanIn struct {
-	ctx       context.Context
-	cancel    context.CancelFunc
-	count     int
-	out       chan *Msg
-	addCh     chan (chan *Msg)
-	mu        sync.Mutex
-	accepting bool
-	pool      *pool.ContextPool
-	drained   chan bool
+	ctx        context.Context
+	cancel     context.CancelFunc
+	out        chan *Msg
+	addCh      chan (chan *Msg)
+	drainQueue []chan *Msg
+	accepting  bool
+	mu         sync.Mutex
+	wg         sync.WaitGroup
+	pool       *pool.ContextPool
 }
 
 func NewFanIn(ctx context.Context, limit int) *FanIn {
 	ctx, cancel := context.WithCancel(ctx)
 
 	f := &FanIn{
-		ctx:       ctx,
-		cancel:    cancel,
-		count:     0,
-		out:       make(chan *Msg, limit),
-		addCh:     make(chan (chan *Msg), limit),
-		accepting: true,
-		mu:        sync.Mutex{},
-		pool:      concurrency.NewPool(ctx, limit),
-		drained:   make(chan bool, 1),
+		ctx:        ctx,
+		cancel:     cancel,
+		out:        make(chan *Msg, limit),
+		addCh:      make(chan (chan *Msg), limit),
+		drainQueue: make([]chan *Msg, 0),
+		accepting:  true,
+		mu:         sync.Mutex{},
+		wg:         sync.WaitGroup{},
+		pool:       concurrency.NewPool(ctx, limit),
 	}
 
+	f.wg.Add(1)
 	go f.run()
+
 	return f
+}
+
+func (f *FanIn) cleaner() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.drainQueue {
+		Drain(ch)
+	}
+	f.wg.Done()
 }
 
 func (f *FanIn) run() {
@@ -46,10 +57,15 @@ func (f *FanIn) run() {
 		_ = f.pool.Wait()
 		close(f.out)
 		for ch := range f.addCh {
-			drainOnExit(ch)
+			f.drainOnExit(ch)
 		}
-		f.drained <- true
-		close(f.drained)
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if len(f.drainQueue) > 0 {
+			f.wg.Add(1)
+			go f.cleaner()
+		}
+		f.wg.Done()
 	}()
 	for {
 		select {
@@ -60,7 +76,7 @@ func (f *FanIn) run() {
 				return
 			}
 			f.pool.Go(func(ctx context.Context) error {
-				defer drainOnExit(ch)
+				defer f.drainOnExit(ch)
 				for {
 					select {
 					case <-ctx.Done():
@@ -81,7 +97,29 @@ func (f *FanIn) run() {
 	}
 }
 
-func drainOnExit(ch chan *Msg) {
+func (f *FanIn) drainOnExit(ch chan *Msg) {
+	f.mu.Lock()
+	f.drainQueue = append(f.drainQueue, ch)
+	f.mu.Unlock()
+}
+
+// Add will not block if the amount of messages accumulated is (limit * 2) + 1 (out, pool, buffer)
+func (f *FanIn) Add(ch chan *Msg) bool {
+	f.mu.Lock()
+	if !f.accepting {
+		f.mu.Unlock()
+		return false
+	}
+	if !concurrency.TrySendThroughChannel(f.ctx, ch, f.addCh) {
+		f.mu.Unlock()
+		return false
+	}
+	f.mu.Unlock()
+	return true
+}
+
+func Drain(ch chan *Msg) {
+	// sync drain
 	for msg := range ch {
 		if msg.Iter != nil {
 			msg.Iter.Stop()
@@ -89,28 +127,8 @@ func drainOnExit(ch chan *Msg) {
 	}
 }
 
-func (f *FanIn) Add(ch chan *Msg) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.count++
-	if !f.accepting {
-		drainOnExit(ch)
-		return
-	}
-	if !concurrency.TrySendThroughChannel(f.ctx, ch, f.addCh) {
-		drainOnExit(ch)
-		return
-	}
-}
-
 func (f *FanIn) Out() chan *Msg {
 	return f.out
-}
-
-func (f *FanIn) Count() int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.count
 }
 
 func (f *FanIn) Done() {
@@ -122,8 +140,8 @@ func (f *FanIn) Done() {
 	}
 }
 
-func (f *FanIn) Close() {
+func (f *FanIn) Stop() {
 	// Done gets called internally
 	f.cancel()
-	drainOnExit(f.out)
+	f.drainOnExit(f.out)
 }

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -143,5 +143,4 @@ func (f *FanIn) Done() {
 func (f *FanIn) Stop() {
 	// Done gets called internally
 	f.cancel()
-	f.drainOnExit(f.out)
 }

--- a/internal/iterator/fan_in.go
+++ b/internal/iterator/fan_in.go
@@ -103,7 +103,7 @@ func (f *FanIn) drainOnExit(ch chan *Msg) {
 	f.mu.Unlock()
 }
 
-// Add will not block if the amount of messages accumulated is (limit * 2) + 1 (out, pool, buffer)
+// Add will not block if the amount of messages accumulated is (limit * 2) + 1 (out, pool, buffer).
 func (f *FanIn) Add(ch chan *Msg) bool {
 	f.mu.Lock()
 	if !f.accepting {

--- a/internal/iterator/fan_in_test.go
+++ b/internal/iterator/fan_in_test.go
@@ -70,5 +70,5 @@ func TestFanIn(t *testing.T) {
 	}
 	fanin.Stop()
 	fanin.wg.Wait()
-	Drain(fanin.Out())
+	Drain(fanin.Out()).Wait()
 }

--- a/internal/iterator/fan_in_test.go
+++ b/internal/iterator/fan_in_test.go
@@ -33,7 +33,7 @@ func TestFanIn(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	t.Cleanup(ctrl.Finish)
-	fanin := NewFanIn(ctx, 3)
+	fanin := NewFanIn(ctx, 5)
 
 	fanin.Add(makeIterChan(ctrl, "1", true))
 	fanin.Add(makeIterChan(ctrl, "2", true))
@@ -70,4 +70,5 @@ func TestFanIn(t *testing.T) {
 	}
 	fanin.Stop()
 	fanin.wg.Wait()
+	Drain(fanin.Out())
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Move draining of `fanin.out` channel to consumers rather than itself to prevent race conditions.
Make draining be completely in deferred goroutines.
Change `fanin.Add` to return if new channel is accepted, and handle it's draining if rejected at the client.
Fix bug in `breadthFirstRecursiveMatch` where `fanin.Stop` was not being called as early as possible in the case of recurssion.
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

