### PR TITLE
fix: shared iterator should not store context cancelled error

### DIFF
--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -609,6 +609,9 @@ func (s *sharedIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 	item, err := s.inner.Next(ctx)
 	if err != nil {
 		telemetry.TraceError(span, err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		*s.sharedErr = err
 		return nil, err
 	}
@@ -656,6 +659,9 @@ func (s *sharedIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	item, err := s.inner.Next(ctx)
 	if err != nil {
 		telemetry.TraceError(span, err)
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return nil, err
+		}
 		*s.sharedErr = err
 		return nil, err
 	}

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -336,6 +336,7 @@ func testRunAll(t *testing.T, engine string) {
 	cfg.Datastore.Engine = engine
 	// extend the timeout for the tests, coverage makes them slower
 	cfg.RequestTimeout = 10 * time.Second
+	cfg.SharedIterator.Enabled = true
 
 	cfg.CheckIteratorCache.Enabled = true
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -85,6 +85,7 @@ func BuildClientInterface(t *testing.T, engine string, experimentals []string) C
 	cfg.ListObjectsDeadline = 0 // no deadline
 	// extend the timeout for the tests, coverage makes them slower
 	cfg.RequestTimeout = 10 * time.Second
+	cfg.SharedIterator.Enabled = true
 
 	cfg.CheckIteratorCache.Enabled = true
 	cfg.ListObjectsIteratorCache.Enabled = true


### PR DESCRIPTION

## Description
1. In the case of context cancelled error, do not store this error as this error is only specific to the request and has no bearing on the actual datastore connection.
2. Update matrix + test suite to use shared iterator.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

