### PR TITLE
feat: add JWT fallback handling for tokens without kid header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Add `check_count` grpc tag to list objects requests. [#2515](https://github.com/openfga/openfga/pull/2515)
 - Promote the Check fast path v2 implementations to no longer being behind the `enable-check-optimizations` config flag. [#2609](https://github.com/openfga/openfga/pull/2609)
+- Support for verifying JWTs without a `kid` header by checking against all available keys in the JWK Set. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ### Changed
 - Change ListObjectsResolutionMetadata fields to value types instead of pointers. [#2583](https://github.com/openfga/openfga/pull/2583)
@@ -37,6 +38,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Update go toolchain version to 1.24.6 - related: [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907)
 - Revert min supported go version to 1.24.0
 - Bump the base docker image to `cgr.dev/chainguard/static@sha256:6a4b683f4708f1f167ba218e31fcac0b7515d94c33c3acf223c36d5c6acd3783`
+- - Upgraded `keyfunc` library from v2 to v3 to enable access to all keys for JWT verification. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ### Fixed
 - Fixed bug in how experimental ReverseExpand is handling duplicate TTUs. [#2589](https://github.com/openfga/openfga/pull/2589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
+- Upgraded `keyfunc` library from v2 to v3 to enable access to all keys for JWT verification. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ### Fixed
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)
 - Update ListObjects' check resolver to use correct environment variable. [#2653](https://github.com/openfga/openfga/pull/2653)
+- Support for verifying JWTs without a `kid` header by checking against all available keys in the JWK Set. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ## [1.9.5] - 2025-08-15
 ### Fixed
@@ -29,7 +31,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Add `check_count` grpc tag to list objects requests. [#2515](https://github.com/openfga/openfga/pull/2515)
 - Promote the Check fast path v2 implementations to no longer being behind the `enable-check-optimizations` config flag. [#2609](https://github.com/openfga/openfga/pull/2609)
-- Support for verifying JWTs without a `kid` header by checking against all available keys in the JWK Set. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ### Changed
 - Change ListObjectsResolutionMetadata fields to value types instead of pointers. [#2583](https://github.com/openfga/openfga/pull/2583)
@@ -38,7 +39,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Update go toolchain version to 1.24.6 - related: [CVE-2025-47907](https://nvd.nist.gov/vuln/detail/CVE-2025-47907)
 - Revert min supported go version to 1.24.0
 - Bump the base docker image to `cgr.dev/chainguard/static@sha256:6a4b683f4708f1f167ba218e31fcac0b7515d94c33c3acf223c36d5c6acd3783`
-- - Upgraded `keyfunc` library from v2 to v3 to enable access to all keys for JWT verification. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ### Fixed
 - Fixed bug in how experimental ReverseExpand is handling duplicate TTUs. [#2589](https://github.com/openfga/openfga/pull/2589)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)
 - Update ListObjects' check resolver to use correct environment variable. [#2653](https://github.com/openfga/openfga/pull/2653)
 - Support for verifying JWTs without a `kid` header by checking against all available keys in the JWK Set. [#2309](https://github.com/openfga/openfga/issues/2309)
+- Upgraded `keyfunc` library from v2 to v3 to enable access to all keys for JWT verification. [#2309](https://github.com/openfga/openfga/issues/2309)
 
 ## [1.9.5] - 2025-08-15
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,8 @@ require (
 	cel.dev/expr v0.24.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
+	github.com/MicahParks/jwkset v0.8.0 // indirect
+	github.com/MicahParks/keyfunc/v3 v3.6.1-0.20250804232944-2245943d43ec // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,12 @@ github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg6
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
+github.com/MicahParks/jwkset v0.8.0 h1:jHtclI38Gibmu17XMI6+6/UB59srp58pQVxePHRK5o8=
+github.com/MicahParks/jwkset v0.8.0/go.mod h1:fVrj6TmG1aKlJEeceAz7JsXGTXEn72zP1px3us53JrA=
 github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=
 github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
+github.com/MicahParks/keyfunc/v3 v3.6.1-0.20250804232944-2245943d43ec h1:/wkBSnRQ78/AckRWolSdYmRWoO9/PVwrv4rboFXF7Cw=
+github.com/MicahParks/keyfunc/v3 v3.6.1-0.20250804232944-2245943d43ec/go.mod h1:y6Ed3dMgNKTcpxbaQHD8mmrYDUZWJAxteddA6OQj+ag=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Yiling-J/theine-go v0.6.1 h1:njE/rBBviU/Sq2G7PJKdLdwXg8j1azvZQulIjmshD+o=

--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -21,6 +21,8 @@ type Authenticator interface {
 	// Authenticate returns a nil error and the AuthClaims info (if available) if the subject is authenticated or a
 	// non-nil error with an appropriate error cause otherwise.
 	Authenticate(requestContext context.Context) (*authclaims.AuthClaims, error)
+	// Legacy Close Method
+	Close()
 }
 
 type NoopAuthenticator struct{}

--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -3,7 +3,7 @@ package authn
 import (
 	"context"
 
-	"github.com/MicahParks/keyfunc/v2"
+	"github.com/MicahParks/keyfunc/v3"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -21,8 +21,6 @@ type Authenticator interface {
 	// Authenticate returns a nil error and the AuthClaims info (if available) if the subject is authenticated or a
 	// non-nil error with an appropriate error cause otherwise.
 	Authenticate(requestContext context.Context) (*authclaims.AuthClaims, error)
-	// Close Cleans up the authenticator.
-	Close()
 }
 
 type NoopAuthenticator struct{}
@@ -46,5 +44,5 @@ type OidcConfig struct {
 
 type OIDCAuthenticator interface {
 	GetConfiguration() (*OidcConfig, error)
-	GetKeys() (*keyfunc.JWKS, error)
+	GetKeys() (keyfunc.Keyfunc, error)
 }

--- a/internal/authn/authn.go
+++ b/internal/authn/authn.go
@@ -21,7 +21,7 @@ type Authenticator interface {
 	// Authenticate returns a nil error and the AuthClaims info (if available) if the subject is authenticated or a
 	// non-nil error with an appropriate error cause otherwise.
 	Authenticate(requestContext context.Context) (*authclaims.AuthClaims, error)
-	// Legacy Close Method
+	// Close Cleans up the authenticator.
 	Close()
 }
 

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -203,6 +203,8 @@ func (oidc *RemoteOidcAuthenticator) GetConfiguration() (*authn.OidcConfig, erro
 		return nil, fmt.Errorf("error getting OIDC: %w", err)
 	}
 
+	defer res.Body.Close()
+
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code getting OIDC: %v", res.StatusCode)
 	}

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -256,3 +256,6 @@ func KeyfuncWithFallback(authHeader string, jwks keyfunc.Keyfunc) jwt.Keyfunc {
 		return nil, fmt.Errorf("verification failed using all keys: %w", lastErr)
 	}
 }
+
+func (oidc *RemoteOidcAuthenticator) Close() {
+}

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/MicahParks/keyfunc/v2"
+	"github.com/MicahParks/keyfunc/v3"
 	jwt "github.com/golang-jwt/jwt/v5"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/hashicorp/go-retryablehttp"
@@ -32,7 +32,7 @@ type RemoteOidcAuthenticator struct {
 	ClientIDClaims []string
 
 	JwksURI string
-	JWKs    *keyfunc.JWKS
+	JWKs    keyfunc.Keyfunc
 
 	httpClient *http.Client
 }
@@ -93,9 +93,7 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 
 	jwtParser := jwt.NewParser(options...)
 
-	token, err := jwtParser.Parse(authHeader, func(token *jwt.Token) (any, error) {
-		return oidc.JWKs.Keyfunc(token)
-	})
+	token, err := jwtParser.Parse(authHeader, KeyfuncWithFallback(authHeader, oidc.JWKs))
 	if err != nil || !token.Valid {
 		return nil, errInvalidClaims
 	}
@@ -183,9 +181,8 @@ func fetchJWK(oidc *RemoteOidcAuthenticator) error {
 	return nil
 }
 
-func (oidc *RemoteOidcAuthenticator) GetKeys() (*keyfunc.JWKS, error) {
-	jwks, err := keyfunc.Get(oidc.JwksURI, keyfunc.Options{
-		Client:          oidc.httpClient,
+func (oidc *RemoteOidcAuthenticator) GetKeys() (keyfunc.Keyfunc, error) {
+	jwks, err := keyfunc.NewDefaultOverrideCtx(context.Background(), []string{oidc.JwksURI}, keyfunc.Override{
 		RefreshInterval: jwkRefreshInterval,
 	})
 	if err != nil {
@@ -205,7 +202,6 @@ func (oidc *RemoteOidcAuthenticator) GetConfiguration() (*authn.OidcConfig, erro
 	if err != nil {
 		return nil, fmt.Errorf("error getting OIDC: %w", err)
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code getting OIDC: %v", res.StatusCode)
@@ -231,6 +227,32 @@ func (oidc *RemoteOidcAuthenticator) GetConfiguration() (*authn.OidcConfig, erro
 	return oidcConfig, nil
 }
 
-func (oidc *RemoteOidcAuthenticator) Close() {
-	oidc.JWKs.EndBackground()
+func KeyfuncWithFallback(authHeader string, jwks keyfunc.Keyfunc) jwt.Keyfunc {
+	return func(t *jwt.Token) (interface{}, error) {
+		kid, _ := t.Header["kid"].(string)
+
+		if kid != "" {
+			return jwks.Keyfunc(t)
+		}
+
+		var allKeys jwt.VerificationKeySet
+		allKeys, err := jwks.VerificationKeySet(context.Background())
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch all keys: %w", err)
+		}
+
+		var lastErr error
+		for _, key := range allKeys.Keys {
+			tk := jwt.NewParser()
+			_, err := tk.Parse(authHeader, func(_ *jwt.Token) (interface{}, error) {
+				return key, nil
+			})
+			if err == nil {
+				return key, nil
+			}
+			lastErr = err
+		}
+
+		return nil, fmt.Errorf("verification failed using all keys: %w", lastErr)
+	}
 }

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -33,7 +33,7 @@ type RemoteOidcAuthenticator struct {
 
 	JwksURI string
 	JWKs    keyfunc.Keyfunc
-	cancel context.CancelFunc
+	cancel  context.CancelFunc
 
 	httpClient *http.Client
 }
@@ -264,7 +264,7 @@ func KeyfuncWithFallback(authHeader string, jwks keyfunc.Keyfunc) jwt.Keyfunc {
 }
 
 func (oidc *RemoteOidcAuthenticator) Close() {
-    if oidc.cancel != nil {
-        oidc.cancel()
-    }
+	if oidc.cancel != nil {
+		oidc.cancel()
+	}
 }

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -24,8 +24,15 @@ import (
 func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 	t.Run("fails_on_invalid_oidc_issuer_url", func(t *testing.T) {
 		_, err := NewRemoteOidcAuthenticator("https://does-not-exist.invalid", nil, "", nil, nil)
-		require.Error(t, err, "Expected an error for an invalid OIDC issuer URL")
-		require.Contains(t, err.Error(), "error fetching OIDC configuration", "Error message should indicate a configuration fetching problem")
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "error getting OIDC")
+	})
+	t.Run("fails_on_malformed_oidc_issuer_url", func(t *testing.T) {
+		_, err := NewRemoteOidcAuthenticator(":", nil, "", nil, nil)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "error forming request to get OIDC")
 	})
 	t.Run("when_the_authorization_header_is_missing_from_the_gRPC_metadata_of_the_request,_returns_'missing_bearer_token'_error", func(t *testing.T) {
 		authenticator := &RemoteOidcAuthenticator{}

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -222,6 +222,30 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 			},
 			expectedError: "invalid claims",
 		},
+		{
+			testDescription: "when_jwt_header_lacks_kid_and_signed_with_different_key,_return_'invalid_bearer_token'",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
+				differentPriv, _ := generateJWTSignatureKeys()
+
+				return quickConfigSetup(Config{
+					jwkKid:         "kid_1",
+					jwtKid:         "",
+					issuerURL:      "right_issuer",
+					audience:       "right_audience",
+					issuerAliases:  []string{"issuer_alias"},
+					subjects:       []string{"openfga client"},
+					clientIDClaims: []string{"azp"},
+					jwtClaims: jwt.MapClaims{
+						"iss": "issuer_alias",
+						"aud": "right_audience",
+						"sub": "openfga client",
+						"exp": time.Now().Add(10 * time.Minute).Unix(),
+					},
+					privateKeyOverride: differentPriv,
+				})
+			},
+			expectedError: "invalid claims",
+		},
 	}
 
 	for _, testC := range errorTestCases {

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -22,6 +22,11 @@ import (
 )
 
 func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
+	t.Run("fails_on_invalid_oidc_issuer_url", func(t *testing.T) {
+		_, err := NewRemoteOidcAuthenticator("https://does-not-exist.invalid", nil, "", nil, nil)
+		require.Error(t, err, "Expected an error for an invalid OIDC issuer URL")
+		require.Contains(t, err.Error(), "error fetching OIDC configuration", "Error message should indicate a configuration fetching problem")
+	})
 	t.Run("when_the_authorization_header_is_missing_from_the_gRPC_metadata_of_the_request,_returns_'missing_bearer_token'_error", func(t *testing.T) {
 		authenticator := &RemoteOidcAuthenticator{}
 		_, err := authenticator.Authenticate(context.Background())

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -28,6 +28,14 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "error getting OIDC")
 	})
+	t.Run("fails_on_malformed_jwks_url", func(t *testing.T) {
+		oidc := &RemoteOidcAuthenticator{
+			JwksURI: "://malformed-url",
+		}
+		_, err := oidc.GetKeys()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "error fetching keys from ://malformed-url")
+	})
 	t.Run("fails_on_malformed_oidc_issuer_url", func(t *testing.T) {
 		_, err := NewRemoteOidcAuthenticator(":", nil, "", nil, nil)
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

OpenFGA was unable to verify JWTs that lacked the kid header, even though kid is optional according to RFC 7517 Section 4.5. This limitation was due to the old keyfunc v2 library, which did not expose all available keys for fallback verification.

#### What problem is being solved?

This fixes the issue where JWTs without a kid header could not be verified. The update enables verification of such tokens by checking all available keys in the JWK Set.

#### How is it being solved?

In keyfunc library version 3.5.0 and above, all keys are exposed through the VerificationKeySet function. This PR leverages that to check the JWT against all available keys in the JWK Set when the kid header is absent, enabling proper verification fallback.

#### What changes are made to solve it?

This PR updates keyfunc from v2 to v3 and upgrades all related dependencies accordingly.

Closes Issue: #2309

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs

 

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced authentication to support JWT validation even when the token header lacks a key ID ("kid"), improving compatibility with a wider range of tokens.

* **Bug Fixes**
  * Improved fallback mechanism for JWT key verification, ensuring tokens without a "kid" can still be validated.

* **Tests**
  * Added test coverage for authenticating tokens without a "kid" in the header.

* **Chores**
  * Updated dependencies to newer versions for improved security and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->