### PR TITLE
feat: switching postgresql to use pgxpool to allow for finer control

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -258,11 +258,23 @@
                     "default": "30",
                     "x-env-variable": "OPENFGA_DATASTORE_MAX_OPEN_CONNS"
                 },
+                "minOpenConns": {
+                    "description": "The minimum number of open connections to the datastore.",
+                    "type": "integer",
+                    "default": "0",
+                    "x-env-variable": "OPENFGA_DATASTORE_MIN_OPEN_CONNS"
+                },
                 "maxIdleConns": {
                     "description": "the maximum number of connections to the datastore in the idle connection pool.",
                     "type": "integer",
                     "default": "10",
                     "x-env-variable": "OPENFGA_DATASTORE_MAX_IDLE_CONNS"
+                },
+                "minIdleConns": {
+                    "description": "the minimum number of connections to the datastore in the idle connection pool.",
+                    "type": "integer",
+                    "default": "0",
+                    "x-env-variable": "OPENFGA_DATASTORE_MIN_IDLE_CONNS"
                 },
                 "connMaxIdleTime": {
                     "description": "the maximum amount of time a connection to the datastore may be idle",

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -110,8 +110,14 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("datastore.maxCacheSize", flags.Lookup("datastore-max-cache-size"))
 		util.MustBindEnv("datastore.maxCacheSize", "OPENFGA_DATASTORE_MAX_CACHE_SIZE", "OPENFGA_DATASTORE_MAXCACHESIZE")
 
+		util.MustBindPFlag("datastore.minOpenConns", flags.Lookup("datastore-min-open-conns"))
+		util.MustBindEnv("datastore.minOpenConns", "OPENFGA_DATASTORE_MIN_OPEN_CONNS")
+
 		util.MustBindPFlag("datastore.maxOpenConns", flags.Lookup("datastore-max-open-conns"))
 		util.MustBindEnv("datastore.maxOpenConns", "OPENFGA_DATASTORE_MAX_OPEN_CONNS", "OPENFGA_DATASTORE_MAXOPENCONNS")
+
+		util.MustBindPFlag("datastore.minIdleConns", flags.Lookup("datastore-min-idle-conns"))
+		util.MustBindEnv("datastore.minIdleConns", "OPENFGA_DATASTORE_MIN_IDLE_CONNS")
 
 		util.MustBindPFlag("datastore.maxIdleConns", flags.Lookup("datastore-max-idle-conns"))
 		util.MustBindEnv("datastore.maxIdleConns", "OPENFGA_DATASTORE_MAX_IDLE_CONNS", "OPENFGA_DATASTORE_MAXIDLECONNS")

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -161,7 +161,11 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Int("datastore-max-cache-size", defaultConfig.Datastore.MaxCacheSize, "the maximum number of authorization models that will be cached in memory")
 
+	flags.Int("datastore-min-open-conns", defaultConfig.Datastore.MinOpenConns, "the minimum number of open connections to the datastore")
+
 	flags.Int("datastore-max-open-conns", defaultConfig.Datastore.MaxOpenConns, "the maximum number of open connections to the datastore")
+
+	flags.Int("datastore-min-idle-conns", defaultConfig.Datastore.MinIdleConns, "the minimum number of connections to the datastore in the idle connection pool")
 
 	flags.Int("datastore-max-idle-conns", defaultConfig.Datastore.MaxIdleConns, "the maximum number of connections to the datastore in the idle connection pool")
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
+	github.com/IBM/pgxpoolprometheus v1.1.2
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/Yiling-J/theine-go v0.6.2

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/IBM/pgxpoolprometheus v1.1.2 h1:sHJwxoL5Lw4R79Zt+H4Uj1zZ4iqXJLdk7XDE7TPs97U=
+github.com/IBM/pgxpoolprometheus v1.1.2/go.mod h1:+vWzISN6S9ssgurhUNmm6AlXL9XLah3TdWJktquKTR8=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -125,9 +125,17 @@ type DatastoreConfig struct {
 	// MaxOpenConns is the maximum number of open connections to the database.
 	MaxOpenConns int
 
+	// MinOpenConns is the minimum number of open connections to the database.
+	// This is only used for some datastore engines (PostgresSQL that uses pgxpool).
+	MinOpenConns int
+
 	// MaxIdleConns is the maximum number of connections to the datastore in the idle connection
-	// pool.
+	// pool. This is only used for some datastore engines (non-PostgresSQL that uses sql.DB).
 	MaxIdleConns int
+
+	// MinIdleConns is the minimum number of connections to the datastore in the idle connection
+	// pool. This is only used for some datastore engines (PostgresSQL that uses pgxpool).
+	MinIdleConns int
 
 	// ConnMaxIdleTime is the maximum amount of time a connection to the datastore may be idle.
 	ConnMaxIdleTime time.Duration
@@ -466,6 +474,14 @@ func (cfg *Config) VerifyServerSettings() error {
 		return errors.New("maxConditionsEvaluationCosts less than 100 can cause API compatibility problems with Conditions")
 	}
 
+	if cfg.Datastore.MaxOpenConns < cfg.Datastore.MinOpenConns {
+		return errors.New("datastore MaxOpenConns must not be less than datastore MinOpenConns")
+	}
+
+	if cfg.Datastore.MinOpenConns < cfg.Datastore.MinIdleConns {
+		return errors.New("datastore MinOpenConns must not be less than datastore MinIdleConns")
+	}
+
 	return nil
 }
 
@@ -706,7 +722,9 @@ func DefaultConfig() *Config {
 		Datastore: DatastoreConfig{
 			Engine:       "memory",
 			MaxCacheSize: DefaultMaxAuthorizationModelCacheSize,
+			MinIdleConns: 0,
 			MaxIdleConns: 10,
+			MinOpenConns: 0,
 			MaxOpenConns: 30,
 		},
 		GRPC: GRPCConfig{

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -859,6 +859,42 @@ func TestVerifyServerSettings(t *testing.T) {
 
 		require.NotContains(t, buf.String(), "WARNING: Logging is not enabled. It is highly recommended to enable logging in production environments to avoid masking attacker operations.")
 	})
+
+	t.Run("verify_open_conns_settings", func(t *testing.T) {
+		t.Run("error_when_open_max_less_than_open_min", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Datastore.MaxOpenConns = 50
+			cfg.Datastore.MinOpenConns = 51
+			err := cfg.VerifyServerSettings()
+			require.Error(t, err)
+		})
+
+		t.Run("no_error_when_open_max_equal_open_min", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Datastore.MaxOpenConns = 50
+			cfg.Datastore.MinOpenConns = 50
+			err := cfg.VerifyServerSettings()
+			require.NoError(t, err)
+		})
+
+		t.Run("error_when_open_min_is_less_than_idle_min", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Datastore.MinOpenConns = 50
+			cfg.Datastore.MaxOpenConns = 52
+			cfg.Datastore.MinIdleConns = 51
+			err := cfg.VerifyServerSettings()
+			require.Error(t, err)
+		})
+
+		t.Run("no_error_when_open_min_is_less_than_idle_min", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Datastore.MinOpenConns = 50
+			cfg.Datastore.MaxOpenConns = 52
+			cfg.Datastore.MinIdleConns = 50
+			err := cfg.VerifyServerSettings()
+			require.NoError(t, err)
+		})
+	})
 }
 
 func TestVerifyBinarySettings(t *testing.T) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -243,7 +243,7 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 
 	t.Run("invalid_dialect", func(t *testing.T) {
 		require.PanicsWithValue(t, `failed to set database dialect: "invalid-dialect": unknown dialect`, func() {
-			sqlcommon.NewDBInfo(nil, sq.StatementBuilder, nil, "invalid-dialect")
+			sqlcommon.NewDBInfo(sq.StatementBuilder, nil, "invalid-dialect")
 		})
 	})
 
@@ -807,7 +807,9 @@ func BenchmarkOpenFGAServer(b *testing.B) {
 		uri := testDatastore.GetConnectionURI(true)
 		ds, err := postgres.New(uri, sqlcommon.NewConfig(
 			sqlcommon.WithMaxOpenConns(10),
+			sqlcommon.WithMinOpenConns(10),
 			sqlcommon.WithMaxIdleConns(10),
+			sqlcommon.WithMinIdleConns(10),
 		))
 		require.NoError(b, err)
 		b.Cleanup(ds.Close)

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -90,7 +90,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
@@ -100,7 +101,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
@@ -110,7 +112,8 @@ func TestReadEnsureNoOrder(t *testing.T) {
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
@@ -196,7 +199,8 @@ func TestCtxCancel(t *testing.T) {
 			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
@@ -206,7 +210,8 @@ func TestCtxCancel(t *testing.T) {
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
@@ -216,7 +221,8 @@ func TestCtxCancel(t *testing.T) {
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+				ds.db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
@@ -261,7 +267,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
 
 	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+		sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+		ds.db,
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{firstTuple},
@@ -271,7 +278,8 @@ func TestReadPageEnsureOrder(t *testing.T) {
 
 	// Tweak time so that ULID is smaller.
 	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.db, ds.stbl, HandleSQLError, "mysql"),
+		sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "mysql"),
+		ds.db,
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{secondTuple},

--- a/pkg/storage/postgres/pgxpool_iter_query.go
+++ b/pkg/storage/postgres/pgxpool_iter_query.go
@@ -1,0 +1,94 @@
+package postgres
+
+import (
+	"context"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+)
+
+// pgxpoolIterQuery is a helper to run queries using pgxpool when used in sqlcommon iterator.
+type pgxpoolIterQuery struct {
+	db    *pgxpool.Pool
+	query string
+	args  []interface{}
+}
+
+var _ sqlcommon.SQLIteratorRowGetter = (*pgxpoolIterQuery)(nil)
+
+func newPgxPoolGetRows(db *pgxpool.Pool, sb sq.SelectBuilder) (*pgxpoolIterQuery, error) {
+	stmt, args, err := sb.ToSql()
+	if err != nil {
+		return nil, err
+	}
+	return &pgxpoolIterQuery{
+		db:    db,
+		query: stmt,
+		args:  args,
+	}, nil
+}
+
+// GetRows executes the pgxpool query and returns the sqlcommon.Rows.
+func (p *pgxpoolIterQuery) GetRows(ctx context.Context) (sqlcommon.Rows, error) {
+	rows, err := p.db.Query(ctx, p.query, p.args...)
+	if err != nil {
+		return nil, HandleSQLError(err)
+	}
+	return &pgxRowsWrapper{row: rows}, nil
+}
+
+// pgxtxnIterQuery is a helper to run queries using pgxpool when used in sqlcommon iterator.
+type pgxtxnIterQuery struct {
+	txn   pgx.Tx
+	query string
+	args  []interface{}
+}
+
+var _ sqlcommon.SQLIteratorRowGetter = (*pgxtxnIterQuery)(nil)
+
+func newPgxTxnGetRows(txn pgx.Tx, sb sq.SelectBuilder) (*pgxtxnIterQuery, error) {
+	stmt, args, err := sb.ToSql()
+	if err != nil {
+		return nil, err
+	}
+	return &pgxtxnIterQuery{
+		txn:   txn,
+		query: stmt,
+		args:  args,
+	}, nil
+}
+
+// GetRows executes the txn query and returns the sqlcommon.Rows.
+func (p *pgxtxnIterQuery) GetRows(ctx context.Context) (sqlcommon.Rows, error) {
+	rows, err := p.txn.Query(ctx, p.query, p.args...)
+	if err != nil {
+		return nil, HandleSQLError(err)
+	}
+	return &pgxRowsWrapper{row: rows}, nil
+}
+
+type pgxRowsWrapper struct {
+	row pgx.Rows
+}
+
+func (r *pgxRowsWrapper) Err() error {
+	return r.row.Err()
+}
+
+func (r *pgxRowsWrapper) Next() bool {
+	return r.row.Next()
+}
+
+func (r *pgxRowsWrapper) Scan(dest ...any) error {
+	return r.row.Scan(dest...)
+}
+
+func (r *pgxRowsWrapper) Close() error {
+	r.row.Close()
+	return nil
+}
+
+var _ sqlcommon.Rows = (*pgxRowsWrapper)(nil)

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -124,33 +124,48 @@ func TestReadEnsureNoOrder(t *testing.T) {
 			secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
 			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
+			cp := ds.primaryDB.Config().ConnConfig.ConnString()
+			db, err := sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
+
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			db, err = sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
 
+			db, err = sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
 
 			iter, err := ds.Read(ctx, store, tuple.
 				NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
@@ -229,33 +244,49 @@ func TestCtxCancel(t *testing.T) {
 			secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
 			thirdTuple := tuple.NewTupleKey("doc:object_id_3", "relation", "user:user_3")
 
+			cp := ds.primaryDB.Config().ConnConfig.ConnString()
+			db, err := sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
+
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{firstTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now())
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			db, err = sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
 
 			// Tweak time so that ULID is smaller.
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{secondTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-1))
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
+
+			db, err = sql.Open("pgx/v5", cp)
+			require.NoError(t, err)
 
 			err = sqlcommon.Write(ctx,
-				sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+				sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+				db,
 				store,
 				[]*openfgav1.TupleKeyWithoutCondition{},
 				[]*openfgav1.TupleKey{thirdTuple},
 				storage.NewTupleWriteOptions(),
 				time.Now().Add(time.Minute*-2))
 			require.NoError(t, err)
+			require.NoError(t, db.Close())
 
 			iter, err := ds.Read(ctx, store, tuple.
 				NewTupleKey("doc:", "relation", ""), storage.ReadOptions{})
@@ -292,24 +323,35 @@ func TestReadPageEnsureOrder(t *testing.T) {
 	firstTuple := tuple.NewTupleKey("doc:object_id_1", "relation", "user:user_1")
 	secondTuple := tuple.NewTupleKey("doc:object_id_2", "relation", "user:user_2")
 
+	cp := ds.primaryDB.Config().ConnConfig.ConnString()
+	db, err := sql.Open("pgx/v5", cp)
+	require.NoError(t, err)
+
 	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+		sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+		db,
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{firstTuple},
 		storage.NewTupleWriteOptions(),
 		time.Now())
 	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	db, err = sql.Open("pgx/v5", cp)
+	require.NoError(t, err)
 
 	// Tweak time so that ULID is smaller.
 	err = sqlcommon.Write(ctx,
-		sqlcommon.NewDBInfo(ds.primaryDB, ds.primaryStbl, HandleSQLError, "postgres"),
+		sqlcommon.NewDBInfo(ds.stbl, HandleSQLError, "postgres"),
+		db,
 		store,
 		[]*openfgav1.TupleKeyWithoutCondition{},
 		[]*openfgav1.TupleKey{secondTuple},
 		storage.NewTupleWriteOptions(),
 		time.Now().Add(time.Minute*-1))
 	require.NoError(t, err)
+	require.NoError(t, db.Close())
 
 	opts := storage.ReadPageOptions{
 		Pagination: storage.NewPaginationOptions(storage.DefaultPageSize, ""),
@@ -344,7 +386,7 @@ func TestReadAuthorizationModelUnmarshallError(t *testing.T) {
 	require.NoError(t, err)
 	pbdata := []byte{0x01, 0x02, 0x03}
 
-	_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, pbdata)
+	_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, pbdata)
 	require.NoError(t, err)
 
 	_, err = ds.ReadAuthorizationModel(ctx, store, modelID)
@@ -369,7 +411,7 @@ func TestReadAuthorizationModelReturnValue(t *testing.T) {
 	bytes, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
 	require.NoError(t, err)
 
-	_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, nil)
+	_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)", store, modelID, schemaVersion, "document", bytes, nil)
 
 	require.NoError(t, err)
 
@@ -411,14 +453,14 @@ func TestFindLatestModel(t *testing.T) {
 		// write type "document"
 		bytesDocumentType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
 		require.NoError(t, err)
-		_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
+		_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
 			store, modelID, schemaVersion, "document", bytesDocumentType, nil)
 		require.NoError(t, err)
 
 		// write type "user"
 		bytesUserType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "user"})
 		require.NoError(t, err)
-		_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
+		_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
 			store, modelID, schemaVersion, "user", bytesUserType, nil)
 		require.NoError(t, err)
 
@@ -432,14 +474,14 @@ func TestFindLatestModel(t *testing.T) {
 		// write type "document"
 		bytesDocumentType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "document"})
 		require.NoError(t, err)
-		_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
+		_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
 			store, modelID, schemaVersion, "document", bytesDocumentType, nil)
 		require.NoError(t, err)
 
 		// write type "user"
 		bytesUserType, err := proto.Marshal(&openfgav1.TypeDefinition{Type: "user"})
 		require.NoError(t, err)
-		_, err = ds.primaryDB.ExecContext(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
+		_, err = ds.primaryDB.Exec(ctx, "INSERT INTO authorization_model (store, authorization_model_id, schema_version, type, type_definition, serialized_protobuf) VALUES ($1, $2, $3, $4, $5, $6)",
 			store, modelID, schemaVersion, "user", bytesUserType, nil)
 		require.NoError(t, err)
 
@@ -478,7 +520,7 @@ func TestAllowNullCondition(t *testing.T) {
 			condition_name, condition_context, inserted_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW());
 	`
-	_, err = ds.primaryDB.ExecContext(
+	_, err = ds.primaryDB.Exec(
 		ctx, stmt, "store", "folder", "2021-budget", "owner", "user:anne", "user",
 		ulid.Make().String(), nil, nil,
 	)
@@ -506,7 +548,7 @@ func TestAllowNullCondition(t *testing.T) {
 	require.Equal(t, tk, userTuple.GetKey())
 
 	tk2 := tuple.NewTupleKey("folder:2022-budget", "viewer", "user:anne")
-	_, err = ds.primaryDB.ExecContext(
+	_, err = ds.primaryDB.Exec(
 		ctx, stmt, "store", "folder", "2022-budget", "viewer", "user:anne", "userset",
 		ulid.Make().String(), nil, nil,
 	)
@@ -540,13 +582,13 @@ func TestAllowNullCondition(t *testing.T) {
 		condition_name, condition_context, inserted_at, operation
 	) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), $9);
 `
-	_, err = ds.primaryDB.ExecContext(
+	_, err = ds.primaryDB.Exec(
 		ctx, stmt, "store", "folder", "2021-budget", "owner", "user:anne",
 		ulid.Make().String(), nil, nil, openfgav1.TupleOperation_TUPLE_OPERATION_WRITE,
 	)
 	require.NoError(t, err)
 
-	_, err = ds.primaryDB.ExecContext(
+	_, err = ds.primaryDB.Exec(
 		ctx, stmt, "store", "folder", "2021-budget", "owner", "user:anne",
 		ulid.Make().String(), nil, nil, openfgav1.TupleOperation_TUPLE_OPERATION_DELETE,
 	)
@@ -581,7 +623,7 @@ func TestMarshalledAssertions(t *testing.T) {
 			store, authorization_model_id, assertions
 		) VALUES ($1, $2, DECODE('0a2b0a270a12666f6c6465723a323032312d62756467657412056f776e65721a0a757365723a616e6e657a1001','hex'));
 	`
-	_, err = ds.primaryDB.ExecContext(ctx, stmt, "store", "model")
+	_, err = ds.primaryDB.Exec(ctx, stmt, "store", "model")
 	require.NoError(t, err)
 
 	assertions, err := ds.ReadAssertions(ctx, "store", "model")

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -125,7 +125,7 @@ func NewWithDB(db *sql.DB, cfg *sqlcommon.Config) (*Datastore, error) {
 	}
 
 	stbl := sq.StatementBuilder.RunWith(db)
-	dbInfo := sqlcommon.NewDBInfo(db, stbl, HandleSQLError, "sqlite")
+	dbInfo := sqlcommon.NewDBInfo(stbl, HandleSQLError, "sqlite")
 
 	return &Datastore{
 		stbl:                   stbl,


### PR DESCRIPTION


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Currently, the PostgreSQL driver does not allow for finer control such as MaxConnLifetimeJitter, MinIdleConns, MinConns.  Fine tune control of these parameters allow more optimal performance for PostgreSQL

#### How is it being solved?
Switching driver to use [pgxpool](https://github.com/jackc/pgx/tree/master/pgxpool) instead of the standard pgx/sql.DB allows for more control. 

#### What changes are made to solve it?
Switching to use pgxpool for PostgreSQL.  In addition, introducing new configuration parameter such as OPENFGA_DATASTORE_MIN_IDLE_CONNS and OPENFGA_DATASTORE_MIN_OPEN_CONNS.  Note that these two parameters are only applicable for PostgreSQL for now.  


## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

