### PR TITLE
Fix the action used

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -1,16 +1,9 @@
 name: Claude Code PR Review
-
 on:
   issue_comment:
     types: [ created ]
   pull_request_review_comment:
     types: [ created ]
-  pull_request_review:
-    types: [ submitted ]
-
-permissions:
-  contents: read
-
 jobs:
   claude-review:
     permissions:
@@ -18,4 +11,4 @@ jobs:
       issues: write
       pull-requests: write
       id-token: write
-    uses: openfga/ai-pr-analyzer-gh-action/.github/workflows/claude-code-review.yml@707da7c9e19accae1bf9a5bac634e6f928067099
+    uses: auth0/auth0-ai-pr-analyzer-gh-action/.github/workflows/claude-code-review.yml@main


### PR DESCRIPTION
## Description
Fix action by pointing to the correct workflow to use Claude

## References
https://github.com/openfga/openfga/pull/2736

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated the automated code review workflow to a new action provider to streamline CI maintenance.
  * Simplified triggers by removing an unused review event while preserving comment-based triggers for PRs and issues.
  * Reduced unnecessary permissions for improved security.
  * Keeps PR analysis behavior intact with no impact on application features or performance.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->