### PR TITLE
fix: perform check validation as first step

### DIFF
--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -1,0 +1,83 @@
+package server
+
+import (
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestCheck_Validation(t *testing.T) {
+	t.Parallel()
+
+	testServer := &Server{}
+	ctx := t.Context()
+
+	tests := []struct {
+		name                 string
+		givenRequest         *openfgav1.CheckRequest
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "missing store id",
+			givenRequest:         &openfgav1.CheckRequest{},
+			expectedErrorMessage: "invalid CheckRequest.StoreId: value does not match regex pattern \"^[ABCDEFGHJKMNPQRSTVWXYZ0-9]{26}$\"",
+		},
+		{
+			name: "missing tuple_key",
+			givenRequest: &openfgav1.CheckRequest{
+				StoreId: "01K3RZVNE3NJ4FYKK99QN013G2",
+			},
+			expectedErrorMessage: "invalid CheckRequest.TupleKey: value is required",
+		},
+		{
+			name: "missing object",
+			givenRequest: &openfgav1.CheckRequest{
+				StoreId: "01K3RZVNE3NJ4FYKK99QN013G2",
+				TupleKey: &openfgav1.CheckRequestTupleKey{
+					User:     "user:anne",
+					Relation: "viewer",
+				},
+			},
+			expectedErrorMessage: "invalid CheckRequest.TupleKey: embedded message failed validation | caused by: invalid CheckRequestTupleKey.Object: value does not match regex pattern \"^[^\\\\s]{2,256}$\"",
+		},
+		{
+			name: "missing relation",
+			givenRequest: &openfgav1.CheckRequest{
+				StoreId: "01K3RZVNE3NJ4FYKK99QN013G2",
+				TupleKey: &openfgav1.CheckRequestTupleKey{
+					Object: "doc:1",
+					User:   "user:anne",
+				},
+			},
+			expectedErrorMessage: "invalid CheckRequest.TupleKey: embedded message failed validation | caused by: invalid CheckRequestTupleKey.Relation: value does not match regex pattern \"^[^:#@\\\\s]{1,50}$\"",
+		},
+		{
+			name: "missing user",
+			givenRequest: &openfgav1.CheckRequest{
+				StoreId: "01K3RZVNE3NJ4FYKK99QN013G2",
+				TupleKey: &openfgav1.CheckRequestTupleKey{
+					Object:   "doc:1",
+					Relation: "viewer",
+				},
+			},
+			expectedErrorMessage: "invalid CheckRequest.TupleKey: embedded message failed validation | caused by: invalid CheckRequestTupleKey.User: value does not match regex pattern \"^[^\\\\s]{2,512}$\"",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actualResponse, err := testServer.Check(ctx, test.givenRequest)
+
+			gRPCStatus, ok := status.FromError(err)
+			require.True(t, ok)
+			require.Equal(t, codes.InvalidArgument, gRPCStatus.Code())
+			require.Equal(t, test.expectedErrorMessage, gRPCStatus.Message())
+			require.Nil(t, actualResponse)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

### What problem is being solved?

- Request validation for `Check` could occur after authz/model resolution, leading to misleading errors, unnecessary work, and inconsistent gRPC statuses for malformed inputs.
- Clients could receive non-`InvalidArgument` errors when the request itself was invalid.

### How is it being solved?

- Ensure `CheckRequest` validation runs at the very start of `Server.Check`, before authz checks and typesystem resolution.
- Skip re-validation if the request has already been validated upstream via `validator.RequestIsValidatedFromContext`.
- Add unit tests to assert that invalid requests consistently return `codes.InvalidArgument` with precise validation messages.

### What changes are made to solve it?

- In `pkg/server/check.go`: call `req.Validate()` immediately (guarded by `validator.RequestIsValidatedFromContext`) and return `codes.InvalidArgument` on failure, before calling authz or resolving the typesystem.
- In `pkg/server/check_test.go`: add `TestCheck_Validation` with cases covering missing store id, tuple key, object, relation, and user; verify response is `nil` and the gRPC status/code/message match expected validation errors.




## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

- https://github.com/openfga/openfga/issues/965

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

