### PR TITLE
add latency and query count numbers in shadow check resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Added
 - Make number of querying goroutines in experimental reverse_expand configurable via `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
-- Add microsecond latency numbers in shadow check resolver. [#2658](https://github.com/openfga/openfga/pull/2658)
+- Add microsecond latency numbers and datastore query count in shadow check resolver. [#2658](https://github.com/openfga/openfga/pull/2658)
 
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Added
 - Make number of querying goroutines in experimental reverse_expand configurable via `resolveNodeBreadthLimit`. [#2652](https://github.com/openfga/openfga/pull/2652)
+- Add microsecond latency numbers in shadow check resolver. [#2658](https://github.com/openfga/openfga/pull/2658)
 
 ### Changed
 - Make experimental reverse_expand behave the same as old reverse_expand in case of timeouts. [#2649](https://github.com/openfga/openfga/pull/2649)

--- a/internal/graph/shadow_resolver.go
+++ b/internal/graph/shadow_resolver.go
@@ -106,11 +106,11 @@ func (s ShadowResolver) ResolveCheck(ctx context.Context, req *ResolveCheckReque
 					zap.String("store_id", reqClone.GetStoreID()),
 					zap.String("model_id", reqClone.GetAuthorizationModelID()),
 					zap.Bool("main", resClone.GetAllowed()),
-					zap.Bool("main-cycle", resClone.GetCycleDetected()),
+					zap.Bool("main_cycle", resClone.GetCycleDetected()),
 					zap.Int64("main_latency_us", mainDuration.Microseconds()),
 					zap.Uint32("main_query_count", resClone.GetResolutionMetadata().DatastoreQueryCount),
 					zap.Bool("shadow", shadowRes.GetAllowed()),
-					zap.Bool("shadow-cycle", shadowRes.GetCycleDetected()),
+					zap.Bool("shadow_cycle", shadowRes.GetCycleDetected()),
 					zap.Int64("shadow_latency_us", shadowDuration.Microseconds()),
 					zap.Uint32("shadow_query_count", shadowRes.GetResolutionMetadata().DatastoreQueryCount),
 				)

--- a/internal/graph/shadow_resolver.go
+++ b/internal/graph/shadow_resolver.go
@@ -108,14 +108,18 @@ func (s ShadowResolver) ResolveCheck(ctx context.Context, req *ResolveCheckReque
 					zap.Bool("main", resClone.GetAllowed()),
 					zap.Bool("main-cycle", resClone.GetCycleDetected()),
 					zap.Int64("main_latency_us", mainDuration.Microseconds()),
+					zap.Uint32("main_query_count", resClone.GetResolutionMetadata().DatastoreQueryCount),
 					zap.Bool("shadow", shadowRes.GetAllowed()),
 					zap.Bool("shadow-cycle", shadowRes.GetCycleDetected()),
 					zap.Int64("shadow_latency_us", shadowDuration.Microseconds()),
+					zap.Uint32("shadow_query_count", shadowRes.GetResolutionMetadata().DatastoreQueryCount),
 				)
 			} else {
 				s.logger.InfoWithContext(ctx, "shadow check match",
 					zap.Int64("main_latency_us", mainDuration.Microseconds()),
+					zap.Uint32("main_query_count", resClone.GetResolutionMetadata().DatastoreQueryCount),
 					zap.Int64("shadow_latency_us", shadowDuration.Microseconds()),
+					zap.Uint32("shadow_query_count", shadowRes.GetResolutionMetadata().DatastoreQueryCount),
 				)
 			}
 		}()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
We use this shadow pattern to test experimental improvements to Check, but we don't currently have latency metrics built into the comparison. This PR calculates the duration of both `main` and `shadow` check resolution and adds the data as log attributes.

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Chores
  - Added latency metrics to logs for main and shadow checks to improve observability.
  - Logs now include microsecond-level durations for both execution paths (when results match or differ).
  - No changes to behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->