### PR TITLE
chore: add main query count to shadow list objects logging

### DIFF
--- a/pkg/server/commands/list_objects_shadow.go
+++ b/pkg/server/commands/list_objects_shadow.go
@@ -172,7 +172,7 @@ func (q *shadowedListObjectsQuery) Execute(
 				}
 			}()
 
-			q.executeShadowModeAndCompareResults(cloneCtx, req, res.Objects, latency)
+			q.executeShadowModeAndCompareResults(cloneCtx, req, res, latency)
 		}()
 	}
 	return res, err
@@ -190,19 +190,27 @@ func (q *shadowedListObjectsQuery) checkShadowModeSampleRate() bool {
 // It compares the results of the main and shadow functions, logging any differences.
 // If the shadow function takes longer than shadowTimeout, it will be cancelled, and its result will be ignored, but the shadowTimeout event will be logged.
 // This function is designed to be run in a separate goroutine to avoid blocking the main execution flow.
-func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx context.Context, req *openfgav1.ListObjectsRequest, mainResult []string, latency time.Duration) {
+func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx context.Context, req *openfgav1.ListObjectsRequest, mainResult *ListObjectsResponse, latency time.Duration) {
 	shadowCtx, shadowCancel := context.WithTimeout(parentCtx, q.shadowTimeout)
 	defer shadowCancel()
 
 	startTime := time.Now()
 	shadowRes, errShadow := q.shadow.Execute(shadowCtx, req)
 	shadowLatency := time.Since(startTime)
+
+	var mainQueryCount uint32
+	var mainResultObjects []string
+	if mainResult != nil {
+		mainQueryCount = mainResult.ResolutionMetadata.DatastoreQueryCount.Load()
+		mainResultObjects = mainResult.Objects
+	}
+
 	if errShadow != nil {
 		q.logger.WarnWithContext(parentCtx, "shadowed list objects error",
 			loShadowLogFields(req,
 				zap.Duration("main_latency", latency),
 				zap.Duration("shadow_latency", shadowLatency),
-				zap.Int("main_result_count", len(mainResult)),
+				zap.Int("main_result_count", len(mainResultObjects)),
 				zap.Any("error", errShadow),
 			)...,
 		)
@@ -210,13 +218,13 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 	}
 
 	var resultShadowed []string
-	var queryCount uint32
+	var shadowQueryCount uint32
 	if shadowRes != nil {
 		resultShadowed = shadowRes.Objects
-		queryCount = shadowRes.ResolutionMetadata.DatastoreQueryCount.Load()
+		shadowQueryCount = shadowRes.ResolutionMetadata.DatastoreQueryCount.Load()
 	}
 
-	mapResultMain := keyMapFromSlice(mainResult)
+	mapResultMain := keyMapFromSlice(mainResultObjects)
 	mapResultShadow := keyMapFromSlice(resultShadowed)
 
 	// compare sorted string arrays - sufficient for equality check
@@ -233,11 +241,12 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 				zap.Bool("is_match", false),
 				zap.Duration("main_latency", latency),
 				zap.Duration("shadow_latency", shadowLatency),
-				zap.Int("main_result_count", len(mainResult)),
+				zap.Int("main_result_count", len(mainResultObjects)),
 				zap.Int("shadow_result_count", len(resultShadowed)),
 				zap.Int("total_delta", totalDelta),
 				zap.Any("delta", delta),
-				zap.Uint32("datastore_query_count", queryCount),
+				zap.Uint32("main_datastore_query_count", mainQueryCount),
+				zap.Uint32("shadow_datastore_query_count", shadowQueryCount),
 			)...,
 		)
 	} else {
@@ -246,8 +255,9 @@ func (q *shadowedListObjectsQuery) executeShadowModeAndCompareResults(parentCtx 
 				zap.Bool("is_match", true),
 				zap.Duration("main_latency", latency),
 				zap.Duration("shadow_latency", shadowLatency),
-				zap.Int("main_result_count", len(mainResult)),
-				zap.Uint32("datastore_query_count", queryCount),
+				zap.Int("main_result_count", len(mainResultObjects)),
+				zap.Uint32("main_datastore_query_count", mainQueryCount),
+				zap.Uint32("shadow_datastore_query_count", shadowQueryCount),
 			)...,
 		)
 	}

--- a/pkg/server/commands/list_objects_shadow_test.go
+++ b/pkg/server/commands/list_objects_shadow_test.go
@@ -404,7 +404,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 	}
 	type args struct {
 		req     *openfgav1.ListObjectsRequest
-		result  []string
+		result  *ListObjectsResponse
 		latency time.Duration
 	}
 	tests := []struct {
@@ -442,7 +442,8 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Duration("main_latency", 77*time.Millisecond)),
 						gomock.Any(),
 						zap.Int("main_result_count", 3),
-						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("main_datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("shadow_datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},
@@ -452,7 +453,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 					StoreId:              "req.GetStoreId()",
 					AuthorizationModelId: "req.GetAuthorizationModelId()",
 				},
-				result:  []string{"a", "b", "c"},
+				result:  &ListObjectsResponse{Objects: []string{"a", "b", "c"}},
 				latency: 77 * time.Millisecond,
 			},
 		},
@@ -486,14 +487,15 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Int("shadow_result_count", 2)),
 						gomock.Eq(zap.Int("total_delta", 3)),
 						gomock.Eq(zap.Any("delta", []string{"+d", "-a", "-b"})),
-						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("main_datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("shadow_datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},
 			},
 			args: args{
 				req:     &openfgav1.ListObjectsRequest{},
-				result:  []string{"a", "b", "c"},
+				result:  &ListObjectsResponse{Objects: []string{"a", "b", "c"}},
 				latency: 77 * time.Millisecond,
 			},
 		},
@@ -527,14 +529,15 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 						gomock.Eq(zap.Int("shadow_result_count", 5)),
 						gomock.Eq(zap.Int("total_delta", 11)),
 						gomock.Eq(zap.Any("delta", []string{"+x", "+y", "+z"})),
-						gomock.Eq(zap.Uint32("datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("main_datastore_query_count", uint32(0))),
+						gomock.Eq(zap.Uint32("shadow_datastore_query_count", uint32(0))),
 					)
 					return mockLogger
 				},
 			},
 			args: args{
 				req:     &openfgav1.ListObjectsRequest{},
-				result:  []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+				result:  &ListObjectsResponse{Objects: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}},
 				latency: 77 * time.Millisecond,
 			},
 		},
@@ -569,7 +572,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 			},
 			args: args{
 				req:     &openfgav1.ListObjectsRequest{},
-				result:  []string{"a", "b", "c"},
+				result:  &ListObjectsResponse{Objects: []string{"a", "b", "c"}},
 				latency: 77 * time.Millisecond,
 			},
 		},
@@ -603,7 +606,7 @@ func Test_shadowedListObjectsQuery_executeShadowModeAndCompareResults(t *testing
 			},
 			args: args{
 				req:     &openfgav1.ListObjectsRequest{},
-				result:  []string{"a", "b", "c"},
+				result:  &ListObjectsResponse{Objects: []string{"a", "b", "c"}},
 				latency: 77 * time.Millisecond,
 			},
 		},


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
It's difficult to compare the difference in datastore query counts between the existing `main` ListObjects code and the new `shadow` ListObjects code. Adding an additional piece to the logs will make it easier.

It won't be exactly an apples-to-apples comparison, since the main query's cache is likely to be hit much more often due to its higher usage, but this should still provide some helpful data.

#### How is it being solved?
This PR adds an additional piece of information to the log attributes in the shadow list objects query.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging to display separate datastore query counts for main and shadow queries when comparing results.
* **Tests**
  * Updated tests to reflect changes in result structure and logging fields, ensuring accurate validation of query count logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->