### PR TITLE
Update changelog to prep for release `1.9.6`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+## [1.9.6] - 2025-08-06
+
 ## [1.9.5] - 2025-08-06
 
 ## [1.9.4] - 2025-08-06
@@ -1385,7 +1387,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.9.5...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.9.6...HEAD
+[1.9.6]: https://github.com/openfga/openfga/compare/v1.9.5...v1.9.6
 [1.9.5]: https://github.com/openfga/openfga/compare/v1.9.4...v1.9.5
 [1.9.4]: https://github.com/openfga/openfga/compare/v1.9.3...v1.9.4
 [1.9.3]: https://github.com/openfga/openfga/compare/v1.9.2...v1.9.3


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.9.6`.