### PR TITLE
perf: create per datastore operation caches for shared iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Shared iterator improvement to reduce lock contention when creating and cloning. [#2530](https://github.com/openfga/openfga/pull/2530)
 - Enable experimental list object optimizations in shadow mode using flag `enable-list-objects-optimizations`. [#2509](https://github.com/openfga/openfga/pull/2509)
 - Invalidated iterators will be removed from cache if an invalid entity entry is found allowing for less time to refresh. [#2536](https://github.com/openfga/openfga/pull/2536)
+- Shared iterator cache map split into a single map per datastore operation. [#2549](https://github.com/openfga/openfga/pull/2549)
 
 ### Fixed
 - Cache Controller was always completely invalidating. [#2522](https://github.com/openfga/openfga/pull/2522)

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -62,10 +62,14 @@ const (
 // The limit is set to defaultSharedIteratorLimit, which can be overridden by the user.
 // The storage is used to share iterators across multiple requests, allowing for efficient reuse of iterators.
 type Storage struct {
-	// iters is a map of iterators that are shared across requests.
-	// The key is a string that uniquely identifies the iterator, and the value is a storageItem that contains
-	// the iterator and its producer function.
-	iters sync.Map
+	// read stores shared iterators for the Read operation.
+	read sync.Map
+
+	// rswu stores shared iterators for the ReadWithUser operation.
+	rswu sync.Map
+
+	// rut stores shared iterators for the ReadUserTuples operation.
+	rut sync.Map
 
 	// limit is the maximum number of items that can be stored in the storage.
 	// If the number of items exceeds this limit, new iterators will not be created and the request will be bypassed.
@@ -271,7 +275,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 		// Set a timer to remove the item from the internal storage if it is not used within the max admission time.
 		// This is to prevent clones from being created indefinitely and to ensure that the storage does not grow indefinitely.
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.rswu.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 			}
 		})
@@ -283,7 +287,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 		// The cleanup function will also stop the timer, ensuring that the item is removed from the internal storage immediately.
 		newIterator := newSharedIterator(it, func() {
 			timer.Stop()
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.rswu.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 				sharedIteratorCount.Dec()
 			}
@@ -296,7 +300,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 
 	// Load or store the new storage item in the internal storage map.
 	// If the item is not already present, it will be added to the map and the counter will be incremented.
-	value, loaded := sf.internalStorage.iters.LoadOrStore(cacheKey, newStorageItem)
+	value, loaded := sf.internalStorage.rswu.LoadOrStore(cacheKey, newStorageItem)
 	if !loaded {
 		sf.internalStorage.ctr.Add(1)
 	}
@@ -307,7 +311,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 	// If this is the first time the iterator is accessed, it will call the producer function to create a new iterator.
 	it, created, err := item.unwrap()
 	if err != nil {
-		sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem)
+		sf.internalStorage.rswu.CompareAndDelete(cacheKey, newStorageItem)
 		return nil, err
 	}
 
@@ -377,7 +381,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 		// Set a timer to remove the item from the internal storage if it is not used within the max admission time.
 		// This is to prevent clones from being created indefinitely and to ensure that the storage does not grow indefinitely.
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.rut.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 			}
 		})
@@ -389,7 +393,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 		// The cleanup function will also stop the timer, ensuring that the item is removed from the internal storage.
 		newIterator := newSharedIterator(it, func() {
 			timer.Stop()
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.rut.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 				sharedIteratorCount.Dec()
 			}
@@ -402,7 +406,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 
 	// Load or store the new storage item in the internal storage map.
 	// If the item is not already present, it will be added to the map and the counter will be incremented.
-	value, loaded := sf.internalStorage.iters.LoadOrStore(cacheKey, newStorageItem)
+	value, loaded := sf.internalStorage.rut.LoadOrStore(cacheKey, newStorageItem)
 	if !loaded {
 		sf.internalStorage.ctr.Add(1)
 	}
@@ -413,7 +417,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 	// If this is the first time the iterator is accessed, it will call the producer function to create a new iterator.
 	it, created, err := item.unwrap()
 	if err != nil {
-		sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem)
+		sf.internalStorage.rut.CompareAndDelete(cacheKey, newStorageItem)
 		return nil, err
 	}
 
@@ -482,7 +486,7 @@ func (sf *IteratorDatastore) Read(
 		// Set a timer to remove the item from the internal storage if it is not used within the max admission time.
 		// This is to prevent clones from being created indefinitely and to ensure that the storage does not grow indefinitely.
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.read.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 			}
 		})
@@ -494,7 +498,7 @@ func (sf *IteratorDatastore) Read(
 		// The cleanup function will also stop the timer, ensuring that the item is removed from the internal storage.
 		newIterator := newSharedIterator(it, func() {
 			timer.Stop()
-			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
+			if sf.internalStorage.read.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
 				sharedIteratorCount.Dec()
 			}
@@ -507,7 +511,7 @@ func (sf *IteratorDatastore) Read(
 
 	// Load or store the new storage item in the internal storage map.
 	// If the item is not already present, it will be added to the map and the counter will be incremented.
-	value, loaded := sf.internalStorage.iters.LoadOrStore(cacheKey, newStorageItem)
+	value, loaded := sf.internalStorage.read.LoadOrStore(cacheKey, newStorageItem)
 	if !loaded {
 		sf.internalStorage.ctr.Add(1)
 	}
@@ -518,7 +522,7 @@ func (sf *IteratorDatastore) Read(
 	// If this is the first time the iterator is accessed, it will call the producer function to create a new iterator.
 	it, created, err := item.unwrap()
 	if err != nil {
-		sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem)
+		sf.internalStorage.read.CompareAndDelete(cacheKey, newStorageItem)
 		return nil, err
 	}
 

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -797,8 +797,8 @@ func BenchmarkIteratorDatastoreReadRapidCreateDestroy(b *testing.B) {
 		wg.Wait()
 
 		// Verify internal storage is cleaned up
-		if length(&internalStorage.iters) != 0 {
-			b.Errorf("Expected internal storage to be empty, but found %d items", length(&internalStorage.iters))
+		if length(&internalStorage.read) != 0 {
+			b.Errorf("Expected internal storage to be empty, but found %d items", length(&internalStorage.read))
 		}
 	}
 }
@@ -883,13 +883,13 @@ func BenchmarkIteratorDatastoreReadWithContextCancellation(b *testing.B) {
 }
 
 // helper function to validate the single client case.
-func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStorage *Storage, iter storage.TupleIterator, expected []*openfgav1.Tuple) {
+func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStorage *sync.Map, iter storage.TupleIterator, expected []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{
 		testutils.TupleKeyCmpTransformer,
 		protocmp.Transform(),
 	}
 
-	require.NotEmpty(t, length(&internalStorage.iters))
+	require.NotEmpty(t, length(internalStorage))
 
 	var actual []*openfgav1.Tuple
 
@@ -910,7 +910,7 @@ func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStora
 		actual = append(actual, tup)
 	}
 
-	require.NotEmpty(t, length(&internalStorage.iters))
+	require.NotEmpty(t, length(internalStorage))
 
 	iter.Stop() // has to be sync otherwise the assertion fails
 
@@ -919,16 +919,16 @@ func helperValidateSingleClient(ctx context.Context, t *testing.T, internalStora
 	}
 	// make sure the internal map is deallocated
 
-	require.Empty(t, length(&internalStorage.iters))
+	require.Empty(t, length(internalStorage))
 }
 
-func helperValidateMultipleClients(ctx context.Context, t *testing.T, internalStorage *Storage, iterInfos []testIteratorInfo, expected []*openfgav1.Tuple) {
+func helperValidateMultipleClients(ctx context.Context, t *testing.T, internalStorage *sync.Map, iterInfos []testIteratorInfo, expected []*openfgav1.Tuple) {
 	cmpOpts := []cmp.Option{
 		testutils.TupleKeyCmpTransformer,
 		protocmp.Transform(),
 	}
 
-	require.NotEmpty(t, length(&internalStorage.iters))
+	require.NotEmpty(t, length(internalStorage))
 	for i := 0; i < len(iterInfos); i++ {
 		require.NoError(t, iterInfos[i].err)
 		require.NotNil(t, iterInfos[i].iter)
@@ -963,15 +963,15 @@ func helperValidateMultipleClients(ctx context.Context, t *testing.T, internalSt
 
 	// make sure the internal map has not deallocated
 
-	require.NotEmpty(t, length(&internalStorage.iters))
+	require.NotEmpty(t, length(internalStorage))
 
 	for i, iterInfo := range iterInfos {
 		iterInfo.iter.Stop()
 
 		if i < len(iterInfos)-1 {
-			require.NotEmpty(t, length(&internalStorage.iters))
+			require.NotEmpty(t, length(internalStorage))
 		} else {
-			require.Empty(t, length(&internalStorage.iters))
+			require.Empty(t, length(internalStorage))
 		}
 	}
 }
@@ -1009,7 +1009,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
 		require.NoError(t, err)
-		helperValidateSingleClient(ctx, t, internalStorage, iter, tuples)
+		helperValidateSingleClient(ctx, t, &internalStorage.read, iter, tuples)
 	})
 
 	t.Run("multiple_concurrent_clients", func(t *testing.T) {
@@ -1038,7 +1038,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 			}(i)
 		}
 		wg.Wait()
-		helperValidateMultipleClients(ctx, t, internalStorage, iterInfos, tuples)
+		helperValidateMultipleClients(ctx, t, &internalStorage.read, iterInfos, tuples)
 	})
 	t.Run("error_when_querying", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1061,7 +1061,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		_, err = ds.Read(ctx, storeID, tk1, storage.ReadOptions{})
 		require.Error(t, err)
 
-		require.Empty(t, length(&internalStorage.iters))
+		require.Empty(t, length(&internalStorage.read))
 	})
 	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1069,8 +1069,8 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
 
-		internalStorageLimit := NewSharedIteratorDatastoreStorage(WithSharedIteratorDatastoreStorageLimit(0))
-		dsLimit := NewSharedIteratorDatastore(mockDatastore, internalStorageLimit)
+		internalStorage := NewSharedIteratorDatastoreStorage(WithSharedIteratorDatastoreStorageLimit(0))
+		dsLimit := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
@@ -1078,7 +1078,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		iter, err := dsLimit.Read(ctx, storeID, tk, storage.ReadOptions{})
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&internalStorageLimit.iters))
+		require.Empty(t, length(&internalStorage.read))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1104,7 +1104,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&ds.internalStorage.iters))
+		require.Empty(t, length(&ds.internalStorage.read))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1165,7 +1165,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 
 		err := p.Wait()
 		require.NoError(t, err)
-		require.Empty(t, length(&ds.internalStorage.iters))
+		require.Empty(t, length(&ds.internalStorage.read))
 	})
 }
 
@@ -1212,7 +1212,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
-		helperValidateSingleClient(ctx, t, internalStorage, iter, tuples)
+		helperValidateSingleClient(ctx, t, &internalStorage.rut, iter, tuples)
 	})
 
 	t.Run("multiple_concurrent_clients", func(t *testing.T) {
@@ -1239,7 +1239,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 			}(i)
 		}
 		wg.Wait()
-		helperValidateMultipleClients(ctx, t, internalStorage, iterInfos, tuples)
+		helperValidateMultipleClients(ctx, t, &internalStorage.rut, iterInfos, tuples)
 	})
 
 	t.Run("error_when_querying", func(t *testing.T) {
@@ -1267,7 +1267,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		_, err = ds.ReadUsersetTuples(ctx, storeID, filter1, options)
 		require.Error(t, err)
 
-		require.Empty(t, length(&internalStorage.iters))
+		require.Empty(t, length(&internalStorage.rut))
 	})
 	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1283,7 +1283,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		iter, err := dsLimit.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&internalStorageLimit.iters))
+		require.Empty(t, length(&internalStorageLimit.rut))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1307,7 +1307,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&ds.internalStorage.iters))
+		require.Empty(t, length(&ds.internalStorage.rut))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1366,7 +1366,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 
 		err := p.Wait()
 		require.NoError(t, err)
-		require.Empty(t, length(&ds.internalStorage.iters))
+		require.Empty(t, length(&ds.internalStorage.rut))
 	})
 }
 
@@ -1413,7 +1413,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
-		helperValidateSingleClient(ctx, t, internalStorage, iter, tuples)
+		helperValidateSingleClient(ctx, t, &internalStorage.rswu, iter, tuples)
 	})
 
 	t.Run("multiple_concurrent_clients", func(t *testing.T) {
@@ -1440,7 +1440,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 			}(i)
 		}
 		wg.Wait()
-		helperValidateMultipleClients(ctx, t, internalStorage, iterInfos, tuples)
+		helperValidateMultipleClients(ctx, t, &internalStorage.rswu, iterInfos, tuples)
 	})
 	t.Run("error_when_querying", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1469,7 +1469,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		_, err = ds.ReadStartingWithUser(ctx, storeID, filter1, options)
 		require.Error(t, err)
 
-		require.Empty(t, length(&internalStorage.iters))
+		require.Empty(t, length(&internalStorage.rswu))
 	})
 	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1485,7 +1485,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		iter, err := dsLimit.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&internalStorageLimit.iters))
+		require.Empty(t, length(&internalStorageLimit.rswu))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1509,7 +1509,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
 		// this should not come from the map
-		require.Empty(t, length(&ds.internalStorage.iters))
+		require.Empty(t, length(&ds.internalStorage.rswu))
 
 		_, ok := iter.(*sharedIterator)
 		require.False(t, ok)
@@ -1529,25 +1529,25 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		iter1, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, length(&internalStorage.iters))
+		require.NotEmpty(t, length(&internalStorage.rswu))
 
 		iter2, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 
-		require.NotEmpty(t, length(&internalStorage.iters))
+		require.NotEmpty(t, length(&internalStorage.rswu))
 
 		iter1.Stop()
 
-		require.NotEmpty(t, length(&internalStorage.iters))
+		require.NotEmpty(t, length(&internalStorage.rswu))
 
 		// we call stop more than once
 		iter1.Stop()
 
-		require.NotEmpty(t, length(&internalStorage.iters))
+		require.NotEmpty(t, length(&internalStorage.rswu))
 
 		iter2.Stop()
 
-		require.Empty(t, length(&internalStorage.iters))
+		require.Empty(t, length(&internalStorage.rswu))
 	})
 	t.Run("multiple_concurrent_clients_read_and_done", func(t *testing.T) {
 		mockController := gomock.NewController(t)
@@ -1601,7 +1601,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 
 		err := p.Wait()
 		require.NoError(t, err)
-		require.Empty(t, length(&internalStorage.iters))
+		require.Empty(t, length(&internalStorage.rswu))
 	})
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

### Problem
Currently a single `sync.Map` is used to store all active shared iterators. This can cause a lot of lock contention between iterator datastore operations such as `Read`, `ReadStartingWithUser`, and `ReadUsersetTuples`.

### Solution
This change adds a separate `sync.Map` to the iterator datastore dedicated to each operation. Doing so will split the lock contention between the individual operations.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of shared iterators for different read operations, resulting in clearer separation and maintainability.
* **Tests**
  * Updated tests to align with the new internal structure, ensuring continued reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->