### PR TITLE
docs(v1.8.15): add v1.8.15 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.8.15] - 2025-06-11
 ### Added
 - Add support for separate read and write datastores for PostgreSQL. [#2479](https://github.com/openfga/openfga/pull/2479)
 
@@ -1315,7 +1317,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.14...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.15...HEAD
+[1.8.15]: https://github.com/openfga/openfga/compare/v1.8.14...v1.8.15
 [1.8.14]: https://github.com/openfga/openfga/compare/v1.8.13...v1.8.14
 [1.8.13]: https://github.com/openfga/openfga/compare/v1.8.12...v1.8.13
 [1.8.12]: https://github.com/openfga/openfga/compare/v1.8.11...v1.8.12


### PR DESCRIPTION


## Description
Add v1.8.15 release details to the CHANGELOG.


## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

