### PR TITLE
fix: shared iterator metrics

### DIFF
--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -223,7 +223,10 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 		"sharedIterator.ReadStartingWithUser",
 	)
 	defer span.End()
-	span.SetAttributes(attribute.String("consistency_preference", options.Consistency.Preference.String()))
+	span.SetAttributes(
+		attribute.String("consistency_preference", options.Consistency.Preference.String()),
+		attribute.String("bypassed", "false"),
+	)
 
 	if options.Consistency.Preference == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		// for now, we will skip shared iterator since there is a possibility that the request
@@ -260,6 +263,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 	})
 
 	if full {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationReadStartingWithUser).Inc()
 		return sf.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	}
@@ -321,6 +325,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 	// If the iterator is nil, we will fall back to the inner RelationshipTupleReader.
 	// This can happen if the cloned shared iterator is already stopped and all references have been cleaned up.
 	if it == nil {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationReadStartingWithUser).Inc()
 		return sf.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	}
@@ -347,7 +352,10 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 		"sharedIterator.ReadUsersetTuples",
 	)
 	defer span.End()
-	span.SetAttributes(attribute.String("consistency_preference", options.Consistency.Preference.String()))
+	span.SetAttributes(
+		attribute.String("consistency_preference", options.Consistency.Preference.String()),
+		attribute.String("bypassed", "false"),
+	)
 
 	if options.Consistency.Preference == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		return sf.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
@@ -376,6 +384,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 	})
 
 	if full {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationReadUsersetTuples).Inc()
 		return sf.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	}
@@ -437,6 +446,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 	// If the iterator is nil, we will fall back to the inner RelationshipTupleReader.
 	// This can happen if the cloned shared iterator is already stopped and all references have been cleaned up.
 	if it == nil {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationReadUsersetTuples).Inc()
 		return sf.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	}
@@ -462,7 +472,10 @@ func (sf *IteratorDatastore) Read(
 		"sharedIterator.Read",
 	)
 	defer span.End()
-	span.SetAttributes(attribute.String("consistency_preference", options.Consistency.Preference.String()))
+	span.SetAttributes(
+		attribute.String("consistency_preference", options.Consistency.Preference.String()),
+		attribute.String("bypassed", "false"),
+	)
 
 	if options.Consistency.Preference == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		return sf.RelationshipTupleReader.Read(ctx, store, tupleKey, options)
@@ -491,6 +504,7 @@ func (sf *IteratorDatastore) Read(
 	})
 
 	if full {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationRead).Inc()
 		return sf.RelationshipTupleReader.Read(ctx, store, tupleKey, options)
 	}
@@ -552,6 +566,7 @@ func (sf *IteratorDatastore) Read(
 	// If the iterator is nil, we will fall back to the inner RelationshipTupleReader.
 	// This can happen if the cloned shared iterator is already stopped and all references have been cleaned up.
 	if it == nil {
+		span.SetAttributes(attribute.String("bypassed", "true"))
 		sharedIteratorBypassed.WithLabelValues(storagewrappersutil.OperationRead).Inc()
 		return sf.RelationshipTupleReader.Read(ctx, store, tupleKey, options)
 	}

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -291,6 +291,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 			timer.Stop()
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 
@@ -413,6 +414,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 			timer.Stop()
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 
@@ -535,6 +537,7 @@ func (sf *IteratorDatastore) Read(
 			timer.Stop()
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -729,7 +729,7 @@ func (s *sharedIterator) clone() *sharedIterator {
 		remaining := s.refs.Load()
 
 		// If the reference count is zero, it means that the iterator has been stopped and cleaned up.
-		if remaining == 0 {
+		if remaining <= 0 {
 			return nil
 		}
 

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -244,23 +244,8 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 	}
 	span.SetAttributes(attribute.String("cache_key", cacheKey))
 
-	// Check if the internal storage has reached its limit.
-	// If it has, we will bypass the shared iterator and use the inner reader directly.
-	// This is to prevent memory exhaustion and ensure that the storage does not grow indefinitely.
-	var count int
-
 	// If the limit is zero, we will not use the shared iterator.
-	full := sf.internalStorage.limit == 0
-
-	// Iterate over the internal storage to count the number of items.
-	// This call will short-circuit if the count exceeds the limit.
-	// The outcome of this operation is not guaranteed to be accurate, but it is sufficient for our use case.
-	// The number of items admitted may be able to exceed the limit.
-	sf.internalStorage.iters.Range(func(_, _ any) bool {
-		count++
-		full = count >= int(sf.internalStorage.limit)
-		return !full
-	})
+	full := sf.internalStorage.limit == 0 || sf.internalStorage.ctr.Load() >= sf.internalStorage.limit
 
 	if full {
 		span.SetAttributes(attribute.String("bypassed", "true"))
@@ -365,23 +350,8 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 	cacheKey := storagewrappersutil.ReadUsersetTuplesKey(store, filter)
 	span.SetAttributes(attribute.String("cache_key", cacheKey))
 
-	// Check if the internal storage has reached its limit.
-	// If it has, we will bypass the shared iterator and use the inner reader directly.
-	// This is to prevent memory exhaustion and ensure that the storage does not grow indefinitely.
-	var count int
-
 	// If the limit is zero, we will not use the shared iterator.
-	full := sf.internalStorage.limit == 0
-
-	// Iterate over the internal storage to count the number of items.
-	// This call will short-circuit if the count exceeds the limit.
-	// The outcome of this operation is not guaranteed to be accurate, but it is sufficient for our use case.
-	// The number of items admitted may be able to exceed the limit.
-	sf.internalStorage.iters.Range(func(_, _ any) bool {
-		count++
-		full = count >= int(sf.internalStorage.limit)
-		return !full
-	})
+	full := sf.internalStorage.limit == 0 || sf.internalStorage.ctr.Load() >= sf.internalStorage.limit
 
 	if full {
 		span.SetAttributes(attribute.String("bypassed", "true"))
@@ -485,23 +455,8 @@ func (sf *IteratorDatastore) Read(
 	cacheKey := storagewrappersutil.ReadKey(store, tupleKey)
 	span.SetAttributes(attribute.String("cache_key", cacheKey))
 
-	// Check if the internal storage has reached its limit.
-	// If it has, we will bypass the shared iterator and use the inner reader directly.
-	// This is to prevent memory exhaustion and ensure that the storage does not grow indefinitely.
-	var count int
-
 	// If the limit is zero, we will not use the shared iterator.
-	full := sf.internalStorage.limit == 0
-
-	// Iterate over the internal storage to count the number of items.
-	// This call will short-circuit if the count exceeds the limit.
-	// The outcome of this operation is not guaranteed to be accurate, but it is sufficient for our use case.
-	// The number of items admitted may be able to exceed the limit.
-	sf.internalStorage.iters.Range(func(_, _ any) bool {
-		count++
-		full = count >= int(sf.internalStorage.limit)
-		return !full
-	})
+	full := sf.internalStorage.limit == 0 || sf.internalStorage.ctr.Load() >= sf.internalStorage.limit
 
 	if full {
 		span.SetAttributes(attribute.String("bypassed", "true"))

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -2,6 +2,7 @@ package sharediterator
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -297,13 +298,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 
 		sharedIteratorCount.Inc()
 
-		span.SetAttributes(attribute.Bool("found", false))
-
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationReadStartingWithUser, sf.method, "false",
-		).Observe(float64(time.Since(start).Milliseconds()))
-
-		return newIterator, err
+		return newIterator, nil
 	}
 
 	// Load or store the new storage item in the internal storage map.
@@ -330,13 +325,12 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 		return sf.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	}
 
-	if !created {
-		span.SetAttributes(attribute.Bool("found", true))
+	span.SetAttributes(attribute.Bool("found", !created))
 
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationReadStartingWithUser, sf.method, "true",
-		).Observe(float64(time.Since(start).Milliseconds()))
-	}
+	sharedIteratorQueryHistogram.WithLabelValues(
+		storagewrappersutil.OperationReadStartingWithUser, sf.method, strconv.FormatBool(!created),
+	).Observe(float64(time.Since(start).Milliseconds()))
+
 	return it, nil
 }
 
@@ -420,13 +414,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 
 		sharedIteratorCount.Inc()
 
-		span.SetAttributes(attribute.Bool("found", false))
-
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationReadUsersetTuples, sf.method, "false",
-		).Observe(float64(time.Since(start).Milliseconds()))
-
-		return newIterator, err
+		return newIterator, nil
 	}
 
 	// Load or store the new storage item in the internal storage map.
@@ -453,13 +441,11 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 		return sf.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	}
 
-	if !created {
-		span.SetAttributes(attribute.Bool("found", true))
+	span.SetAttributes(attribute.Bool("found", !created))
 
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationReadUsersetTuples, sf.method, "true",
-		).Observe(float64(time.Since(start).Milliseconds()))
-	}
+	sharedIteratorQueryHistogram.WithLabelValues(
+		storagewrappersutil.OperationReadUsersetTuples, sf.method, strconv.FormatBool(!created),
+	).Observe(float64(time.Since(start).Milliseconds()))
 
 	return it, nil
 }
@@ -543,13 +529,7 @@ func (sf *IteratorDatastore) Read(
 
 		sharedIteratorCount.Inc()
 
-		span.SetAttributes(attribute.Bool("found", false))
-
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationRead, sf.method, "false",
-		).Observe(float64(time.Since(start).Milliseconds()))
-
-		return newIterator, err
+		return newIterator, nil
 	}
 
 	// Load or store the new storage item in the internal storage map.
@@ -576,13 +556,11 @@ func (sf *IteratorDatastore) Read(
 		return sf.RelationshipTupleReader.Read(ctx, store, tupleKey, options)
 	}
 
-	if !created {
-		span.SetAttributes(attribute.Bool("found", true))
+	span.SetAttributes(attribute.Bool("found", !created))
 
-		sharedIteratorQueryHistogram.WithLabelValues(
-			storagewrappersutil.OperationRead, sf.method, "true",
-		).Observe(float64(time.Since(start).Milliseconds()))
-	}
+	sharedIteratorQueryHistogram.WithLabelValues(
+		storagewrappersutil.OperationRead, sf.method, strconv.FormatBool(!created),
+	).Observe(float64(time.Since(start).Milliseconds()))
 
 	return it, nil
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This PR fixes numerous issues surrounding the collections of metrics for the new shared iterator implementation.

Chiefly, we were reporting `shared:true` for every call, even if a new iterator was created, and even when we already reported `shared:false`. This was heavily skewing the metrics.

There were also places where the shared iterator was being bypassed, but we were not incrementing the bypass counter.

Lastly, we were not adding a `found` attribute to the span when the shared iterator was cloned (reused).

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a metric label in user set tuple reading operations to ensure accurate telemetry reporting.

- **New Features**
	- Enhanced telemetry and tracing for iterator operations, providing clearer insights into whether iterators are newly created or reused. This results in more precise monitoring and diagnostics for shared iterator usage.
	- Improved tracking of shared iterator creation and removal, enabling better resource usage visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->