### PR TITLE
fix: in-memory condition context not checked correctly for write

### DIFF
--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -449,7 +449,7 @@ func sanitizeTuplesWriteDelete(
 		if record != nil {
 			if opts.OnDuplicateInsert == storage.OnDuplicateInsertIgnore {
 				// need to validate against condition and context
-				if record.ConditionName == tk.GetCondition().GetName() && record.ConditionContext == tk.GetCondition().GetContext() {
+				if record.ConditionName == tk.GetCondition().GetName() && record.ConditionContext.String() == tk.GetCondition().GetContext().String() {
 					duplicateWrites = append(duplicateWrites, i)
 					continue
 				}

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -962,8 +962,12 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
 		require.NoError(t, err)
 
+		tk2:= &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
+			Name:    "condition1",
+			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+		}}
 		// Second write of the same tuple should not fail.
-		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk},
+		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk2},
 			storage.WithOnDuplicateInsert(storage.OnDuplicateInsertIgnore))
 		require.NoError(t, err)
 

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -962,7 +962,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk})
 		require.NoError(t, err)
 
-		tk2:= &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
+		tk2 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
 			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
 		}}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
For write, the assertion for condition and context being identical for in-memory database is incorrect.
 
#### How is it being solved?
The assertion for context should be based on the string, not the raw object itself.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved duplicate detection for conditioned writes by comparing contexts by value. This ensures consistent handling of repeated inserts with equivalent conditions, preventing unintended duplicates and resolving inconsistent conflict detection.
- Tests
  - Expanded test coverage to validate the corrected behavior for conditioned duplicate inserts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->