### PR TITLE
Move SQLite to lazy iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- SQLite based iterators will load tuples only when needed (lazy loading). [#2511](https://github.com/openfga/openfga/pull/2511)
 
 ## [1.8.16] - 2025-06-17
 ### Fixed

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -163,7 +163,7 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, tupleKey *openfg
 }
 
 func (s *Datastore) read(ctx context.Context, store string, tupleKey *openfgav1.TupleKey, options *storage.ReadPageOptions) (*SQLTupleIterator, error) {
-	ctx, span := startTrace(ctx, "read")
+	_, span := startTrace(ctx, "read")
 	defer span.End()
 
 	sb := s.stbl.
@@ -469,7 +469,7 @@ func (s *Datastore) ReadUsersetTuples(
 	filter storage.ReadUsersetTuplesFilter,
 	_ storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "ReadUsersetTuples")
+	_, span := startTrace(ctx, "ReadUsersetTuples")
 	defer span.End()
 
 	sb := s.stbl.
@@ -521,7 +521,7 @@ func (s *Datastore) ReadStartingWithUser(
 	filter storage.ReadStartingWithUserFilter,
 	_ storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "ReadStartingWithUser")
+	_, span := startTrace(ctx, "ReadStartingWithUser")
 	defer span.End()
 
 	var targetUsersArg sq.Or

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"sync"
 
+	sq "github.com/Masterminds/squirrel"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -19,7 +21,8 @@ type errorHandlerFn func(error, ...interface{}) error
 // SQLTupleIterator is a struct that implements the storage.TupleIterator
 // interface for iterating over tuples fetched from a SQL database.
 type SQLTupleIterator struct {
-	rows           *sql.Rows // GUARDED_BY(mu) // TODO: move this to lazy loading if possible
+	rows           *sql.Rows // GUARDED_BY(mu)
+	sb             sq.SelectBuilder
 	handleSQLError errorHandlerFn
 	// firstRow is used as a temporary storage place if head is called.
 	// If firstRow is nil and Head is called, rows.Next() will return the first item and advance
@@ -33,17 +36,37 @@ type SQLTupleIterator struct {
 var _ storage.TupleIterator = (*SQLTupleIterator)(nil)
 
 // NewSQLTupleIterator returns a SQL tuple iterator.
-func NewSQLTupleIterator(rows *sql.Rows, errHandler errorHandlerFn) *SQLTupleIterator {
+func NewSQLTupleIterator(sb sq.SelectBuilder, errHandler errorHandlerFn) *SQLTupleIterator {
 	return &SQLTupleIterator{
-		rows:           rows,
+		sb:             sb,
+		rows:           nil,
 		handleSQLError: errHandler,
 		firstRow:       nil,
 		mu:             sync.Mutex{},
 	}
 }
 
-func (t *SQLTupleIterator) next() (*storage.TupleRecord, error) {
+func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "sqlite.fetchBuffer", trace.WithAttributes())
+	defer span.End()
+	ctx = context.WithoutCancel(ctx)
+	rows, err := t.sb.QueryContext(ctx)
+	if err != nil {
+		return t.handleSQLError(err)
+	}
+	t.rows = rows
+	return nil
+}
+
+func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, error) {
 	t.mu.Lock()
+
+	if t.rows == nil {
+		if err := t.fetchBuffer(ctx); err != nil {
+			t.mu.Unlock()
+			return nil, err
+		}
+	}
 
 	if t.firstRow != nil {
 		// If head was called previously, we don't need to scan / next
@@ -105,9 +128,15 @@ func (t *SQLTupleIterator) next() (*storage.TupleRecord, error) {
 	return &record, nil
 }
 
-func (t *SQLTupleIterator) head() (*storage.TupleRecord, error) {
+func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+
+	if t.rows == nil {
+		if err := t.fetchBuffer(ctx); err != nil {
+			return nil, err
+		}
+	}
 
 	if t.firstRow != nil {
 		// If head was called previously, we don't need to scan / next
@@ -167,11 +196,12 @@ func (t *SQLTupleIterator) head() (*storage.TupleRecord, error) {
 // ToArray converts the tupleIterator to an []*openfgav1.Tuple and a possibly empty continuation token.
 // If the continuation token exists it is the ulid of the last element of the returned array.
 func (t *SQLTupleIterator) ToArray(
+	ctx context.Context,
 	opts storage.PaginationOptions,
 ) ([]*openfgav1.Tuple, string, error) {
 	var res []*openfgav1.Tuple
 	for i := 0; i < opts.PageSize; i++ {
-		tupleRecord, err := t.next()
+		tupleRecord, err := t.next(ctx)
 		if err != nil {
 			if errors.Is(err, storage.ErrIteratorDone) {
 				return res, "", nil
@@ -184,7 +214,7 @@ func (t *SQLTupleIterator) ToArray(
 	// Check if we are at the end of the iterator.
 	// If we are then we do not need to return a continuation token.
 	// This is why we have LIMIT+1 in the query.
-	tupleRecord, err := t.next()
+	tupleRecord, err := t.next(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
 			return res, "", nil
@@ -201,7 +231,7 @@ func (t *SQLTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 		return nil, ctx.Err()
 	}
 
-	record, err := t.next()
+	record, err := t.next(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +245,7 @@ func (t *SQLTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 		return nil, ctx.Err()
 	}
 
-	record, err := t.head()
+	record, err := t.head(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -225,5 +255,9 @@ func (t *SQLTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 
 // Stop terminates iteration.
 func (t *SQLTupleIterator) Stop() {
-	_ = t.rows.Close()
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.rows != nil {
+		_ = t.rows.Close()
+	}
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
With the fix introduced https://github.com/openfga/openfga/pull/2508 the test suite for SQLite moving to async passes consistently.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

