### PR TITLE
fix: iteratorToUserset with multiple messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Fixed
 - SQL drivers now respect zero value for MaxOpenConns, ConnMaxIdleTime, ConnMaxLifetime. [#2484](https://github.com/openfga/openfga/pull/2484)
-- When `enable-check-optimizations` experiment flag is enabled, check for model with recursive TTU incorrect and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491)
+- When `enable-check-optimizations` experiment flag is enabled, incorrect check for model with recursion and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491)
 
 ## [1.8.13] - 2025-05-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Fixed
 - SQL drivers now respect zero value for MaxOpenConns, ConnMaxIdleTime, ConnMaxLifetime. [#2484](https://github.com/openfga/openfga/pull/2484)
-- When `enable-check-optimizations` experiment flag is enabled, check for model with recursive TTU incorrect and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491) 
+- When `enable-check-optimizations` experiment flag is enabled, check for model with recursive TTU incorrect and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491)
 
 ## [1.8.13] - 2025-05-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Fixed
 - SQL drivers now respect zero value for MaxOpenConns, ConnMaxIdleTime, ConnMaxLifetime. [#2484](https://github.com/openfga/openfga/pull/2484)
+- When `enable-check-optimizations` experiment flag is enabled, check for model with recursive TTU incorrect and user is assigned to more than 100 groups due to iteratorToUserset not handling multiple messages incorrectly. [#2491](https://github.com/openfga/openfga/pull/2491) 
 
 ## [1.8.13] - 2025-05-22
 ### Added

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -3,6 +3,7 @@ package graph
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -12,6 +13,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
+	"github.com/openfga/openfga/internal/iterator"
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
@@ -449,4 +451,90 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestIteratorToUserset(t *testing.T) {
+	type inputMessage struct {
+		input []string
+		err   error
+	}
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		inputMessages  []inputMessage
+		expectedResult []usersetMessage
+		expectedErr    error
+	}{
+		{
+			name: "simple",
+			inputMessages: []inputMessage{
+				{input: []string{"1", "2"}},
+			},
+			expectedResult: []usersetMessage{
+				{
+					userset: "1",
+				},
+				{
+					userset: "2",
+				},
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "multiple_messages",
+			inputMessages: []inputMessage{
+				{input: []string{"1"}},
+				{input: []string{"2"}},
+			},
+			expectedResult: []usersetMessage{
+				{
+					userset: "1",
+				},
+				{
+					userset: "2",
+				},
+			},
+			ctx: context.Background(),
+		},
+		{
+			name: "error_message",
+			inputMessages: []inputMessage{
+				{err: fmt.Errorf("error")},
+			},
+			expectedResult: []usersetMessage{
+				{
+					err: fmt.Errorf("error"),
+				},
+			},
+			ctx:         context.Background(),
+			expectedErr: fmt.Errorf("error"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputMessages := make(chan *iterator.Msg, len(tt.inputMessages))
+			for _, msg := range tt.inputMessages {
+				inputMessages <- &iterator.Msg{
+					Iter: storage.NewStaticIterator(msg.input),
+					Err:  msg.err,
+				}
+			}
+			close(inputMessages)
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+			var output []usersetMessage
+			outChan := make(chan usersetMessage)
+			go func() {
+				defer wg.Done()
+				for msg := range outChan {
+					output = append(output, msg)
+				}
+			}()
+			err := iteratorToUserset(inputMessages, outChan)(tt.ctx)
+			require.Equal(t, tt.expectedErr, err)
+
+			wg.Wait()
+			require.Equal(t, tt.expectedResult, output)
+		})
+	}
 }

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -454,6 +454,8 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 }
 
 func TestIteratorToUserset(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
 	type inputMessage struct {
 		input []string
 		err   error
@@ -508,6 +510,15 @@ func TestIteratorToUserset(t *testing.T) {
 			},
 			ctx:         context.Background(),
 			expectedErr: fmt.Errorf("error"),
+		},
+		{
+			name: "cancelledCtx",
+			inputMessages: []inputMessage{
+				{input: []string{"1"}},
+			},
+			expectedResult: nil,
+			ctx:            cancelledCtx,
+			expectedErr:    context.Canceled,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION


## Description
With enable-check-optimizations enabled, check for a model with recursive tuple to userset model may be incorrect if the user is assigned to more than 100 different groups due to iteratorToUserset not handline multiple messages correctly.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

