### PR TITLE
Update changelog to prep for 1.9.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Shadow list objects' check resolver should use its own cache. [#2574](https://github.com/openfga/openfga/pull/2574)
 - Improve performance for list objects intersection/exclusion with `enable-list-objects-optimizations` flag. [#2569](https://github.com/openfga/openfga/pull/2569)
 
+## [1.9.1] - 2025-07-22
+### Changed
+- This is an unstable release
+
 ## [1.9.0] - 2025-07-03
 ### Added
 - Add separate reverse_expand path utilizing the weighted graph. Gated behind `enable-list-objects-optimizations` flag. [#2529](https://github.com/openfga/openfga/pull/2529)
@@ -1359,7 +1363,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Early support for preshared key or OIDC authentication methods
 
 [Unreleased]: https://github.com/openfga/openfga/compare/v1.9.2...HEAD
-[1.9.2]: https://github.com/openfga/openfga/compare/v1.9.0...v1.9.2
+[1.9.2]: https://github.com/openfga/openfga/compare/v1.9.1...v1.9.2
+[1.9.1]: https://github.com/openfga/openfga/compare/v1.9.0...v1.9.1
 [1.9.0]: https://github.com/openfga/openfga/compare/v1.8.16...v1.9.0
 [1.8.16]: https://github.com/openfga/openfga/compare/v1.8.15...v1.8.16
 [1.8.15]: https://github.com/openfga/openfga/compare/v1.8.14...v1.8.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [1.9.1] - 2025-07-22
 ### Changed
-⚠️ This is an incorrect version and should not be used. Please upgrade to version `v1.9.2`.
-
-Also do not use its companion docker image with the sha: `sha256:71212e9aa2f26cd74287babf7eb92743b8510960388ff0b5ac68d89a23728898`
+- **WARNING:** This is an incorrect version and should not be used. Please upgrade to version `v1.9.2` and do not use its companion docker image with the sha:
+  `sha256:71212e9aa2f26cd74287babf7eb92743b8510960388ff0b5ac68d89a23728898`
 
 ## [1.9.0] - 2025-07-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
-## [1.9.1] - 2025-07-22
+## [1.9.2] - 2025-07-24
 ### Added
 - Add `list_objects_optimization_count` metric to list objects requests. [#2524](https://github.com/openfga/openfga/pull/2524)
 
@@ -1358,8 +1358,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.9.1...HEAD
-[1.9.1]: https://github.com/openfga/openfga/compare/v1.9.0...v1.9.1
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.9.2...HEAD
+[1.9.2]: https://github.com/openfga/openfga/compare/v1.9.0...v1.9.2
 [1.9.0]: https://github.com/openfga/openfga/compare/v1.8.16...v1.9.0
 [1.8.16]: https://github.com/openfga/openfga/compare/v1.8.15...v1.8.16
 [1.8.15]: https://github.com/openfga/openfga/compare/v1.8.14...v1.8.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [1.9.1] - 2025-07-22
 ### Changed
-- This is an unstable release
+⚠️ This is an incorrect version and should not be used. Please upgrade to version `v1.9.2`.
+
+Also do not use its companion docker image with the sha: `sha256:71212e9aa2f26cd74287babf7eb92743b8510960388ff0b5ac68d89a23728898`
 
 ## [1.9.0] - 2025-07-03
 ### Added


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
This PR updates the changelog in preparation for releasing `v1.9.2`

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to reflect version 1.9.2 with the latest release date and revised comparison links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->