### PR TITLE
refactor: move ReverseExpand's LoopOnEdges into its own function

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -323,7 +323,7 @@ func (c *ReverseExpandQuery) execute(
 		return err
 	}
 
-	errs := c.LoopOnEdges(
+	errs := c.loopOnEdges(
 		ctx,
 		req,
 		resultChan,
@@ -341,7 +341,7 @@ func (c *ReverseExpandQuery) execute(
 	return nil
 }
 
-func (c *ReverseExpandQuery) LoopOnEdges(
+func (c *ReverseExpandQuery) loopOnEdges(
 	ctx context.Context,
 	req *ReverseExpandRequest,
 	resultChan chan<- *ReverseExpandResult,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
In the reverse_expand operation (within ListObjects), the `execute` method does several things, including looping over all necessary edges in a named loop `LoopOnEdges`. This PR extracts that LoopOnEdges logic into its own method.

There are no changes in this PR, just organizing to prepare for some coming changes in this file.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

