### PR TITLE
chore: remove dead code

### DIFF
--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -53,7 +53,6 @@ type checkOutcome struct {
 type LocalChecker struct {
 	delegate             CheckResolver
 	concurrencyLimit     int
-	usersetBatchSize     int // TODO: delete this, its not used.
 	planner              *planner.Planner
 	logger               logger.Logger
 	optimizationsEnabled bool
@@ -81,13 +80,6 @@ func WithPlanner(p *planner.Planner) LocalCheckerOption {
 	}
 }
 
-// WithUsersetBatchSize see server.WithUsersetBatchSize.
-func WithUsersetBatchSize(usersetBatchSize uint32) LocalCheckerOption {
-	return func(d *LocalChecker) {
-		d.usersetBatchSize = int(usersetBatchSize)
-	}
-}
-
 func WithLocalCheckerLogger(logger logger.Logger) LocalCheckerOption {
 	return func(d *LocalChecker) {
 		d.logger = logger
@@ -108,7 +100,6 @@ func WithMaxResolutionDepth(depth uint32) LocalCheckerOption {
 func NewLocalChecker(opts ...LocalCheckerOption) *LocalChecker {
 	checker := &LocalChecker{
 		concurrencyLimit:   serverconfig.DefaultResolveNodeBreadthLimit,
-		usersetBatchSize:   serverconfig.DefaultUsersetBatchSize,
 		maxResolutionDepth: serverconfig.DefaultResolveNodeLimit,
 		logger:             logger.NewNoopLogger(),
 		planner:            planner.NewNoopPlanner(),

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -21,7 +21,6 @@ const (
 	DefaultChangelogHorizonOffset           = 0
 	DefaultResolveNodeLimit                 = 25
 	DefaultResolveNodeBreadthLimit          = 10
-	DefaultUsersetBatchSize                 = 1000
 	DefaultListObjectsDeadline              = 3 * time.Second
 	DefaultListObjectsMaxResults            = 1000
 	DefaultMaxConcurrentReadsForCheck       = math.MaxUint32

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -160,7 +160,6 @@ type Server struct {
 	transport                        gateway.Transport
 	resolveNodeLimit                 uint32
 	resolveNodeBreadthLimit          uint32
-	usersetBatchSize                 uint32
 	changelogHorizonOffset           int
 	listObjectsDeadline              time.Duration
 	listObjectsMaxResults            uint32
@@ -313,30 +312,6 @@ func WithResolveNodeLimit(limit uint32) OpenFGAServiceV1Option {
 func WithResolveNodeBreadthLimit(limit uint32) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.resolveNodeBreadthLimit = limit
-	}
-}
-
-// WithUsersetBatchSize in Check requests, configures how many usersets are collected
-// before we start processing them.
-//
-// For example in this model:
-// type user
-// type folder
-//
-//	relations
-//	   define viewer: [user]
-//
-// type doc
-//
-//	relations
-//	   define viewer: viewer from parent
-//	   define parent: [folder]
-//
-// If the Check(user:maria, viewer,doc:1) and this setting is 100,
-// we will find 100 parent folders of doc:1 and immediately start processing them.
-func WithUsersetBatchSize(usersetBatchSize uint32) OpenFGAServiceV1Option {
-	return func(s *Server) {
-		s.usersetBatchSize = usersetBatchSize
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Removed support for configuring a userset batch size in Check requests. Deployments relying on this setting must remove it from their configuration. Other options and default behavior remain unchanged.

- Refactor
  - Simplified internal logic by eliminating userset batch size handling, reducing configuration surface and maintenance overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->