### PR TITLE
chore: add copyloopvar linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,6 +7,7 @@ run:
 linters:
   enable:
     - bodyclose
+    - copyloopvar
     - errname
     - gocritic
     - gocyclo

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1502,7 +1502,6 @@ func TestHTTPHeaders(t *testing.T) {
 	}
 
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			req, err := retryablehttp.NewRequest(test.httpVerb, test.httpPath, strings.NewReader(test.httpJSONBody))

--- a/internal/checkutil/checkutil_test.go
+++ b/internal/checkutil/checkutil_test.go
@@ -129,7 +129,6 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ts, err := typesystem.NewAndValidate(context.Background(), tt.model)
@@ -253,7 +252,6 @@ func TestUserFilter(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := userFilter(tt.hasPubliclyAssignedType, tt.user, tt.userType)
@@ -345,7 +343,6 @@ func TestIteratorReadStartingFromUser(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -468,7 +465,6 @@ func TestBuildUsersetDetailsUserset(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ts, err := typesystem.New(testutils.MustTransformDSLToProtoWithID(tt.model))
@@ -582,7 +578,6 @@ func TestBuildUsersetDetailsTTU(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ts, err := typesystem.New(testutils.MustTransformDSLToProtoWithID(tt.model))

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -450,7 +450,6 @@ func TestResolveCheckFromCache(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -2156,7 +2156,6 @@ func TestProduceUsersets(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			expectedUsersetsChannelResult := usersetsChannelFromUsersetsChannelStruct(tt.usersetsChannelResult)
@@ -2427,7 +2426,6 @@ func TestCheckAssociatedObjects(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2765,7 +2763,6 @@ func TestConsumeUsersets(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2978,7 +2975,6 @@ func TestProduceUsersetDispatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -3143,7 +3139,6 @@ func TestProduceTTUDispatches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -3304,7 +3299,6 @@ func TestProcessDispatch(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -3519,7 +3513,6 @@ func TestConsumeDispatch(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -3640,7 +3633,6 @@ func TestCheckUsersetSlowPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples), filter)
@@ -3824,7 +3816,6 @@ func TestCheckTTUSlowPath(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -425,7 +425,6 @@ func (q *ExpandQuery) resolveUsersets(
 	grp, ctx := errgroup.WithContext(ctx)
 	for i, us := range usersets {
 		// https://golang.org/doc/faq#closures_and_goroutines
-		i, us := i, us
 		grp.Go(func() error {
 			node, err := q.resolveUserset(ctx, store, us, tk, typesys, consistency)
 			if err != nil {

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -549,8 +549,6 @@ func (l *listUsersQuery) expandIntersection(
 	childOperands := rewrite.Intersection.GetChild()
 	intersectionFoundUsersChans := make([]chan foundUser, len(childOperands))
 	for i, rewrite := range childOperands {
-		i := i
-		rewrite := rewrite
 		intersectionFoundUsersChans[i] = make(chan foundUser, 1)
 		pool.Go(func(ctx context.Context) error {
 			resp := l.expandRewrite(ctx, req, rewrite, intersectionFoundUsersChans[i])
@@ -653,8 +651,6 @@ func (l *listUsersQuery) expandUnion(
 	childOperands := rewrite.Union.GetChild()
 	unionFoundUsersChans := make([]chan foundUser, len(childOperands))
 	for i, rewrite := range childOperands {
-		i := i
-		rewrite := rewrite
 		unionFoundUsersChans[i] = make(chan foundUser, 1)
 		pool.Go(func(ctx context.Context) error {
 			resp := l.expandRewrite(ctx, req, rewrite, unionFoundUsersChans[i])

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -3356,7 +3356,6 @@ func TestListUsersDatastoreQueryCountAndDispatchCount(t *testing.T) {
 	// run the test many times to exercise all the possible DBReads
 	for i := 1; i < 100; i++ {
 		for _, test := range tests {
-			test := test
 			t.Run(fmt.Sprintf("%s_iteration_%v", test.name, i), func(t *testing.T) {
 				l := NewListUsersQuery(ds, emptyContextualTuples)
 				resp, err := l.ListUsers(ctx, &openfgav1.ListUsersRequest{

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -992,7 +992,6 @@ func TestDefaultContextTimeout(t *testing.T) {
 		},
 	}
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			timeout := DefaultContextTimeout(&test.config)
@@ -1017,7 +1016,6 @@ func TestGetCheckDispatchThrottlingConfig(t *testing.T) {
 		},
 	}
 	for name, test := range testCases {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Cleanup(func() {
 				viper.Reset()

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -468,7 +468,6 @@ func TestListObjects(t *testing.T, ds storage.OpenFGADatastore) {
 	}
 
 	for _, test := range testCases {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -190,7 +190,6 @@ func TestSplitObjectId(t *testing.T) {
 			expectedOID:             "https://bar/baz",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			td, oid := SplitObject(tc.objectID)
 
@@ -564,7 +563,6 @@ func TestFromUserProto(t *testing.T) {
 			expected: "user:*",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := UserProtoToString(tc.input)
 			require.Equal(t, tc.expected, actual)
@@ -615,7 +613,6 @@ func TestToUserProto(t *testing.T) {
 			},
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := StringToUserProto(tc.input)
 			require.Equal(t, tc.expected, actual)

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -1014,7 +1014,6 @@ func TestResolveComputedRelation(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ts, err := New(testutils.MustTransformDSLToProtoWithID(tt.model))

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -84,7 +84,6 @@ func runTests(t *testing.T, params testParams) {
 	}
 
 	for _, test := range allTestCases {
-		test := test
 		runTest(t, test, params, false)
 		runTest(t, test, params, true)
 	}

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -257,8 +257,6 @@ func TestCheckWithQueryCacheEnabled(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
-
 		t.Run(test.name, func(t *testing.T) {
 			createResp, err := client.CreateStore(context.Background(), &openfgav1.CreateStoreRequest{
 				Name: test.name,

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -104,7 +104,6 @@ func runTests(t *testing.T, params testParams) {
 	}
 
 	for _, test := range allTestCases {
-		test := test
 		runTest(t, test, params, false)
 		runTest(t, test, params, true)
 	}

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -65,7 +65,6 @@ func RunAllTests(t *testing.T, client tests.ClientInterface) {
 			}
 
 			for _, test := range allTestCases {
-				test := test
 				runTest(t, test, client, false)
 				runTest(t, test, client, true)
 			}


### PR DESCRIPTION
## Description
As part of #598  , it is desired to include additional linters as part of the golangci config. This PR adds one of the mentioned linters copyloopvar and addresses applicable lints.


## References
#598 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

