### PR TITLE
Add errorlint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
     - bodyclose
     - copyloopvar
     - errname
+    - errorlint
     - fatcontext
     - gocritic
     - gocyclo

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -321,7 +321,7 @@ func ReadConfig() (*serverconfig.Config, error) {
 	viper.SetTypeByDefaultValue(true)
 	err := viper.ReadInConfig()
 	if err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+		if !errors.As(err, &viper.ConfigFileNotFoundError{}) {
 			return nil, fmt.Errorf("failed to load server config: %w", err)
 		}
 	}
@@ -904,7 +904,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 
 		go func() {
 			err = playground.ListenAndServe()
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				s.Logger.Fatal("failed to start the openfga playground server", zap.Error(err))
 			}
 			s.Logger.Info("playground shut down.")

--- a/cmd/validatemodels/validate_models.go
+++ b/cmd/validatemodels/validate_models.go
@@ -75,7 +75,7 @@ func runValidate(_ *cobra.Command, _ []string) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to open a connection to the datastore: %v", err)
+		return fmt.Errorf("failed to open a connection to the datastore: %w", err)
 	}
 
 	validationResults, err := ValidateAllAuthorizationModels(ctx, db)

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -94,7 +94,7 @@ func (e *EvaluableCondition) compile() error {
 		if err != nil {
 			return &CompilationError{
 				Condition: e.Name,
-				Cause:     fmt.Errorf("failed to decode parameter type for parameter '%s': %v", paramName, err),
+				Cause:     fmt.Errorf("failed to decode parameter type for parameter '%s': %w", paramName, err),
 			}
 		}
 
@@ -175,7 +175,7 @@ func (e *EvaluableCondition) CastContextToTypedParameters(contextMap map[string]
 		if err != nil {
 			return nil, &ParameterTypeError{
 				Condition: e.Name,
-				Cause:     fmt.Errorf("failed to decode condition parameter type '%s': %v", paramTypeRef.GetTypeName(), err),
+				Cause:     fmt.Errorf("failed to decode condition parameter type '%s': %w", paramTypeRef.GetTypeName(), err),
 			}
 		}
 
@@ -228,7 +228,7 @@ func (e *EvaluableCondition) Evaluate(
 
 	activation, err := e.celEnv.PartialVars(typedParams)
 	if err != nil {
-		return emptyEvaluationResult, NewEvaluationError(e.Name, fmt.Errorf("failed to construct condition partial vars: %v", err))
+		return emptyEvaluationResult, NewEvaluationError(e.Name, fmt.Errorf("failed to construct condition partial vars: %w", err))
 	}
 
 	var missingParameters []string
@@ -244,7 +244,7 @@ func (e *EvaluableCondition) Evaluate(
 	if err != nil {
 		return emptyEvaluationResult, NewEvaluationError(
 			e.Name,
-			fmt.Errorf("failed to evaluate condition expression: %v", err),
+			fmt.Errorf("failed to evaluate condition expression: %w", err),
 		)
 	}
 
@@ -268,7 +268,7 @@ func (e *EvaluableCondition) Evaluate(
 	if err != nil {
 		return emptyEvaluationResult, NewEvaluationError(
 			e.Name,
-			fmt.Errorf("failed to convert condition output to bool: %v", err),
+			fmt.Errorf("failed to convert condition output to bool: %w", err),
 		)
 	}
 

--- a/internal/condition/errors.go
+++ b/internal/condition/errors.go
@@ -1,6 +1,7 @@
 package condition
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/natefinch/wrap"
@@ -34,7 +35,8 @@ func NewEvaluationError(condition string, cause error) error {
 }
 
 func (e *EvaluationError) Error() string {
-	if _, ok := e.Cause.(*ParameterTypeError); ok {
+	var pTypeErr *ParameterTypeError
+	if errors.As(e.Cause, &pTypeErr) {
 		return e.Unwrap().Error()
 	}
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -188,7 +188,7 @@ func resolver(ctx context.Context, concurrencyLimit int, resultChan chan<- check
 		close(limiter)
 
 		if recoveredError != nil {
-			return fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())
+			return fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())
 		}
 
 		return nil
@@ -352,7 +352,7 @@ func exclusion(ctx context.Context, concurrencyLimit int, handlers ...CheckHandl
 		})
 
 		if recoveredError != nil {
-			baseChan <- checkOutcome{nil, fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())}
+			baseChan <- checkOutcome{nil, fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())}
 		}
 	}()
 
@@ -369,7 +369,7 @@ func exclusion(ctx context.Context, concurrencyLimit int, handlers ...CheckHandl
 			subChan <- checkOutcome{resp, err}
 		})
 		if recoveredError != nil {
-			subChan <- checkOutcome{nil, fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())}
+			subChan <- checkOutcome{nil, fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())}
 		}
 	}()
 
@@ -678,7 +678,7 @@ func (c *LocalChecker) processDispatches(ctx context.Context, limit int, dispatc
 						if recoveredError != nil {
 							concurrency.TrySendThroughChannel(
 								ctx,
-								checkOutcome{err: fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())},
+								checkOutcome{err: fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())},
 								outcomes,
 							)
 						}
@@ -763,7 +763,7 @@ func (c *LocalChecker) checkUsersetSlowPath(ctx context.Context, req *ResolveChe
 		})
 
 		if recoveredError != nil {
-			return fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())
+			return fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())
 		}
 		return nil
 	})
@@ -856,7 +856,7 @@ func (c *LocalChecker) checkMembership(ctx context.Context, req *ResolveCheckReq
 		})
 
 		if recoveredError != nil {
-			return fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())
+			return fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())
 		}
 		return nil
 	})
@@ -903,7 +903,7 @@ func (c *LocalChecker) processUsersets(ctx context.Context, req *ResolveCheckReq
 					if recoveredError != nil {
 						concurrency.TrySendThroughChannel(
 							ctx,
-							checkOutcome{err: fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())},
+							checkOutcome{err: fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())},
 							outcomes,
 						)
 					}

--- a/internal/graph/check_fast_path.go
+++ b/internal/graph/check_fast_path.go
@@ -390,7 +390,7 @@ func fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, resol
 		})
 
 		if recoveredError != nil {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Err: fmt.Errorf("%w: %s", ErrPanic, recoveredError.AsError())}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Err: fmt.Errorf("%w: %w", ErrPanic, recoveredError.AsError())}, outChan)
 		}
 	}()
 	return outChan, nil

--- a/pkg/server/commands/expand.go
+++ b/pkg/server/commands/expand.go
@@ -167,7 +167,7 @@ func (q *ExpandQuery) resolveThis(ctx context.Context, store string, tk *openfga
 	for {
 		tk, err := filteredIter.Next(ctx)
 		if err != nil {
-			if err == storage.ErrIteratorDone {
+			if errors.Is(err, storage.ErrIteratorDone) {
 				break
 			}
 			return nil, serverErrors.HandleError("", err)
@@ -287,7 +287,7 @@ func (q *ExpandQuery) resolveTupleToUserset(
 	for {
 		tk, err := filteredIter.Next(ctx)
 		if err != nil {
-			if err == storage.ErrIteratorDone {
+			if errors.Is(err, storage.ErrCollision) {
 				break
 			}
 			return nil, serverErrors.HandleError("", err)

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -263,7 +263,7 @@ func (q *ListObjectsQuery) evaluate(
 	}
 
 	if err := validation.ValidateUser(typesys, req.GetUser()); err != nil {
-		return serverErrors.ValidationError(fmt.Errorf("invalid 'user' value: %s", err))
+		return serverErrors.ValidationError(fmt.Errorf("invalid 'user' value: %w", err))
 	}
 
 	handler := func() {

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -987,7 +987,7 @@ func tupleConditionMet(ctx context.Context, reqCtx *structpb.Struct, typesys *ty
 }
 
 func panicError(recovered *panics.Recovered) error {
-	return fmt.Errorf("%w: %s", ErrPanic, recovered.AsError())
+	return fmt.Errorf("%w: %w", ErrPanic, recovered.AsError())
 }
 
 func panicExpanseResponse(recovered *panics.Recovered) expandResponse {

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -139,7 +139,7 @@ func HandleError(public string, err error) error {
 
 // HandleTupleValidateError provide common routines for handling tuples validation error.
 func HandleTupleValidateError(err error) error {
-	switch t := err.(type) {
+	switch t := err.(type) { //nolint:errorlint
 	case *tuple.InvalidTupleError:
 		return status.Error(
 			codes.Code(openfgav1.ErrorCode_invalid_tuple),

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -53,7 +53,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		// Parse the database uri with the mysql drivers function for it and update username/password, if set via flags
 		dsn, err := mysql.ParseDSN(uri)
 		if err != nil {
-			return fmt.Errorf("invalid database uri: %v", err)
+			return fmt.Errorf("invalid database uri: %w", err)
 		}
 		if cfg.Username != "" {
 			dsn.User = cfg.Username
@@ -71,7 +71,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		// Parse the database uri with url.Parse() and update username/password, if set via flags
 		dbURI, err := url.Parse(uri)
 		if err != nil {
-			return fmt.Errorf("invalid database uri: %v", err)
+			return fmt.Errorf("invalid database uri: %w", err)
 		}
 		// if username not set
 		if cfg.Username == "" && dbURI.User != nil {

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -103,7 +103,7 @@ func helperValidateMultipleClients(ctx context.Context, t *testing.T, internalSt
 					if errors.Is(err, storage.ErrIteratorDone) {
 						break
 					}
-					return fmt.Errorf("no error was expected %v", err)
+					return fmt.Errorf("no error was expected %w", err)
 				}
 
 				actual = append(actual, tup)
@@ -303,7 +303,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 						if errors.Is(err, storage.ErrIteratorDone) {
 							break
 						}
-						return fmt.Errorf("no error was expected %v", err)
+						return fmt.Errorf("no error was expected %w", err)
 					}
 
 					actual = append(actual, tup)
@@ -508,7 +508,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 						if errors.Is(err, storage.ErrIteratorDone) {
 							break
 						}
-						return fmt.Errorf("no error was expected %v", err)
+						return fmt.Errorf("no error was expected %w", err)
 					}
 
 					actual = append(actual, tup)
@@ -747,7 +747,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 						if errors.Is(err, storage.ErrIteratorDone) {
 							break
 						}
-						return fmt.Errorf("no error was expected %v", err)
+						return fmt.Errorf("no error was expected %w", err)
 					}
 
 					actual = append(actual, tup)

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -98,7 +98,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 
 		typesys, err := NewAndValidate(ctx, model)
 		if err != nil {
-			return nil, fmt.Errorf("%w: %v", ErrInvalidModel, err)
+			return nil, fmt.Errorf("%w: %w", ErrInvalidModel, err)
 		}
 
 		cache.Set(key, typesys, typesystemCacheTTL)


### PR DESCRIPTION
## Description

Adds the `errorlint` linter to golangci-lint as referenced in #598 
## References
#598 

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

