### PR TITLE
fix: removes isDuplicateQuery check from reverse_expand_weighted

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -389,10 +389,11 @@ func (c *ReverseExpandQuery) executeQueryJob(
 
 	currentReq.relationStack = newStack
 
+	// TODO: removed temporarily to investigate correctness issue
 	// Ensure that we haven't already run this query
-	if c.isDuplicateQuery(userFilter, typeRel, newStack) {
-		return nil, nil
-	}
+	// if c.isDuplicateQuery(userFilter, typeRel, newStack) {
+	//	return nil, nil
+	// }
 
 	objectType, relation := tuple.SplitObjectRelation(typeRel)
 
@@ -479,7 +480,7 @@ func buildUserFilter(
 	return []*openfgav1.ObjectRelation{filter}, nil
 }
 
-func (c *ReverseExpandQuery) isDuplicateQuery(
+func (c *ReverseExpandQuery) isDuplicateQuery( //nolint:unused
 	userFilter []*openfgav1.ObjectRelation,
 	typeRel string,
 	relationStack stack.Stack[typeRelEntry],

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openfga/openfga/internal/concurrency"
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/stack"
-	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/internal/validation"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/telemetry"
@@ -389,12 +388,6 @@ func (c *ReverseExpandQuery) executeQueryJob(
 
 	currentReq.relationStack = newStack
 
-	// TODO: removed temporarily to investigate correctness issue
-	// Ensure that we haven't already run this query
-	// if c.isDuplicateQuery(userFilter, typeRel, newStack) {
-	//	return nil, nil
-	// }
-
 	objectType, relation := tuple.SplitObjectRelation(typeRel)
 
 	filteredIter, err := c.buildFilteredIterator(ctx, currentReq, objectType, relation, userFilter)
@@ -478,34 +471,6 @@ func buildUserFilter(
 	}
 
 	return []*openfgav1.ObjectRelation{filter}, nil
-}
-
-func (c *ReverseExpandQuery) isDuplicateQuery( //nolint:unused
-	userFilter []*openfgav1.ObjectRelation,
-	typeRel string,
-	relationStack stack.Stack[typeRelEntry],
-) bool {
-	objectType, relation := tuple.SplitObjectRelation(typeRel)
-
-	// Create a unique key for the current query to avoid duplicate work.
-	key := utils.Reduce(userFilter, "", func(accumulator string, current *openfgav1.ObjectRelation) string {
-		return current.String() + accumulator
-	})
-
-	// Also need to consider the query's context, as it is possible that many different branches end at the
-	// same leaf or have a common ancestor as part of a unique traversal, and we don't want to kill a unique branch.
-	stackStr := ""
-	for relationStack != nil {
-		var val typeRelEntry
-		val, relationStack = stack.Pop(relationStack)
-		stackStr += fmt.Sprintf("%v", val)
-	}
-	key += stackStr
-
-	key += relation + objectType
-	_, loaded := c.queryDedupeMap.LoadOrStore(key, struct{}{})
-
-	return loaded
 }
 
 // buildFilteredIterator constructs the iterator used when reverse_expand queries for tuples.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
We are seeing mismatches in live data between the main LO query and the weighted graph version. We've traced them locally to this block of code. It looks like the deduplication work in #2567 is deduplicating queries which it should not be.

#### How is it being solved?
Disable query deduplication in the new reverse_expand temporarily while we investigate what's happening.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled duplicate query detection logic in reverse expand queries to address a correctness issue. No other functionality has been affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->