### PR TITLE
chore: add fatcontext linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
   enable:
     - bodyclose
     - errname
+    - fatcontext
     - gocritic
     - gocyclo
     - godot

--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -1097,7 +1097,7 @@ func TestExpand(t *testing.T) {
 			storeID := ulid.Make().String()
 			// arrange
 			ts, err := typesystem.NewAndValidate(ctx, test.model)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx := typesystem.ContextWithTypesystem(ctx, ts)
 			require.NoError(t, err)
 
 			err = datastore.Write(

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -238,7 +238,7 @@ func TestListObjectsDispatchCount(t *testing.T) {
 				model,
 			)
 			require.NoError(t, err)
-			ctx = typesystem.ContextWithTypesystem(ctx, ts)
+			ctx := typesystem.ContextWithTypesystem(ctx, ts)
 
 			checker, checkResolverCloser, err := graph.NewOrderedCheckResolvers(
 				graph.WithDispatchThrottlingCheckResolverOpts(true, []graph.DispatchThrottlingCheckResolverOpt{


### PR DESCRIPTION
## Description
As part of #598 , it is desired to include additional linters as part of the golangci config. This PR adds one of the mentioned linters `fatcontext` and addresses applicable lints

## References
#598 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

