### PR TITLE
fix-iterator-cache-invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - SQLite based iterators will load tuples only when needed (lazy loading). [#2511](https://github.com/openfga/openfga/pull/2511)
 - Shared iterator improvement to reduce lock contention when creating and cloning. [#2530](https://github.com/openfga/openfga/pull/2530)
 - Enable experimental list object optimizations in shadow mode using flag `enable-list-objects-optimizations`. [#2509](https://github.com/openfga/openfga/pull/2509)
+- Invalidated iterators will be removed from cache if an invalid entity entry is found allowing for less time to refresh. [#2536](https://github.com/openfga/openfga/pull/2536)
 
 ### Fixed
 - Cache Controller was always completely invalidating. [#2522](https://github.com/openfga/openfga/pull/2522)

--- a/internal/mocks/mock_cache.go
+++ b/internal/mocks/mock_cache.go
@@ -79,15 +79,15 @@ func (m *MockInMemoryCache[T]) EXPECT() *MockInMemoryCacheMockRecorder[T] {
 }
 
 // Delete mocks base method.
-func (m *MockInMemoryCache[T]) Delete(prefix string) {
+func (m *MockInMemoryCache[T]) Delete(key string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Delete", prefix)
+	m.ctrl.Call(m, "Delete", key)
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockInMemoryCacheMockRecorder[T]) Delete(prefix any) *gomock.Call {
+func (mr *MockInMemoryCacheMockRecorder[T]) Delete(key any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInMemoryCache[T])(nil).Delete), prefix)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockInMemoryCache[T])(nil).Delete), key)
 }
 
 // Get mocks base method.

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -60,7 +60,7 @@ type InMemoryCache[T any] interface {
 	Get(key string) T
 	Set(key string, value T, ttl time.Duration)
 
-	Delete(prefix string)
+	Delete(key string)
 
 	// Stop cleans resources.
 	Stop()

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -244,10 +244,15 @@ func (c *CachedDatastore) Read(
 }
 
 func isInvalidAt(cache storage.InMemoryCache[any], ts time.Time, invalidStore string, invalidEntityKeys []string) bool {
-	keys := make([]string, 1, len(invalidEntityKeys)+1) // micro optimization, start 1 to append
-	keys[0] = invalidStore                              // set the first value directly
-	keys = append(keys, invalidEntityKeys...)
-	for _, invalidEntityKey := range keys {
+	if res := cache.Get(invalidStore); res != nil {
+		invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
+		// if the invalid entity is not valid, do not discard
+		if ok && ts.Before(invalidEntry.LastModified) {
+			return true
+		}
+	}
+
+	for _, invalidEntityKey := range invalidEntityKeys {
 		if res := cache.Get(invalidEntityKey); res != nil {
 			invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
 			// if the invalid entity is not valid, do not discard

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -244,7 +244,10 @@ func (c *CachedDatastore) Read(
 }
 
 func isInvalidAt(cache storage.InMemoryCache[any], ts time.Time, invalidStore string, invalidEntityKeys []string) bool {
-	for _, invalidEntityKey := range append([]string{invalidStore}, invalidEntityKeys...) {
+	keys := make([]string, 1, len(invalidEntityKeys)+1) // micro optimization, start 1 to append
+	keys[0] = invalidStore                              // set the first value directly
+	keys = append(keys, invalidEntityKeys...)
+	for _, invalidEntityKey := range keys {
 		if res := cache.Get(invalidEntityKey); res != nil {
 			invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
 			// if the invalid entity is not valid, do not discard

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -243,65 +243,42 @@ func (c *CachedDatastore) Read(
 		tupleKey.GetRelation())
 }
 
+func isInvalidAt(cache storage.InMemoryCache[any], ts time.Time, invalidStore string, invalidEntityKeys []string) bool {
+	for _, invalidEntityKey := range append([]string{invalidStore}, invalidEntityKeys...) {
+		if res := cache.Get(invalidEntityKey); res != nil {
+			invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
+			// if the invalid entity is not valid, do not discard
+			if ok && ts.Before(invalidEntry.LastModified) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // findInCache tries to find a key in the cache.
 // It returns true if and only if:
 // the key is present, and
 // the cache key satisfies TS(key) >= TS(store), and
 // all of the invalidEntityKeys satisfy TS(key) >= TS(invalid).
-func findInCache(cache storage.InMemoryCache[any], store, key string, invalidEntityKeys []string, logger logger.Logger) (*storage.TupleIteratorCacheEntry, bool) {
+func findInCache(cache storage.InMemoryCache[any], key, storeKey string, invalidEntityKeys []string) (*storage.TupleIteratorCacheEntry, bool) {
 	var tupleEntry *storage.TupleIteratorCacheEntry
 	var ok bool
 
-	// The iterator cache has a TTL and will eventually consistent.
-	if res := cache.Get(key); res != nil {
-		tupleEntry, ok = res.(*storage.TupleIteratorCacheEntry)
-		if !ok {
-			return nil, false
-		}
-	} else {
-		logger.Debug("CachedDatastore findInCache not found ", zap.String("store_id", store), zap.String("key", key))
+	res := cache.Get(key)
+	if res == nil {
+		return nil, false
+	}
+	tupleEntry, ok = res.(*storage.TupleIteratorCacheEntry)
+	if !ok {
 		return nil, false
 	}
 
-	invalidCacheKey := storage.GetInvalidIteratorCacheKey(store)
-	if res := cache.Get(invalidCacheKey); res != nil {
-		invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
-		if !ok || tupleEntry.LastModified.Before(invalidEntry.LastModified) {
-			invalidEntryLastModifiedTime := time.Time{}
-			if ok {
-				invalidEntryLastModifiedTime = invalidEntry.LastModified
-			}
-
-			logger.Debug("CachedDatastore found in cache but has expired for invalidCacheKey",
-				zap.String("store_id", store),
-				zap.String("key", key),
-				zap.Time("invalidEntry.LastModified", invalidEntryLastModifiedTime),
-				zap.Time("tupleEntry.LastModified", tupleEntry.LastModified))
-
-			return nil, false
-		}
+	invalid := isInvalidAt(cache, tupleEntry.LastModified, storeKey, invalidEntityKeys)
+	if invalid {
+		cache.Delete(key)
+		return nil, false
 	}
-	for _, invalidEntityKey := range invalidEntityKeys {
-		if res := cache.Get(invalidEntityKey); res != nil {
-			invalidEntry, ok := res.(*storage.InvalidEntityCacheEntry)
-			if !ok || tupleEntry.LastModified.Before(invalidEntry.LastModified) {
-				invalidEntryLastModifiedTime := time.Time{}
-				if ok {
-					invalidEntryLastModifiedTime = invalidEntry.LastModified
-				}
-
-				logger.Debug("CachedDatastore findInCache but has expired for invalidEntry",
-					zap.String("store_id", store),
-					zap.String("key", key),
-					zap.String("invalidEntityKey", invalidEntityKey),
-					zap.Time("invalidEntry.LastModified", invalidEntryLastModifiedTime),
-					zap.Time("tupleEntry.LastModified", tupleEntry.LastModified))
-
-				return nil, false
-			}
-		}
-	}
-	logger.Debug("CachedDatastore findInCache ", zap.String("store_id", store), zap.String("key", key))
 
 	return tupleEntry, true
 }
@@ -363,7 +340,8 @@ func (c *CachedDatastore) newCachedIterator(
 	span.SetAttributes(attribute.String("cache_key", cacheKey))
 	tuplesCacheTotalCounter.WithLabelValues(operation, c.method).Inc()
 
-	if cacheEntry, ok := findInCache(c.cache, store, cacheKey, invalidEntityKeys, c.logger); ok {
+	invalidStoreKey := storage.GetInvalidIteratorCacheKey(store)
+	if cacheEntry, ok := findInCache(c.cache, cacheKey, invalidStoreKey, invalidEntityKeys); ok {
 		tuplesCacheHitCounter.WithLabelValues(operation, c.method).Inc()
 		span.SetAttributes(attribute.Bool("cached", true))
 
@@ -394,10 +372,12 @@ func (c *CachedDatastore) newCachedIterator(
 		// set an initial fraction capacity to balance constant reallocation and memory usage
 		tuples:            make([]*openfgav1.Tuple, 0, c.maxResultSize/2),
 		cacheKey:          cacheKey,
+		invalidStoreKey:   invalidStoreKey,
 		invalidEntityKeys: invalidEntityKeys,
 		cache:             c.cache,
 		maxResultSize:     c.maxResultSize,
 		ttl:               c.ttl,
+		initializedAt:     time.Now(),
 		sf:                c.sf,
 		objectType:        objectType,
 		objectID:          objectID,
@@ -415,9 +395,11 @@ type cachedIterator struct {
 	operation         string
 	method            string
 	cacheKey          string
+	invalidStoreKey   string
 	invalidEntityKeys []string
 	cache             storage.InMemoryCache[any]
 	ttl               time.Duration
+	initializedAt     time.Time
 
 	objectID   string
 	objectType string
@@ -513,9 +495,16 @@ func (c *cachedIterator) Stop() {
 		defer c.wg.Done()
 		defer c.iter.Stop()
 
-		// if cache is already set, we don't need to drain the iterator
-		_, ok := findInCache(c.cache, c.store, c.cacheKey, c.invalidEntityKeys, c.logger)
+		// if cache is already set by another instance, we don't need to drain the iterator
+		_, ok := findInCache(c.cache, c.cacheKey, c.invalidStoreKey, c.invalidEntityKeys)
 		if ok {
+			c.iter.Stop()
+			c.tuples = nil
+			return
+		}
+
+		// if there was an invalidation _after_ the initialization, it shouldn't be stored
+		if isInvalidAt(c.cache, c.initializedAt, c.invalidStoreKey, c.invalidEntityKeys) {
 			c.iter.Stop()
 			c.tuples = nil
 			return


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cache invalidation logic by centralizing checks and updating parameter naming for clarity.
  * Refined cache key handling and usage across the codebase for consistency.
  * Enhanced iterator behavior to prevent caching stale data if invalidation occurs after iterator creation.

* **Tests**
  * Updated tests to align with new cache key generation and invalidation logic, ensuring more precise and consistent cache interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->