### PR TITLE
fix: Reduce number of DB queries needed in ReverseExpand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Update ReverseExpand to use a LinkedList to track its relation stack for performance. [#2542](https://github.com/openfga/openfga/pull/2542)
 - Update ReverseExpand to use a intersection and exclusion handler to fast path check calls. [#2543](https://github.com/openfga/openfga/pull/2543)
+- Deduplicate queries more effectively in ReverseExpand. [#2567](https://github.com/openfga/openfga/pull/2567)
 
 ### Fixed
 - Shared iterator race condition and deadlock. [#2544](https://github.com/openfga/openfga/pull/2544)

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,7 +1,5 @@
 package stack
 
-import "fmt"
-
 // Stack is an implementation of a stack based on a linked list.
 //
 // *Important*: Each push() or pop() operation creates and returns a pointer to a new stack entirely to

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,5 +1,7 @@
 package stack
 
+import "fmt"
+
 // Stack is an implementation of a stack based on a linked list.
 //
 // *Important*: Each push() or pop() operation creates and returns a pointer to a new stack entirely to

--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -138,6 +138,10 @@ type ReverseExpandQuery struct {
 	// candidateObjectsMap map prevents returning the same object twice
 	candidateObjectsMap *sync.Map
 
+	// queryDedupeMap prevents multiple branches of exploration from running
+	// the same queries, since multiple leaf nodes can have a common ancestor
+	queryDedupeMap *sync.Map
+
 	// localCheckResolver allows reverse expand to call check locally
 	localCheckResolver   graph.CheckRewriteResolver
 	optimizationsEnabled bool
@@ -194,6 +198,7 @@ func NewReverseExpandQuery(ds storage.RelationshipTupleReader, ts *typesystem.Ty
 		},
 		candidateObjectsMap: new(sync.Map),
 		visitedUsersetsMap:  new(sync.Map),
+		queryDedupeMap:      new(sync.Map),
 		localCheckResolver:  graph.NewLocalChecker(),
 	}
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -297,13 +297,10 @@ func (c *ReverseExpandQuery) queryForTuples(
 ) error {
 	span := trace.SpanFromContext(ctx)
 
-	// This map is used for memoization of database queries for this branch of the reverse expansion.
-	// It prevents re-running the exact same database query for a given object type, relation, and user filter.
-	jobDedupeMap := new(sync.Map)
 	queryJobQueue := newJobQueue()
 
 	// Now kick off the chain of queries
-	items, err := c.executeQueryJob(ctx, queryJob{req: req, foundObject: foundObject}, resultChan, needsCheck, jobDedupeMap)
+	items, err := c.executeQueryJob(ctx, queryJob{req: req, foundObject: foundObject}, resultChan, needsCheck)
 	if err != nil {
 		telemetry.TraceError(span, err)
 		return err
@@ -335,7 +332,7 @@ func (c *ReverseExpandQuery) queryForTuples(
 				if !ok {
 					break
 				}
-				newItems, err := c.executeQueryJob(ctx, nextJob, resultChan, needsCheck, jobDedupeMap)
+				newItems, err := c.executeQueryJob(ctx, nextJob, resultChan, needsCheck)
 				if err != nil {
 					return err
 				}
@@ -369,7 +366,6 @@ func (c *ReverseExpandQuery) executeQueryJob(
 	job queryJob,
 	resultChan chan<- *ReverseExpandResult,
 	needsCheck bool,
-	jobDedupeMap *sync.Map,
 ) ([]queryJob, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -394,7 +390,7 @@ func (c *ReverseExpandQuery) executeQueryJob(
 	currentReq.relationStack = newStack
 
 	// Ensure that we haven't already run this query
-	if isDuplicateQuery(jobDedupeMap, userFilter, typeRel) {
+	if c.isDuplicateQuery(userFilter, typeRel) {
 		return nil, nil
 	}
 
@@ -483,8 +479,7 @@ func buildUserFilter(
 	return []*openfgav1.ObjectRelation{filter}, nil
 }
 
-func isDuplicateQuery(
-	dedupeMap *sync.Map,
+func (c *ReverseExpandQuery) isDuplicateQuery(
 	userFilter []*openfgav1.ObjectRelation,
 	typeRel string,
 ) bool {
@@ -496,7 +491,7 @@ func isDuplicateQuery(
 	})
 
 	key += relation + objectType
-	_, loaded := dedupeMap.LoadOrStore(key, struct{}{})
+	_, loaded := c.queryDedupeMap.LoadOrStore(key, struct{}{})
 
 	return loaded
 }

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -420,7 +420,6 @@ func (c *ReverseExpandQuery) executeQueryJob(
 		// and this object is a candidate for return to the user.
 		if currentReq.relationStack == nil {
 			c.trySendCandidate(ctx, needsCheck, foundObject, resultChan)
-			fmt.Printf("SENDING CANDIDATE: %s\n", foundObject)
 			continue
 		}
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
In the weighted reverse_expand, each individual leaf node kicks off its own independent chain of queries. Each query chain attempts to deduplicate its own work, but for some models these query chains can start to overlap as they move up the graph because they have common ancestors. This model for example, has 3 leaf nodes which all share a common ancestor in `document#viewer`:

```
type user
type document
	relations
		define commenter: [user]
		define editor: [user]
		define writer: [user]
		define viewer: writer or editor or commenter
		define owner: [document#viewer]
```

You can clearly see the common ancestor `document#viewer` in the graph:
<img width="605" height="382" alt="image" src="https://github.com/user-attachments/assets/3c3b3444-d664-430d-903d-0cdfc66921cd" />


If a `user` is related to `document:a` via `#commenter`, `#editor`, and `#writer`, all 3 of those independent branches will attempt to read from the DB to find the common ancestor `document#owner@document:a#viewer`. That means this query will run 3 times instead of 1.

#### How is it being solved?
We have an existing `jobDedupeMap`, but it is scoped _within_ each query chain. So multiple query chains which lead to the same tuples will do duplicate work.


#### What changes are made to solve it?
Add `queryDedupeMap` to the `ReverseExpandQuery` object itself, so all querying routines will be aware of all duplicate work.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of duplicate queries to optimize performance and efficiency. Query deduplication is now managed centrally within the query process, reducing redundant operations during exploration. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->