### PR TITLE
release: update changelog for release `v1.10.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.10.1] - 2025-09-22
 ### Fixed
 - Revert spf13/viper back to v.1.20.1 to avoid bumping sourcegraph/conc to an unreleased version as it causes performance degradation. [#2706](https://github.com/openfga/openfga/pull/2706)
 
@@ -1423,7 +1425,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/openfga/openfga/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/openfga/openfga/compare/v1.9.5...v1.10.0
 [1.9.5]: https://github.com/openfga/openfga/compare/v1.9.4...v1.9.5
 [1.9.4]: https://github.com/openfga/openfga/compare/v1.9.3...v1.9.4


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.10.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Release
  - Prepare 1.10.1 (2025-09-22) with stability improvements.
- Bug Fixes
  - Revert configuration library to a stable version to prevent performance degradation and unintended version bump.
- Documentation
  - Update CHANGELOG with 1.10.1 “Fixed” entry.
  - Refresh comparison links: Unreleased now references v1.10.1…HEAD; add link for 1.10.0→1.10.1; adjust historical links accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->