### PR TITLE
fix: support tuple iterator cache in integration tests

### DIFF
--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -10164,43 +10164,48 @@ tests:
               define can_read: [role#assignee]
         tuples:
           - user: user:1
-            relation: assignee
-            object: role:admin
+            relation: placeholder
+            object: role:awesome
 
           # This tuple will become obsolete after the model change in the next stage.
           - object: role:invalid
             user: role:awesome#placeholder
             relation: assignee
+
+          - object: job:1
+            user: role:invalid#assignee
+            relation: can_read
         checkAssertions:
           - tuple:
               user: user:1
               relation: can_read
               object: job:1
-            expectation: false
+            expectation: true
       - model: |
           model
             schema 1.1
           type user
           type role
             relations
+              define placeholder: [user]
               define assignee: [user]
           type job
             relations
               define can_read: [role#assignee]
         tuples:
           - user: user:2
-            relation: assignee
-            object: role:admin2
+            relation: placeholder
+            object: role:awesome
 
           - object: job:2
-            user: role:admin2#assignee
+            user: role:invalid#assignee
             relation: can_read
         checkAssertions:
           - tuple:
               user: user:2
               relation: can_read
               object: job:2
-            expectation: true
+            expectation: false
 
   - name: userset_discard_invalid_wildcard
     # Tests that after a model change, any now obsolete tuples should not affect the check assertion.

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -10090,6 +10090,7 @@ tests:
               - user:1
 
   - name: ttu_discard_invalid
+    # Tests that after a model change, any now obsolete tuples should not affect the check assertion.
     stages:
       - model: |
           model
@@ -10105,17 +10106,22 @@ tests:
         tuples:
           - user: user:1
             relation: assignee
-            object: role:admin
+            object: role:minion
 
+          # This tuple will become obsolete after the model change in the next stage.
           - object: role:parent
             user: role:minion#assignee
             relation: assignee
+
+          - object: job:1
+            user: role:parent
+            relation: parent 
         checkAssertions:
           - tuple:
               user: user:1
               relation: can_read
               object: job:1
-            expectation: false
+            expectation: true
       - model: |
           model
             schema 1.1
@@ -10128,21 +10134,22 @@ tests:
               define parent: [role]
               define can_read: assignee from parent
         tuples:
-          - object: job:2
-            user: role:admin2
-            relation: parent
-
           - user: user:2
             relation: assignee
-            object: role:admin2
+            object: role:minion
+          
+          - object: job:2
+            user: role:parent
+            relation: parent
         checkAssertions:
           - tuple:
               user: user:2
               relation: can_read
               object: job:2
-            expectation: true
+            expectation: false
 
   - name: userset_discard_invalid
+    # Tests that after a model change, any now obsolete tuples should not affect the check assertion.
     stages:
       - model: |
           model
@@ -10160,6 +10167,7 @@ tests:
             relation: assignee
             object: role:admin
 
+          # This tuple will become obsolete after the model change in the next stage.
           - object: role:invalid
             user: role:awesome#placeholder
             relation: assignee
@@ -10195,6 +10203,7 @@ tests:
             expectation: true
 
   - name: userset_discard_invalid_wildcard
+    # Tests that after a model change, any now obsolete tuples should not affect the check assertion.
     stages:
       - model: |
           model
@@ -10207,9 +10216,12 @@ tests:
             relations
               define can_read: [role#assignee, user:*]
         tuples:
+          # This tuple will become obsolete after the model change in the next stage.
           - user: user:*
             relation: can_read
             object: job:1
+          
+          # This tuple will become obsolete after the model change in the next stage.
           - user: user:*
             relation: can_read
             object: job:2

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -10128,14 +10128,18 @@ tests:
               define parent: [role]
               define can_read: assignee from parent
         tuples:
-          - object: job:1
-            user: role:admin
+          - object: job:2
+            user: role:admin2
             relation: parent
+
+          - user: user:2
+            relation: assignee
+            object: role:admin2
         checkAssertions:
           - tuple:
-              user: user:1
+              user: user:2
               relation: can_read
-              object: job:1
+              object: job:2
             expectation: true
 
   - name: userset_discard_invalid
@@ -10176,14 +10180,18 @@ tests:
             relations
               define can_read: [role#assignee]
         tuples:
-          - object: job:1
-            user: role:admin#assignee
+          - user: user:2
+            relation: assignee
+            object: role:admin2
+
+          - object: job:2
+            user: role:admin2#assignee
             relation: can_read
         checkAssertions:
           - tuple:
-              user: user:1
+              user: user:2
               relation: can_read
-              object: job:1
+              object: job:2
             expectation: true
 
   - name: userset_discard_invalid_wildcard
@@ -10202,6 +10210,9 @@ tests:
           - user: user:*
             relation: can_read
             object: job:1
+          - user: user:*
+            relation: can_read
+            object: job:2
         checkAssertions:
           - tuple:
               user: user:1
@@ -10224,22 +10235,22 @@ tests:
             relations
               define can_read: [role#assignee]
         tuples:
-          - object: job:1
+          - object: job:2
             user: role:admin#assignee
             relation: can_read
-          - user: user:1
+          - user: user:3
             relation: assignee
             object: role:admin
         checkAssertions:
           - tuple:
-              user: user:1
+              user: user:3
               relation: can_read
-              object: job:1
+              object: job:2
             expectation: true
           - tuple:
-              user: user:2
+              user: user:4
               relation: can_read
-              object: job:1
+              object: job:2
             expectation: false
   - name: recursive_ttu_union_algebraic_operations
     stages:

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -340,11 +340,6 @@ func testRunAll(t *testing.T, engine string) {
 
 	cfg.CheckIteratorCache.Enabled = true
 
-	// Some tests/stages are sensitive to the cache TTL,
-	// so we set it to a very low value to still exercise
-	// the Check iterator cache.
-	cfg.CheckIteratorCache.TTL = 1 * time.Nanosecond
-
 	tests.StartServer(t, cfg)
 
 	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Currently, the tuple iterator cache TTL is set to 1 nanosecond when running integration tests. This is necessary because 3 tests cannot currently work with the cache in play:
- ttu_discard_invalid
- userset_discard_invalid
- userset_discard_invalid_wildcard

However, this effectively disables the cache for testing purposes and adds the potential for these tests to be flaky. These tests need not be designed in such a way.
#### How is it being solved?
The tests are changed so that their subsequent stage assertions do not depend upon or conflict with the tuples of the previous stages.

#### What changes are made to solve it?
The three tests are updated to use different user and object identifiers from previous stages.
The tuple iterator cache TTL limitation is removed, allowing the default value to be used.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases with new object and user identifiers, and added new tuples to reflect updated user-role relationships.
  * Adjusted test data in permission checks to use the new identifiers and relationships.
  * Removed explicit cache TTL configuration from test setup, now using default cache settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->