### PR TITLE
fix: add panic error handling in checkTTUSlowPath

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -3853,12 +3853,13 @@ func TestCheckTTUSlowPath(t *testing.T) {
 		iter := &mockPanicIterator[*openfgav1.TupleKey]{}
 		checker := NewLocalChecker()
 		defer checker.Close()
-
 		req := &ResolveCheckRequest{
 			TupleKey:        tuple.NewTupleKey("group:1", "member", "user:maria"),
 			RequestMetadata: NewCheckRequestMetadata(),
 		}
-		resp, err := checker.checkTTUSlowPath(ctx, req, nil, iter)
+
+		resp, err := checker.checkTTUSlowPath(context.Background(), req, typesystem.TupleToUserset("owner", "member"), iter)
+
 		require.ErrorContains(t, err, panicErr)
 		require.ErrorIs(t, err, ErrPanic)
 		require.Equal(t, (*ResolveCheckResponse)(nil), resp)

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -3848,6 +3848,21 @@ func TestCheckTTUSlowPath(t *testing.T) {
 			require.Equal(t, tt.expected, resp)
 		})
 	}
+
+	t.Run("should_error_if_panic_occurs", func(t *testing.T) {
+		iter := &mockPanicIterator[*openfgav1.TupleKey]{}
+		checker := NewLocalChecker()
+		defer checker.Close()
+
+		req := &ResolveCheckRequest{
+			TupleKey:        tuple.NewTupleKey("group:1", "member", "user:maria"),
+			RequestMetadata: NewCheckRequestMetadata(),
+		}
+		resp, err := checker.checkTTUSlowPath(ctx, req, nil, iter)
+		require.ErrorContains(t, err, panicErr)
+		require.ErrorIs(t, err, ErrPanic)
+		require.Equal(t, (*ResolveCheckResponse)(nil), resp)
+	})
 }
 
 func TestStreamedLookupUsersetFromIterator(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Add panics.Try to capture error in `checkTTUSlowPath` in check. This will ensure that panics are captured as errors and don't cause a crash.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

