### PR TITLE
Log main and shadow ListObjects query latencies

### DIFF
--- a/pkg/server/commands/list_objects_shadow.go
+++ b/pkg/server/commands/list_objects_shadow.go
@@ -157,14 +157,20 @@ func (q *shadowedListObjectsQuery) Execute(
 	if q.checkShadowModePreconditions(cloneCtx, req, res, latency) {
 		q.wg.Add(1) // only used for testing signals
 		go func() {
+			startTime = time.Now()
 			defer func() {
+				defer q.wg.Done() // only used for testing signals
 				if r := recover(); r != nil {
 					q.logger.ErrorWithContext(cloneCtx, "panic recovered",
-						loShadowLogFields(req, zap.Any("error", r))...,
+						loShadowLogFields(req,
+							zap.Duration("main_latency", latency),
+							zap.Duration("shadow_latency", time.Since(startTime)),
+							zap.Int("main_result_count", len(res.Objects)),
+							zap.Any("error", r),
+						)...,
 					)
 				}
 			}()
-			defer q.wg.Done() // only used for testing signals
 
 			q.executeShadowModeAndCompareResults(cloneCtx, req, res.Objects, latency)
 		}()
@@ -185,26 +191,23 @@ func (q *shadowedListObjectsQuery) checkShadowModeSampleRate() bool {
 // If the shadow function takes longer than shadowTimeout, it will be cancelled, and its result will be ignored, but the shadowTimeout event will be logged.
 // This function is designed to be run in a separate goroutine to avoid blocking the main execution flow.
 func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx context.Context, req *openfgav1.ListObjectsRequest, mainResult []string, latency time.Duration) {
-	defer func() {
-		if r := recover(); r != nil {
-			q.logger.ErrorWithContext(parentCtx, "panic recovered",
-				loShadowLogFields(req, zap.Any("error", r))...,
-			)
-		}
-	}()
-
 	shadowCtx, shadowCancel := context.WithTimeout(parentCtx, q.shadowTimeout)
 	defer shadowCancel()
 
 	startTime := time.Now()
 	shadowRes, errShadow := q.shadow.Execute(shadowCtx, req)
+	shadowLatency := time.Since(startTime)
 	if errShadow != nil {
 		q.logger.WarnWithContext(parentCtx, "shadowed list objects error",
-			loShadowLogFields(req, zap.Any("error", errShadow))...,
+			loShadowLogFields(req,
+				zap.Duration("main_latency", latency),
+				zap.Duration("shadow_latency", shadowLatency),
+				zap.Int("main_result_count", len(mainResult)),
+				zap.Any("error", errShadow),
+			)...,
 		)
 		return
 	}
-	shadowLatency := time.Since(startTime)
 
 	var resultShadowed []string
 	if shadowRes != nil {
@@ -225,6 +228,9 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 		// log the differences if the shadow query failed or if the results are not equal
 		q.logger.WarnWithContext(parentCtx, "shadowed list objects result difference",
 			loShadowLogFields(req,
+				zap.Bool("is_match", false),
+				zap.Duration("main_latency", latency),
+				zap.Duration("shadow_latency", shadowLatency),
 				zap.Int("main_result_count", len(mainResult)),
 				zap.Int("shadow_result_count", len(resultShadowed)),
 				zap.Int("total_delta", totalDelta),
@@ -234,9 +240,10 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 	} else {
 		q.logger.InfoWithContext(parentCtx, "shadowed list objects result matches",
 			loShadowLogFields(req,
-				zap.Int("result_count", len(mainResult)),
+				zap.Bool("is_match", true),
 				zap.Duration("main_latency", latency),
 				zap.Duration("shadow_latency", shadowLatency),
+				zap.Int("main_result_count", len(mainResult)),
 			)...,
 		)
 	}

--- a/pkg/server/commands/list_objects_shadow_test.go
+++ b/pkg/server/commands/list_objects_shadow_test.go
@@ -372,6 +372,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 		parentCtx context.Context
 		req       *openfgav1.ListObjectsRequest
 		result    []string
+		latency   time.Duration
 	}
 	tests := []struct {
 		name   string
@@ -402,6 +403,8 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.String("store_id", "req.GetStoreId()")),
 						gomock.Eq(zap.String("model_id", "req.GetAuthorizationModelId()")),
 						gomock.Eq(zap.Int("result_count", 3)),
+						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
+						gomock.Any(),
 					)
 					return mockLogger
 				},
@@ -413,7 +416,8 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 					StoreId:              "req.GetStoreId()",
 					AuthorizationModelId: "req.GetAuthorizationModelId()",
 				},
-				result: []string{"a", "b", "c"},
+				result:  []string{"a", "b", "c"},
+				latency: 77 * time.Millisecond,
 			},
 		},
 		{
@@ -597,7 +601,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 				wg:            tt.fields.wg,
 			}
 			t.Cleanup(q.wg.Wait)
-			q.executeShadowModeAndCompareResults(tt.args.parentCtx, tt.args.req, tt.args.result)
+			q.executeShadowModeAndCompareResults(tt.args.parentCtx, tt.args.req, tt.args.result, tt.args.latency)
 			q.wg.Wait()
 		})
 	}

--- a/pkg/server/commands/list_objects_shadow_test.go
+++ b/pkg/server/commands/list_objects_shadow_test.go
@@ -33,6 +33,8 @@ func TestNewShadowedListObjectsQuery(t *testing.T) {
 		noopLogger := logger.NewNoopLogger()
 		result, err := newShadowedListObjectsQuery(&mockTupleReader{}, &mockCheckResolver{}, NewShadowListObjectsQueryConfig(
 			WithShadowListObjectsQuerySamplePercentage(13),
+			WithShadowListObjectsQueryMaxDeltaItems(99),
+			WithShadowListObjectsQueryTimeout(66*time.Millisecond),
 		), WithListObjectsOptimizationsEnabled(true))
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -40,6 +42,9 @@ func TestNewShadowedListObjectsQuery(t *testing.T) {
 		assert.False(t, query.main.(*ListObjectsQuery).optimizationsEnabled)
 		assert.True(t, query.shadow.(*ListObjectsQuery).optimizationsEnabled)
 		assert.Equal(t, noopLogger, query.logger)
+		assert.Equal(t, 13, query.shadowPct)
+		assert.Equal(t, 99, query.maxDeltaItems)
+		assert.Equal(t, 66*time.Millisecond, query.shadowTimeout)
 	})
 
 	t.Run("ds_error", func(t *testing.T) {
@@ -162,6 +167,7 @@ func TestShadowedListObjectsQuery_Panics(t *testing.T) {
 		mainFunc    func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error)
 		shadowFunc  func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error)
 		expectedErr error
+		loggerFn    func(t *testing.T, ctrl *gomock.Controller) logger.Logger
 	}{
 		{
 			name:       "stardard_panics",
@@ -169,15 +175,36 @@ func TestShadowedListObjectsQuery_Panics(t *testing.T) {
 			mainFunc: func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error) {
 				panic("this is a panic in main query")
 			},
+			loggerFn: func(t *testing.T, ctrl *gomock.Controller) logger.Logger {
+				return mocks.NewMockLogger(ctrl)
+			},
 		},
 		{
 			name:       "shadow_panics",
 			percentage: 100,
 			mainFunc: func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error) {
-				return &ListObjectsResponse{}, nil
+				return &ListObjectsResponse{
+					Objects: []string{"a", "b", "c"},
+				}, nil
 			},
 			shadowFunc: func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error) {
 				panic("this is a panic in shadow query")
+			},
+			loggerFn: func(t *testing.T, ctrl *gomock.Controller) logger.Logger {
+				mockLogger := mocks.NewMockLogger(ctrl)
+				mockLogger.EXPECT().ErrorWithContext(
+					gomock.Any(),
+					gomock.Eq("panic recovered"),
+					gomock.Eq(zap.String("func", ListObjectsShadowExecute)),
+					gomock.Eq(zap.Any("request", req)),
+					gomock.Eq(zap.String("store_id", "")),
+					gomock.Eq(zap.String("model_id", "")),
+					gomock.Any(), // main_latency - can't be determined here
+					gomock.Any(), // shadow_latency - can't be determined here
+					gomock.Eq(zap.Int("main_result_count", 3)),
+					gomock.Eq(zap.String("error", "this is a panic in shadow query")),
+				).Times(1)
+				return mockLogger
 			},
 		},
 	}
@@ -185,26 +212,29 @@ func TestShadowedListObjectsQuery_Panics(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			mockCtl := gomock.NewController(t)
 			q := &shadowedListObjectsQuery{
 				main:      &mockListObjectsQuery{executeFunc: tt.mainFunc},
 				shadow:    &mockListObjectsQuery{executeFunc: tt.shadowFunc},
-				logger:    logger.NewNoopLogger(),
+				logger:    tt.loggerFn(t, mockCtl),
 				shadowPct: tt.percentage,
 				wg:        &sync.WaitGroup{},
 			}
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						// should only panic in main mode
-						panicMsg := fmt.Sprintf("%v", r)
-						assert.Contains(t, panicMsg, "this is a panic in main query")
-					}
-				}()
-				_, err := q.Execute(ctx, req)
-
-				q.wg.Wait()
-				assert.NoError(t, err)
+			defer func() {
+				if r := recover(); r != nil {
+					// add extra wait to ensure the goroutine has finished
+					defer q.wg.Wait()
+					// should only panic in main mode
+					panicMsg := fmt.Sprintf("%v", r)
+					assert.Contains(t, panicMsg, "this is a panic in main query")
+				}
 			}()
+
+			_, err := q.Execute(ctx, req)
+
+			// this will never be reached if the main query panics
+			q.wg.Wait()
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -402,9 +432,10 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						})),
 						gomock.Eq(zap.String("store_id", "req.GetStoreId()")),
 						gomock.Eq(zap.String("model_id", "req.GetAuthorizationModelId()")),
-						gomock.Eq(zap.Int("result_count", 3)),
+						gomock.Eq(zap.Bool("is_match", true)),
 						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
 						gomock.Any(),
+						zap.Int("main_result_count", 3),
 					)
 					return mockLogger
 				},
@@ -440,6 +471,9 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Any("request", &openfgav1.ListObjectsRequest{})),
 						gomock.Eq(zap.String("store_id", "")),
 						gomock.Eq(zap.String("model_id", "")),
+						gomock.Eq(zap.Bool("is_match", false)),
+						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
+						gomock.Any(),
 						gomock.Eq(zap.Int("main_result_count", 3)),
 						gomock.Eq(zap.Int("shadow_result_count", 2)),
 						gomock.Eq(zap.Int("total_delta", 3)),
@@ -453,6 +487,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 				parentCtx: context.TODO(),
 				req:       &openfgav1.ListObjectsRequest{},
 				result:    []string{"a", "b", "c"},
+				latency:   77 * time.Millisecond,
 			},
 		},
 		{
@@ -475,6 +510,9 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Any("request", &openfgav1.ListObjectsRequest{})),
 						gomock.Eq(zap.String("store_id", "")),
 						gomock.Eq(zap.String("model_id", "")),
+						gomock.Eq(zap.Bool("is_match", false)),
+						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
+						gomock.Any(),
 						gomock.Eq(zap.Int("main_result_count", 10)),
 						gomock.Eq(zap.Int("shadow_result_count", 5)),
 						gomock.Eq(zap.Int("total_delta", 11)),
@@ -488,6 +526,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 				parentCtx: context.TODO(),
 				req:       &openfgav1.ListObjectsRequest{},
 				result:    []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+				latency:   77 * time.Millisecond,
 			},
 		},
 		{
@@ -511,6 +550,9 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Any("request", &openfgav1.ListObjectsRequest{})),
 						gomock.Eq(zap.String("store_id", "")),
 						gomock.Eq(zap.String("model_id", "")),
+						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
+						gomock.Any(),
+						gomock.Eq(zap.Int("main_result_count", 3)),
 						gomock.Eq(zap.Any("error", context.DeadlineExceeded)),
 					)
 					return mockLogger
@@ -521,6 +563,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 				parentCtx: context.TODO(),
 				req:       &openfgav1.ListObjectsRequest{},
 				result:    []string{"a", "b", "c"},
+				latency:   77 * time.Millisecond,
 			},
 		},
 		{
@@ -543,6 +586,9 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Any("request", &openfgav1.ListObjectsRequest{})),
 						gomock.Eq(zap.String("store_id", "")),
 						gomock.Eq(zap.String("model_id", "")),
+						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
+						gomock.Any(),
+						gomock.Eq(zap.Int("main_result_count", 3)),
 						gomock.Eq(zap.Any("error", errors.New("shadow query error"))),
 					)
 					return mockLogger
@@ -553,38 +599,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 				parentCtx: context.TODO(),
 				req:       &openfgav1.ListObjectsRequest{},
 				result:    []string{"a", "b", "c"},
-			},
-		},
-		{
-			name: "recover_from_panic",
-			fields: fields{
-				shadow: &mockListObjectsQuery{
-					executeFunc: func(ctx context.Context, req *openfgav1.ListObjectsRequest) (*ListObjectsResponse, error) {
-						panic("this is a panic in shadow query")
-					},
-				},
-				shadowPct:     100,
-				shadowTimeout: 1 * time.Nanosecond,
-				maxDeltaItems: 100,
-				loggerFn: func(t *testing.T, ctrl *gomock.Controller) logger.Logger {
-					mockLogger := mocks.NewMockLogger(ctrl)
-					mockLogger.EXPECT().ErrorWithContext(
-						gomock.Any(),
-						gomock.Eq("panic recovered"),
-						gomock.Eq(zap.String("func", ListObjectsShadowExecute)),
-						gomock.Eq(zap.Any("request", &openfgav1.ListObjectsRequest{})),
-						gomock.Eq(zap.String("store_id", "")),
-						gomock.Eq(zap.String("model_id", "")),
-						gomock.Eq(zap.String("error", "this is a panic in shadow query")),
-					)
-					return mockLogger
-				},
-				wg: &sync.WaitGroup{},
-			},
-			args: args{
-				parentCtx: context.TODO(),
-				req:       &openfgav1.ListObjectsRequest{},
-				result:    []string{"a", "b", "c"},
+				latency:   77 * time.Millisecond,
 			},
 		},
 	}


### PR DESCRIPTION
Log main and shadow ListObjects query latencies

## Description

Feature: Log main and shadow ListObjects query latencies

As an operator,
I want the system to log the duration of both the main and shadow ListObjects queries when their results match,
so that I can monitor and compare their performance.

```gherkin
  Scenario: Both queries return matching results
    Given the main ListObjects query completes successfully
    And the shadow ListObjects query completes successfully with the same results
    When the result is logged
    Then the log entry includes the main_latency and shadow_latency fields

  Scenario: Queries return different results
    Given the main and shadow ListObjects queries return different results
    When the result is logged
    Then the log entry does not include main_latency and shadow_latency fields for matches

  Scenario: Shadow query fails
    Given the main ListObjects query completes successfully
    And the shadow ListObjects query fails
    When the result is logged
    Then the log entry does not include main_latency and shadow_latency fields for matches
```

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging now includes both main and shadow query execution times when comparing results, providing more detailed performance insights.

* **Tests**
  * Updated tests to verify the inclusion of main query latency in logs during shadow query comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->