### PR TITLE
feat: Introduce enums for OnMissingDelete and OnDuplicateInsert behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
+- Breaking: Changes to storage interface
+
+  > [!NOTE]
+  > The following breaking changes are related to the storage interface. If you are not implementing a storage adaptor, then there are these changes should not impact your usage of OpenFGA.
+
+  - Changed `RelationshipTupleWriter` Datastore interface to accept `TupleWriteOptions` param, enabling customizable behavior for write operations across all storage backends and mocks. [#2651](https://github.com/openfga/openfga/pull/2651)
+    Implementers will need to update the `Write` method signature to accept the new `TupleWriteOptions` parameter.
 
 ### Fixed
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -133,7 +133,7 @@ func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter, op
 }
 
 // Write mocks base method.
-func (m *MockTupleBackend) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
+func (m *MockTupleBackend) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, store, d, w}
 	for _, a := range opts {
@@ -290,7 +290,7 @@ func (mr *MockRelationshipTupleWriterMockRecorder) MaxTuplesPerWrite() *gomock.C
 }
 
 // Write mocks base method.
-func (m *MockRelationshipTupleWriter) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
+func (m *MockRelationshipTupleWriter) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, store, d, w}
 	for _, a := range opts {
@@ -998,7 +998,7 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter
 }
 
 // Write mocks base method.
-func (m *MockOpenFGADatastore) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
+func (m *MockOpenFGADatastore) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, store, d, w}
 	for _, a := range opts {

--- a/internal/mocks/mock_storage.go
+++ b/internal/mocks/mock_storage.go
@@ -133,17 +133,22 @@ func (mr *MockTupleBackendMockRecorder) ReadUsersetTuples(ctx, store, filter, op
 }
 
 // Write mocks base method.
-func (m *MockTupleBackend) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes) error {
+func (m *MockTupleBackend) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", ctx, store, d, w)
+	varargs := []any{ctx, store, d, w}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Write", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockTupleBackendMockRecorder) Write(ctx, store, d, w any) *gomock.Call {
+func (mr *MockTupleBackendMockRecorder) Write(ctx, store, d, w any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockTupleBackend)(nil).Write), ctx, store, d, w)
+	varargs := append([]any{ctx, store, d, w}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockTupleBackend)(nil).Write), varargs...)
 }
 
 // MockRelationshipTupleReader is a mock of RelationshipTupleReader interface.
@@ -285,17 +290,22 @@ func (mr *MockRelationshipTupleWriterMockRecorder) MaxTuplesPerWrite() *gomock.C
 }
 
 // Write mocks base method.
-func (m *MockRelationshipTupleWriter) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes) error {
+func (m *MockRelationshipTupleWriter) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", ctx, store, d, w)
+	varargs := []any{ctx, store, d, w}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Write", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockRelationshipTupleWriterMockRecorder) Write(ctx, store, d, w any) *gomock.Call {
+func (mr *MockRelationshipTupleWriterMockRecorder) Write(ctx, store, d, w any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockRelationshipTupleWriter)(nil).Write), ctx, store, d, w)
+	varargs := append([]any{ctx, store, d, w}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockRelationshipTupleWriter)(nil).Write), varargs...)
 }
 
 // MockAuthorizationModelReadBackend is a mock of AuthorizationModelReadBackend interface.
@@ -988,17 +998,22 @@ func (mr *MockOpenFGADatastoreMockRecorder) ReadUsersetTuples(ctx, store, filter
 }
 
 // Write mocks base method.
-func (m *MockOpenFGADatastore) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes) error {
+func (m *MockOpenFGADatastore) Write(ctx context.Context, store string, d storage.Deletes, w storage.Writes, opts ...storage.TupleWriteOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Write", ctx, store, d, w)
+	varargs := []any{ctx, store, d, w}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Write", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Write indicates an expected call of Write.
-func (mr *MockOpenFGADatastoreMockRecorder) Write(ctx, store, d, w any) *gomock.Call {
+func (mr *MockOpenFGADatastoreMockRecorder) Write(ctx, store, d, w any, opts ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockOpenFGADatastore)(nil).Write), ctx, store, d, w)
+	varargs := append([]any{ctx, store, d, w}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Write", reflect.TypeOf((*MockOpenFGADatastore)(nil).Write), varargs...)
 }
 
 // WriteAssertions mocks base method.

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -332,7 +332,7 @@ type tupleChangeRec struct {
 }
 
 // Write see [storage.RelationshipTupleWriter].Write.
-func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes, _ ...storage.TupleWriteOptions) error {
+func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes, _ ...storage.TupleWriteOption) error {
 	_, span := tracer.Start(ctx, "memory.Write")
 	defer span.End()
 

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -332,7 +332,7 @@ type tupleChangeRec struct {
 }
 
 // Write see [storage.RelationshipTupleWriter].Write.
-func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes) error {
+func (s *MemoryBackend) Write(ctx context.Context, store string, deletes storage.Deletes, writes storage.Writes, _ ...storage.TupleWriteOptions) error {
 	_, span := tracer.Start(ctx, "memory.Write")
 	defer span.End()
 

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -204,6 +204,7 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
+	_ ...storage.TupleWriteOptions,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -204,12 +204,12 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
-	_ ...storage.TupleWriteOptions,
+	opts ...storage.TupleWriteOption,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()
 
-	return sqlcommon.Write(ctx, s.dbInfo, store, deletes, writes, time.Now().UTC())
+	return sqlcommon.Write(ctx, s.dbInfo, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -85,6 +85,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
 
@@ -94,6 +95,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -103,6 +105,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -188,6 +191,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
 
@@ -197,6 +201,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -206,6 +211,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -250,6 +256,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{firstTuple},
+		storage.NewTupleWriteOptions(),
 		time.Now())
 	require.NoError(t, err)
 
@@ -259,6 +266,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{secondTuple},
+		storage.NewTupleWriteOptions(),
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -299,12 +299,12 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
-	_ ...storage.TupleWriteOptions,
+	opts ...storage.TupleWriteOption,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()
 
-	return sqlcommon.Write(ctx, s.primaryDBInfo, store, deletes, writes, time.Now().UTC())
+	return sqlcommon.Write(ctx, s.primaryDBInfo, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -299,6 +299,7 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
+	_ ...storage.TupleWriteOptions,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -120,6 +120,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
 
@@ -129,6 +130,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -137,6 +139,7 @@ func TestReadEnsureNoOrder(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -222,6 +225,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
 
@@ -231,6 +235,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
 
@@ -239,6 +244,7 @@ func TestCtxCancel(t *testing.T) {
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
+				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
 
@@ -282,6 +288,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{firstTuple},
+		storage.NewTupleWriteOptions(),
 		time.Now())
 	require.NoError(t, err)
 
@@ -291,6 +298,7 @@ func TestReadPageEnsureOrder(t *testing.T) {
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{secondTuple},
+		storage.NewTupleWriteOptions(),
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -481,6 +481,7 @@ func Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
+	_ storage.TupleWriteOptions,
 	now time.Time,
 ) error {
 	txn, err := dbInfo.db.BeginTx(ctx, nil)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -213,7 +213,7 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
-	_ ...storage.TupleWriteOptions,
+	_ ...storage.TupleWriteOption,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -213,6 +213,7 @@ func (s *Datastore) Write(
 	store string,
 	deletes storage.Deletes,
 	writes storage.Writes,
+	_ ...storage.TupleWriteOptions,
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -245,21 +245,21 @@ type TupleWriteOptions struct {
 	OnDuplicateInsert OnDuplicateInsert
 }
 
-type TupleWriteOptionsFunc func(*TupleWriteOptions)
+type TupleWriteOption func(*TupleWriteOptions)
 
-func WithOnMissingDelete(onMissingDelete OnMissingDelete) TupleWriteOptionsFunc {
+func WithOnMissingDelete(onMissingDelete OnMissingDelete) TupleWriteOption {
 	return func(opts *TupleWriteOptions) {
 		opts.OnMissingDelete = onMissingDelete
 	}
 }
 
-func WithOnDuplicateInsert(onDuplicateInsert OnDuplicateInsert) TupleWriteOptionsFunc {
+func WithOnDuplicateInsert(onDuplicateInsert OnDuplicateInsert) TupleWriteOption {
 	return func(opts *TupleWriteOptions) {
 		opts.OnDuplicateInsert = onDuplicateInsert
 	}
 }
 
-func NewTupleWriteOptions(opts ...TupleWriteOptionsFunc) TupleWriteOptions {
+func NewTupleWriteOptions(opts ...TupleWriteOption) TupleWriteOptions {
 	res := TupleWriteOptions{
 		OnMissingDelete:   OnMissingDeleteError,
 		OnDuplicateInsert: OnDuplicateInsertError,
@@ -279,7 +279,7 @@ type RelationshipTupleWriter interface {
 	// If two concurrent requests attempt to write the same tuple at the same time, it must return ErrTransactionalWriteFailed. TODO write test
 	// If the tuple to be written already existed or the tuple to be deleted didn't exist, it must return InvalidWriteInputError. TODO write test
 	// opts are optional and can be used to customize the behavior of the write operation.
-	Write(ctx context.Context, store string, d Deletes, w Writes, opts ...TupleWriteOptions) error
+	Write(ctx context.Context, store string, d Deletes, w Writes, opts ...TupleWriteOption) error
 
 	// MaxTuplesPerWrite returns the maximum number of items (writes and deletes combined)
 	// allowed in a single write transaction.

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -213,6 +213,63 @@ type RelationshipTupleReader interface {
 	) (TupleIterator, error)
 }
 
+// OnMissingDelete defines the behavior of delete operation when the tuple to be deleted does not exist.
+type OnMissingDelete int32
+
+// OnDuplicateInsert defines the behavior of insert operation when the tuple to be inserted already exists.
+type OnDuplicateInsert int32
+
+const (
+	// OnMissingDeleteError indicates that if a delete operation is attempted on a tuple that does
+	// not exist, an error should be returned.
+	OnMissingDeleteError OnMissingDelete = 0
+
+	// OnMissingDeleteIgnore indicates that if a delete operation is attempted on a tuple that does
+	// not exist, it should be ignored as no-op and no error should be returned.
+	OnMissingDeleteIgnore OnMissingDelete = 1
+
+	// OnDuplicateInsertError indicates that if an insert operation is attempted on a tuple that already exists,
+	// an error should be returned.
+	OnDuplicateInsertError OnDuplicateInsert = 0
+
+	// OnDuplicateInsertIgnore indicates that if an insert operation is attempted on a tuple that already exists,
+	// it should be ignored as a no-op and no error should be returned.
+	OnDuplicateInsertIgnore OnDuplicateInsert = 1
+)
+
+// TupleWriteOptions defines the options that can be used when writing tuples.
+// It allows customization of the behavior when a delete operation is attempted on a tuple that does not
+// exist, or when an insert operation is attempted on a tuple that already exists.
+type TupleWriteOptions struct {
+	OnMissingDelete   OnMissingDelete
+	OnDuplicateInsert OnDuplicateInsert
+}
+
+type TupleWriteOptionsFunc func(*TupleWriteOptions)
+
+func WithOnMissingDelete(onMissingDelete OnMissingDelete) TupleWriteOptionsFunc {
+	return func(opts *TupleWriteOptions) {
+		opts.OnMissingDelete = onMissingDelete
+	}
+}
+
+func WithOnDuplicateInsert(onDuplicateInsert OnDuplicateInsert) TupleWriteOptionsFunc {
+	return func(opts *TupleWriteOptions) {
+		opts.OnDuplicateInsert = onDuplicateInsert
+	}
+}
+
+func NewTupleWriteOptions(opts ...TupleWriteOptionsFunc) TupleWriteOptions {
+	res := TupleWriteOptions{
+		OnMissingDelete:   OnMissingDeleteError,
+		OnDuplicateInsert: OnDuplicateInsertError,
+	}
+	for _, opt := range opts {
+		opt(&res)
+	}
+	return res
+}
+
 // RelationshipTupleWriter is an interface that defines the set of methods
 // required for writing relationship tuples in a data store.
 type RelationshipTupleWriter interface {
@@ -221,7 +278,8 @@ type RelationshipTupleWriter interface {
 	// It must also write to the changelog.
 	// If two concurrent requests attempt to write the same tuple at the same time, it must return ErrTransactionalWriteFailed. TODO write test
 	// If the tuple to be written already existed or the tuple to be deleted didn't exist, it must return InvalidWriteInputError. TODO write test
-	Write(ctx context.Context, store string, d Deletes, w Writes) error
+	// opts are optional and can be used to customize the behavior of the write operation.
+	Write(ctx context.Context, store string, d Deletes, w Writes, opts ...TupleWriteOptions) error
 
 	// MaxTuplesPerWrite returns the maximum number of items (writes and deletes combined)
 	// allowed in a single write transaction.


### PR DESCRIPTION
### Description

This pull request is a required step for idempotent write and delete functionality to OpenFGA. It updates the API protocol to include new parameters and refactors the storage layer to accommodate these changes, laying the groundwork for the server-side implementation.

---

#### What problem is being solved?
The current OpenFGA `Write` API fails an entire batched request if any single tuple being written already exists. This forces developers to write complex client-side logic to avoid or handle these failures, which leads to a poor developer experience and brittle application code.

#### How is it being solved?
This PR updates the API to be idempotent, allowing clients to opt in to a behavior where duplicate writes or missing deletes are simply ignored.

#### What changes are made to solve it?

This is achieved by adding new `TupleWriteOptions` with values for `OnMissingDelete` and `OnDuplicateInsert` that will be used in Datastore implementation(s).

**Note** OpenFGA API Proto changes will be introduced once SQL functionality implemented

### References
* **RFC:** [link to the public RFC document]
* **Required for:** https://github.com/openfga/roadmap/issues/79

### Review Checklist
* [x] I have clicked on [["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
* [ ] I have added documentation for new/changed functionality in this PR or in a PR to [[openfga.dev](https://github.com/openfga/openfga.dev)](https://github.com/openfga/openfga.dev)
* [ ] The correct base branch is being used, if not `main`
* [ ] I have added tests to validate that the change in functionality is working as expected

