### PR TITLE
fix: regression of empty string initiation for `migrate` pkg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Fixed
 - Reverts the base docker image back to `cgr.dev/chainguard/static` [#2473](https://github.com/openfga/openfga/issues/2473)
+- Fix for picking up env vars for `migrate` pkg [#2493](https://github.com/openfga/openfga/issues/2493)
 
 ## [1.8.14] - 2025-06-10
 ### Fixed

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -73,11 +73,14 @@ func RunMigrations(cfg MigrationConfig) error {
 		if err != nil {
 			return fmt.Errorf("invalid database uri: %v", err)
 		}
-		// if username not set
-		if cfg.Username == "" && dbURI.User != nil {
+		if cfg.Username != "" {
+			username = cfg.Username
+		} else if dbURI.User != nil {
 			username = dbURI.User.Username()
 		}
-		if cfg.Password == "" && dbURI.User != nil {
+		if cfg.Password != "" {
+			password = cfg.Password
+		} else if dbURI.User != nil {
 			password, _ = dbURI.User.Password()
 		}
 		dbURI.User = url.UserPassword(username, password)


### PR DESCRIPTION
We used to have https://github.com/openfga/openfga/blob/5f720784ae7c637bc9a9ae8a18adc230982aba50/cmd/migrate/migrate.go#L64-L65

Then the regression was introduced in https://github.com/openfga/openfga/pull/2442, where we set https://github.com/openfga/openfga/blob/a3cae63e511715c91198673a1a72e7b0facc8168/pkg/storage/migrate/migrate.go#L69 to empty string initiation.

We now evaluate the following priority:
- If `--datastore-username` is provided, use
- If `--datastore-password` is provided, use
- Otherwise: fall back to URI credentials

Maintains same behavior as MySQL case, and tested on mysql

Fixes:
https://github.com/openfga/openfga/issues/2493