### PR TITLE
feat: update experimental ListObjects max querying goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
+- Increase number of querying goroutines in experimental reverse_expand to `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
 
 ### Fixed
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
-- Increase number of querying goroutines in experimental reverse_expand to `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
+- Make number of querying goroutines in experimental reverse_expand configurable via `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
 
 ### Fixed
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Added
+- Make number of querying goroutines in experimental reverse_expand configurable via `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
+
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)
-- Make number of querying goroutines in experimental reverse_expand configurable via `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
 
 ### Fixed
 - Improve performance by allowing weight 2 optimization if the directly assignable userset types are of different types. [#2645](https://github.com/openfga/openfga/pull/2645)

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -339,12 +339,12 @@ func (c *ReverseExpandQuery) queryForTuples(
 		return err
 	}
 
-	// stack.Populate the jobQueue with the initial jobs
+	// Populate the jobQueue with the initial jobs
 	queryJobQueue.enqueue(items...)
 
 	// We could potentially have c.resolveNodeBreadthLimit active routines reaching this point.
-	// Limit querying routines to 2 to avoid explosion of routines.
-	pool := concurrency.NewPool(ctx, 2)
+	// Limit querying routines to avoid explosion of routines.
+	pool := concurrency.NewPool(ctx, int(c.resolveNodeBreadthLimit))
 
 	for !queryJobQueue.Empty() {
 		job, ok := queryJobQueue.dequeue()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
We've seen general performance improvements with the current experimental ListObjects. However, for some models querying for heavier weight relations, performance may degrade. [Via benchmarking](https://github.com/openfga/openfga/pull/2584), we've narrowed the issue down to our self-imposed, very conservative limit of 2 simultaneous querying goroutines for each branch of the graph traversal in ReverseExpand.

When benchmarking with only 1 CPU (OpenFGA makefile default), speed is similar:

<img width="1269" height="258" alt="image" src="https://github.com/user-attachments/assets/af0d59c3-c514-4387-bfe0-6f36470d9f91" />

---

As more CPU becomes available, the non-experimental code becomes faster specifically for weight_two and weight_three queries. with CPU=4:
<img width="1033" height="72" alt="image" src="https://github.com/user-attachments/assets/75c4271f-f77c-4f0c-8363-4e1da054cedd" />

As CPU increases further, the gap widens.

---

With the change introduced in this PR, we see the performance of the currently-under-development version of ReverseExpand come back up to or exceed the existing implementation:
<img width="1032" height="72" alt="image" src="https://github.com/user-attachments/assets/85755e93-f870-4e0f-922f-47ee543ae79f" />





#### What problem is being solved?
Increase performance of experimental list objects optimization.

#### How is it being solved?
Increased the number of goroutines we allow to query the database at a time during ReverseExpand.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configuration option to control the concurrency/breadth of experimental reverse expand queries, allowing better tuning for performance and resource usage.

- Documentation
  - Updated the changelog to describe the new configurability for experimental reverse expand.
  - Removed the previous note about timeout behavior parity between experimental and legacy reverse expand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->