### PR TITLE
fix: add shared iterator count decrement when the timer evicts the iterator

### DIFF
--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -273,6 +273,7 @@ func (sf *IteratorDatastore) ReadStartingWithUser(
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 
@@ -379,6 +380,7 @@ func (sf *IteratorDatastore) ReadUsersetTuples(
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 
@@ -484,6 +486,7 @@ func (sf *IteratorDatastore) Read(
 		timer := time.AfterFunc(sf.maxAdmissionTime, func() {
 			if sf.internalStorage.iters.CompareAndDelete(cacheKey, newStorageItem) {
 				sf.internalStorage.ctr.Add(-1)
+				sharedIteratorCount.Dec()
 			}
 		})
 

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/oklog/ulid/v2"
+	prometheus_model "github.com/prometheus/client_model/go"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -2350,5 +2351,237 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer iter2.Stop()
 		_, err = iter2.Next(ctx)
 		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+}
+
+func TestSharedIteratorCountMetric(t *testing.T) {
+	ctx := context.Background()
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	// Helper function to get current metric value
+	getSharedIteratorCount := func() float64 {
+		dto := &prometheus_model.Metric{}
+		sharedIteratorCount.Write(dto)
+		return dto.GetGauge().GetValue()
+	}
+
+	tk := tuple.NewTupleKey("license:1", "owner", "")
+	ts := timestamppb.New(time.Now())
+	tuples := []*openfgav1.Tuple{
+		{Key: tuple.NewTupleKey("license:1", "owner", "user:1"), Timestamp: ts},
+		{Key: tuple.NewTupleKey("license:1", "owner", "user:2"), Timestamp: ts},
+	}
+
+	t.Run("read_increment_decrement", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		mockDatastore.EXPECT().
+			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create iterator - should increment count
+		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+		require.NoError(t, err)
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Stop iterator - should decrement count
+		iter.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("readstartingwithuser_increment_decrement", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		filter := storage.ReadStartingWithUserFilter{
+			ObjectType: "document",
+			Relation:   "viewer",
+			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
+		}
+
+		mockDatastore.EXPECT().
+			ReadStartingWithUser(gomock.Any(), storeID, filter, storage.ReadStartingWithUserOptions{}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create iterator - should increment count
+		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{})
+		require.NoError(t, err)
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Stop iterator - should decrement count
+		iter.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("readusersettuples_increment_decrement", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		filter := storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				{Type: "user"},
+			},
+		}
+
+		mockDatastore.EXPECT().
+			ReadUsersetTuples(gomock.Any(), storeID, filter, storage.ReadUsersetTuplesOptions{}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create iterator - should increment count
+		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Stop iterator - should decrement count
+		iter.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("multiple_clones_single_increment", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		// Should only be called once due to sharing
+		mockDatastore.EXPECT().
+			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create first iterator - should increment count
+		iter1, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+		require.NoError(t, err)
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Create second iterator (clone) - should NOT increment count again
+		iter2, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+		require.NoError(t, err)
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Stop first iterator - count should remain the same (second clone exists)
+		iter1.Stop()
+		require.Equal(t, initialCount+1, getSharedIteratorCount())
+
+		// Stop last iterator - should decrement count
+		iter2.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("bypassed_higher_consistency_no_increment", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		mockDatastore.EXPECT().
+			Read(gomock.Any(), storeID, tk, storage.ReadOptions{
+				Consistency: storage.ConsistencyOptions{
+					Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+				},
+			}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create iterator with higher consistency - should bypass shared iterator
+		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{
+			Consistency: storage.ConsistencyOptions{
+				Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
+			},
+		})
+		require.NoError(t, err)
+
+		// Verify count was not incremented (bypassed)
+		require.Equal(t, initialCount, getSharedIteratorCount())
+
+		iter.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("bypassed_storage_limit_no_increment", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+
+		// Create storage with limit of 0 to force bypass
+		internalStorage := NewSharedIteratorDatastoreStorage(
+			WithSharedIteratorDatastoreStorageLimit(0))
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		mockDatastore.EXPECT().
+			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+			Return(storage.NewStaticTupleIterator(tuples), nil)
+
+		// Create iterator - should bypass due to limit
+		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+		require.NoError(t, err)
+
+		// Verify count was not incremented (bypassed)
+		require.Equal(t, initialCount, getSharedIteratorCount())
+
+		iter.Stop()
+		require.Equal(t, initialCount, getSharedIteratorCount())
+	})
+
+	t.Run("error_during_creation_no_increment", func(t *testing.T) {
+		initialCount := getSharedIteratorCount()
+
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
+		storeID := ulid.Make().String()
+		internalStorage := NewSharedIteratorDatastoreStorage()
+		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
+			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
+
+		// Mock error during iterator creation
+		mockDatastore.EXPECT().
+			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
+			Return(nil, errors.New("mock error"))
+
+		// Try to create iterator - should fail
+		_, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
+		require.Error(t, err)
+
+		// Verify count was not incremented
+		require.Equal(t, initialCount, getSharedIteratorCount())
 	})
 }

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -2392,11 +2392,11 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		// Create iterator - should increment count
 		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
 		require.NoError(t, err)
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Stop iterator - should decrement count
 		iter.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("readstartingwithuser_increment_decrement", func(t *testing.T) {
@@ -2423,11 +2423,11 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		// Create iterator - should increment count
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{})
 		require.NoError(t, err)
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Stop iterator - should decrement count
 		iter.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("readusersettuples_increment_decrement", func(t *testing.T) {
@@ -2456,11 +2456,11 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		// Create iterator - should increment count
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{})
 		require.NoError(t, err)
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Stop iterator - should decrement count
 		iter.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("multiple_clones_single_increment", func(t *testing.T) {
@@ -2482,20 +2482,20 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		// Create first iterator - should increment count
 		iter1, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
 		require.NoError(t, err)
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Create second iterator (clone) - should NOT increment count again
 		iter2, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
 		require.NoError(t, err)
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Stop first iterator - count should remain the same (second clone exists)
 		iter1.Stop()
-		require.Equal(t, initialCount+1, getSharedIteratorCount())
+		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
 
 		// Stop last iterator - should decrement count
 		iter2.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("bypassed_higher_consistency_no_increment", func(t *testing.T) {
@@ -2526,10 +2526,10 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify count was not incremented (bypassed)
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 
 		iter.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("bypassed_storage_limit_no_increment", func(t *testing.T) {
@@ -2555,10 +2555,10 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify count was not incremented (bypassed)
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 
 		iter.Stop()
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 
 	t.Run("error_during_creation_no_increment", func(t *testing.T) {
@@ -2582,6 +2582,6 @@ func TestSharedIteratorCountMetric(t *testing.T) {
 		require.Error(t, err)
 
 		// Verify count was not incremented
-		require.Equal(t, initialCount, getSharedIteratorCount())
+		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
 	})
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

### Problem
Currently the shared iterator count is not decremented when a shared iterator is removed from the cache by timer expiration.

### Solution
Add a decrement to the metric.

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of active shared iterator count in monitoring metrics. The displayed count now correctly decreases when iterators are removed or cleaned up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->