### PR TITLE
feat: introduce params for Write command: Deletes OnMissing and Writes OnDuplicate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jon-whit/go-grpc-prometheus v1.4.0
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.1
-	github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369
+	github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/prometheus/client_golang v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/jon-whit/go-grpc-prometheus v1.4.0
 	github.com/natefinch/wrap v0.2.0
 	github.com/oklog/ulid/v2 v2.1.1
-	github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd
+	github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe
 	github.com/pressly/goose/v3 v3.24.3
 	github.com/prometheus/client_golang v1.23.0

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd h1:IY+S/EX2/ufxXui1zFGy+P/WASZThPqVQniAS4Vk3EM=
-github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd/go.mod h1:XDX4qYNBUM2Rsa2AbKPh+oocZc2zgme+EF2fFC6amVU=
+github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369 h1:wEsCZ4oBuu8LfEJ3VXbveXO8uEhCthrxA40WSvxO044=
+github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369/go.mod h1:m74TNgnAAIJ03gfHcx+xaRWnr+IbQy3y/AVNwwCFrC0=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe h1:X1g0rBUMvvzMudsak/jmoEZ1NhSsp6yR0VGxWHnGMzs=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe/go.mod h1:5Z0pbTT7Jz/oQFLfadb+C5t5NwHrduAO7j7L07Ec1GM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/go.sum
+++ b/go.sum
@@ -216,8 +216,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQb2IpWsCzug=
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
-github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369 h1:wEsCZ4oBuu8LfEJ3VXbveXO8uEhCthrxA40WSvxO044=
-github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369/go.mod h1:m74TNgnAAIJ03gfHcx+xaRWnr+IbQy3y/AVNwwCFrC0=
+github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd h1:IY+S/EX2/ufxXui1zFGy+P/WASZThPqVQniAS4Vk3EM=
+github.com/openfga/api/proto v0.0.0-20250818224041-c53dab700afd/go.mod h1:XDX4qYNBUM2Rsa2AbKPh+oocZc2zgme+EF2fFC6amVU=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe h1:X1g0rBUMvvzMudsak/jmoEZ1NhSsp6yR0VGxWHnGMzs=
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250428093642-7aeebe78bbfe/go.mod h1:5Z0pbTT7Jz/oQFLfadb+C5t5NwHrduAO7j7L07Ec1GM=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -828,10 +828,10 @@ func TestNonStratifiableCheckQueries(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:jon"),
 			tuple.NewTupleKey("document:1", "restricted", "document:1#viewer"),
-		})
+		}})
 		require.NoError(t, err)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -865,10 +865,10 @@ func TestNonStratifiableCheckQueries(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:jon"),
 			tuple.NewTupleKey("document:1", "restrictedb", "document:1#viewer"),
-		})
+		}})
 		require.NoError(t, err)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -912,10 +912,10 @@ func TestResolveCheckDeterministic(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:budget", "admin", "user:*"),
 			tuple.NewTupleKeyWithCondition("document:budget", "viewer", "user:maria", "condX", nil),
-		})
+		}})
 		require.NoError(t, err)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -959,9 +959,9 @@ func TestResolveCheckDeterministic(t *testing.T) {
 
 		storeID := ulid.Make().String()
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKeyWithCondition("document:budget", "admin", "user:maria", "condX", nil),
-		})
+		}})
 		require.NoError(t, err)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -1006,7 +1006,7 @@ func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
 
 	storeID := ulid.Make().String()
 
-	err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+	err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:1", "viewer", "group:1#member"),
 		tuple.NewTupleKey("document:1", "viewer", "group:2#member"),
 		tuple.NewTupleKey("group:1", "member", "group:1a#member"),
@@ -1014,7 +1014,7 @@ func TestCheckWithOneConcurrentGoroutineCausesNoDeadlock(t *testing.T) {
 		tuple.NewTupleKey("group:2", "member", "group:2a#member"),
 		tuple.NewTupleKey("group:2", "member", "group:2b#member"),
 		tuple.NewTupleKey("group:2b", "member", "user:jon"),
-	})
+	}})
 	require.NoError(t, err)
 
 	checker, checkResolverCloser, err := NewOrderedCheckResolvers(
@@ -1095,7 +1095,7 @@ func TestCheckConditions(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "user:jon"),
 	}
 
-	err = ds.Write(context.Background(), storeID, nil, tuples)
+	err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 	require.NoError(t, err)
 
 	checker, checkResolverCloser, err := NewOrderedCheckResolvers().Build()
@@ -1169,12 +1169,12 @@ func TestCheckDispatchCount(t *testing.T) {
 					define parent: [folder]
 			`)
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("folder:C", "viewer", "user:jon"),
 			tuple.NewTupleKey("folder:B", "parent", "folder:C"),
 			tuple.NewTupleKey("folder:A", "parent", "folder:B"),
 			tuple.NewTupleKey("doc:readme", "parent", "folder:A"),
-		})
+		}})
 		require.NoError(t, err)
 
 		checker := NewLocalChecker(WithMaxResolutionDepth(5))
@@ -1235,13 +1235,13 @@ func TestCheckDispatchCount(t *testing.T) {
 					define viewer: [group#member]
 			`)
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("group:1", "member", "user:jon"),
 			tuple.NewTupleKey("group:eng", "member", "group:1#member"),
 			tuple.NewTupleKey("group:eng", "member", "group:2#member"),
 			tuple.NewTupleKey("group:eng", "member", "group:3#member"),
 			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-		})
+		}})
 		require.NoError(t, err)
 
 		checker := NewLocalChecker(WithMaxResolutionDepth(5))
@@ -1294,10 +1294,10 @@ func TestCheckDispatchCount(t *testing.T) {
 					define owner: [user]
 					define editor: [user] or owner`)
 
-		err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "owner", "user:jon"),
 			tuple.NewTupleKey("document:2", "editor", "user:will"),
-		})
+		}})
 		require.NoError(t, err)
 
 		checker := NewLocalChecker(WithMaxResolutionDepth(5))

--- a/internal/graph/mock_check_resolver.go
+++ b/internal/graph/mock_check_resolver.go
@@ -21,7 +21,6 @@ import (
 type MockCheckResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockCheckResolverMockRecorder
-	isgomock struct{}
 }
 
 // MockCheckResolverMockRecorder is the mock recorder for MockCheckResolver.
@@ -98,7 +97,6 @@ func (mr *MockCheckResolverMockRecorder) SetDelegate(delegate any) *gomock.Call 
 type MockCheckRewriteResolver struct {
 	ctrl     *gomock.Controller
 	recorder *MockCheckRewriteResolverMockRecorder
-	isgomock struct{}
 }
 
 // MockCheckRewriteResolverMockRecorder is the mock recorder for MockCheckRewriteResolver.

--- a/internal/mocks/mock_cache.go
+++ b/internal/mocks/mock_cache.go
@@ -20,7 +20,6 @@ import (
 type MockCacheItem struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheItemMockRecorder
-	isgomock struct{}
 }
 
 // MockCacheItemMockRecorder is the mock recorder for MockCacheItem.
@@ -58,7 +57,6 @@ func (mr *MockCacheItemMockRecorder) CacheEntityType() *gomock.Call {
 type MockInMemoryCache[T any] struct {
 	ctrl     *gomock.Controller
 	recorder *MockInMemoryCacheMockRecorder[T]
-	isgomock struct{}
 }
 
 // MockInMemoryCacheMockRecorder is the mock recorder for MockInMemoryCache.

--- a/internal/mocks/mock_encoder.go
+++ b/internal/mocks/mock_encoder.go
@@ -19,7 +19,6 @@ import (
 type MockEncoder struct {
 	ctrl     *gomock.Controller
 	recorder *MockEncoderMockRecorder
-	isgomock struct{}
 }
 
 // MockEncoderMockRecorder is the mock recorder for MockEncoder.

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -22,7 +22,6 @@ import (
 type MockTupleBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockTupleBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockTupleBackendMockRecorder is the mock recorder for MockTupleBackend.
@@ -150,7 +149,6 @@ func (mr *MockTupleBackendMockRecorder) Write(ctx, store, d, w any) *gomock.Call
 type MockRelationshipTupleReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelationshipTupleReaderMockRecorder
-	isgomock struct{}
 }
 
 // MockRelationshipTupleReaderMockRecorder is the mock recorder for MockRelationshipTupleReader.
@@ -250,7 +248,6 @@ func (mr *MockRelationshipTupleReaderMockRecorder) ReadUsersetTuples(ctx, store,
 type MockRelationshipTupleWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockRelationshipTupleWriterMockRecorder
-	isgomock struct{}
 }
 
 // MockRelationshipTupleWriterMockRecorder is the mock recorder for MockRelationshipTupleWriter.
@@ -302,7 +299,6 @@ func (mr *MockRelationshipTupleWriterMockRecorder) Write(ctx, store, d, w any) *
 type MockAuthorizationModelReadBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockAuthorizationModelReadBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockAuthorizationModelReadBackendMockRecorder is the mock recorder for MockAuthorizationModelReadBackend.
@@ -372,7 +368,6 @@ func (mr *MockAuthorizationModelReadBackendMockRecorder) ReadAuthorizationModels
 type MockTypeDefinitionWriteBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockTypeDefinitionWriteBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockTypeDefinitionWriteBackendMockRecorder is the mock recorder for MockTypeDefinitionWriteBackend.
@@ -424,7 +419,6 @@ func (mr *MockTypeDefinitionWriteBackendMockRecorder) WriteAuthorizationModel(ct
 type MockAuthorizationModelBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockAuthorizationModelBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockAuthorizationModelBackendMockRecorder is the mock recorder for MockAuthorizationModelBackend.
@@ -522,7 +516,6 @@ func (mr *MockAuthorizationModelBackendMockRecorder) WriteAuthorizationModel(ctx
 type MockStoresBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockStoresBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockStoresBackendMockRecorder is the mock recorder for MockStoresBackend.
@@ -606,7 +599,6 @@ func (mr *MockStoresBackendMockRecorder) ListStores(ctx, options any) *gomock.Ca
 type MockAssertionsBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockAssertionsBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockAssertionsBackendMockRecorder is the mock recorder for MockAssertionsBackend.
@@ -659,7 +651,6 @@ func (mr *MockAssertionsBackendMockRecorder) WriteAssertions(ctx, store, modelID
 type MockChangelogBackend struct {
 	ctrl     *gomock.Controller
 	recorder *MockChangelogBackendMockRecorder
-	isgomock struct{}
 }
 
 // MockChangelogBackendMockRecorder is the mock recorder for MockChangelogBackend.
@@ -699,7 +690,6 @@ func (mr *MockChangelogBackendMockRecorder) ReadChanges(ctx, store, filter, opti
 type MockOpenFGADatastore struct {
 	ctrl     *gomock.Controller
 	recorder *MockOpenFGADatastoreMockRecorder
-	isgomock struct{}
 }
 
 // MockOpenFGADatastoreMockRecorder is the mock recorder for MockOpenFGADatastore.

--- a/internal/mocks/mock_throttler.go
+++ b/internal/mocks/mock_throttler.go
@@ -20,7 +20,6 @@ import (
 type MockThrottler struct {
 	ctrl     *gomock.Controller
 	recorder *MockThrottlerMockRecorder
-	isgomock struct{}
 }
 
 // MockThrottlerMockRecorder is the mock recorder for MockThrottler.

--- a/internal/mocks/mock_token_serializer.go
+++ b/internal/mocks/mock_token_serializer.go
@@ -19,7 +19,6 @@ import (
 type MockContinuationTokenSerializer struct {
 	ctrl     *gomock.Controller
 	recorder *MockContinuationTokenSerializerMockRecorder
-	isgomock struct{}
 }
 
 // MockContinuationTokenSerializerMockRecorder is the mock recorder for MockContinuationTokenSerializer.

--- a/pkg/server/commands/expand_test.go
+++ b/pkg/server/commands/expand_test.go
@@ -1103,8 +1103,8 @@ func TestExpand(t *testing.T) {
 			err = datastore.Write(
 				ctx,
 				storeID,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				test.tuples,
+				storage.Deletes{},
+				storage.Writes{Tuples: test.tuples},
 			)
 			require.NoError(t, err)
 

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -2957,7 +2957,7 @@ func (testCases ListUsersTests) runListUsersTestCases(t *testing.T) {
 			require.NoError(t, err)
 
 			if len(test.tuples) > 0 {
-				err = ds.Write(context.Background(), storeID, nil, test.tuples)
+				err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: test.tuples})
 				require.NoError(t, err)
 			}
 
@@ -3105,7 +3105,7 @@ func TestListUsersDatastoreQueryCountAndDispatchCount(t *testing.T) {
 
 	storeID := ulid.Make().String()
 
-	err := ds.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{
+	err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:x", "a", "user:jon"),
 		tuple.NewTupleKey("document:x", "a", "user:maria"),
 		tuple.NewTupleKey("document:x", "b", "user:maria"),
@@ -3116,7 +3116,7 @@ func TestListUsersDatastoreQueryCountAndDispatchCount(t *testing.T) {
 		tuple.NewTupleKey("document:x", "multiple_userset", "org:fga#member"),
 		tuple.NewTupleKey("document:x", "multiple_userset", "company:fga#member"),
 		tuple.NewTupleKey("document:public", "wildcard", "user:*"),
-	})
+	}})
 	require.NoError(t, err)
 
 	model := parser.MustTransformDSLToProto(`
@@ -3481,7 +3481,7 @@ func TestListUsersConfig_MaxResults(t *testing.T) {
 			require.NoError(t, err)
 
 			// arrange: write tuples
-			err = ds.Write(context.Background(), storeID, nil, test.inputTuples)
+			err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: test.inputTuples})
 			require.NoError(t, err)
 
 			typesys, err := typesystem.NewAndValidate(context.Background(), model)
@@ -3607,7 +3607,7 @@ func TestListUsersConfig_Deadline(t *testing.T) {
 			require.NoError(t, err)
 
 			// arrange: write tuples
-			err = ds.Write(context.Background(), storeID, nil, test.inputTuples)
+			err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: test.inputTuples})
 			require.NoError(t, err)
 
 			typesys, err := typesystem.NewAndValidate(context.Background(), model)
@@ -3718,7 +3718,7 @@ func TestListUsersConfig_MaxConcurrency(t *testing.T) {
 			require.NoError(t, err)
 
 			// arrange: write tuples
-			err = ds.Write(context.Background(), storeID, nil, test.inputTuples)
+			err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: test.inputTuples})
 			require.NoError(t, err)
 
 			typesys, err := typesystem.NewAndValidate(context.Background(), model)

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -64,8 +64,14 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 	err := c.datastore.Write(
 		ctx,
 		req.GetStoreId(),
-		req.GetDeletes().GetTupleKeys(),
-		req.GetWrites().GetTupleKeys(),
+		storage.Deletes{
+			Tuples:    req.GetDeletes().GetTupleKeys(),
+			OnMissing: req.GetDeletes().GetOnMissing(),
+		},
+		storage.Writes{
+			Tuples:      req.GetWrites().GetTupleKeys(),
+			OnDuplicate: req.GetWrites().GetOnDuplicate(),
+		},
 	)
 	if err != nil {
 		if errors.Is(err, storage.ErrTransactionalWriteFailed) {

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -66,11 +66,11 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 		req.GetStoreId(),
 		storage.Deletes{
 			Tuples:    req.GetDeletes().GetTupleKeys(),
-			OnMissing: req.GetDeletes().GetOnMissing(),
+			OnMissing: storage.OnMissingUnspecified,
 		},
 		storage.Writes{
 			Tuples:      req.GetWrites().GetTupleKeys(),
-			OnDuplicate: req.GetWrites().GetOnDuplicate(),
+			OnDuplicate: storage.OnDuplicateUnspecified,
 		},
 	)
 	if err != nil {

--- a/pkg/server/test/check.go
+++ b/pkg/server/test/check.go
@@ -380,7 +380,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 				tuplesToWrite = append(tuplesToWrite, tuples[i])
 				i++
 			}
-			err := ds.Write(context.Background(), storeID, nil, tuplesToWrite)
+			err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuplesToWrite})
 			require.NoError(b, err)
 		}
 
@@ -452,7 +452,7 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 			tuplesToWrite = append(tuplesToWrite, tuples[i])
 			i++
 		}
-		err := ds.Write(context.Background(), storeID, nil, tuplesToWrite)
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuplesToWrite})
 		require.NoError(b, err)
 	}
 

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -481,7 +481,7 @@ func TestListObjects(t *testing.T, ds storage.OpenFGADatastore) {
 
 			// arrange: write tuples in random order
 			test.tuples = testutils.Shuffle(test.tuples)
-			err = ds.Write(context.Background(), storeID, nil, test.tuples)
+			err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: test.tuples})
 			require.NoError(t, err)
 
 			// act: run ListObjects
@@ -628,7 +628,7 @@ func setupListObjectsBenchmark(b *testing.B, ds storage.OpenFGADatastore, storeI
 
 		tuples = testutils.Shuffle(tuples)
 
-		err := ds.Write(context.Background(), storeID, nil, tuples)
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(b, err)
 	}
 

--- a/pkg/server/test/list_users.go
+++ b/pkg/server/test/list_users.go
@@ -173,7 +173,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				i++
 			}
 			tuplesToWrite = testutils.Shuffle(tuplesToWrite)
-			err = ds.Write(context.Background(), storeID, nil, tuplesToWrite)
+			err = ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuplesToWrite})
 			require.NoError(b, err)
 		}
 

--- a/pkg/server/test/read_changes.go
+++ b/pkg/server/test/read_changes.go
@@ -39,7 +39,7 @@ func BenchmarkReadChanges(b *testing.B, ds storage.OpenFGADatastore) {
 		for j := 0; j < len(tuples); j++ {
 			tuples[j] = tuple.NewTupleKey("doc:"+strconv.Itoa(i)+"_"+strconv.Itoa(j), "viewer", "user:maria")
 		}
-		err := ds.Write(ctx, storeID, nil, tuples)
+		err := ds.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(b, err)
 	}
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -341,7 +341,7 @@ func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage
 
 	now := timestamppb.Now()
 
-	if err := validateTuples(s.tuples[store], deletes, writes); err != nil {
+	if err := validateTuples(s.tuples[store], deletes.Tuples, writes.Tuples); err != nil {
 		return err
 	}
 
@@ -351,7 +351,7 @@ Delete:
 	for _, tr := range s.tuples[store] {
 		t := tr.AsTuple()
 		tk := t.GetKey()
-		for _, k := range deletes {
+		for _, k := range deletes.Tuples {
 			if match(tr, tupleUtils.TupleKeyWithoutConditionToTupleKey(k)) {
 				s.changes[store] = append(
 					s.changes[store],
@@ -371,7 +371,7 @@ Delete:
 	}
 
 Write:
-	for _, t := range writes {
+	for _, t := range writes.Tuples {
 		for _, et := range records {
 			if match(et, t) {
 				continue Write

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -83,8 +83,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{firstTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 				time.Now())
 			require.NoError(t, err)
 
@@ -92,8 +92,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{secondTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -101,8 +101,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{thirdTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{thirdTuple}},
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -186,8 +186,8 @@ func TestCtxCancel(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{firstTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 				time.Now())
 			require.NoError(t, err)
 
@@ -195,8 +195,8 @@ func TestCtxCancel(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{secondTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -204,8 +204,8 @@ func TestCtxCancel(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{thirdTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{thirdTuple}},
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -248,8 +248,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	err = sqlcommon.Write(ctx,
 		sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{firstTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 		time.Now())
 	require.NoError(t, err)
 
@@ -257,8 +257,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	err = sqlcommon.Write(ctx,
 		sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{secondTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -118,8 +118,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{firstTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 				time.Now())
 			require.NoError(t, err)
 
@@ -127,16 +127,16 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{secondTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{thirdTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{thirdTuple}},
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -220,8 +220,8 @@ func TestCtxCancel(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{firstTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 				time.Now())
 			require.NoError(t, err)
 
@@ -229,16 +229,16 @@ func TestCtxCancel(t *testing.T) {
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{secondTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
 			err = sqlcommon.Write(ctx,
 				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{thirdTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{thirdTuple}},
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -280,8 +280,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	err = sqlcommon.Write(ctx,
 		sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{firstTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 		time.Now())
 	require.NoError(t, err)
 
@@ -289,8 +289,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	err = sqlcommon.Write(ctx,
 		sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{secondTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -500,7 +500,7 @@ func Write(
 
 	deleteBuilder := dbInfo.stbl.Delete("tuple")
 
-	for _, tk := range deletes {
+	for _, tk := range deletes.Tuples {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
@@ -547,7 +547,7 @@ func Write(
 			"condition_name", "condition_context", "ulid", "inserted_at",
 		)
 
-	for _, tk := range writes {
+	for _, tk := range writes.Tuples {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 
@@ -589,7 +589,7 @@ func Write(
 		)
 	}
 
-	if len(writes) > 0 || len(deletes) > 0 {
+	if len(writes.Tuples) > 0 || len(deletes.Tuples) > 0 {
 		_, err := changelogBuilder.RunWith(txn).ExecContext(ctx) // Part of a txn.
 		if err != nil {
 			return dbInfo.HandleSQLError(err)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -260,7 +260,7 @@ func (s *Datastore) write(
 
 	deleteBuilder := s.stbl.Delete("tuple")
 
-	for _, tk := range deletes {
+	for _, tk := range deletes.Tuples {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 		userObjectType, userObjectID, userRelation := tupleUtils.ToUserParts(tk.GetUser())
@@ -332,7 +332,7 @@ func (s *Datastore) write(
 			"inserted_at",
 		)
 
-	for _, tk := range writes {
+	for _, tk := range writes.Tuples {
 		id := ulid.MustNew(ulid.Timestamp(now), ulid.DefaultEntropy()).String()
 		objectType, objectID := tupleUtils.SplitObject(tk.GetObject())
 		userObjectType, userObjectID, userRelation := tupleUtils.ToUserParts(tk.GetUser())
@@ -382,7 +382,7 @@ func (s *Datastore) write(
 		)
 	}
 
-	if len(writes) > 0 || len(deletes) > 0 {
+	if len(writes.Tuples) > 0 || len(deletes.Tuples) > 0 {
 		err := busyRetry(func() error {
 			_, err := changelogBuilder.RunWith(txn).ExecContext(ctx) // Part of a txn.
 			return err

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -74,23 +74,23 @@ func TestReadEnsureNoOrder(t *testing.T) {
 
 			err = ds.write(ctx,
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{firstTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 				time.Now())
 			require.NoError(t, err)
 
 			// Tweak time so that ULID is smaller.
 			err = ds.write(ctx,
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{secondTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
 			err = ds.write(ctx,
 				store,
-				[]*openfgav1.TupleKeyWithoutCondition{},
-				[]*openfgav1.TupleKey{thirdTuple},
+				storage.Deletes{},
+				storage.Writes{Tuples: []*openfgav1.TupleKey{thirdTuple}},
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -162,16 +162,16 @@ func TestReadPageEnsureOrder(t *testing.T) {
 
 	err = ds.write(ctx,
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{firstTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{firstTuple}},
 		time.Now())
 	require.NoError(t, err)
 
 	// Tweak time so that ULID is smaller.
 	err = ds.write(ctx,
 		store,
-		[]*openfgav1.TupleKeyWithoutCondition{},
-		[]*openfgav1.TupleKey{secondTuple},
+		storage.Deletes{},
+		storage.Writes{Tuples: []*openfgav1.TupleKey{secondTuple}},
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -138,10 +138,16 @@ type ReadStartingWithUserOptions struct {
 }
 
 // Writes is a typesafe alias for Write arguments.
-type Writes = []*openfgav1.TupleKey
+type Writes struct {
+	Tuples      []*openfgav1.TupleKey
+	OnDuplicate openfgav1.OnDuplicate
+}
 
 // Deletes is a typesafe alias for Delete arguments.
-type Deletes = []*openfgav1.TupleKeyWithoutCondition
+type Deletes struct {
+	Tuples    []*openfgav1.TupleKeyWithoutCondition
+	OnMissing openfgav1.OnMissing
+}
 
 // A TupleBackend provides a read/write interface for managing tuples.
 type TupleBackend interface {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -137,16 +137,32 @@ type ReadStartingWithUserOptions struct {
 	WithResultsSortedAscending bool
 }
 
+type OnDuplicate int32
+
+const (
+	OnDuplicateUnspecified OnDuplicate = 0 // If set to 'OnDuplicateUnspecified' OR not set, the API will behave as if it was set to 'OnDuplicateError'.
+	OnDuplicateError       OnDuplicate = 1 // Return an error if a tuple already exists.
+	OnDuplicateIgnore      OnDuplicate = 2 // Treat identical writes as no-ops if all attributes (including the RelationshipCondition) match.
+)
+
 // Writes is a typesafe alias for Write arguments.
 type Writes struct {
 	Tuples      []*openfgav1.TupleKey
-	OnDuplicate openfgav1.OnDuplicate
+	OnDuplicate OnDuplicate
 }
+
+type OnMissing int32
+
+const (
+	OnMissingUnspecified OnMissing = 0 // If set to 'OnMissingUnspecified' or not set, the API behaves as if it were set to 'OnMissingError'.
+	OnMissingError       OnMissing = 1 // Return an error if a tuple does not exist.
+	OnMissingIgnore      OnMissing = 2 // Do not return an error if a tuple does not exist.
+)
 
 // Deletes is a typesafe alias for Delete arguments.
 type Deletes struct {
 	Tuples    []*openfgav1.TupleKeyWithoutCondition
-	OnMissing openfgav1.OnMissing
+	OnMissing OnMissing
 }
 
 // A TupleBackend provides a read/write interface for managing tuples.

--- a/pkg/storage/storagewrappers/bounded_datastore_test.go
+++ b/pkg/storage/storagewrappers/bounded_datastore_test.go
@@ -27,9 +27,9 @@ func TestBoundedWrapper(t *testing.T) {
 	store := ulid.Make().String()
 	slowBackend := mocks.NewMockSlowDataStorage(memory.New(), time.Second)
 
-	err := slowBackend.Write(context.Background(), store, []*openfgav1.TupleKeyWithoutCondition{}, []*openfgav1.TupleKey{
+	err := slowBackend.Write(context.Background(), store, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 		tuple.NewTupleKey("obj:1", "viewer", "user:anne"),
-	})
+	}})
 	require.NoError(t, err)
 
 	t.Run("normal case", func(t *testing.T) {

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -72,7 +72,7 @@ func BootstrapFGAStore(
 	for batch := 0; batch < len(tuples); batch += batchSize {
 		batchEnd := min(batch+batchSize, len(tuples))
 
-		err := ds.Write(context.Background(), storeID, nil, tuples[batch:batchEnd])
+		err := ds.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuples[batch:batchEnd]})
 		require.NoError(t, err)
 	}
 

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -47,7 +47,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		var writtenTuples []*openfgav1.TupleKey
 		for i := 0; i < numOfWrites; i++ {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
-			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{newTuple}})
 			require.NoError(t, err)
 			writtenTuples = append(writtenTuples, newTuple)
 		}
@@ -76,7 +76,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		var writtenTuplesBefore, writtenTuplesAfter []*openfgav1.TupleKey
 		for i := 0; i < numOfWrites/2; i++ {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:before")
-			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{newTuple}})
 			require.NoError(t, err)
 			writtenTuplesBefore = append(writtenTuplesBefore, newTuple)
 		}
@@ -89,7 +89,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 
 		for i := numOfWrites / 2; i < numOfWrites; i++ {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:after")
-			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{newTuple}})
 			require.NoError(t, err)
 			writtenTuplesAfter = append(writtenTuplesAfter, newTuple)
 		}
@@ -134,7 +134,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		for i := 0; i < numOfWrites; i++ {
 			newTuple1 := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
 			newTuple2 := tuple.NewTupleKey(fmt.Sprintf("%s:%d", filter, i), "viewer", "user:jon")
-			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple1, newTuple2})
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{newTuple1, newTuple2}})
 			require.NoError(t, err)
 			writtenTuples = append(writtenTuples, newTuple1, newTuple2)
 		}
@@ -175,10 +175,10 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "user:anne",
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1}})
 		require.NoError(t, err)
 
-		err = datastore.Write(ctx, storeID, []*openfgav1.TupleKeyWithoutCondition{tk1WithoutCond}, nil)
+		err = datastore.Write(ctx, storeID, storage.Deletes{Tuples: []*openfgav1.TupleKeyWithoutCondition{tk1WithoutCond}}, storage.Writes{})
 		require.NoError(t, err)
 
 		changes := readChangesWithPageSize(t, datastore, storeID, storage.DefaultPageSize, "")
@@ -203,7 +203,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "bill",
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1, tk2}})
 		require.NoError(t, err)
 
 		expectedChanges := []*openfgav1.TupleChange{
@@ -255,7 +255,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "bill",
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1, tk2}})
 		require.NoError(t, err)
 
 		opts := storage.ReadChangesOptions{
@@ -280,7 +280,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "bill",
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1, tk2}})
 		require.NoError(t, err)
 
 		changes := readChangesWithPageSize(t, datastore, storeID, storage.DefaultPageSize, "folder")
@@ -314,7 +314,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		for i := 0; i < 100; i++ {
 			object := fmt.Sprintf("document:%d", i)
 			tuple := []*openfgav1.TupleKey{tuple.NewTupleKey(object, "viewer", "user:jon")}
-			err := datastore.Write(context.Background(), storeID, nil, tuple)
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: tuple})
 			require.NoError(t, err)
 		}
 
@@ -391,7 +391,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1, tk2})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1, tk2}})
 		require.NoError(t, err)
 
 		expectedChanges := []*openfgav1.TupleChange{
@@ -433,7 +433,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 				}),
 			},
 		}
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1}})
 		require.NoError(t, err)
 
 		tk2 := &openfgav1.TupleKeyWithoutCondition{
@@ -442,7 +442,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "user:jon",
 		}
 
-		err = datastore.Write(ctx, storeID, []*openfgav1.TupleKeyWithoutCondition{tk2}, nil)
+		err = datastore.Write(ctx, storeID, storage.Deletes{Tuples: []*openfgav1.TupleKeyWithoutCondition{tk2}}, storage.Writes{})
 		require.NoError(t, err)
 
 		changes := readChangesWithPageSize(t, datastore, storeID, storage.DefaultPageSize, "")
@@ -484,13 +484,13 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "user:anne@github.com|special_user",
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1}})
 		require.NoError(t, err)
 
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk2})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk2}})
 		require.NoError(t, err)
 
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk3})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk3}})
 		require.NoError(t, err)
 
 		changes := readChangesWithPageSize(t, datastore, storeID, storage.DefaultPageSize, "")
@@ -534,13 +534,13 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		}
 
 		var err error
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1}})
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk2})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk2}})
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk3})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk3}})
 		require.NoError(t, err)
 
 		opts := storage.ReadChangesOptions{
@@ -587,13 +587,13 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		}
 
 		var err error
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk1}})
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk2})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk2}})
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk3})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk3}})
 		require.NoError(t, err)
 
 		opts := storage.ReadChangesOptions{
@@ -629,7 +629,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		var writtenTuples []*openfgav1.TupleKey
 		for i := 0; i < storage.DefaultPageSize*50; i++ {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
-			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
+			err := datastore.Write(context.Background(), storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{newTuple}})
 			require.NoError(t, err)
 			writtenTuples = append(writtenTuples, newTuple)
 		}
@@ -696,18 +696,22 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		expectedError := storage.InvalidWriteInputError(tks[2], openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)
 
 		// Write tks.
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		// Try to delete tks[0,1], and at the same time write tks[2]. It should fail with expectedError.
 		err = datastore.Write(
 			ctx,
 			storeID,
-			[]*openfgav1.TupleKeyWithoutCondition{
-				tuple.TupleKeyToTupleKeyWithoutCondition(tks[0]),
-				tuple.TupleKeyToTupleKeyWithoutCondition(tks[1]),
+			storage.Deletes{
+				Tuples: []*openfgav1.TupleKeyWithoutCondition{
+					tuple.TupleKeyToTupleKeyWithoutCondition(tks[0]),
+					tuple.TupleKeyToTupleKeyWithoutCondition(tks[1]),
+				},
 			},
-			[]*openfgav1.TupleKey{tks[2]},
+			storage.Writes{
+				Tuples: []*openfgav1.TupleKey{tks[2]},
+			},
 		)
 		require.EqualError(t, err, expectedError.Error())
 
@@ -725,10 +729,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(
 			ctx,
 			storeID,
-			[]*openfgav1.TupleKeyWithoutCondition{
+			storage.Deletes{Tuples: []*openfgav1.TupleKeyWithoutCondition{
 				tuple.TupleKeyToTupleKeyWithoutCondition(tk),
-			},
-			nil,
+			}},
+			storage.Writes{},
 		)
 		require.ErrorContains(t, err, "cannot delete a tuple which does not exist")
 	})
@@ -738,17 +742,17 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		tk := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10"}
 
 		// Write.
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk}})
 		require.NoError(t, err)
 
 		// Then delete.
 		err = datastore.Write(
 			ctx,
 			storeID,
-			[]*openfgav1.TupleKeyWithoutCondition{
+			storage.Deletes{Tuples: []*openfgav1.TupleKeyWithoutCondition{
 				tuple.TupleKeyToTupleKeyWithoutCondition(tk),
-			},
-			nil,
+			}},
+			storage.Writes{},
 		)
 		require.NoError(t, err)
 
@@ -763,11 +767,11 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		expectedError := storage.InvalidWriteInputError(tk, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)
 
 		// First write should succeed.
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk}})
 		require.NoError(t, err)
 
 		// Second write of the same tuple should fail.
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk}})
 		require.EqualError(t, err, expectedError.Error())
 	})
 
@@ -777,11 +781,11 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		expectedError := storage.InvalidWriteInputError(tk, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE)
 
 		// First write should succeed.
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tk}})
 		require.NoError(t, err)
 
 		// Second write of the same tuple but conditioned should still fail.
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{
+		err = datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{
 			{
 				Object:   tk.GetObject(),
 				Relation: tk.GetRelation(),
@@ -790,7 +794,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 					Name: "condition",
 				},
 			},
-		})
+		}})
 		require.EqualError(t, err, expectedError.Error())
 	})
 
@@ -817,10 +821,10 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, writes)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: writes})
 		require.NoError(t, err)
 
-		err = datastore.Write(ctx, storeID, deletes, nil)
+		err = datastore.Write(ctx, storeID, storage.Deletes{Tuples: deletes}, storage.Writes{})
 		require.NoError(t, err)
 	})
 
@@ -839,7 +843,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tuple1, tuple2, tuple3, tuple4})
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: []*openfgav1.TupleKey{tuple1, tuple2, tuple3, tuple4}})
 		require.NoError(t, err)
 
 		gotTuple, err := datastore.ReadUserTuple(ctx, storeID, tuple1, storage.ReadUserTupleOptions{})
@@ -904,7 +908,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -962,7 +966,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -998,7 +1002,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -1040,7 +1044,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -1076,7 +1080,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -1119,7 +1123,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -1163,7 +1167,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
@@ -1213,7 +1217,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.ReadOptions{})
@@ -1300,7 +1304,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 			},
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tks)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tks})
 		require.NoError(t, err)
 
 		iter, err := datastore.Read(ctx, storeID, tupleKey1, storage.ReadOptions{})
@@ -1402,7 +1406,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	t.Run("returns_results_with_two_user_filters", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, storeID, nil, tuples)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1432,7 +1436,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	t.Run("returns_no_results_if_the_input_users_do_not_match_the_tuples", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, storeID, nil, tuples)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1458,7 +1462,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	t.Run("returns_no_results_if_the_input_relation_does_not_match_any_tuples", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, storeID, nil, tuples)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1484,7 +1488,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	t.Run("returns_no_results_if_the_input_object_type_does_not_match_any_tuples", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, storeID, nil, tuples)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1510,7 +1514,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 	t.Run("returns_results_that_match_objectids_provided", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		err := datastore.Write(ctx, storeID, nil, tuples)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 		require.NoError(t, err)
 		objectIDs := storage.NewSortedSet()
 		for _, v := range []string{"doc1", "doc2", "doc3"} {
@@ -1554,7 +1558,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 			tuple.NewTupleKey("folder:folder1", "viewer", "user:bob"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tupleInReverseOrder)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tupleInReverseOrder})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1598,7 +1602,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 			tuple.NewTupleKey("folder:folder1", "viewer", "user:bob"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tupleInReverseOrder)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tupleInReverseOrder})
 		require.NoError(t, err)
 
 		tupleIterator, err := datastore.ReadStartingWithUser(
@@ -1648,7 +1652,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 			tuple.NewTupleKey("folder:folder1", "viewer", "user:bob"),
 		}
 
-		err := datastore.Write(ctx, storeID, nil, tupleInReverseOrder)
+		err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tupleInReverseOrder})
 		require.NoError(t, err)
 
 		objectIDs := storage.NewSortedSet()
@@ -1724,7 +1728,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 
 	storeID := ulid.Make().String()
 
-	err := datastore.Write(ctx, storeID, nil, tuples)
+	err := datastore.Write(ctx, storeID, storage.Deletes{}, storage.Writes{Tuples: tuples})
 	require.NoError(t, err)
 
 	t.Run("returns_non_empty_timestamps", func(t *testing.T) {
@@ -2015,8 +2019,8 @@ func writeTuplesConcurrently(t *testing.T, store string, datastore storage.OpenF
 		err := datastore.Write(
 			ctx,
 			store,
-			[]*openfgav1.TupleKeyWithoutCondition{},
-			tupleGroupOne,
+			storage.Deletes{},
+			storage.Writes{Tuples: tupleGroupOne},
 		)
 		if err != nil {
 			t.Logf("failed to write tuples: %s", err)
@@ -2028,8 +2032,8 @@ func writeTuplesConcurrently(t *testing.T, store string, datastore storage.OpenF
 		err := datastore.Write(
 			ctx,
 			store,
-			[]*openfgav1.TupleKeyWithoutCondition{},
-			tupleGroupTwo,
+			storage.Deletes{},
+			storage.Writes{Tuples: tupleGroupTwo},
 		)
 		if err != nil {
 			t.Logf("failed to write tuples: %s", err)


### PR DESCRIPTION
### Description

This pull request is a required step for idempotent write and delete functionality to OpenFGA. It updates the API protocol to include new parameters and refactors the storage layer to accommodate these changes, laying the groundwork for the server-side implementation.

---

#### What problem is being solved?
The current OpenFGA `Write` API fails an entire batched request if any single tuple being written already exists. This forces developers to write complex client-side logic to avoid or handle these failures, which leads to a poor developer experience and brittle application code.

#### How is it being solved?
This PR updates the API to be idempotent, allowing clients to opt in to a behavior where duplicate writes or missing deletes are simply ignored. This is achieved by:

* **Refactoring Storage Types:** Changing `storage.Deletes` and `storage.Writes` from simple slices to new structs that encapsulate the list of `TupleKey`s along with the new `on_missing` and `on_duplicate` parameters.

#### What changes are made to solve it?
* The `storage.Deletes` type is changed from `[]*openfgapb.TupleKey` to a new `Deletes` struct that contains `[]*openfgapb.TupleKey` and the `OnMissing` enum.
* The `storage.Writes` type is changed from `[]*openfgapb.TupleKey` to a new `Writes` struct that contains `[]*openfgapb.TupleKey` and the `OnDuplicate` enum.
* All downstream callers of the `Write` method are updated to use the new `Writes` and `Deletes` structs.

**Note** OpenFGA API Proto changes will be introduced once SQL functionality implemented

### References
* **RFC:** [link to the public RFC document]
* **Required for:** https://github.com/openfga/roadmap/issues/79

### Review Checklist
* [x] I have clicked on [["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
* [ ] I have added documentation for new/changed functionality in this PR or in a PR to [[openfga.dev](https://github.com/openfga/openfga.dev)](https://github.com/openfga/openfga.dev)
* [ ] The correct base branch is being used, if not `main`
* [ ] I have added tests to validate that the change in functionality is working as expected

