### PR TITLE
chore: specify github-native as changelog generation to use

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -191,6 +191,7 @@ snapshot:
   name_template: "{{ incpatch .Version }}-next"
 
 changelog:
+  use: github-native
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Set the changelog generation in goreleaser to github-native, rather than the default being git. This should allow goreleaser to generate our changelog release notes properly.

https://goreleaser.com/customization/changelog/

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process to use GitHub's native changelog generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->