### PR TITLE
fix data race around wait group in shared iterator

### DIFF
--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -564,8 +564,9 @@ type await struct {
 func (a *await) Do(fn func()) {
 	a.mu.Lock()
 	if a.active {
+		wg := a.wg
 		a.mu.Unlock()
-		a.wg.Wait()
+		wg.Wait()
 		return
 	}
 	a.active = true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
There is currently a race condition in the shared iterator `await` structure where a read of its `wg` property can collide with a write to it.

#### How is it being solved?
Only access the data while a lock is held.

#### What changes are made to solve it?
Instead of calling `Wait()` directly on the property, I first create a copy of the value before unlocking the mutex, and then call `Wait()` on the copy.

#### Notes:
Line 578 still accesses `a.wg` outside of a mutex lock; however it is not possible for another goroutine to write to `a.wg` at this point.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

