### PR TITLE
chore: add workflow that generates a release

### DIFF
--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -1,0 +1,65 @@
+name: tag-generation
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - 'CHANGELOG.md'
+
+jobs:
+  create-tag:
+    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'release') && contains(github.event.pull_request.title, 'Update changelog to prep for release')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check if PR author is a maintainer
+        run: |
+          pr_author="${{ github.event.pull_request.user.login }}"
+          permission=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/collaborators/$pr_author/permission" | jq -r .permission)
+
+          if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+            echo "$pr_author is a maintainer. Continue with tag creation."
+          else
+            echo "$pr_author is NOT a maintainer. Exiting..."
+            exit 1
+          fi
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get current branch commit SHA
+        id: get_sha
+        run: |
+          echo "Getting the latest commit SHA..."
+          sha=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ github.repository }}/git/refs/heads/main | jq -r .object.sha)
+          echo "SHA=$sha" >> $GITHUB_ENV
+      - name: Create new tag
+        id: create_tag
+        run: |
+          echo "Getting the latest version from CHANGELOG..."
+          tag_name=$(awk '
+            BEGIN { unreleased_found=0 }
+            /^## \[Unreleased\]/ { unreleased_found=1; next }
+            unreleased_found && /^## \[[0-9]+\.[0-9]+\.[0-9]+\]/ {
+              # Extract version using split
+              line = $0
+              n = split(line, arr, "[")
+              m = split(arr[2], ver, "]")
+              print ver[1]
+              exit
+            }
+          ' "CHANGELOG.md")
+          if [ -z "$tag_name" ]; then
+            echo "No version found in CHANGELOG. Exiting..."
+            exit 1
+          else
+            tag_name="v$tag_name"
+          fi
+          echo "Creating a new tag $tag_name..."
+          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -d "{\"ref\":\"refs/tags/$tag_name\", \"sha\":\"${{ env.SHA }}\"}" \
+            https://api.github.com/repos/${{ github.repository }}/git/refs
+          echo "TAG_NAME=$tag_name" >> $GITHUB_ENV

--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   create-tag:
-    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'release') && contains(github.event.pull_request.title, 'Update changelog to prep for release')
+    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'release') && startsWith(github.event.pull_request.title, 'Update changelog to prep for release')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Workflow generates a release tag when a release PR is merged. Requires a PR merged into main with a `CHANGELOG.md` change and
- the PR title starts with `Update changelog to prep for release`
- the PR has the `release` tag
- the PR author must be a maintainer

For the tag generation,
- gets the tag from the `CHANGELOG.md` file
- the tag must not already exist

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

