### PR TITLE
fix: race condition and deadlock in shared iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 - Cache Controller was always completely invalidating. [#2522](https://github.com/openfga/openfga/pull/2522)
+- Shared iterator contained a race condition and deadlock. [#2538](https://github.com/openfga/openfga/pull/2538)
 
 ## [1.8.16] - 2025-06-17
 ### Fixed

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -625,19 +625,11 @@ type sharedIterator struct {
 
 	// refs is a shared atomic counter that keeps track of the number of shared instances of the iterator.
 	refs *atomic.Int64
-
-	// ch is a shared atomic pointer to a channel that is used to signal when new items are available.
-	ch *atomic.Pointer[chan struct{}]
 }
 
 // newSharedIterator creates a new shared iterator from the given storage.TupleIterator.
 // It initializes the shared context, cancellation function, and other necessary fields.
 func newSharedIterator(it storage.TupleIterator, cleanup func()) *sharedIterator {
-	// Initialize the channel that will be used to signal when new items are available.
-	ch := make(chan struct{})
-	var pch atomic.Pointer[chan struct{}]
-	pch.Store(&ch)
-
 	// Initialize the reference counter to 1, indicating that there is one active instance of the iterator.
 	var refs atomic.Int64
 	refs.Store(1)
@@ -671,7 +663,6 @@ func newSharedIterator(it storage.TupleIterator, cleanup func()) *sharedIterator
 		ir:      ir,
 		state:   &pstate,
 		refs:    &refs,
-		ch:      &pch,
 	}
 
 	return &newIter
@@ -698,7 +689,6 @@ func (s *sharedIterator) clone() *sharedIterator {
 				ir:      s.ir,
 				state:   s.state,
 				refs:    s.refs,
-				ch:      s.ch,
 			}
 		}
 	}

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -41,6 +41,846 @@ type testIteratorInfo struct {
 	err  error
 }
 
+func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Clone the shared iterator for each benchmark iteration
+		clonedIter := sharedIter.clone()
+		if clonedIter == nil {
+			b.Fatal("Failed to clone shared iterator")
+		}
+
+		// Read all tuples from the cloned iterator
+		for {
+			_, err := clonedIter.Next(ctx)
+			if err != nil {
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+				b.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		clonedIter.Stop()
+	}
+}
+
+func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator for each goroutine
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			// Read all tuples from the cloned iterator
+			for {
+				_, err := clonedIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	b.Run("SharedIterator", func(b *testing.B) {
+		staticIter := storage.NewStaticTupleIterator(tuples)
+		sharedIter := newSharedIterator(staticIter, func() {})
+		defer sharedIter.Stop()
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			for {
+				_, err := clonedIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			clonedIter.Stop()
+		}
+	})
+
+	b.Run("DirectStaticIterator", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			staticIter := storage.NewStaticTupleIterator(tuples)
+
+			for {
+				_, err := staticIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			staticIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorClone(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Clone the shared iterator
+		clonedIter := sharedIter.clone()
+		if clonedIter == nil {
+			b.Fatal("Failed to clone shared iterator")
+		}
+		clonedIter.Stop()
+	}
+}
+
+func BenchmarkSharedIteratorConcurrentCloning(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator concurrently
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorCloneAndRead(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator concurrently
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			// Read one tuple to simulate realistic usage
+			_, err := clonedIter.Next(ctx)
+			if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+				b.Fatalf("Unexpected error: %v", err)
+			}
+
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorConcurrentCloneStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create larger test data for stress testing
+	var tks []*openfgav1.TupleKey
+	for i := 0; i < 100; i++ {
+		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	// Use a higher number of goroutines for stress testing
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Clone the shared iterator
+				clonedIter := sharedIter.clone()
+				if clonedIter == nil {
+					b.Error("Failed to clone shared iterator")
+					return
+				}
+
+				// Simulate some work by reading a few tuples
+				for k := 0; k < 3; k++ {
+					_, err := clonedIter.Next(ctx)
+					if err != nil {
+						if errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						break
+					}
+				}
+
+				clonedIter.Stop()
+			}()
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadConcurrentStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects single call that returns static iterator
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Create iterator
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					b.Errorf("Failed to create iterator: %v", err)
+					return
+				}
+				defer iter.Stop()
+
+				// Read all tuples
+				var count int
+				for {
+					_, err := iter.Next(ctx)
+					if err != nil {
+						if errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						return
+					}
+					count++
+				}
+
+				if count != len(tuples) {
+					b.Errorf("Expected %d tuples, got %d", len(tuples), count)
+				}
+			}()
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadConcurrentMixedOperations(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 50
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		// Mix of different operation patterns
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+
+			switch j % 4 {
+			case 0:
+				// Full read
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					for {
+						_, err := iter.Next(ctx)
+						if err != nil {
+							if errors.Is(err, storage.ErrIteratorDone) {
+								break
+							}
+							b.Errorf("Unexpected error: %v", err)
+							return
+						}
+					}
+				}()
+
+			case 1:
+				// Head then partial read
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					// Check head
+					_, err = iter.Head(ctx)
+					if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+						b.Errorf("Unexpected error on Head: %v", err)
+						return
+					}
+
+					// Read a few items
+					for k := 0; k < 2; k++ {
+						_, err := iter.Next(ctx)
+						if err != nil {
+							if errors.Is(err, storage.ErrIteratorDone) {
+								break
+							}
+							b.Errorf("Unexpected error: %v", err)
+							return
+						}
+					}
+				}()
+
+			case 2:
+				// Early stop
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+
+					// Read one item then stop
+					_, err = iter.Next(ctx)
+					if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+						b.Errorf("Unexpected error: %v", err)
+					}
+
+					iter.Stop()
+				}()
+
+			case 3:
+				// Multiple head calls
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					// Multiple head calls
+					for k := 0; k < 3; k++ {
+						_, err = iter.Head(ctx)
+						if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+							b.Errorf("Unexpected error on Head: %v", err)
+							break
+						}
+					}
+				}()
+			}
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create larger test data for stress testing
+	var tks []*openfgav1.TupleKey
+	for i := 0; i < 1000; i++ {
+		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects single call
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 1000
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var wg sync.WaitGroup
+
+			for j := 0; j < numGoroutines; j++ {
+				wg.Add(1)
+				go func(id int) {
+					defer wg.Done()
+
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Goroutine %d: Failed to create iterator: %v", id, err)
+						return
+					}
+					defer iter.Stop()
+
+					// Simulate different reading patterns
+					if id%3 == 0 {
+						// Full read
+						var count int
+						for {
+							_, err := iter.Next(ctx)
+							if err != nil {
+								if errors.Is(err, storage.ErrIteratorDone) {
+									break
+								}
+								b.Errorf("Goroutine %d: Unexpected error: %v", id, err)
+								return
+							}
+							count++
+						}
+					} else if id%3 == 1 {
+						// Partial read with random stop
+						readCount := id%10 + 1
+						for k := 0; k < readCount; k++ {
+							_, err := iter.Next(ctx)
+							if err != nil {
+								if errors.Is(err, storage.ErrIteratorDone) {
+									break
+								}
+								b.Errorf("Goroutine %d: Unexpected error: %v", id, err)
+								return
+							}
+						}
+					} else {
+						// Head operations
+						for k := 0; k < 5; k++ {
+							_, err := iter.Head(ctx)
+							if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+								b.Errorf("Goroutine %d: Unexpected error on Head: %v", id, err)
+								return
+							}
+						}
+					}
+				}(j)
+			}
+
+			wg.Wait()
+		}
+	})
+}
+
+func BenchmarkIteratorDatastoreReadRapidCreateDestroy(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		// Rapidly create and destroy iterators
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Create iterator
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					b.Errorf("Failed to create iterator: %v", err)
+					return
+				}
+
+				// Immediately stop (stress test reference counting)
+				iter.Stop()
+			}()
+		}
+
+		wg.Wait()
+
+		// Verify internal storage is cleaned up
+		if length(&internalStorage.iters) != 0 {
+			b.Errorf("Expected internal storage to be empty, but found %d items", length(&internalStorage.iters))
+		}
+	}
+}
+
+func BenchmarkIteratorDatastoreReadWithContextCancellation(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 50
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+
+				// Create context with random timeout
+				timeout := time.Duration(id%10+1) * time.Millisecond
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					// Context might be cancelled during Read
+					return
+				}
+				defer iter.Stop()
+
+				// Try to read with cancelled context
+				for {
+					_, err := iter.Next(ctx)
+					if err != nil {
+						// Expected to get context cancelled or iterator done
+						if errors.Is(err, context.Canceled) ||
+							errors.Is(err, context.DeadlineExceeded) ||
+							errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						return
+					}
+				}
+			}(j)
+		}
+
+		wg.Wait()
+	}
+}
+
 // helper function to validate the single client case.
 func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStorage *Storage, iter storage.TupleIterator, expected []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -687,7 +687,8 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 					defer iter.Stop()
 
 					// Simulate different reading patterns
-					if id%3 == 0 {
+					switch id % 3 {
+					case 0:
 						// Full read
 						var count int
 						for {
@@ -701,7 +702,7 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 							}
 							count++
 						}
-					} else if id%3 == 1 {
+					case 1:
 						// Partial read with random stop
 						readCount := id%10 + 1
 						for k := 0; k < readCount; k++ {
@@ -714,7 +715,7 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 								return
 							}
 						}
-					} else {
+					default:
 						// Head operations
 						for k := 0; k < 5; k++ {
 							_, err := iter.Head(ctx)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This change addresses a bug in the shared iterator that can cause an instance to return `ErrIteratorDone` on a call to `Next`, before having fully traversed the underlying iterator.

This bug is caused by a race condition introduced by the read and write of two disparate atomic fields: `items` and `err`; instead, the values should be read and written as a single atomic unit.

This change also addresses another bug in the shared iterator that can cause a deadlock. This can happen as a result of a race to load a shared channel, and then swap the shared channel with a new one and select over it.

The internal `context.Context` of the shared iterator has also been removed. This internal context only applied to the call to `Next` on the internal iterator, and served no meaningful purpose.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition and potential deadlock in the shared iterator, improving stability during concurrent access.

* **Tests**
  * Added comprehensive benchmark tests to measure and stress test the performance and concurrency handling of the shared iterator and datastore implementations.

* **Documentation**
  * Updated the changelog to reflect the fixed concurrency issue in the shared iterator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->