### PR TITLE
Fix migrate command logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Shared iterator race condition and deadlock. [#2544](https://github.com/openfga/openfga/pull/2544)
 - Fixed bug in how experimental ReverseExpand is handling Intersection nodes. [#2556](https://github.com/openfga/openfga/pull/2556)
+- Migration command now respects logging configuration options. [#2541](https://github.com/openfga/openfga/issues/2541)
 
 ## [1.9.0] - 2025-07-03
 ### Added

--- a/cmd/migrate/flags.go
+++ b/cmd/migrate/flags.go
@@ -30,5 +30,14 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 
 		util.MustBindPFlag(verboseMigrationFlag, flags.Lookup(verboseMigrationFlag))
 		util.MustBindEnv(verboseMigrationFlag, "OPENFGA_VERBOSE")
+
+		util.MustBindPFlag(logFormatFlag, flags.Lookup(logFormatFlag))
+		util.MustBindEnv(logFormatFlag, "OPENFGA_LOG_FORMAT")
+
+		util.MustBindPFlag(logLevelFlag, flags.Lookup(logLevelFlag))
+		util.MustBindEnv(logLevelFlag, "OPENFGA_LOG_LEVEL")
+
+		util.MustBindPFlag(logTimestampFlag, flags.Lookup(logTimestampFlag))
+		util.MustBindEnv(logTimestampFlag, "OPENFGA_LOG_TIMESTAMP_FORMAT")
 	}
 }

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -8,6 +8,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/storage/migrate"
 )
 
@@ -19,6 +21,9 @@ const (
 	versionFlag           = "version"
 	timeoutFlag           = "timeout"
 	verboseMigrationFlag  = "verbose"
+	logFormatFlag         = "log-format"
+	logLevelFlag          = "log-level"
+	logTimestampFlag      = "log-timestamp-format"
 )
 
 func NewMigrateCommand() *cobra.Command {
@@ -31,6 +36,7 @@ func NewMigrateCommand() *cobra.Command {
 	}
 
 	flags := cmd.Flags()
+	defaultConfig := config.DefaultConfig()
 
 	flags.String(datastoreEngineFlag, "", "(required) the datastore engine that will be used for persistence")
 	flags.String(datastoreURIFlag, "", "(required) the connection uri of the database to run the migrations against (e.g. 'postgres://postgres:password@localhost:5432/postgres')")
@@ -39,6 +45,9 @@ func NewMigrateCommand() *cobra.Command {
 	flags.Uint(versionFlag, 0, "the version to migrate to (if omitted the latest schema will be used)")
 	flags.Duration(timeoutFlag, 1*time.Minute, "a timeout for the time it takes the migrate process to connect to the database")
 	flags.Bool(verboseMigrationFlag, false, "enable verbose migration logs (default false)")
+	flags.String(logFormatFlag, defaultConfig.Log.Format, "the log format to output logs in")
+	flags.String(logLevelFlag, defaultConfig.Log.Level, "the log level to use")
+	flags.String(logTimestampFlag, defaultConfig.Log.TimestampFormat, "the timestamp format to use for log messages")
 
 	// NOTE: if you add a new flag here, update the function below, too
 
@@ -55,6 +64,11 @@ func runMigration(_ *cobra.Command, _ []string) error {
 	verbose := viper.GetBool(verboseMigrationFlag)
 	username := viper.GetString(datastoreUsernameFlag)
 	password := viper.GetString(datastorePasswordFlag)
+	logFormat := viper.GetString(logFormatFlag)
+	logLevel := viper.GetString(logLevelFlag)
+	logTimestamp := viper.GetString(logTimestampFlag)
+
+	log := logger.MustNewLogger(logFormat, logLevel, logTimestamp)
 
 	cfg := migrate.MigrationConfig{
 		Engine:        engine,
@@ -64,6 +78,7 @@ func runMigration(_ *cobra.Command, _ []string) error {
 		Verbose:       verbose,
 		Username:      username,
 		Password:      password,
+		Logger:        log,
 	}
 	return migrate.RunMigrations(cfg)
 }

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -142,7 +142,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		return nil
 	}
 
-	log.Info(fmt.Sprintf("migrating to %d", cfg.TargetVersion))
+	log.Info("migration to", zap.Int("target version", cfg.TargetVersion))
 	targetInt64Version := int64(cfg.TargetVersion)
 
 	switch {

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -131,7 +131,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		return fmt.Errorf("failed to get db version: %w", err)
 	}
 
-	log.Info(fmt.Sprintf("current version %d", currentVersion))
+	log.Info("db info", zap.Int("current version", currentVersion))
 
 	if cfg.TargetVersion == 0 {
 		log.Info("running all migrations")

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -131,7 +131,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		return fmt.Errorf("failed to get db version: %w", err)
 	}
 
-	log.Info("db info", zap.Int("current version", currentVersion))
+	log.Info("db info", zap.Int64("current version", currentVersion))
 
 	if cfg.TargetVersion == 0 {
 		log.Info("running all migrations")
@@ -142,7 +142,7 @@ func RunMigrations(cfg MigrationConfig) error {
 		return nil
 	}
 
-	log.Info("migration to", zap.Int("target version", cfg.TargetVersion))
+	log.Info("migration to", zap.Uint("target version", cfg.TargetVersion))
 	targetInt64Version := int64(cfg.TargetVersion)
 
 	switch {

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/go-sql-driver/mysql"
 	"github.com/pressly/goose/v3"
+	"go.uber.org/zap"
 
 	"github.com/openfga/openfga/assets"
 	"github.com/openfga/openfga/pkg/logger"


### PR DESCRIPTION
## Summary
- respect logging config in migrate command
- expose logger in migration package
- document fix in changelog

## Testing
- `golangci-lint run -c .golangci.yaml ./cmd/... ./pkg/storage/migrate/...`
- `go test ./cmd/... ./pkg/storage/migrate -run TestMigrateCommandRollbacks -count=1` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6877a274a4c88322974ac777642ce26d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring log format, log level, and log timestamp format in the migration command via command-line flags or environment variables.

* **Bug Fixes**
  * Updated the migration command to respect logging configuration options as documented in the changelog.

* **Chores**
  * Updated the changelog to reflect the latest changes to migration logging options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->