### PR TITLE
release: update changelog for release `v1.10.3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 
 ## [1.10.3] - 2025-10-14
+### Changed
+- Remove zap type conversion on request logger [#2717](https://github.com/openfga/openfga/pull/2717)
+
 ### Fixed
 - Align datastore throttle configuration names with struct property names. [#2668](https://github.com/openfga/openfga/pull/2668)
 
@@ -16,7 +19,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Bumped the version of `openfga/language/pkg` to a version of the weighted graph that includes recursive relation detection. [#2716](https://github.com/openfga/openfga/pull/2716)
 - Log the reason on server failure start [#2703](https://github.com/openfga/openfga/pull/2703)
-- Remove zap type conversion on request logger [#2717](https://github.com/openfga/openfga/pull/2717)
 
 ### Fixed
 - Fixed a bug where experimental ReverseExpand constructed the underlying check relation incorrectly for intersection and exclusion in ListObjects. [#2721](https://github.com/openfga/openfga/pull/2721)


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.10.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Aligned datastore throttle configuration names for consistency, ensuring settings are recognized and applied as expected during throttling.

* Documentation
  * Added the 1.10.3 entry to the changelog with details of the fix.
  * Updated the Unreleased comparison to point from v1.10.3 to HEAD.
  * Added the v1.10.2…v1.10.3 comparison link and preserved existing release links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->