### PR TITLE
fix: shared iterator race and deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.9.0] - 2025-07-03
 ### Added
 - Add separate reverse_expand path utilizing the weighted graph. Gated behind `enable-list-objects-optimizations` flag. [#2529](https://github.com/openfga/openfga/pull/2529)
 
@@ -1335,7 +1337,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.8.16...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/openfga/openfga/compare/v1.8.16...v1.9.0
 [1.8.16]: https://github.com/openfga/openfga/compare/v1.8.15...v1.8.16
 [1.8.15]: https://github.com/openfga/openfga/compare/v1.8.14...v1.8.15
 [1.8.14]: https://github.com/openfga/openfga/compare/v1.8.13...v1.8.14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Shared iterator race condition and deadlock. [#2544](https://github.com/openfga/openfga/pull/2544)
 
 ## [1.9.0] - 2025-07-03
 ### Added

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -543,6 +543,9 @@ func (sf *IteratorDatastore) Read(
 const bufferSize = 100
 
 // await is an object that executes an action exactly once at a time.
+//
+// The singleflight.Group type was used as a comparison to the await type, but was found to be ~59% slower than await
+// in concurrent stress test benchmarks.
 type await struct {
 	executing *atomic.Bool
 	ch        *atomic.Pointer[chan struct{}]

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -738,6 +738,10 @@ func (s *sharedIterator) clone() *sharedIterator {
 func (s *sharedIterator) fetchAndWait(ctx context.Context, items *[]*openfgav1.Tuple, err *error) {
 	// Iterate until we have items available or an error occurs.
 	for {
+		if ctx.Err() != nil {
+			return
+		}
+
 		state := *s.state.Load()
 		*items = state.items
 		*err = state.err

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -769,14 +769,13 @@ func (s *sharedIterator) fetchAndWait(ctx context.Context, items *[]*openfgav1.T
 			read, e := s.ir.Read(context.Background(), buf[:])
 
 			// Load the current items from the shared items pointer and append the newly fetched items to it.
-			ptrState := s.state.Load()
-			loadedState := *ptrState
-			loadedState.items = append(loadedState.items, buf[:read]...)
+			state := *s.state.Load()
+			state.items = append(state.items, buf[:read]...)
 
 			if e != nil {
-				loadedState.err = e
+				state.err = e
 			}
-			s.state.Store(&loadedState)
+			s.state.Store(&state)
 		})
 	}
 }

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -593,24 +593,6 @@ func newAwait() *await {
 	}
 }
 
-// reader is an interface that defines a method to read items from a source iterator.
-type reader[T any] interface {
-	// Read reads items from the source iterator into the provided buffer.
-	Read(context.Context, []T) (int, error)
-}
-
-// stopper is an interface that defines a method to stop the iterator.
-type stopper interface {
-	// Stop stops the iterator and releases any resources associated with it.
-	Stop()
-}
-
-// readStopper is an interface that combines the reader and stopper interfaces.
-type readStopper[T any] interface {
-	reader[T]
-	stopper
-}
-
 // iteratorReader is a wrapper around a storage.Iterator that implements the reader interface.
 type iteratorReader[T any] struct {
 	storage.Iterator[T]
@@ -669,7 +651,7 @@ type sharedIterator struct {
 	await *await
 
 	// ir is the underlying iterator reader that provides the actual implementation of reading tuples.
-	ir readStopper[*openfgav1.Tuple]
+	ir *iteratorReader[*openfgav1.Tuple]
 
 	// state is a shared atomic pointer to the iterator state, which contains the items and any error encountered during iteration.
 	state *atomic.Pointer[iteratorState]

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -538,9 +538,8 @@ func (sf *IteratorDatastore) Read(
 	return it, nil
 }
 
-// BufferSize is the number of items to fetch at a time when reading from the shared iterator.
-// This is primarily adjusted at runtime for testing purposes, but can be set to a different value if needed.
-var BufferSize = 100
+// bufferSize is the number of items to fetch at a time when reading from the shared iterator.
+const bufferSize = 100
 
 // await is an object that executes an action exactly once at a time.
 type await struct {
@@ -766,8 +765,8 @@ func (s *sharedIterator) fetchAndWait(ctx context.Context, items *[]*openfgav1.T
 		}
 
 		s.await.Do(ctx, func() {
-			buf := make([]*openfgav1.Tuple, BufferSize)
-			read, e := s.ir.Read(context.Background(), buf)
+			var buf [bufferSize]*openfgav1.Tuple
+			read, e := s.ir.Read(context.Background(), buf[:])
 
 			// Load the current items from the shared items pointer and append the newly fetched items to it.
 			ptrState := s.state.Load()

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -735,14 +735,14 @@ func (s *sharedIterator) fetchAndWait(ctx context.Context, items *[]*openfgav1.T
 				}
 				s.state.Store(&loadedState)
 
-				// Initialize a new channel to signal that new items are available on the next fetch.
-				newCh := make(chan struct{})
-				currentCh := s.ch.Swap(&newCh)
-
 				// Important! The fetching state must be set to false before closing the old channel.
 				// This avoids a race condition in which a goroutine waiting on the channel close might
 				// enter this function again and try to fetch items before the fetching state is reset.
 				s.fetching.Store(false)
+
+				// Initialize a new channel to signal that new items are available on the next fetch.
+				newCh := make(chan struct{})
+				currentCh := s.ch.Swap(&newCh)
 
 				// Close the old channel to signal waiting consumers to wake up.
 				close(*currentCh)

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -41,6 +41,846 @@ type testIteratorInfo struct {
 	err  error
 }
 
+func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Clone the shared iterator for each benchmark iteration
+		clonedIter := sharedIter.clone()
+		if clonedIter == nil {
+			b.Fatal("Failed to clone shared iterator")
+		}
+
+		// Read all tuples from the cloned iterator
+		for {
+			_, err := clonedIter.Next(ctx)
+			if err != nil {
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+				b.Fatalf("Unexpected error: %v", err)
+			}
+		}
+
+		clonedIter.Stop()
+	}
+}
+
+func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator for each goroutine
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			// Read all tuples from the cloned iterator
+			for {
+				_, err := clonedIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	b.Run("SharedIterator", func(b *testing.B) {
+		staticIter := storage.NewStaticTupleIterator(tuples)
+		sharedIter := newSharedIterator(staticIter, func() {})
+		defer sharedIter.Stop()
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			for {
+				_, err := clonedIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			clonedIter.Stop()
+		}
+	})
+
+	b.Run("DirectStaticIterator", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			staticIter := storage.NewStaticTupleIterator(tuples)
+
+			for {
+				_, err := staticIter.Next(ctx)
+				if err != nil {
+					if errors.Is(err, storage.ErrIteratorDone) {
+						break
+					}
+					b.Fatalf("Unexpected error: %v", err)
+				}
+			}
+
+			staticIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorClone(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Clone the shared iterator
+		clonedIter := sharedIter.clone()
+		if clonedIter == nil {
+			b.Fatal("Failed to clone shared iterator")
+		}
+		clonedIter.Stop()
+	}
+}
+
+func BenchmarkSharedIteratorConcurrentCloning(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator concurrently
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorCloneAndRead(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Clone the shared iterator concurrently
+			clonedIter := sharedIter.clone()
+			if clonedIter == nil {
+				b.Fatal("Failed to clone shared iterator")
+			}
+
+			// Read one tuple to simulate realistic usage
+			_, err := clonedIter.Next(ctx)
+			if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+				b.Fatalf("Unexpected error: %v", err)
+			}
+
+			clonedIter.Stop()
+		}
+	})
+}
+
+func BenchmarkSharedIteratorConcurrentCloneStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create larger test data for stress testing
+	var tks []*openfgav1.TupleKey
+	for i := 0; i < 100; i++ {
+		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Create a static iterator as the internal iterator
+	staticIter := storage.NewStaticTupleIterator(tuples)
+
+	// Create shared iterator with cleanup function
+	sharedIter := newSharedIterator(staticIter, func() {
+		// Cleanup function - no-op for benchmark
+	})
+	defer sharedIter.Stop()
+
+	// Use a higher number of goroutines for stress testing
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Clone the shared iterator
+				clonedIter := sharedIter.clone()
+				if clonedIter == nil {
+					b.Error("Failed to clone shared iterator")
+					return
+				}
+
+				// Simulate some work by reading a few tuples
+				for k := 0; k < 3; k++ {
+					_, err := clonedIter.Next(ctx)
+					if err != nil {
+						if errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						break
+					}
+				}
+
+				clonedIter.Stop()
+			}()
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadConcurrentStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects single call that returns static iterator
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Create iterator
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					b.Errorf("Failed to create iterator: %v", err)
+					return
+				}
+				defer iter.Stop()
+
+				// Read all tuples
+				var count int
+				for {
+					_, err := iter.Next(ctx)
+					if err != nil {
+						if errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						return
+					}
+					count++
+				}
+
+				if count != len(tuples) {
+					b.Errorf("Expected %d tuples, got %d", len(tuples), count)
+				}
+			}()
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadConcurrentMixedOperations(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+		tuple.NewTupleKey("document:4", "viewer", "user:4"),
+		tuple.NewTupleKey("document:5", "viewer", "user:5"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 50
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		// Mix of different operation patterns
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+
+			switch j % 4 {
+			case 0:
+				// Full read
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					for {
+						_, err := iter.Next(ctx)
+						if err != nil {
+							if errors.Is(err, storage.ErrIteratorDone) {
+								break
+							}
+							b.Errorf("Unexpected error: %v", err)
+							return
+						}
+					}
+				}()
+
+			case 1:
+				// Head then partial read
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					// Check head
+					_, err = iter.Head(ctx)
+					if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+						b.Errorf("Unexpected error on Head: %v", err)
+						return
+					}
+
+					// Read a few items
+					for k := 0; k < 2; k++ {
+						_, err := iter.Next(ctx)
+						if err != nil {
+							if errors.Is(err, storage.ErrIteratorDone) {
+								break
+							}
+							b.Errorf("Unexpected error: %v", err)
+							return
+						}
+					}
+				}()
+
+			case 2:
+				// Early stop
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+
+					// Read one item then stop
+					_, err = iter.Next(ctx)
+					if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+						b.Errorf("Unexpected error: %v", err)
+					}
+
+					iter.Stop()
+				}()
+
+			case 3:
+				// Multiple head calls
+				go func() {
+					defer wg.Done()
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Failed to create iterator: %v", err)
+						return
+					}
+					defer iter.Stop()
+
+					// Multiple head calls
+					for k := 0; k < 3; k++ {
+						_, err = iter.Head(ctx)
+						if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+							b.Errorf("Unexpected error on Head: %v", err)
+							break
+						}
+					}
+				}()
+			}
+		}
+
+		wg.Wait()
+	}
+}
+
+func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
+	ctx := context.Background()
+
+	// Create larger test data for stress testing
+	var tks []*openfgav1.TupleKey
+	for i := 0; i < 1000; i++ {
+		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects single call
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 1000
+
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var wg sync.WaitGroup
+
+			for j := 0; j < numGoroutines; j++ {
+				wg.Add(1)
+				go func(id int) {
+					defer wg.Done()
+
+					iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+					if err != nil {
+						b.Errorf("Goroutine %d: Failed to create iterator: %v", id, err)
+						return
+					}
+					defer iter.Stop()
+
+					// Simulate different reading patterns
+					if id%3 == 0 {
+						// Full read
+						var count int
+						for {
+							_, err := iter.Next(ctx)
+							if err != nil {
+								if errors.Is(err, storage.ErrIteratorDone) {
+									break
+								}
+								b.Errorf("Goroutine %d: Unexpected error: %v", id, err)
+								return
+							}
+							count++
+						}
+					} else if id%3 == 1 {
+						// Partial read with random stop
+						readCount := id%10 + 1
+						for k := 0; k < readCount; k++ {
+							_, err := iter.Next(ctx)
+							if err != nil {
+								if errors.Is(err, storage.ErrIteratorDone) {
+									break
+								}
+								b.Errorf("Goroutine %d: Unexpected error: %v", id, err)
+								return
+							}
+						}
+					} else {
+						// Head operations
+						for k := 0; k < 5; k++ {
+							_, err := iter.Head(ctx)
+							if err != nil && !errors.Is(err, storage.ErrIteratorDone) {
+								b.Errorf("Goroutine %d: Unexpected error on Head: %v", id, err)
+								return
+							}
+						}
+					}
+				}(j)
+			}
+
+			wg.Wait()
+		}
+	})
+}
+
+func BenchmarkIteratorDatastoreReadRapidCreateDestroy(b *testing.B) {
+	ctx := context.Background()
+
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 100
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		// Rapidly create and destroy iterators
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// Create iterator
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					b.Errorf("Failed to create iterator: %v", err)
+					return
+				}
+
+				// Immediately stop (stress test reference counting)
+				iter.Stop()
+			}()
+		}
+
+		wg.Wait()
+
+		// Verify internal storage is cleaned up
+		if length(&internalStorage.iters) != 0 {
+			b.Errorf("Expected internal storage to be empty, but found %d items", length(&internalStorage.iters))
+		}
+	}
+}
+
+func BenchmarkIteratorDatastoreReadWithContextCancellation(b *testing.B) {
+	// Create test data
+	tks := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "viewer", "user:1"),
+		tuple.NewTupleKey("document:2", "viewer", "user:2"),
+		tuple.NewTupleKey("document:3", "viewer", "user:3"),
+	}
+
+	var tuples []*openfgav1.Tuple
+	for _, tk := range tks {
+		ts := timestamppb.New(time.Now())
+		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
+	}
+
+	// Setup mock datastore
+	mockController := gomock.NewController(b)
+	defer mockController.Finish()
+	mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+
+	storeID := ulid.Make().String()
+	tk := tuple.NewTupleKey("document:1", "viewer", "")
+
+	// Setup shared iterator datastore
+	internalStorage := NewSharedIteratorDatastoreStorage()
+	ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+		WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+	// Mock expects calls
+	mockDatastore.EXPECT().
+		Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+		DoAndReturn(func(_ context.Context, _ string, _ *openfgav1.TupleKey, _ storage.ReadOptions) (storage.TupleIterator, error) {
+			return storage.NewStaticTupleIterator(tuples), nil
+		}).AnyTimes()
+
+	const numGoroutines = 50
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+
+		for j := 0; j < numGoroutines; j++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+
+				// Create context with random timeout
+				timeout := time.Duration(id%10+1) * time.Millisecond
+				ctx, cancel := context.WithTimeout(context.Background(), timeout)
+				defer cancel()
+
+				iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+				if err != nil {
+					// Context might be cancelled during Read
+					return
+				}
+				defer iter.Stop()
+
+				// Try to read with cancelled context
+				for {
+					_, err := iter.Next(ctx)
+					if err != nil {
+						// Expected to get context cancelled or iterator done
+						if errors.Is(err, context.Canceled) ||
+							errors.Is(err, context.DeadlineExceeded) ||
+							errors.Is(err, storage.ErrIteratorDone) {
+							break
+						}
+						b.Errorf("Unexpected error: %v", err)
+						return
+					}
+				}
+			}(j)
+		}
+
+		wg.Wait()
+	}
+}
+
 // helper function to validate the single client case.
 func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStorage *Storage, iter storage.TupleIterator, expected []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -1728,7 +1728,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		require.Contains(t, err.Error(), "custom panic error")
 
 		// Verify it's wrapped properly
-		require.True(t, errors.Is(err, panicErr))
+		require.ErrorIs(t, err, panicErr)
 	})
 
 	t.Run("panic_after_successful_items", func(t *testing.T) {

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -1611,8 +1611,6 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 
-	BufferSize = 1
-
 	tk := tuple.NewTupleKey("license:1", "owner", "")
 
 	t.Run("stopped_iterator", func(t *testing.T) {
@@ -1863,6 +1861,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 			mockIterator.EXPECT().Next(gomock.Any()).Return(tupleOne, nil),
 			mockIterator.EXPECT().Next(gomock.Any()).Return(tupleTwo, nil),
 			mockIterator.EXPECT().Next(gomock.Any()).Return(tupleThree, nil),
+			mockIterator.EXPECT().Next(gomock.Any()).Return(nil, storage.ErrIteratorDone),
 			mockIterator.EXPECT().Stop(),
 		)
 		mockDatastore.EXPECT().
@@ -2007,6 +2006,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		tupleOne := &openfgav1.Tuple{Key: tuple.NewTupleKey("license:1", "owner", "user:1"), Timestamp: ts}
 		gomock.InOrder(
 			mockIterator.EXPECT().Next(gomock.Any()).Return(tupleOne, nil),
+			mockIterator.EXPECT().Next(gomock.Any()).Return(nil, storage.ErrIteratorDone),
 			mockIterator.EXPECT().Stop(),
 		)
 		mockDatastore.EXPECT().

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -687,7 +687,8 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 					defer iter.Stop()
 
 					// Simulate different reading patterns
-					if id%3 == 0 {
+					switch id % 3 {
+					case 0:
 						// Full read
 						var count int
 						for {
@@ -701,7 +702,7 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 							}
 							count++
 						}
-					} else if id%3 == 1 {
+					case 1:
 						// Partial read with random stop
 						readCount := id%10 + 1
 						for k := 0; k < readCount; k++ {
@@ -714,7 +715,7 @@ func BenchmarkIteratorDatastoreReadHighContentionStress(b *testing.B) {
 								return
 							}
 						}
-					} else {
+					default:
 						// Head operations
 						for k := 0; k < 5; k++ {
 							_, err := iter.Head(ctx)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

This change addresses a bug in the shared iterator that can cause an instance to return ErrIteratorDone on a call to Next, before having fully traversed the underlying iterator.

This bug is caused by a race condition introduced by the read and write of two disparate atomic fields: items and err; instead, the values should be read and written as a single atomic unit.

This change also addresses another bug in the shared iterator that can cause a deadlock. This can happen as a result of a race to load a shared channel, and then swap the shared channel with a new one and select over it.

The internal context.Context of the shared iterator has also been removed. This internal context only applied to the call to Next on the internal iterator, and served no meaningful purpose.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for shared iterators, enhancing reliability and thread safety.

* **Tests**
  * Added a comprehensive set of benchmark tests to measure performance and concurrency behavior of shared iterators and related datastore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->