### PR TITLE
Upgrade SECURITY-INSIGHTS.yml to v2.0.0 schema

### DIFF
--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -10,102 +10,131 @@ header:
 project:
   name: OpenFGA
   homepage: https://openfga.dev
-  funding: https://github.com/openfga/.github/blob/main/FUNDING.yml
   roadmap: https://github.com/orgs/openfga/projects/1
   steward:
     uri: https://www.cncf.io
     comment: |
       OpenFGA is a Cloud Native Computing Foundation (CNCF) project.
   administrators:
-    - name: Adrián Tamayo
+    - name: Adrian Tam
       affiliation: OpenFGA
-      email: adrian@openfga.dev
+      email: adrian.tam@okta.com
       social: https://github.com/adriantam
       primary: true
-    - name: Andrés Aguiar
+    - name: Andres Aguiar
       affiliation: OpenFGA
-      email: andres@openfga.dev
+      email: andres.aguiar@okta.com
       social: https://github.com/aaguiarz
       primary: true
-    - name: Evans Sims
+    - name: Dan Cech
+      affiliation: Grafana Labs
+      email: dcech@grafana.com
+      social: https://github.com/DanCech
+      primary: true
+    - name: Evan Sims
       affiliation: OpenFGA
-      email: evans@openfga.dev
+      email: evan.sims@okta.com
       social: https://github.com/evansims
       primary: true
     - name: Ewan Harris
       affiliation: OpenFGA
-      email: ewan@openfga.dev
+      email: ewan.harris@okta.com
       social: https://github.com/ewanharris
       primary: true
-    - name: Jimmy James
+    - name: Jim Anderson
       affiliation: OpenFGA
-      email: jimmy@openfga.dev
+      email: jim.anderson@okta.com
       social: https://github.com/jimmyjames
       primary: true
-    - name: José Padilla
+    - name: Jose Padilla
       affiliation: OpenFGA
-      email: jose@openfga.dev
+      email: jose.padilla@okta.com
       social: https://github.com/jpadilla
+      primary: true
+    - name: Joshua Jones
+      affiliation: OpenFGA
+      email: joshua.jones@okta.com
+      social: https://github.com/senojj
       primary: true
     - name: Justin Cohen
       affiliation: OpenFGA
-      email: justin@openfga.dev
+      email: justin.cohen@okta.com
       social: https://github.com/justincoh
+      primary: true
+    - name: Maurice Ackel
+      affiliation: Netlight
+      email: maurice.ackel@netlight.com
+      social: https://github.com/mauriceackel
       primary: true
     - name: Patrick Dillon
       affiliation: OpenFGA
-      email: patrick@openfga.dev
+      email: patrick.dillon@okta.com
       social: https://github.com/pdillon
       primary: true
-    - name: Poovamraj
+    - name: Poovamraj Thanganadar Thiagarajan
       affiliation: OpenFGA
-      email: poovamraj@openfga.dev
+      email: poovamraj.thanganadarthiagarajan@okta.com
       social: https://github.com/poovamraj
       primary: true
-    - name: Rami Hamzeh
+    - name: Raghd Hamzeh
       affiliation: OpenFGA
-      email: rami@openfga.dev
+      email: raghd.hamzeh@okta.com
       social: https://github.com/rhamzeh
       primary: true
-    - name: Sergio Gutierrez
+    - name: Ryan Quinn
       affiliation: OpenFGA
-      email: sergio@openfga.dev
+      email: ryan.quinn@okta.com
+      social: https://github.com/ryanpq
+      primary: true
+    - name: Sergiu Githea
+      affiliation: OpenFGA
+      email: sergiu.githea@okta.com
       social: https://github.com/sergiught
+      primary: true
+    - name: Siddhant Khare
+      affiliation: Independent
+      email: siddhantkhare2694@gmail.com
+      social: https://github.com/Siddhant-K-code
       primary: true
     - name: Steve Hobbs
       affiliation: OpenFGA
-      email: steve@openfga.dev
+      email: steve.hobbs@okta.com
       social: https://github.com/stevehobbsdev
       primary: true
-    - name: Tricia Trzeng
+    - name: Talent Zeng
       affiliation: OpenFGA
-      email: tricia@openfga.dev
+      email: talent.zeng@okta.com
       social: https://github.com/ttrzeng
       primary: true
-    - name: Victor Dev
+    - name: Tyler Nix
       affiliation: OpenFGA
-      email: victor@openfga.dev
+      email: tyler.nix@okta.com
+      social: https://github.com/tylernix
+      primary: true
+    - name: Victoria Johns
+      affiliation: OpenFGA
+      email: victoria.johns@okta.com
       social: https://github.com/vic-dev
       primary: true
     - name: Will Vedder
       affiliation: OpenFGA
-      email: will@openfga.dev
+      email: will.vedder@okta.com
       social: https://github.com/willvedd
       primary: true
-    - name: Yisrael Sellem
+    - name: Yamil Asusta
       affiliation: OpenFGA
-      email: yisrael@openfga.dev
+      email: yamil.asusta@okta.com
+      social: https://github.com/elbuo8
+      primary: true
+    - name: Yissel Garna
+      affiliation: OpenFGA
+      email: yissel.garma@okta.com
       social: https://github.com/yissellokta
       primary: true
-    - name: Cika Sari
+    - name: Zilvinas Vilutis
       affiliation: OpenFGA
-      email: cika@openfga.dev
+      email: zilvinas.vilutis@okta.com
       social: https://github.com/cikasfm
-      primary: true
-    - name: Luis Buena
-      affiliation: OpenFGA
-      email: luis@openfga.dev
-      social: https://github.com/elbuo8
       primary: true
   documentation:
     quickstart-guide: https://openfga.dev/docs/getting-started

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -227,7 +227,7 @@ repository:
       email: raghd.hamzeh@okta.com
       social: https://github.com/rhamzeh
       primary: true
-    - name: Sergiu Githea
+    - name: Sergiu Ghitea
       affiliation: OpenFGA
       email: sergiu.githea@okta.com
       social: https://github.com/sergiught

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -300,7 +300,7 @@ repository:
   security:
     assessments:
       self:
-        evidence: https://github.com/cncf/tag-security/blob/main/assessments/projects/openfga/self-assessment.md
+        evidence: https://github.com/cncf/tag-security/blob/main/community/assessments/projects/openfga/self-assessment.md
         date: '2024-12-19'
         comment: |
           OpenFGA has completed a CNCF security self-assessment.

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -142,7 +142,7 @@ project:
     code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
     release-process: https://github.com/openfga/openfga/blob/main/RELEASES.md
     support-policy: https://openfga.dev/community
-    signature-verification: https://github.com/openfga/openfga/releases
+    signature-verification: https://github.com/openfga/community/blob/main/provenance-implementation/openfga.md
   repositories:
     - name: OpenFGA
       url: https://github.com/openfga/openfga

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -126,7 +126,7 @@ project:
       email: yamil.asusta@okta.com
       social: https://github.com/elbuo8
       primary: true
-    - name: Yissel Garna
+    - name: Yissel Garma
       affiliation: OpenFGA
       email: yissel.garma@okta.com
       social: https://github.com/yissellokta

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -109,7 +109,7 @@ project:
       primary: true
   documentation:
     quickstart-guide: https://openfga.dev/docs/getting-started
-    detailed-guide: https://openfga.dev/docs
+    detailed-guide: https://openfga.dev/docs/getting-started/setup-openfga/overview
     code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
     release-process: https://github.com/openfga/openfga/blob/main/RELEASES.md
     support-policy: https://openfga.dev/community

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -14,7 +14,7 @@ project:
   steward:
     uri: https://www.cncf.io
     comment: |
-      OpenFGA is a Cloud Native Computing Foundation (CNCF) project.
+      OpenFGA is a Cloud Native Computing Foundation (CNCF) Sandbox project.
   administrators:
     - name: Adrian Tam
       affiliation: OpenFGA
@@ -167,95 +167,115 @@ repository:
   accepts-automated-change-request: true
   no-third-party-packages: false
   core-team:
-    - name: Adrián Tamayo
+    - name: Adrian Tam
       affiliation: OpenFGA
-      email: adrian@openfga.dev
+      email: adrian.tam@okta.com
       social: https://github.com/adriantam
       primary: true
-    - name: Andrés Aguiar
+    - name: Andres Aguiar
       affiliation: OpenFGA
-      email: andres@openfga.dev
+      email: andres.aguiar@okta.com
       social: https://github.com/aaguiarz
       primary: true
-    - name: Evans Sims
+    - name: Dan Cech
+      affiliation: Grafana Labs
+      email: dcech@grafana.com
+      social: https://github.com/DanCech
+      primary: true
+    - name: Evan Sims
       affiliation: OpenFGA
-      email: evans@openfga.dev
+      email: evan.sims@okta.com
       social: https://github.com/evansims
       primary: true
     - name: Ewan Harris
       affiliation: OpenFGA
-      email: ewan@openfga.dev
+      email: ewan.harris@okta.com
       social: https://github.com/ewanharris
       primary: true
-    - name: Jimmy James
+    - name: Jim Anderson
       affiliation: OpenFGA
-      email: jimmy@openfga.dev
+      email: jim.anderson@okta.com
       social: https://github.com/jimmyjames
       primary: true
-    - name: José Padilla
+    - name: Jose Padilla
       affiliation: OpenFGA
-      email: jose@openfga.dev
+      email: jose.padilla@okta.com
       social: https://github.com/jpadilla
+      primary: true
+    - name: Joshua Jones
+      affiliation: OpenFGA
+      email: joshua.jones@okta.com
+      social: https://github.com/senojj
       primary: true
     - name: Justin Cohen
       affiliation: OpenFGA
-      email: justin@openfga.dev
+      email: justin.cohen@okta.com
       social: https://github.com/justincoh
       primary: true
     - name: Patrick Dillon
       affiliation: OpenFGA
-      email: patrick@openfga.dev
+      email: patrick.dillon@okta.com
       social: https://github.com/pdillon
       primary: true
-    - name: Poovamraj
+    - name: Poovamraj Thanganadar Thiagarajan
       affiliation: OpenFGA
-      email: poovamraj@openfga.dev
+      email: poovamraj.thanganadarthiagarajan@okta.com
       social: https://github.com/poovamraj
       primary: true
-    - name: Rami Hamzeh
+    - name: Raghd Hamzeh
       affiliation: OpenFGA
-      email: rami@openfga.dev
+      email: raghd.hamzeh@okta.com
       social: https://github.com/rhamzeh
       primary: true
-    - name: Sergio Gutierrez
+    - name: Ryan Quinn
       affiliation: OpenFGA
-      email: sergio@openfga.dev
+      email: ryan.quinn@okta.com
+      social: https://github.com/ryanpq
+      primary: true
+    - name: Sergiu Githea
+      affiliation: OpenFGA
+      email: sergiu.githea@okta.com
       social: https://github.com/sergiught
       primary: true
     - name: Steve Hobbs
       affiliation: OpenFGA
-      email: steve@openfga.dev
+      email: steve.hobbs@okta.com
       social: https://github.com/stevehobbsdev
       primary: true
-    - name: Tricia Trzeng
+    - name: Talent Zeng
       affiliation: OpenFGA
-      email: tricia@openfga.dev
+      email: talent.zeng@okta.com
       social: https://github.com/ttrzeng
       primary: true
-    - name: Victor Dev
+    - name: Tyler Nix
       affiliation: OpenFGA
-      email: victor@openfga.dev
+      email: tyler.nix@okta.com
+      social: https://github.com/tylernix
+      primary: true
+    - name: Victoria Johns
+      affiliation: OpenFGA
+      email: victoria.johns@okta.com
       social: https://github.com/vic-dev
       primary: true
     - name: Will Vedder
       affiliation: OpenFGA
-      email: will@openfga.dev
+      email: will.vedder@okta.com
       social: https://github.com/willvedd
       primary: true
-    - name: Yisrael Sellem
+    - name: Yamil Asusta
       affiliation: OpenFGA
-      email: yisrael@openfga.dev
+      email: yamil.asusta@okta.com
+      social: https://github.com/elbuo8
+      primary: true
+    - name: Yissel Garna
+      affiliation: OpenFGA
+      email: yissel.garma@okta.com
       social: https://github.com/yissellokta
       primary: true
-    - name: Cika Sari
+    - name: Zilvinas Vilutis
       affiliation: OpenFGA
-      email: cika@openfga.dev
+      email: zilvinas.vilutis@okta.com
       social: https://github.com/cikasfm
-      primary: true
-    - name: Luis Buena
-      affiliation: OpenFGA
-      email: luis@openfga.dev
-      social: https://github.com/elbuo8
       primary: true
   documentation:
     contributing-guide: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -276,7 +276,7 @@ repository:
     contributing-guide: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
     review-policy: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
     security-policy: https://github.com/openfga/openfga/security/policy
-    governance: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
+    governance: https://github.com/openfga/.github/blob/main/GOVERNANCE.md
     dependency-management-policy: https://github.com/openfga/openfga/blob/main/docs/dependencies-policy.md
   license:
     url: https://raw.githubusercontent.com/openfga/openfga/main/LICENSE

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -305,7 +305,7 @@ repository:
         comment: |
           OpenFGA has completed a CNCF security self-assessment.
       third-party:
-        - evidence: https://insights.linuxfoundation.org/project/openfga/security
+        - evidence: https://github.com/cncf/tag-security/blob/main/community/assessments/projects/openfga/joint-assessment.md
           date: '2024-12-19'
           comment: |
             LFX Insights Security assessment for OpenFGA project.

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -1,122 +1,305 @@
 header:
-  schema-version: 1.0.0
-  expiration-date: '2024-12-31T23:23:59.000Z'
-  last-updated: '2024-22-03'
-  last-reviewed: '2024-22-03'
-  commit-hash: e95aa72bf95485e03896709a096ad17f89f6fdad
-  project-url: https://github.com/openfga/openfga
-  project-release: '1.5.1'
-  changelog: https://github.com/openfga/openfga/CHANGELOG.md
-  license: https://raw.githubusercontent.com/openfga/openfga/main/LICENSE
-project-lifecycle:
-  status: active
-  roadmap: https://github.com/orgs/openfga/projects/1
-  bug-fixes-only: false
-  core-maintainers:
-  - https://github.com/adriantam
-  - https://github.com/aaguiarz
-  - https://github.com/evansims
-  - https://github.com/ewanharris
-  - https://github.com/curfew-marathon
-  - https://github.com/jimmyjames
-  - https://github.com/jpadilla
-  - https://github.com/justincoh
-  - https://github.com/pdillon
-  - https://github.com/poovamraj
-  - https://github.com/rhamzeh
-  - https://github.com/sergiught
-  - https://github.com/stevehobbsdev
-  - https://github.com/ttrzeng
-  - https://github.com/vic-dev
-  - https://github.com/willvedd
-  - https://github.com/yissellokta
-  - https://github.com/cikasfm
-  - https://github.com/elbuo8
+  schema-version: 2.0.0
+  last-updated: '2025-07-20'
+  last-reviewed: '2025-07-20'
+  url: https://github.com/openfga/openfga
+  comment: |
+    OpenFGA is a high-performance and flexible authorization/permission engine built for developers
+    and inspired by Google Zanzibar. This file contains security insights for the OpenFGA project.
 
-contribution-policy:
-  accepts-pull-requests: true
-  accepts-automated-pull-requests: true
-  automated-tools-list:
-  - automated-tool: dependabot
-    action: allowed
-    path:
-    - .github/workflows
-    - go.mod
-    - go.sum
-    - tools/go.mod
-    - tools/go.sum
-    - Dockerfile
-    - Dockerfile.goreleaser
-  - automated-tool: snyk
-    action: allowed
-    path:
-    - .github/workflows
-    - go.mod
-    - go.sum
-    - tools/go.mod
-    - tools/go.sum
-    - Dockerfile
-    - Dockerfile.goreleaser
-  contributing-policy: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
-  code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
-documentation:
-- https://openfga.dev
-distribution-points:
-- https://github.com/openfga/openfga
-- https://hub.docker.com/r/openfga/openfga
-security-testing:
-- tool-type: sca
-  tool-name: Dependabot
-  tool-version: latest
-  integration:
-    ad-hoc: false
-    ci: true
-    before-release: true
-  comment: |
-    Dependabot is enabled for this repo.
-- tool-type: sca
-  tool-name: Snyk
-  tool-version: latest
-  integration:
-    ad-hoc: false
-    ci: true
-    before-release: true
-  comment: |
-    Snyk is enabled for this repo.
-- tool-type: sca
-  tool-name: Semgrep
-  tool-version: latest
-  tool-url: https://github.com/openfga/openfga/blob/main/.github/workflows/semgrep.yaml
-  integration:
-    ad-hoc: false
-    ci: true
-    before-release: true
-  comment: |
-    Semgrep is enabled for this repo.
-security-contacts:
-- type: email
-  value: security@openfga.dev
-  primary: true
-vulnerability-reporting:
-  accepts-vulnerability-reports: true
-  email-contact: security@openfga.dev
-  security-policy: https://github.com/openfga/openfga/security/policy
-  bug-bounty-available: false
-dependencies:
-  third-party-packages: true
-  dependencies-lists:
-  - https://github.com/openfga/openfga/blob/main/go.mod
-  - https://github.com/openfga/openfga/blob/main/tools/go.mod
-  sbom:
-  - sbom-file: https://github.com/openfga/openfga/releases/download/v1.5.1/openfga_1.5.1_linux_arm64.tar.gz.sbom
-    sbom-format: SPDX
-    sbom-url: https://github.com/openfga/openfga/releases
-  env-dependencies-policy:
-    policy-url: https://github.com/openfga/openfga/blob/main/docs/dependencies-policy.md
-security-artifacts:
-  threat-model:
-    threat-model-created: false
-  self-assessment:
-    self-assessment-created: true
-    evidence-url: 
-      - https://github.com/cncf/tag-security/blob/main/assessments/projects/openfga/self-assessment.md
+project:
+  name: OpenFGA
+  homepage: https://openfga.dev
+  funding: https://github.com/openfga/.github/blob/main/FUNDING.yml
+  roadmap: https://github.com/orgs/openfga/projects/1
+  steward:
+    uri: https://www.cncf.io
+    comment: |
+      OpenFGA is a Cloud Native Computing Foundation (CNCF) project.
+  administrators:
+    - name: Adrián Tamayo
+      affiliation: OpenFGA
+      email: adrian@openfga.dev
+      social: https://github.com/adriantam
+      primary: true
+    - name: Andrés Aguiar
+      affiliation: OpenFGA
+      email: andres@openfga.dev
+      social: https://github.com/aaguiarz
+      primary: true
+    - name: Evans Sims
+      affiliation: OpenFGA
+      email: evans@openfga.dev
+      social: https://github.com/evansims
+      primary: true
+    - name: Ewan Harris
+      affiliation: OpenFGA
+      email: ewan@openfga.dev
+      social: https://github.com/ewanharris
+      primary: true
+    - name: Jimmy James
+      affiliation: OpenFGA
+      email: jimmy@openfga.dev
+      social: https://github.com/jimmyjames
+      primary: true
+    - name: José Padilla
+      affiliation: OpenFGA
+      email: jose@openfga.dev
+      social: https://github.com/jpadilla
+      primary: true
+    - name: Justin Cohen
+      affiliation: OpenFGA
+      email: justin@openfga.dev
+      social: https://github.com/justincoh
+      primary: true
+    - name: Patrick Dillon
+      affiliation: OpenFGA
+      email: patrick@openfga.dev
+      social: https://github.com/pdillon
+      primary: true
+    - name: Poovamraj
+      affiliation: OpenFGA
+      email: poovamraj@openfga.dev
+      social: https://github.com/poovamraj
+      primary: true
+    - name: Rami Hamzeh
+      affiliation: OpenFGA
+      email: rami@openfga.dev
+      social: https://github.com/rhamzeh
+      primary: true
+    - name: Sergio Gutierrez
+      affiliation: OpenFGA
+      email: sergio@openfga.dev
+      social: https://github.com/sergiught
+      primary: true
+    - name: Steve Hobbs
+      affiliation: OpenFGA
+      email: steve@openfga.dev
+      social: https://github.com/stevehobbsdev
+      primary: true
+    - name: Tricia Trzeng
+      affiliation: OpenFGA
+      email: tricia@openfga.dev
+      social: https://github.com/ttrzeng
+      primary: true
+    - name: Victor Dev
+      affiliation: OpenFGA
+      email: victor@openfga.dev
+      social: https://github.com/vic-dev
+      primary: true
+    - name: Will Vedder
+      affiliation: OpenFGA
+      email: will@openfga.dev
+      social: https://github.com/willvedd
+      primary: true
+    - name: Yisrael Sellem
+      affiliation: OpenFGA
+      email: yisrael@openfga.dev
+      social: https://github.com/yissellokta
+      primary: true
+    - name: Cika Sari
+      affiliation: OpenFGA
+      email: cika@openfga.dev
+      social: https://github.com/cikasfm
+      primary: true
+    - name: Luis Buena
+      affiliation: OpenFGA
+      email: luis@openfga.dev
+      social: https://github.com/elbuo8
+      primary: true
+  documentation:
+    quickstart-guide: https://openfga.dev/docs/getting-started
+    detailed-guide: https://openfga.dev/docs
+    code-of-conduct: https://github.com/cncf/foundation/blob/main/code-of-conduct.md
+    release-process: https://github.com/openfga/openfga/blob/main/RELEASES.md
+    support-policy: https://openfga.dev/community
+    signature-verification: https://github.com/openfga/openfga/releases
+  repositories:
+    - name: OpenFGA
+      url: https://github.com/openfga/openfga
+      comment: |
+        OpenFGA is the core authorization engine repository.
+  vulnerability-reporting:
+    reports-accepted: true
+    bug-bounty-available: false
+    contact:
+      name: OpenFGA Security Team
+      email: security@openfga.dev
+      primary: true
+    security-policy: https://github.com/openfga/openfga/security/policy
+    comment: |
+      OpenFGA accepts vulnerability reports through GitHub Security Advisories.
+
+repository:
+  url: https://github.com/openfga/openfga
+  status: active
+  bug-fixes-only: false
+  accepts-change-request: true
+  accepts-automated-change-request: true
+  no-third-party-packages: false
+  core-team:
+    - name: Adrián Tamayo
+      affiliation: OpenFGA
+      email: adrian@openfga.dev
+      social: https://github.com/adriantam
+      primary: true
+    - name: Andrés Aguiar
+      affiliation: OpenFGA
+      email: andres@openfga.dev
+      social: https://github.com/aaguiarz
+      primary: true
+    - name: Evans Sims
+      affiliation: OpenFGA
+      email: evans@openfga.dev
+      social: https://github.com/evansims
+      primary: true
+    - name: Ewan Harris
+      affiliation: OpenFGA
+      email: ewan@openfga.dev
+      social: https://github.com/ewanharris
+      primary: true
+    - name: Jimmy James
+      affiliation: OpenFGA
+      email: jimmy@openfga.dev
+      social: https://github.com/jimmyjames
+      primary: true
+    - name: José Padilla
+      affiliation: OpenFGA
+      email: jose@openfga.dev
+      social: https://github.com/jpadilla
+      primary: true
+    - name: Justin Cohen
+      affiliation: OpenFGA
+      email: justin@openfga.dev
+      social: https://github.com/justincoh
+      primary: true
+    - name: Patrick Dillon
+      affiliation: OpenFGA
+      email: patrick@openfga.dev
+      social: https://github.com/pdillon
+      primary: true
+    - name: Poovamraj
+      affiliation: OpenFGA
+      email: poovamraj@openfga.dev
+      social: https://github.com/poovamraj
+      primary: true
+    - name: Rami Hamzeh
+      affiliation: OpenFGA
+      email: rami@openfga.dev
+      social: https://github.com/rhamzeh
+      primary: true
+    - name: Sergio Gutierrez
+      affiliation: OpenFGA
+      email: sergio@openfga.dev
+      social: https://github.com/sergiught
+      primary: true
+    - name: Steve Hobbs
+      affiliation: OpenFGA
+      email: steve@openfga.dev
+      social: https://github.com/stevehobbsdev
+      primary: true
+    - name: Tricia Trzeng
+      affiliation: OpenFGA
+      email: tricia@openfga.dev
+      social: https://github.com/ttrzeng
+      primary: true
+    - name: Victor Dev
+      affiliation: OpenFGA
+      email: victor@openfga.dev
+      social: https://github.com/vic-dev
+      primary: true
+    - name: Will Vedder
+      affiliation: OpenFGA
+      email: will@openfga.dev
+      social: https://github.com/willvedd
+      primary: true
+    - name: Yisrael Sellem
+      affiliation: OpenFGA
+      email: yisrael@openfga.dev
+      social: https://github.com/yissellokta
+      primary: true
+    - name: Cika Sari
+      affiliation: OpenFGA
+      email: cika@openfga.dev
+      social: https://github.com/cikasfm
+      primary: true
+    - name: Luis Buena
+      affiliation: OpenFGA
+      email: luis@openfga.dev
+      social: https://github.com/elbuo8
+      primary: true
+  documentation:
+    contributing-guide: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
+    review-policy: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
+    security-policy: https://github.com/openfga/openfga/security/policy
+    governance: https://github.com/openfga/.github/blob/main/CONTRIBUTING.md
+    dependency-management-policy: https://github.com/openfga/openfga/blob/main/docs/dependencies-policy.md
+  license:
+    url: https://raw.githubusercontent.com/openfga/openfga/main/LICENSE
+    expression: Apache-2.0
+  release:
+    changelog: https://github.com/openfga/openfga/blob/main/CHANGELOG.md
+    automated-pipeline: true
+    attestations:
+      - name: Release SBOM
+        predicate-uri: https://intoto.SPDX
+        location: https://github.com/openfga/openfga/releases
+        comment: SBOM files are generated for each release
+    distribution-points:
+      - uri: https://github.com/openfga/openfga/releases
+        comment: GitHub Release Page
+      - uri: https://hub.docker.com/r/openfga/openfga
+        comment: Docker Hub
+    license:
+      url: https://raw.githubusercontent.com/openfga/openfga/main/LICENSE
+      expression: Apache-2.0
+  security:
+    assessments:
+      self:
+        evidence: https://github.com/cncf/tag-security/blob/main/assessments/projects/openfga/self-assessment.md
+        date: '2024-12-19'
+        comment: |
+          OpenFGA has completed a CNCF security self-assessment.
+      third-party:
+        - evidence: https://insights.linuxfoundation.org/project/openfga/security
+          date: '2024-12-19'
+          comment: |
+            LFX Insights Security assessment for OpenFGA project.
+    champions:
+      - name: OpenFGA Security Team
+        email: security@openfga.dev
+        primary: true
+    tools:
+      - name: Dependabot
+        type: SCA
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: true
+        comment: |
+          Dependabot is enabled for this repo to automatically update dependencies.
+      - name: Snyk
+        type: SCA
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: true
+        comment: |
+          Snyk is enabled for this repo to scan for vulnerabilities.
+      - name: Semgrep
+        type: SAST
+        version: latest
+        rulesets:
+          - built-in
+        integration:
+          adhoc: false
+          ci: true
+          release: true
+        comment: |
+          Semgrep is enabled for this repo to perform static analysis.

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -308,7 +308,7 @@ repository:
         - evidence: https://github.com/cncf/tag-security/blob/main/community/assessments/projects/openfga/joint-assessment.md
           date: '2024-12-19'
           comment: |
-            LFX Insights Security assessment for OpenFGA project.
+            Joint assessment with CNCF Tag-Security.
     champions:
       - name: OpenFGA Security Team
         email: security@openfga.dev

--- a/SECURITY-INSIGHTS.yml
+++ b/SECURITY-INSIGHTS.yml
@@ -227,11 +227,6 @@ repository:
       email: raghd.hamzeh@okta.com
       social: https://github.com/rhamzeh
       primary: true
-    - name: Ryan Quinn
-      affiliation: OpenFGA
-      email: ryan.quinn@okta.com
-      social: https://github.com/ryanpq
-      primary: true
     - name: Sergiu Githea
       affiliation: OpenFGA
       email: sergiu.githea@okta.com


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

#### What problem is being solved?

Upgrades the SECURITY-INSIGHTS.yml file from schema version 1.0.0 to 2.0.0 to comply with the latest OSSF Security Insights specification.


#### What changes are made to solve it?

- ✅ Updated schema version from `1.0.0` to `2.0.0`
- ✅ Restructured content to match v2.0 schema requirements
- ✅ Added comprehensive project and repository sections
- ✅ Enhanced security information with proper categorization
- ✅ Updated maintainer information with proper contact details
- ✅ Added security assessments and tools documentation
- ✅ Improved vulnerability reporting configuration

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

Fixes #2570

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] The correct base branch is being used, if not `main`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the security insights document to a new, more detailed format with enriched project metadata, governance, licensing, release, and security assessment information.
  * Added comprehensive sections for administrators, repository details, documentation links, release attestations, security tools, and vulnerability reporting.
  * Improved clarity and structure for easier reference and enhanced transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->