### PR TITLE
feat: expose `RunMigration` from `cmd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added pkg `migrate` to expose `.RunMigrations()` for programmatic use. [#2422](https://github.com/openfga/openfga/pull/2422)
 - Ensure `fanin.Stop` and `fanin.Drain` are called for all clients which may create blocking goroutines. [#2441](https://github.com/openfga/openfga/pull/2441)
 
-
 ## [1.8.12] - 2025-05-12
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+### Added
+- Added pkg `migrate` to expose `.RunMigrations()` for programmatic use. [#2422](https://github.com/openfga/openfga/pull/2422)
+
 ## [1.8.12] - 2025-05-12
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12)
-
-### Added
-- Added pkg `migrate` to expose `.RunMigrations()` to be used for keeping consistent migrations running openFGA as a library
 
 ### Changed
 - `DefaultResolveNodeBreadthLimit` changed from 100 to 10 in order to reduce connection contention. [#2425](https://github.com/openfga/openfga/pull/2425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.8.12] - 2025-05-12
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12)
 
+### Added
+- Added pkg `migrate` to expose `.RunMigration()` to be used for keeping consistent migrations running openFGA as a library
+
 ### Changed
 - `DefaultResolveNodeBreadthLimit` changed from 100 to 10 in order to reduce connection contention. [#2425](https://github.com/openfga/openfga/pull/2425)
 - PostgreSQL and MySQL based iterators will load tuples only when needed (lazy loading). [#2425](https://github.com/openfga/openfga/pull/2425)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
-
 ### Added
 - Added pkg `migrate` to expose `.RunMigrations()` for programmatic use. [#2422](https://github.com/openfga/openfga/pull/2422)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 [Full changelog](https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12)
 
 ### Added
-- Added pkg `migrate` to expose `.RunMigration()` to be used for keeping consistent migrations running openFGA as a library
+- Added pkg `migrate` to expose `.RunMigrations()` to be used for keeping consistent migrations running openFGA as a library
 
 ### Changed
 - `DefaultResolveNodeBreadthLimit` changed from 100 to 10 in order to reduce connection contention. [#2425](https://github.com/openfga/openfga/pull/2425)

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -2,21 +2,13 @@
 package migrate
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"net/url"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"github.com/go-sql-driver/mysql"
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver.
-	"github.com/pressly/goose/v3"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/openfga/openfga/assets"
-	"github.com/openfga/openfga/pkg/storage/sqlite"
+	"github.com/openfga/openfga/pkg/migrate"
 )
 
 const (
@@ -55,16 +47,6 @@ func NewMigrateCommand() *cobra.Command {
 	return cmd
 }
 
-type MigrationConfig struct {
-	Engine        string
-	URI           string
-	TargetVersion uint
-	Timeout       time.Duration
-	Verbose       bool
-	Username      string
-	Password      string
-}
-
 func runMigration(_ *cobra.Command, _ []string) error {
 	engine := viper.GetString(datastoreEngineFlag)
 	uri := viper.GetString(datastoreURIFlag)
@@ -74,7 +56,7 @@ func runMigration(_ *cobra.Command, _ []string) error {
 	username := viper.GetString(datastoreUsernameFlag)
 	password := viper.GetString(datastorePasswordFlag)
 
-	cfg := MigrationConfig{
+	cfg := migrate.MigrationConfig{
 		Engine:        engine,
 		URI:           uri,
 		TargetVersion: targetVersion,
@@ -83,124 +65,5 @@ func runMigration(_ *cobra.Command, _ []string) error {
 		Username:      username,
 		Password:      password,
 	}
-	return RunMigration(cfg)
-}
-
-func RunMigration(cfg MigrationConfig) error {
-	goose.SetLogger(goose.NopLogger())
-	goose.SetVerbose(cfg.Verbose)
-
-	var driver, migrationsPath string
-	var uri string
-	// We set uri based on engine
-	uri = cfg.URI
-	switch cfg.Engine {
-	case "memory":
-		log.Println("no migrations to run for `memory` datastore")
-		return nil
-	case "mysql":
-		driver = "mysql"
-		migrationsPath = assets.MySQLMigrationDir
-
-		// Parse the database uri with the mysql drivers function for it and update username/password, if set via flags
-		dsn, err := mysql.ParseDSN(uri)
-		if err != nil {
-			return fmt.Errorf("invalid database uri: %v", err)
-		}
-		if cfg.Username != "" {
-			dsn.User = cfg.Username
-		}
-		if cfg.Password != "" {
-			dsn.Passwd = cfg.Password
-		}
-		uri = dsn.FormatDSN()
-
-	case "postgres":
-		driver = "pgx"
-		migrationsPath = assets.PostgresMigrationDir
-		var username, password string
-
-		// Parse the database uri with url.Parse() and update username/password, if set via flags
-		dbURI, err := url.Parse(uri)
-		if err != nil {
-			return fmt.Errorf("invalid database uri: %v", err)
-		}
-		// if username not set
-		if cfg.Username == "" && dbURI.User != nil {
-			username = dbURI.User.Username()
-		}
-		if cfg.Password == "" && dbURI.User != nil {
-			password, _ = dbURI.User.Password()
-		}
-		dbURI.User = url.UserPassword(username, password)
-
-		// Replace CLI uri with the one we just updated.
-		uri = dbURI.String()
-	case "sqlite":
-		driver = "sqlite"
-		migrationsPath = assets.SqliteMigrationDir
-
-		var err error
-		uri, err = sqlite.PrepareDSN(uri)
-		if err != nil {
-			return err
-		}
-	case "":
-		return fmt.Errorf("missing datastore engine type")
-	default:
-		return fmt.Errorf("unknown datastore engine type: %s", cfg.Engine)
-	}
-
-	db, err := goose.OpenDBWithDriver(driver, uri)
-	if err != nil {
-		return fmt.Errorf("failed to open a connection to the datastore: %w", err)
-	}
-	defer db.Close()
-
-	policy := backoff.NewExponentialBackOff()
-	policy.MaxElapsedTime = cfg.Timeout
-	err = backoff.Retry(func() error {
-		return db.PingContext(context.Background())
-	}, policy)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database connection: %w", err)
-	}
-
-	goose.SetBaseFS(assets.EmbedMigrations)
-
-	currentVersion, err := goose.GetDBVersion(db)
-	if err != nil {
-		return fmt.Errorf("failed to get db version: %w", err)
-	}
-
-	log.Printf("current version %d", currentVersion)
-
-	if cfg.TargetVersion == 0 {
-		log.Println("running all migrations")
-		if err := goose.Up(db, migrationsPath); err != nil {
-			return fmt.Errorf("failed to run migrations: %w", err)
-		}
-		log.Println("migration done")
-		return nil
-	}
-
-	log.Printf("migrating to %d", cfg.TargetVersion)
-	targetInt64Version := int64(cfg.TargetVersion)
-
-	switch {
-	case targetInt64Version < currentVersion:
-		if err := goose.DownTo(db, migrationsPath, targetInt64Version); err != nil {
-			return fmt.Errorf("failed to run migrations down to %v: %w", targetInt64Version, err)
-		}
-	case targetInt64Version > currentVersion:
-		if err := goose.UpTo(db, migrationsPath, targetInt64Version); err != nil {
-			return fmt.Errorf("failed to run migrations up to %v: %w", targetInt64Version, err)
-		}
-	default:
-		log.Println("nothing to do")
-		return nil
-	}
-
-	log.Println("migration done")
-	return nil
+	return migrate.RunMigration(cfg)
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -87,7 +87,6 @@ func runMigration(_ *cobra.Command, _ []string) error {
 }
 
 func RunMigration(cfg MigrationConfig) error {
-
 	goose.SetLogger(goose.NopLogger())
 	goose.SetVerbose(cfg.Verbose)
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver.
-	"github.com/openfga/openfga/pkg/storage/migrate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/openfga/openfga/pkg/storage/migrate"
 )
 
 const (

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -65,5 +65,5 @@ func runMigration(_ *cobra.Command, _ []string) error {
 		Username:      username,
 		Password:      password,
 	}
-	return migrate.RunMigration(cfg)
+	return migrate.RunMigrations(cfg)
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -5,10 +5,9 @@ import (
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver.
+	"github.com/openfga/openfga/pkg/storage/migrate"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/openfga/openfga/pkg/migrate"
 )
 
 const (

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -1,7 +1,6 @@
 package migrate
 
 import (
-	"strconv"
 	"testing"
 	"time"
 
@@ -14,37 +13,6 @@ import (
 )
 
 const defaultDuration = 1 * time.Minute
-
-func TestMigrateCommandRollbacks(t *testing.T) {
-	type EngineConfig struct {
-		Engine     string
-		MinVersion int64
-	}
-	engines := []EngineConfig{
-		{Engine: "postgres"},
-		{Engine: "mysql"},
-		{Engine: "sqlite", MinVersion: 5},
-	}
-
-	for _, e := range engines {
-		t.Run(e.Engine, func(t *testing.T) {
-			container, _, uri := util.MustBootstrapDatastore(t, e.Engine)
-
-			// going from version 3 to 4 when migration #4 doesn't exist is a no-op
-			version := container.GetDatabaseSchemaVersion() + 1
-
-			migrateCommand := NewMigrateCommand()
-
-			for version >= e.MinVersion {
-				t.Logf("migrating to version %d", version)
-				migrateCommand.SetArgs([]string{"--datastore-engine", e.Engine, "--datastore-uri", uri, "--version", strconv.Itoa(int(version))})
-				err := migrateCommand.Execute()
-				require.NoError(t, err)
-				version--
-			}
-		})
-	}
-}
 
 func TestMigrateCommandNoConfigDefaultValues(t *testing.T) {
 	util.PrepareTempConfigDir(t)

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"
+	"github.com/pressly/goose/v3"
+
 	"github.com/openfga/openfga/assets"
 	"github.com/openfga/openfga/pkg/storage/sqlite"
-	"github.com/pressly/goose/v3"
 )
 
 type MigrationConfig struct {

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -1,12 +1,11 @@
 package migrate
 
 import (
-	"time"
-
 	"context"
 	"fmt"
 	"log"
 	"net/url"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -25,7 +25,7 @@ type MigrationConfig struct {
 	Password      string
 }
 
-// RunMigration runs the migrations for the given config. This function is exposed to allow embedding openFGA
+// RunMigrations runs the migrations for the given config. This function is exposed to allow embedding openFGA
 // into applications and manage OpenFGA's database schema migrations directly. When OpenFGA is used as a library,
 // the embedding application may have its own migration system that differs from OpenFGA's use of goose.
 // By exposing this function, applications can:
@@ -34,7 +34,7 @@ type MigrationConfig struct {
 // 3. Perform versioned upgrades of the schema as needed
 // The function handles migrations for multiple database engines (postgres, mysql, sqlite) and supports
 // both upgrading and downgrading to specific versions.
-func RunMigration(cfg MigrationConfig) error {
+func RunMigrations(cfg MigrationConfig) error {
 	goose.SetLogger(goose.NopLogger())
 	goose.SetVerbose(cfg.Verbose)
 

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -1,0 +1,154 @@
+package migrate
+
+import (
+	"time"
+
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/go-sql-driver/mysql"
+	"github.com/openfga/openfga/assets"
+	"github.com/openfga/openfga/pkg/storage/sqlite"
+	"github.com/pressly/goose/v3"
+)
+
+type MigrationConfig struct {
+	Engine        string
+	URI           string
+	TargetVersion uint
+	Timeout       time.Duration
+	Verbose       bool
+	Username      string
+	Password      string
+}
+
+// RunMigration runs the migrations for the given config. This function is exposed to allow embedding openFGA
+// into applications and manage OpenFGA's database schema migrations directly. When OpenFGA is used as a library,
+// the embedding application may have its own migration system that differs from OpenFGA's use of goose.
+// By exposing this function, applications can:
+// 1. Explicitly control when OpenFGA migrations run
+// 2. Integrate OpenFGA's schema updates into their own migration workflows
+// 3. Perform versioned upgrades of the schema as needed
+// The function handles migrations for multiple database engines (postgres, mysql, sqlite) and supports
+// both upgrading and downgrading to specific versions.
+func RunMigration(cfg MigrationConfig) error {
+	goose.SetLogger(goose.NopLogger())
+	goose.SetVerbose(cfg.Verbose)
+
+	var driver, migrationsPath string
+	var uri string
+	// We set uri based on engine
+	uri = cfg.URI
+	switch cfg.Engine {
+	case "memory":
+		log.Println("no migrations to run for `memory` datastore")
+		return nil
+	case "mysql":
+		driver = "mysql"
+		migrationsPath = assets.MySQLMigrationDir
+
+		// Parse the database uri with the mysql drivers function for it and update username/password, if set via flags
+		dsn, err := mysql.ParseDSN(uri)
+		if err != nil {
+			return fmt.Errorf("invalid database uri: %v", err)
+		}
+		if cfg.Username != "" {
+			dsn.User = cfg.Username
+		}
+		if cfg.Password != "" {
+			dsn.Passwd = cfg.Password
+		}
+		uri = dsn.FormatDSN()
+
+	case "postgres":
+		driver = "pgx"
+		migrationsPath = assets.PostgresMigrationDir
+		var username, password string
+
+		// Parse the database uri with url.Parse() and update username/password, if set via flags
+		dbURI, err := url.Parse(uri)
+		if err != nil {
+			return fmt.Errorf("invalid database uri: %v", err)
+		}
+		// if username not set
+		if cfg.Username == "" && dbURI.User != nil {
+			username = dbURI.User.Username()
+		}
+		if cfg.Password == "" && dbURI.User != nil {
+			password, _ = dbURI.User.Password()
+		}
+		dbURI.User = url.UserPassword(username, password)
+
+		// Replace CLI uri with the one we just updated.
+		uri = dbURI.String()
+	case "sqlite":
+		driver = "sqlite"
+		migrationsPath = assets.SqliteMigrationDir
+
+		var err error
+		uri, err = sqlite.PrepareDSN(uri)
+		if err != nil {
+			return err
+		}
+	case "":
+		return fmt.Errorf("missing datastore engine type")
+	default:
+		return fmt.Errorf("unknown datastore engine type: %s", cfg.Engine)
+	}
+
+	db, err := goose.OpenDBWithDriver(driver, uri)
+	if err != nil {
+		return fmt.Errorf("failed to open a connection to the datastore: %w", err)
+	}
+	defer db.Close()
+
+	policy := backoff.NewExponentialBackOff()
+	policy.MaxElapsedTime = cfg.Timeout
+	err = backoff.Retry(func() error {
+		return db.PingContext(context.Background())
+	}, policy)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database connection: %w", err)
+	}
+
+	goose.SetBaseFS(assets.EmbedMigrations)
+
+	currentVersion, err := goose.GetDBVersion(db)
+	if err != nil {
+		return fmt.Errorf("failed to get db version: %w", err)
+	}
+
+	log.Printf("current version %d", currentVersion)
+
+	if cfg.TargetVersion == 0 {
+		log.Println("running all migrations")
+		if err := goose.Up(db, migrationsPath); err != nil {
+			return fmt.Errorf("failed to run migrations: %w", err)
+		}
+		log.Println("migration done")
+		return nil
+	}
+
+	log.Printf("migrating to %d", cfg.TargetVersion)
+	targetInt64Version := int64(cfg.TargetVersion)
+
+	switch {
+	case targetInt64Version < currentVersion:
+		if err := goose.DownTo(db, migrationsPath, targetInt64Version); err != nil {
+			return fmt.Errorf("failed to run migrations down to %v: %w", targetInt64Version, err)
+		}
+	case targetInt64Version > currentVersion:
+		if err := goose.UpTo(db, migrationsPath, targetInt64Version); err != nil {
+			return fmt.Errorf("failed to run migrations up to %v: %w", targetInt64Version, err)
+		}
+	default:
+		log.Println("nothing to do")
+		return nil
+	}
+
+	log.Println("migration done")
+	return nil
+}

--- a/pkg/storage/migrate/migrate_test.go
+++ b/pkg/storage/migrate/migrate_test.go
@@ -1,0 +1,45 @@
+package migrate_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openfga/openfga/cmd/util"
+	"github.com/openfga/openfga/pkg/storage/migrate"
+)
+
+func TestMigrateCommandRollbacks(t *testing.T) {
+	type EngineConfig struct {
+		Engine     string
+		MinVersion int64
+	}
+	engines := []EngineConfig{
+		{Engine: "postgres"},
+		{Engine: "mysql"},
+		{Engine: "sqlite", MinVersion: 5},
+	}
+
+	for _, e := range engines {
+		t.Run(e.Engine, func(t *testing.T) {
+			container, _, uri := util.MustBootstrapDatastore(t, e.Engine)
+
+			// going from version 3 to 4 when migration #4 doesn't exist is a no-op
+			version := container.GetDatabaseSchemaVersion() + 1
+
+			for version >= e.MinVersion {
+				t.Logf("migrating to version %d", version)
+				err := migrate.RunMigrations(migrate.MigrationConfig{
+					Engine:        e.Engine,
+					URI:           uri,
+					TargetVersion: uint(version),
+					Timeout:       5 * time.Second,
+					Verbose:       true,
+				})
+				require.NoError(t, err)
+				version--
+			}
+		})
+	}
+}


### PR DESCRIPTION
feat: Expose `RunMigrations()` for library migration management

**Problem:** Grafana, embedding OpenFGA as a library, faces challenges with divergent database migration approaches. OpenFGA uses `goose`, while Grafana's migrator runs once, potentially skipping future OpenFGA schema updates and preventing versioned upgrades.

**Solution:** Utilize `RunMigrations()` from cmd for reliable schema management.

**Changes:**
* Introduces `MigrationConfig` struct.
* Adds `RunMigrations(cfg MigrationConfig) error` function to the library.
* Updates CLI `runMigration` to use the new library function.

This provides any organization that uses openFGA as a library with a method to manage OpenFGA database migrations.

Example:
```go
import "github.com/openfga/openfga/pkg/storage/migrate"

// Then use it
err := migrate.RunMigrations(migrate.MigrationConfig{
    Engine:        "postgres",
    URI:           "postgres://user:password@localhost:5432/openfga",
    TargetVersion: 0, // Latest version
    Timeout:       time.Minute,
    Verbose:       true,
})
```

**NOTE:**
I could add documentation in openfga.dev for how to use this as part of a library, after we have been able to use this.

Fixes issue: https://github.com/openfga/openfga/issues/2440