### PR TITLE
chore: add datastore_query_count to shadow list objects logger

### DIFF
--- a/pkg/server/commands/list_objects_shadow.go
+++ b/pkg/server/commands/list_objects_shadow.go
@@ -210,8 +210,12 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 	}
 
 	var resultShadowed []string
+	var queryCount uint32
 	if shadowRes != nil {
 		resultShadowed = shadowRes.Objects
+		if shadowRes.ResolutionMetadata.DatastoreQueryCount != nil {
+			queryCount = shadowRes.ResolutionMetadata.DatastoreQueryCount.Load()
+		}
 	}
 
 	mapResultMain := keyMapFromSlice(mainResult)
@@ -235,6 +239,7 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 				zap.Int("shadow_result_count", len(resultShadowed)),
 				zap.Int("total_delta", totalDelta),
 				zap.Any("delta", delta),
+				zap.Uint32("datastore_query_count", queryCount),
 			)...,
 		)
 	} else {
@@ -244,6 +249,7 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 				zap.Duration("main_latency", latency),
 				zap.Duration("shadow_latency", shadowLatency),
 				zap.Int("main_result_count", len(mainResult)),
+				zap.Uint32("datastore_query_count", queryCount),
 			)...,
 		)
 	}

--- a/pkg/server/commands/list_objects_shadow_test.go
+++ b/pkg/server/commands/list_objects_shadow_test.go
@@ -437,6 +437,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
 						gomock.Any(),
 						zap.Int("main_result_count", 3),
+						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},
@@ -477,6 +478,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Int("shadow_result_count", 2)),
 						gomock.Eq(zap.Int("total_delta", 3)),
 						gomock.Eq(zap.Any("delta", []string{"+d", "-a", "-b"})),
+						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},
@@ -514,6 +516,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Int("shadow_result_count", 5)),
 						gomock.Eq(zap.Int("total_delta", 11)),
 						gomock.Eq(zap.Any("delta", []string{"+x", "+y", "+z"})),
+						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Adding some additional visibility to the shadow checker's logs before we test it more thoroughly.

#### How is it being solved?
Shadow list objects query already has some resolution metadata in it, this just adds one more piece for extra visibility.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking and logging of the datastore query count in shadow query results for improved visibility.

* **Chores**
  * Enhanced structured logs to include datastore query count information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->