### PR TITLE
fix: Allow experimental reverse_expand to return partial results on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
+
 ### Fixed
-- Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [2645](https://github.com/openfga/openfga/pull/2645)
+- Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)
 
 ## [1.9.5] - 2025-08-15
 ### Fixed

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
@@ -2468,6 +2468,81 @@ func TestIntersectionHandler(t *testing.T) {
 		require.ErrorAs(t, err, &execError)
 	})
 
+	// This is to maintain the same functionality as old ListObjects, which returns partial results
+	// in the case of a context cancellation or timeout.
+	t.Run("return_nil_when_context_is_canceled", func(t *testing.T) {
+		model := `
+			model
+				schema 1.1
+			  type user
+
+			  type document
+				relations
+				  define viewer: [user]
+				  define editor: [user]
+				  define admin: viewer and editor
+		`
+		tuples := []string{
+			"document:1#viewer@user:a",
+			"document:2#editor@user:a",
+		}
+		objectType := "document"
+		relation := "admin"
+		user := &UserRefObject{Object: &openfgav1.Object{Type: "user", Id: "a"}}
+
+		ds := memory.New()
+		t.Cleanup(ds.Close)
+		storeID, authModel := storagetest.BootstrapFGAStore(t, ds, model, tuples)
+		typesys, err := typesystem.New(
+			authModel,
+		)
+		require.NoError(t, err)
+		ctx := storage.ContextWithRelationshipTupleReader(context.Background(), ds)
+		ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		mockCheckResolver := graph.NewMockCheckRewriteResolver(ctrl)
+		mockCheckResolver.EXPECT().CheckRewrite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+			DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest, rewrite *openfgav1.Userset) graph.CheckHandlerFunc {
+				ctx, cancel := context.WithCancel(ctx)
+				defer cancel()
+				return func(ctx context.Context) (*graph.ResolveCheckResponse, error) {
+					return nil, nil
+				}
+			})
+		q := NewReverseExpandQuery(
+			ds,
+			typesys,
+
+			// turn on weighted graph functionality
+			WithListObjectOptimizationsEnabled(true),
+		)
+		q.localCheckResolver = mockCheckResolver
+
+		node, ok := typesys.GetNode("document#admin")
+		require.True(t, ok)
+
+		edges, err := typesys.GetEdgesFromNode(node, "user")
+		require.NoError(t, err)
+		edges, err = typesys.GetEdgesFromNode(edges[0].GetTo(), "user")
+		require.NoError(t, err)
+
+		newStack := stack.Push(nil, typeRelEntry{typeRel: "document#admin"})
+
+		pool := concurrency.NewPool(ctx, 2)
+		err = q.intersectionHandler(pool, &ReverseExpandRequest{
+			StoreID:       storeID,
+			ObjectType:    objectType,
+			Relation:      relation,
+			User:          user,
+			relationStack: newStack,
+		}, make(chan *ReverseExpandResult), edges, "user", NewResolutionMetadata())
+		require.NoError(t, err)
+		err = pool.Wait()
+		require.NoError(t, err)
+	})
+
 	t.Run("return_error_when_queryForTuples_errors", func(t *testing.T) {
 		model := `
 			model

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
@@ -2505,7 +2505,7 @@ func TestIntersectionHandler(t *testing.T) {
 		mockCheckResolver := graph.NewMockCheckRewriteResolver(ctrl)
 		mockCheckResolver.EXPECT().CheckRewrite(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
 			DoAndReturn(func(ctx context.Context, req *graph.ResolveCheckRequest, rewrite *openfgav1.Userset) graph.CheckHandlerFunc {
-				ctx, cancel := context.WithCancel(ctx)
+				_, cancel := context.WithCancel(ctx)
 				defer cancel()
 				return func(ctx context.Context) (*graph.ResolveCheckResponse, error) {
 					return nil, nil


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Existing ListObjects will return partial results in the case of a timeout or context cancellation. The new, experimental reverse_expand_weighted will not. This is a breaking change to users, so for now we are patching the experimental code to perform the same as the old.

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified timeout handling in reverse expand: on cancellation or timeouts, it now returns partial results instead of an error, matching legacy behavior.

* **Documentation**
  * Updated Unreleased notes to reflect the timeout behavior change for reverse expand.
  * Corrected a changelog link formatting issue for a previous weight-2 optimization entry.

* **Tests**
  * Added coverage to ensure reverse expand returns no error on context cancellation/timeout, validating partial-result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->