### PR TITLE
fix: don't specify an oidc audience when one is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Fix breaking changed introuced after upgrading the JWT dependency from v5.2.2 to v.5.3.0. [#2636](https://github.com/openfga/openfga/pull/2636)
 
 ## [1.9.3] - 2025-08-11
 ### Added

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -81,12 +81,17 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 		return nil, authn.ErrMissingBearerToken
 	}
 
-	jwtParser := jwt.NewParser(
+	options := []jwt.ParserOption{
 		jwt.WithValidMethods([]string{"RS256"}),
 		jwt.WithIssuedAt(),
 		jwt.WithExpirationRequired(),
-		jwt.WithAudience(oidc.Audience),
-	)
+	}
+
+	if strings.TrimSpace(oidc.Audience) != "" {
+		options = append(options, jwt.WithAudience(oidc.Audience))
+	}
+
+	jwtParser := jwt.NewParser(options...)
 
 	token, err := jwtParser.Parse(authHeader, func(token *jwt.Token) (any, error) {
 		return oidc.JWKs.Keyfunc(token)

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -243,6 +243,29 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 		testSetup       func() (*RemoteOidcAuthenticator, context.Context, Config, error)
 	}{
 		{
+			testDescription: "empty_audience",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
+				return quickConfigSetup(Config{
+					jwkKid:         "kid_2",
+					jwtKid:         "kid_2",
+					issuerURL:      "right_issuer",
+					audience:       "",
+					issuerAliases:  nil,
+					subjects:       nil,
+					clientIDClaims: []string{"custom_claim", "custom_claim_2"},
+					jwtClaims: jwt.MapClaims{
+						"iss":            "right_issuer",
+						"aud":            "",
+						"sub":            "some-user",
+						"custom_claim_2": customClientID,
+						"scope":          scopes,
+						"exp":            time.Now().Add(10 * time.Minute).Unix(),
+					},
+					privateKeyOverride: nil,
+				})
+			},
+		},
+		{
 			testDescription: "when_the_token_is_valid,_it_MUST_return_the_token_subject_and_its_associated_scopes",
 			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
 				return quickConfigSetup(Config{


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Currently when an empty string is configured for the OIDC audience, a token having an audience claim with an empty string will be required.

#### How is it being solved?
Do not specify a required audience when one is not configured.

#### What changes are made to solve it?
Omit the parser option `WithAudience` when a value is not present in `oidc.Audience` within the `oidc` package.

## References
Close https://github.com/openfga/openfga/issues/2634

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved OIDC authentication flexibility by conditionally validating token audience only when configured.
- Bug Fixes
  - Prevented unintended authentication failures when no audience is set by skipping audience checks.
- Refactor
  - Streamlined token validation options for clearer, more reliable OIDC handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->