### PR TITLE
chore: add makezero linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - gocyclo
     - godot
     - importas
+    - makezero
     - mirror
     - misspell
     - perfsprint

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -291,7 +291,7 @@ func (s *MemoryBackend) read(ctx context.Context, store string, tk *openfgav1.Tu
 
 	var matches []*storage.TupleRecord
 	if tk.GetObject() == "" && tk.GetRelation() == "" && tk.GetUser() == "" {
-		matches = make([]*storage.TupleRecord, len(s.tuples[store]))
+		matches = make([]*storage.TupleRecord, 0, len(s.tuples[store]))
 		copy(matches, s.tuples[store])
 	} else {
 		for _, t := range s.tuples[store] {


### PR DESCRIPTION
## Description
This adds the `makezero` linter as mentioned in #598 .

## References
#598

## Review Checklist
- [X] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [X] The correct base branch is being used, if not `main`
- [X] I have added tests to validate that the change in functionality is working as expected

