### PR TITLE
fix: order of go mod commands in make deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean: ## Clean project files
 
 deps: ## Download dependencies
 	${call print, "Downloading dependencies"}
-	@go mod vendor && go mod tidy
+	@go mod tidy && go mod vendor
 
 $(GO_BIN)/golangci-lint:
 	${call print, "Installing golangci-lint within ${GO_BIN}"}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Previously, `make deps` ran:
```bash
go mod vendor && go mod tidy
```
This caused the `vendor/` directory to sometimes contain stale or unused dependencies, since `go mod tidy` was cleaning up after vendoring.

### Change
This PR updates the order to:

```bash
go mod tidy && go mod vendor
```

### Benefits
✅ Ensures go.mod and go.sum are up-to-date before vendoring
✅ Keeps vendor/ consistent with the cleaned module file
✅ Prevents unnecessary/untracked dependencies from being copied into vendor/

## How to test
Run make deps on a fresh checkout.

Confirm `go.mod` and` go.sum` contain no unexpected changes.

Confirm `vendor/` contains only the required dependencies.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

