### PR TITLE
fix: flaky TestConstructUserset unit test

### DIFF
--- a/pkg/typesystem/weighted_graph_test.go
+++ b/pkg/typesystem/weighted_graph_test.go
@@ -821,26 +821,23 @@ func TestConstructUserset(t *testing.T) {
 		require.Equal(t, graph.RewriteEdge, dut.GetEdgeType())
 		userset, err := typeSystem.ConstructUserset(dut, "user")
 		require.NoError(t, err)
-		require.Equal(t, &openfgav1.Userset{
-			Userset: &openfgav1.Userset_Union{
-				Union: &openfgav1.Usersets{
-					Child: []*openfgav1.Userset{
-						{
-							Userset: &openfgav1.Userset_ComputedUserset{
-								ComputedUserset: &openfgav1.ObjectRelation{
-									Relation: "allowed",
-								},
-							},
-						},
-						{
-							Userset: &openfgav1.Userset_ComputedUserset{
-								ComputedUserset: &openfgav1.ObjectRelation{
-									Relation: "granted",
-								},
-							},
-						},
-					},
-				}}}, userset)
+		innerUserset := userset.GetUserset()
+		require.NotNil(t, innerUserset)
+		innerUnion := innerUserset.(*openfgav1.Userset_Union)
+		require.NotNil(t, innerUnion)
+		innerUnionUserset := innerUnion.Union
+		require.NotNil(t, innerUnionUserset)
+		require.Len(t, innerUnionUserset.GetChild(), 2)
+		var relationName []string
+		for _, child := range innerUnionUserset.GetChild() {
+			cu := child.GetUserset()
+			require.NotNil(t, cu)
+			cr := cu.(*openfgav1.Userset_ComputedUserset)
+			require.NotNil(t, cr)
+			relationName = append(relationName, cr.ComputedUserset.GetRelation())
+		}
+		require.Contains(t, relationName, "allowed")
+		require.Contains(t, relationName, "granted")
 	})
 	t.Run("operator_intersection", func(t *testing.T) {
 		model := `
@@ -875,26 +872,23 @@ func TestConstructUserset(t *testing.T) {
 		require.Equal(t, graph.RewriteEdge, dut.GetEdgeType())
 		userset, err := typeSystem.ConstructUserset(dut, "user")
 		require.NoError(t, err)
-		require.Equal(t, &openfgav1.Userset{
-			Userset: &openfgav1.Userset_Intersection{
-				Intersection: &openfgav1.Usersets{
-					Child: []*openfgav1.Userset{
-						{
-							Userset: &openfgav1.Userset_ComputedUserset{
-								ComputedUserset: &openfgav1.ObjectRelation{
-									Relation: "allowed",
-								},
-							},
-						},
-						{
-							Userset: &openfgav1.Userset_ComputedUserset{
-								ComputedUserset: &openfgav1.ObjectRelation{
-									Relation: "granted",
-								},
-							},
-						},
-					},
-				}}}, userset)
+		innerUserset := userset.GetUserset()
+		require.NotNil(t, innerUserset)
+		innerIntersection := innerUserset.(*openfgav1.Userset_Intersection)
+		require.NotNil(t, innerIntersection)
+		innerIntersectionUserset := innerIntersection.Intersection
+		require.NotNil(t, innerIntersectionUserset)
+		require.Len(t, innerIntersectionUserset.GetChild(), 2)
+		var relationName []string
+		for _, child := range innerIntersectionUserset.GetChild() {
+			cu := child.GetUserset()
+			require.NotNil(t, cu)
+			cr := cu.(*openfgav1.Userset_ComputedUserset)
+			require.NotNil(t, cr)
+			relationName = append(relationName, cr.ComputedUserset.GetRelation())
+		}
+		require.Contains(t, relationName, "allowed")
+		require.Contains(t, relationName, "granted")
 	})
 	t.Run("operator_exclusion", func(t *testing.T) {
 		model := `


### PR DESCRIPTION
There is no guarantee order for GetGroupedEdges.  As such, the unit test should not make any assumption in the order.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
See flaky test for TestConstructUserset (operator_intersection).  Root cause is that [GetGroupedEdges](https://github.com/openfga/openfga/blob/92a663b9edddb64a0d8f1c2cc69b4785859ba1e1/pkg/typesystem/weighted_graph.go#L88) does not guarantee any order.  Hence, unit test should not make assumption in the order.

#### How is it being solved?
Update unit test to test for membership and length instead of the exact order.

#### What changes are made to solve it?
Update unit test.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of userset-related tests to reduce brittleness and better validate expected behavior.
  * Tests now verify outcomes without relying on exact internal structures, making them more resilient to non-functional changes.
* **User Impact**
  * No user-facing changes; functionality and behavior remain the same.
* **Chores**
  * Internal test maintenance to enhance reliability of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->