### PR TITLE
fix: fails to start when using secondary db with db metrics enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Fixed bug in how experimental ReverseExpand is handling duplicate TTUs. [#2589](https://github.com/openfga/openfga/pull/2589)
 - Fixed bug in how experimental ReverseExpand is handling duplicate edge traversals. [#2594](https://github.com/openfga/openfga/pull/2594)
 - Fixed logs in ListObjects weighted graph to include `store_id` and `authorization_model_id` through the context. [#2581](https://github.com/openfga/openfga/pull/2581)
+- Fixed bug where OpenFGA fail to start when both secondary DB and db metrics enabled. [#2598](https://github.com/openfga/openfga/pull/2598)
 
 ## [1.9.2] - 2025-07-24
 ### Added

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -119,7 +119,7 @@ func New(uri string, cfg *sqlcommon.Config) (*Datastore, error) {
 	return NewWithDB(primaryDB, secondaryDB, cfg)
 }
 
-func configureDB(db *sql.DB, cfg *sqlcommon.Config) (*sqlcommon.DBInfo, sq.StatementBuilderType, prometheus.Collector, error) {
+func configureDB(db *sql.DB, cfg *sqlcommon.Config, isPrimary bool) (*sqlcommon.DBInfo, sq.StatementBuilderType, prometheus.Collector, error) {
 	var stbl sq.StatementBuilderType
 	policy := backoff.NewExponentialBackOff()
 	policy.MaxElapsedTime = 1 * time.Minute
@@ -139,7 +139,13 @@ func configureDB(db *sql.DB, cfg *sqlcommon.Config) (*sqlcommon.DBInfo, sq.State
 
 	var collector prometheus.Collector
 	if cfg.ExportMetrics {
-		collector = collectors.NewDBStatsCollector(db, "openfga")
+		dbName := "opefnga"
+
+		if !isPrimary {
+			dbName += "_secondary"
+		}
+
+		collector = collectors.NewDBStatsCollector(db, dbName)
 		if err := prometheus.Register(collector); err != nil {
 			return nil, stbl, nil, fmt.Errorf("initialize metrics: %w", err)
 		}
@@ -153,7 +159,7 @@ func configureDB(db *sql.DB, cfg *sqlcommon.Config) (*sqlcommon.DBInfo, sq.State
 
 // NewWithDB creates a new [Datastore] storage with the provided database connection.
 func NewWithDB(primaryDB, secondaryDB *sql.DB, cfg *sqlcommon.Config) (*Datastore, error) {
-	primaryDBInfo, primaryStbl, primaryCollector, err := configureDB(primaryDB, cfg)
+	primaryDBInfo, primaryStbl, primaryCollector, err := configureDB(primaryDB, cfg, true)
 	if err != nil {
 		return nil, fmt.Errorf("configure primary db: %w", err)
 	}
@@ -162,7 +168,7 @@ func NewWithDB(primaryDB, secondaryDB *sql.DB, cfg *sqlcommon.Config) (*Datastor
 	var secondaryStbl sq.StatementBuilderType
 	var secondaryCollector prometheus.Collector
 	if secondaryDB != nil {
-		secondaryDBInfo, secondaryStbl, secondaryCollector, err = configureDB(secondaryDB, cfg)
+		secondaryDBInfo, secondaryStbl, secondaryCollector, err = configureDB(secondaryDB, cfg, false)
 		if err != nil {
 			return nil, fmt.Errorf("configure secondary db: %w", err)
 		}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -139,7 +139,7 @@ func configureDB(db *sql.DB, cfg *sqlcommon.Config, isPrimary bool) (*sqlcommon.
 
 	var collector prometheus.Collector
 	if cfg.ExportMetrics {
-		dbName := "opefnga"
+		dbName := "openfga"
 
 		if !isPrimary {
 			dbName += "_secondary"

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -27,6 +27,7 @@ func TestPostgresDatastore(t *testing.T) {
 
 	uri := testDatastore.GetConnectionURI(true)
 	cfg := sqlcommon.NewConfig()
+	cfg.ExportMetrics = true
 	ds, err := New(uri, cfg)
 	require.NoError(t, err)
 	defer ds.Close()
@@ -41,6 +42,7 @@ func TestPostgresDatastoreStatusWithSecondaryDB(t *testing.T) {
 
 	cfg := sqlcommon.NewConfig()
 	cfg.SecondaryURI = primaryDatastore.GetSecondaryConnectionURI(true)
+	cfg.ExportMetrics = true
 
 	ds, err := New(primaryURI, cfg)
 	require.NoError(t, err)


### PR DESCRIPTION


Close https://github.com/openfga/openfga/issues/2596

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
OpenFGA cannot start when both secondary DB is configured via OPENFGA_DATASTORE_SECONDARY_URI and OPENFGA_DATASTORE_METRICS_ENABLED is enabled.  Root cause of issue is that OpenFGA attempts to register to stats collector with identical name for both DB.

#### How is it being solved?

For secondary DB, use a different name (openfga_secondary) for stats collector.

#### What changes are made to solve it?
Update postgres.go's configureDB to take into account whether it is for primary or secondary db.

## References
Closes https://github.com/openfga/openfga/issues/2596

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the application failed to start when both the secondary database and database metrics were enabled at the same time.

* **Documentation**
  * Updated the changelog to include details about the fixed startup issue related to secondary database and metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->