### PR TITLE
CICD: skip revive var-naming rule

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,8 +54,9 @@ linters:
       checks:
         - all
     revive:
-      disable:
-        - var-naming
+      rules:
+        - name: var-naming
+          disabled: true
   exclusions:
     generated: lax
     rules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,6 +53,10 @@ linters:
     staticcheck:
       checks:
         - all
+    revive:
+      rules:
+        - name: var-naming
+          disabled: true
   exclusions:
     generated: lax
     rules:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,9 +54,8 @@ linters:
       checks:
         - all
     revive:
-      rules:
-        - name: var-naming
-          disabled: true
+      disable:
+        - var-naming
   exclusions:
     generated: lax
     rules:


### PR DESCRIPTION


## Description
For now, skip var-naming as it flags existing packages.

## References
https://github.com/openfga/openfga/actions/runs/15977236798/job/45062806802?pr=2532

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linter configuration to disable variable naming checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->