### PR TITLE
perf: change shared iterator to a more traditional single-flight implementation

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -110,7 +110,10 @@
                 "type": "integer"
             },
             "minItems": 1,
-            "default": [50, 200],
+            "default": [
+                50,
+                200
+            ],
             "x-env-variable": "OPENFGA_REQUEST_DURATION_DATASTORE_QUERY_COUNT_BUCKETS"
         },
         "requestDurationDispatchCountBuckets": {
@@ -121,7 +124,10 @@
                 "type": "integer"
             },
             "minItems": 1,
-            "default": [50, 200],
+            "default": [
+                50,
+                200
+            ],
             "x-env-variable": "OPENFGA_REQUEST_DURATION_DISPATCH_COUNT_BUCKETS"
         },
         "contextPropagationToDatastore": {
@@ -135,7 +141,11 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "enum": ["enable-check-optimizations", "enable-list-objects-optimizations", "enable-access-control"]
+                "enum": [
+                    "enable-check-optimizations",
+                    "enable-list-objects-optimizations",
+                    "enable-access-control"
+                ]
             },
             "default": [],
             "x-env-variable": "OPENFGA_EXPERIMENTALS"
@@ -204,7 +214,12 @@
                 "engine": {
                     "description": "The datastore engine that will be used for persistence.",
                     "type": "string",
-                    "enum": ["memory", "postgres", "mysql", "sqlite"],
+                    "enum": [
+                        "memory",
+                        "postgres",
+                        "mysql",
+                        "sqlite"
+                    ],
                     "default": "memory",
                     "x-env-variable": "OPENFGA_DATASTORE_ENGINE"
                 },
@@ -297,7 +312,11 @@
                 "method": {
                     "description": "The authentication method to use.",
                     "type": "string",
-                    "enum": ["none", "preshared", "oidc"],
+                    "enum": [
+                        "none",
+                        "preshared",
+                        "oidc"
+                    ],
                     "default": "none",
                     "x-env-variable": "OPENFGA_AUTHN_METHOD"
                 },
@@ -309,7 +328,6 @@
                     "description": "The OIDC provider specific settings. This must be set if 'authn.method=oidc'.",
                     "$ref": "#/definitions/oidc"
                 }
-
             }
         },
         "grpc": {
@@ -341,7 +359,11 @@
                             "x-env-variable": "OPENFGA_GRPC_TLS_KEY"
                         }
                     },
-                    "required": ["enabled", "cert", "key"]
+                    "required": [
+                        "enabled",
+                        "cert",
+                        "key"
+                    ]
                 }
             }
         },
@@ -379,7 +401,11 @@
                             "x-env-variable": "OPENFGA_HTTP_TLS_KEY"
                         }
                     },
-                    "required": ["enabled", "cert", "key"]
+                    "required": [
+                        "enabled",
+                        "cert",
+                        "key"
+                    ]
                 },
                 "upstreamTimeout": {
                     "description": "The timeout duration for proxying HTTP requests upstream to the grpc endpoint.",
@@ -393,7 +419,9 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": ["*"],
+                    "default": [
+                        "*"
+                    ],
                     "x-env-variable": "OPENFGA_HTTP_CORS_ALLOWED_ORIGINS"
                 },
                 "corsAllowedHeaders": {
@@ -402,7 +430,9 @@
                     "items": {
                         "type": "string"
                     },
-                    "default": ["*"],
+                    "default": [
+                        "*"
+                    ],
                     "x-env-variable": "OPENFGA_HTTP_CORS_ALLOWED_HEADERS"
                 }
             }
@@ -413,21 +443,35 @@
                 "format": {
                     "description": "The log format to output logs in. For production we recommend 'json' format.",
                     "type": "string",
-                    "enum": ["text", "json"],
+                    "enum": [
+                        "text",
+                        "json"
+                    ],
                     "default": "text",
                     "x-env-variable": "OPENFGA_LOG_FORMAT"
                 },
                 "level": {
                     "description": "The log level to set. For production we recommend 'info' format.",
                     "type": "string",
-                    "enum": ["none", "debug", "info", "warn", "error", "panic", "fatal"],
+                    "enum": [
+                        "none",
+                        "debug",
+                        "info",
+                        "warn",
+                        "error",
+                        "panic",
+                        "fatal"
+                    ],
                     "default": "info",
                     "x-env-variable": "OPENFGA_LOG_LEVEL"
                 },
                 "timestampFormat": {
                     "description": "The timestamp format to use for the log output.",
                     "type": "string",
-                    "enum": ["Unix", "ISO8601"],
+                    "enum": [
+                        "Unix",
+                        "ISO8601"
+                    ],
                     "default": "Unix",
                     "x-env-variable": "OPENFGA_LOG_TIMESTAMP_FORMAT"
                 }
@@ -699,12 +743,6 @@
                     "type": "boolean",
                     "default": false,
                     "x-env-variable": "OPENFGA_SHARED_ITERATOR_ENABLED"
-                },
-                "limit": {
-                    "description": "if shared-iterator-enabled is enabled, this is the limit of the number of iterators that can be shared.",
-                    "type": "integer",
-                    "default": "1000000",
-                    "x-env-variable": "OPENFGA_SHARED_ITERATOR_LIMIT"
                 }
             }
         },
@@ -755,7 +793,10 @@
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_CLIENT_ID_CLAIMS"
                 }
             },
-            "required": ["issuer", "audience"]
+            "required": [
+                "issuer",
+                "audience"
+            ]
         },
         "preshared": {
             "type": "object",
@@ -770,7 +811,9 @@
                     "x-env-variable": "OPENFGA_AUTHN_PRESHARED_KEYS"
                 }
             },
-            "required": ["keys"]
+            "required": [
+                "keys"
+            ]
         }
     }
 }

--- a/internal/shared/shared.go
+++ b/internal/shared/shared.go
@@ -50,14 +50,12 @@ func NewSharedDatastoreResources(
 	opts ...SharedDatastoreResourcesOpt,
 ) (*SharedDatastoreResources, error) {
 	s := &SharedDatastoreResources{
-		WaitGroup:         &sync.WaitGroup{},
-		SingleflightGroup: sharedSf,
-		ServerCtx:         sharedCtx,
-		CacheController:   cachecontroller.NewNoopCacheController(),
-		Logger:            logger.NewNoopLogger(),
-		SharedIteratorStorage: sharediterator.NewSharedIteratorDatastoreStorage(
-			sharediterator.WithSharedIteratorDatastoreStorageLimit(
-				int(settings.SharedIteratorLimit))),
+		WaitGroup:             &sync.WaitGroup{},
+		SingleflightGroup:     sharedSf,
+		ServerCtx:             sharedCtx,
+		CacheController:       cachecontroller.NewNoopCacheController(),
+		Logger:                logger.NewNoopLogger(),
+		SharedIteratorStorage: new(sharediterator.Storage),
 	}
 
 	if settings.ShouldCreateNewCache() {

--- a/pkg/server/config/cache_settings.go
+++ b/pkg/server/config/cache_settings.go
@@ -35,8 +35,6 @@ func NewDefaultCacheSettings() CacheSettings {
 		ListObjectsIteratorCacheMaxResults: DefaultListObjectsIteratorCacheMaxResults,
 		ListObjectsIteratorCacheTTL:        DefaultListObjectsIteratorCacheTTL,
 		SharedIteratorEnabled:              DefaultSharedIteratorEnabled,
-		SharedIteratorLimit:                DefaultSharedIteratorLimit,
-		SharedIteratorTTL:                  DefaultSharedIteratorTTL,
 	}
 }
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -92,10 +92,7 @@ const (
 	DefaultRequestTimeout     = 3 * time.Second
 	additionalUpstreamTimeout = 3 * time.Second
 
-	DefaultSharedIteratorEnabled          = false
-	DefaultSharedIteratorLimit            = 1000000
-	DefaultSharedIteratorTTL              = 4 * time.Minute
-	DefaultSharedIteratorMaxAdmissionTime = 10 * time.Second
+	DefaultSharedIteratorEnabled = false
 )
 
 type DatastoreMetricsConfig struct {
@@ -758,7 +755,6 @@ func DefaultConfig() *Config {
 		},
 		SharedIterator: SharedIteratorConfig{
 			Enabled: DefaultSharedIteratorEnabled,
-			Limit:   DefaultSharedIteratorLimit,
 		},
 		CacheController: CacheControllerConfig{
 			Enabled: DefaultCacheControllerConfigEnabled,

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -84,7 +84,7 @@ func (g *group) Do(key string, fn func() (*sharedIterator, error)) (*sharedItera
 
 	g.mu.Lock()
 	delete(g.m, key)
-	c.bank = make([]sharedIterator, c.n)
+	c.bank = make([]sharedIterator, atomic.LoadInt64(&c.n))
 	for i := range c.bank {
 		v.clone(&c.bank[i])
 	}

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore.go
@@ -36,12 +36,6 @@ var (
 		Name:      "shared_iterator_bypassed",
 		Help:      "Total number of iterators bypassed by the shared iterator layer because the internal map size exceed specified limit OR max admission time has passed.",
 	}, []string{"operation"})
-
-	sharedIteratorCount = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: build.ProjectName,
-		Name:      "shared_iterator_count",
-		Help:      "The current number of items of shared iterator.",
-	})
 )
 
 // call is a structure that holds the state of a single-flight call.

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -65,10 +65,7 @@ func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
 	staticIter := storage.NewStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
-	sharedIter := new(sharedIterator)
-	initSharedIterator(sharedIter, staticIter, func() {
-		// Cleanup function - no-op for benchmark
-	})
+	sharedIter := newSharedIterator(staticIter)
 	defer sharedIter.Stop()
 
 	b.ResetTimer()
@@ -121,10 +118,7 @@ func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
 	staticIter := storage.NewStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
-	sharedIter := new(sharedIterator)
-	initSharedIterator(sharedIter, staticIter, func() {
-		// Cleanup function - no-op for benchmark
-	})
+	sharedIter := newSharedIterator(staticIter)
 	defer sharedIter.Stop()
 
 	b.ResetTimer()
@@ -173,8 +167,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 
 	b.Run("SharedIterator", func(b *testing.B) {
 		staticIter := storage.NewStaticTupleIterator(tuples)
-		sharedIter := new(sharedIterator)
-		initSharedIterator(sharedIter, staticIter, func() {})
+		sharedIter := newSharedIterator(staticIter)
 		defer sharedIter.Stop()
 
 		b.ResetTimer()

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -65,7 +65,8 @@ func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
 	staticIter := storage.NewStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
-	sharedIter := newSharedIterator(staticIter, func() {
+	sharedIter := new(sharedIterator)
+	initSharedIterator(sharedIter, staticIter, func() {
 		// Cleanup function - no-op for benchmark
 	})
 	defer sharedIter.Stop()
@@ -120,7 +121,8 @@ func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
 	staticIter := storage.NewStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
-	sharedIter := newSharedIterator(staticIter, func() {
+	sharedIter := new(sharedIterator)
+	initSharedIterator(sharedIter, staticIter, func() {
 		// Cleanup function - no-op for benchmark
 	})
 	defer sharedIter.Stop()
@@ -171,7 +173,8 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 
 	b.Run("SharedIterator", func(b *testing.B) {
 		staticIter := storage.NewStaticTupleIterator(tuples)
-		sharedIter := newSharedIterator(staticIter, func() {})
+		sharedIter := new(sharedIterator)
+		initSharedIterator(sharedIter, staticIter, func() {})
 		defer sharedIter.Stop()
 
 		b.ResetTimer()

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -30,15 +30,6 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-func length(m *sync.Map) int {
-	var i int
-	m.Range(func(_, _ any) bool {
-		i++
-		return true
-	})
-	return i
-}
-
 type testIteratorInfo struct {
 	iter storage.TupleIterator
 	err  error

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/oklog/ulid/v2"
-	prometheus_model "github.com/prometheus/client_model/go"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -237,7 +236,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 			mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 
 			// Setup shared iterator datastore
-			internalStorage := NewSharedIteratorDatastoreStorage()
+			internalStorage := new(Storage)
 			ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 				WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -403,7 +402,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -420,7 +419,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -448,7 +447,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -464,32 +463,13 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		_, err = ds.Read(ctx, storeID, tk1, storage.ReadOptions{})
 		require.Error(t, err)
 	})
-	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
 
-		internalStorage := NewSharedIteratorDatastoreStorage(WithSharedIteratorDatastoreStorageLimit(0))
-		dsLimit := NewSharedIteratorDatastore(mockDatastore, internalStorage)
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-		iter, err := dsLimit.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-
-		_, ok := iter.(*sharedIterator)
-		require.False(t, ok)
-
-		iter.Stop()
-	})
 	t.Run("bypass_due_to_strong_consistency", func(t *testing.T) {
 		mockController := gomock.NewController(t)
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -513,7 +493,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -601,7 +581,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
@@ -616,7 +596,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		const numClient = 3
 		mockDatastore.EXPECT().
@@ -643,7 +623,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		filter1 := storage.ReadUsersetTuplesFilter{
 			Object:   "document:1a",
@@ -663,31 +643,13 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		_, err = ds.ReadUsersetTuples(ctx, storeID, filter1, options)
 		require.Error(t, err)
 	})
-	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorageLimit := NewSharedIteratorDatastoreStorage(WithSharedIteratorDatastoreStorageLimit(0))
-		dsLimit := NewSharedIteratorDatastore(mockDatastore, internalStorageLimit)
 
-		mockDatastore.EXPECT().
-			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-		iter, err := dsLimit.ReadUsersetTuples(ctx, storeID, filter, options)
-		require.NoError(t, err)
-
-		_, ok := iter.(*sharedIterator)
-		require.False(t, ok)
-
-		iter.Stop()
-	})
 	t.Run("bypass_due_to_strong_consistency", func(t *testing.T) {
 		mockController := gomock.NewController(t)
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter,
@@ -709,7 +671,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		cmpOpts := []cmp.Option{
 			testutils.TupleKeyCmpTransformer,
@@ -795,7 +757,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
@@ -810,7 +772,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		const numClient = 3
 		mockDatastore.EXPECT().
@@ -836,7 +798,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		filter1 := storage.ReadStartingWithUserFilter{
 			ObjectType: "document",
@@ -858,31 +820,13 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		_, err = ds.ReadStartingWithUser(ctx, storeID, filter1, options)
 		require.Error(t, err)
 	})
-	t.Run("bypass_due_to_map_size_limit", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorageLimit := NewSharedIteratorDatastoreStorage(WithSharedIteratorDatastoreStorageLimit(0))
-		dsLimit := NewSharedIteratorDatastore(mockDatastore, internalStorageLimit)
 
-		mockDatastore.EXPECT().
-			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-		iter, err := dsLimit.ReadStartingWithUser(ctx, storeID, filter, options)
-		require.NoError(t, err)
-
-		_, ok := iter.(*sharedIterator)
-		require.False(t, ok)
-
-		iter.Stop()
-	})
 	t.Run("bypass_due_to_strong_consistency", func(t *testing.T) {
 		mockController := gomock.NewController(t)
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter,
@@ -904,7 +848,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
@@ -927,7 +871,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		cmpOpts := []cmp.Option{
 			testutils.TupleKeyCmpTransformer,
@@ -991,7 +935,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1017,7 +961,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1046,7 +990,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1075,7 +1019,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1114,7 +1058,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1146,7 +1090,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1178,7 +1122,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1220,7 +1164,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1275,7 +1219,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1309,7 +1253,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1370,7 +1314,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1408,7 +1352,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1477,7 +1421,7 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
@@ -1540,42 +1484,6 @@ func TestNewSharedIteratorDatastore_iter(t *testing.T) {
 		_, err = iter2.Next(ctx)
 		require.ErrorIs(t, err, mockedError)
 	})
-
-	t.Run("clone_after_new_admission_time", func(t *testing.T) {
-		ctx := context.Background()
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()),
-			WithMaxAdmissionTime(500*time.Millisecond))
-
-		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
-		mockIterator.EXPECT().Stop()
-
-		mockIterator2 := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
-		mockIterator2.EXPECT().Next(gomock.Any()).Return(nil, storage.ErrIteratorDone)
-		mockIterator2.EXPECT().Stop()
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(mockIterator, nil)
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(mockIterator2, nil)
-		iter1, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		defer iter1.Stop()
-		// sleep time is smaller than watchdog but > admission time
-		time.Sleep(1 * time.Second)
-		iter2, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		defer iter2.Stop()
-		_, err = iter2.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
 }
 
 func TestSharedIterator_ManyTuples(t *testing.T) {
@@ -1604,7 +1512,7 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 		defer mockController.Finish()
 		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
 		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
+		internalStorage := new(Storage)
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
 			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
 
@@ -1640,348 +1548,5 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 		if diff := cmp.Diff(tuples, receivedTuples, cmpOpts...); diff != "" {
 			t.Fatalf("mismatch (-want +got):\n%s", diff)
 		}
-	})
-}
-
-func TestSharedIteratorCountMetric(t *testing.T) {
-	ctx := context.Background()
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
-	// Helper function to get current metric value
-	getSharedIteratorCount := func() float64 {
-		dto := &prometheus_model.Metric{}
-		sharedIteratorCount.Write(dto)
-		return dto.GetGauge().GetValue()
-	}
-
-	tk := tuple.NewTupleKey("license:1", "owner", "")
-	ts := timestamppb.New(time.Now())
-	tuples := []*openfgav1.Tuple{
-		{Key: tuple.NewTupleKey("license:1", "owner", "user:1"), Timestamp: ts},
-		{Key: tuple.NewTupleKey("license:1", "owner", "user:2"), Timestamp: ts},
-	}
-
-	t.Run("read_increment_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Stop iterator - should decrement count
-		iter.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("readstartingwithuser_increment_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		filter := storage.ReadStartingWithUserFilter{
-			ObjectType: "document",
-			Relation:   "viewer",
-			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
-		}
-
-		mockDatastore.EXPECT().
-			ReadStartingWithUser(gomock.Any(), storeID, filter, storage.ReadStartingWithUserOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Stop iterator - should decrement count
-		iter.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("readusersettuples_increment_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		filter := storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				{Type: "user"},
-			},
-		}
-
-		mockDatastore.EXPECT().
-			ReadUsersetTuples(gomock.Any(), storeID, filter, storage.ReadUsersetTuplesOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Stop iterator - should decrement count
-		iter.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("multiple_clones_single_increment", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		// Should only be called once due to sharing
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create first iterator - should increment count
-		iter1, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Create second iterator (clone) - should NOT increment count again
-		iter2, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Stop first iterator - count :w
-		// should remain the same (second clone exists)
-		iter1.Stop()
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Stop last iterator - should decrement count
-		iter2.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("bypassed_higher_consistency_no_increment", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{
-				Consistency: storage.ConsistencyOptions{
-					Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
-				},
-			}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create iterator with higher consistency - should bypass shared iterator
-		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{
-			Consistency: storage.ConsistencyOptions{
-				Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
-			},
-		})
-		require.NoError(t, err)
-
-		// Verify count was not incremented (bypassed)
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-
-		iter.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("bypassed_storage_limit_no_increment", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-
-		// Create storage with limit of 0 to force bypass
-		internalStorage := NewSharedIteratorDatastoreStorage(
-			WithSharedIteratorDatastoreStorageLimit(0))
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
-
-		// Create iterator - should bypass due to limit
-		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-
-		// Verify count was not incremented (bypassed)
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-
-		iter.Stop()
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("error_during_creation_no_increment", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()))
-
-		// Mock error during iterator creation
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(nil, errors.New("mock error"))
-
-		// Try to create iterator - should fail
-		_, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.Error(t, err)
-
-		// Verify count was not incremented
-		require.InDelta(t, initialCount, getSharedIteratorCount(), 0.0001)
-	})
-
-	t.Run("read_timeout_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()),
-			WithMaxAdmissionTime(100*time.Millisecond)) // Very short timeout
-
-		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
-		mockIterator.EXPECT().Stop()
-
-		mockDatastore.EXPECT().
-			Read(gomock.Any(), storeID, tk, storage.ReadOptions{}).
-			Return(mockIterator, nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.Read(ctx, storeID, tk, storage.ReadOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Wait for admission time to expire - count should be decremented automatically
-		require.Eventually(t, func() bool {
-			return getSharedIteratorCount() == initialCount
-		}, 1*time.Second, 50*time.Millisecond)
-
-		iter.Stop() // Clean up
-	})
-
-	t.Run("readstartingwithuser_timeout_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()),
-			WithMaxAdmissionTime(100*time.Millisecond)) // Very short timeout
-
-		filter := storage.ReadStartingWithUserFilter{
-			ObjectType: "document",
-			Relation:   "viewer",
-			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
-		}
-
-		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
-		mockIterator.EXPECT().Stop()
-
-		mockDatastore.EXPECT().
-			ReadStartingWithUser(gomock.Any(), storeID, filter, storage.ReadStartingWithUserOptions{}).
-			Return(mockIterator, nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Wait for admission time to expire - count should be decremented automatically
-		require.Eventually(t, func() bool {
-			return getSharedIteratorCount() == initialCount
-		}, 1*time.Second, 50*time.Millisecond)
-
-		iter.Stop() // Clean up
-	})
-
-	t.Run("readusersettuples_timeout_decrement", func(t *testing.T) {
-		initialCount := getSharedIteratorCount()
-
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-		mockDatastore := mocks.NewMockOpenFGADatastore(mockController)
-		storeID := ulid.Make().String()
-		internalStorage := NewSharedIteratorDatastoreStorage()
-		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage,
-			WithSharedIteratorDatastoreLogger(logger.NewNoopLogger()),
-			WithMaxAdmissionTime(100*time.Millisecond)) // Very short timeout
-
-		filter := storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				{Type: "user"},
-			},
-		}
-
-		mockIterator := mocks.NewMockIterator[*openfgav1.Tuple](mockController)
-		mockIterator.EXPECT().Stop()
-
-		mockDatastore.EXPECT().
-			ReadUsersetTuples(gomock.Any(), storeID, filter, storage.ReadUsersetTuplesOptions{}).
-			Return(mockIterator, nil)
-
-		// Create iterator - should increment count
-		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-		require.InDelta(t, initialCount+1, getSharedIteratorCount(), 0.0001)
-
-		// Wait for admission time to expire - count should be decremented automatically
-		require.Eventually(t, func() bool {
-			return getSharedIteratorCount() == initialCount
-		}, 1*time.Second, 50*time.Millisecond)
-
-		iter.Stop() // Clean up
 	})
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
The current implementation creates a `sharedIterator` instance that is shared with any callers for the same key until one of two events occurs:

- The max admission time has expired.
- The count of references to the sharedIterator instance reaches 0.

The idea is that this solution should allow callers to fetch a copy of a live iterator as long as it is currently being fetched, iterated over, or has not exceeded its TTL or iterator count threshold. By allowing a clone to be made for as long as there is ongoing iteration, the possibility of multiple requests to share the same iterator increases. By enforcing a TTL, the potential staleness of an iterator’s data is reduced. By enforcing an iterator count threshold, the potential for excessive memory consumption is mitigated.

However, the `sharedIterator` instance is often returned immediately and stopped soon after, before any other goroutines have had a chance to clone the instance and increase its internal reference counter. Therefore, the current implementation is ineffective at reducing back-end calls.

#### How is it being solved?
To solve the issue, a more "traditional" single-flight approach is used. The first goroutine to call for a given key is the one that will issue the single back-end request. All other goroutines will wait for the initial goroutine to return a result. However, instead of keeping the shared iterator around in a "cache" for further cloning, subsequent goroutines calling for the same key will be part of a new single-flight group, yielding a new shared iterator.

This implementation eliminates the need for any kind of "cache eviction", either by TTL or reference count.

#### What changes are made to solve it?
`group` and `call` types are introduced for handling the single-flight implementation. It is fairly similar to the Go development team's approach, however it has a slight modification for this specific use case.

Upon receiving a newly created `sharedIterator` instance in the goroutine that performed the single-flight, a `sharedIterator` must be allocated for each blocked participating goroutine and cloned before the initial `sharedIterator` instance is returned. This prevents the calling code from stopping the `sharedIterator` instance before any other goroutines have had a chance to clone it, effectively preventing clone creation.

Additionally, now unused parameters, default values, configurations, and metrics have been removed.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

