### PR TITLE
fix(test): flaky TestIteratorToUserset

### DIFF
--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -561,6 +561,7 @@ func TestIteratorToUserset(t *testing.T) {
 				}
 			}
 		}
-		require.Equal(t, 1, count)
+		require.GreaterOrEqual(t, count, 1)
+		require.LessOrEqual(t, count, 2)
 	})
 }


### PR DESCRIPTION
Fix flaky unit test for TestIteratorToUserset where depending on order of being received from channel, the error count can be 1 or 2.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Flaky unit test for TestIteratorToUserset where the number of errors returned depends on channel message being processed.  If iterChan2 is being processed first, it is possible that the number of errors returned are 2 since iterator error [does not close terminate loop immediately](https://github.com/openfga/openfga/blob/9334adc3563820c700f1b567088e768d45f71ed1/internal/graph/object_providers.go#L172).  Instead, it will close the iterator which will close the channel.  However, if it happens that iterChan1 are processed in the meantime, two errors will be returned.

#### How is it being solved?
Update assertion for test that 1 or 2 errors may be returned.

#### What changes are made to solve it?
Update unit test in object_providers_test.go

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

