### PR TITLE
fix: multiple userset with same type should not use weight 2 opt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Do not run weight 2 optimization for cases where there are more than 1 directly assignable userset. [#2643](https://github.com/openfga/openfga/pull/2643)
 
 ## [1.9.4] - 2025-08-13
 ### Fixed

--- a/assets/tests/consolidated_1_1_tests.yaml
+++ b/assets/tests/consolidated_1_1_tests.yaml
@@ -10436,3 +10436,55 @@ tests:
               relation: can_access
               object: deployment:1
             expectation: false
+  - name: weight_2_more_than_one_userset_assignable
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type scope
+            relations
+              define public: [user:*]
+              define verified: [user]
+          type resource
+            relations
+              define access: [scope#public, scope#verified]
+        tuples:
+          - user: scope:A#verified
+            relation: access
+            object: resource:1
+          - user: user:*
+            relation: public
+            object: scope:A
+        checkAssertions:
+          - tuple:
+              user: user:bob
+              relation: access
+              object: resource:1
+            expectation: false
+  - name: weight_infinite_more_than_one_userset_assignable
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type scope
+            relations
+              define public: [user:*, scope#public]
+              define verified: [user, scope#verified]
+          type resource
+            relations
+              define access: [scope#public, scope#verified]
+        tuples:
+          - user: scope:A#verified
+            relation: access
+            object: resource:1
+          - user: user:*
+            relation: public
+            object: scope:A
+        checkAssertions:
+          - tuple:
+              user: user:bob
+              relation: access
+              object: resource:1
+            expectation: false

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -745,7 +745,10 @@ func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckR
 			userType := tuple.GetType(reqTupleKey.GetUser())
 
 			if !isUserset {
-				if typesys.UsersetUseWeight2Resolver(objectType, relation, userType, directlyRelatedUsersetTypes) {
+				if len(directlyRelatedUsersetTypes) < 2 && typesys.UsersetUseWeight2Resolver(objectType, relation, userType, directlyRelatedUsersetTypes) {
+					// If there are more than 1 directly related userset types of the same type, we cannot do userset optimization because
+					// we cannot rely on the fact that the object ID matches. Instead, we need to take into consideration
+					// on the relation as well.
 					resolver = c.weight2Userset
 					span.SetAttributes(attribute.String("resolver", "weight2"))
 				} else if typesys.UsersetUseRecursiveResolver(objectType, relation, userType) {


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

In the case of multiple directly assignable userset with same type, we should not use weight 2 optimization because we are only comparing the object name.


#### How is it being solved?
Make explicit check on length of directly assignable userset and if it is >= 2, do not run weight 2 optimization code.

#### What changes are made to solve it?
Update in LocalChecker's checkDirect

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected authorization evaluation when multiple directly assignable usersets are present, preventing incorrect access grants. No changes to public APIs.

* **Documentation**
  * Updated changelog to note skipping a specific optimization when multiple usersets are directly assignable.

* **Tests**
  * Added test cases covering weight-based, multi-userset assignability scenarios to ensure accurate access control and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->