### PR TITLE
Revert "Revert "feat: add feature flag support (#2708)""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 ### Added
+- Added a default featureflags.Client to the server and ability to pass custom clients to the server via `server.WithFeatureFlagClient`. [#2708](https://github.com/openfga/openfga/pull/2708)
 - Enable planner for selecting check resolution strategies based on runtime statistics. [#2751](https://github.com/openfga/openfga/pull/2751)
 
 ### Fixed

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -505,10 +505,8 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		s.Logger.Info(fmt.Sprintf("🧪 experimental features enabled: %v", config.Experimentals))
 	}
 
-	var experimentals []server.ExperimentalFeatureFlag
-	for _, feature := range config.Experimentals {
-		experimentals = append(experimentals, server.ExperimentalFeatureFlag(feature))
-	}
+	var experimentals []string
+	experimentals = append(experimentals, config.Experimentals...)
 
 	datastore, continuationTokenSerializer, err := s.datastoreConfig(config)
 	if err != nil {

--- a/pkg/featureflags/client.go
+++ b/pkg/featureflags/client.go
@@ -1,0 +1,44 @@
+package featureflags
+
+type Client interface {
+	Boolean(flagName string, featureCtx map[string]any) bool
+}
+
+type defaultClient struct {
+	flags map[string]any
+}
+
+// NewDefaultClient creates a default feature flag client which takes in a static list of enabled feature flag names
+// and stores them as keys in a map.
+func NewDefaultClient(flags []string) Client {
+	enabledFlags := make(map[string]any, len(flags))
+	for _, flag := range flags {
+		enabledFlags[flag] = struct{}{}
+	}
+	return &defaultClient{
+		flags: enabledFlags,
+	}
+}
+
+func (c *defaultClient) Boolean(flagName string, featureCtx map[string]any) bool {
+	_, ok := c.flags[flagName]
+	return ok
+}
+
+type hardcodedBooleanClient struct {
+	result bool // this client will always return this result
+}
+
+// NewHardcodedBooleanClient creates a hardcodedBooleanClient which always returns the value of `result` it's given.
+// The hardcodedBooleanClient is used in testing and in shadow code paths where we want to force enable/disable a feature.
+func NewHardcodedBooleanClient(result bool) Client {
+	return &hardcodedBooleanClient{result: result}
+}
+
+func (h *hardcodedBooleanClient) Boolean(flagName string, featureCtx map[string]any) bool {
+	return h.result
+}
+
+func NewNoopFeatureFlagClient() Client {
+	return NewHardcodedBooleanClient(false)
+}

--- a/pkg/featureflags/client_test.go
+++ b/pkg/featureflags/client_test.go
@@ -1,0 +1,45 @@
+package featureflags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewDefaultClient checks if the provider is initialized correctly.
+func TestNewDefaultClient(t *testing.T) {
+	flags := []string{"test-flag-1", "test-flag-2"}
+	client := NewDefaultClient(flags).(*defaultClient)
+
+	require.Len(t, client.flags, len(flags))
+
+	for _, flag := range flags {
+		_, ok := client.flags[flag]
+		require.True(t, ok)
+	}
+}
+
+// TestBoolean tests the Boolean method of the defaultClient.
+func TestBoolean(t *testing.T) {
+	client := NewDefaultClient([]string{"enabled-flag", "another-enabled-flag"})
+
+	t.Run("enabled flag", func(t *testing.T) {
+		result := client.Boolean("enabled-flag", nil)
+		require.True(t, result)
+	})
+
+	t.Run("disabled flag", func(t *testing.T) {
+		result := client.Boolean("disabled-flag", nil)
+		require.False(t, result)
+	})
+
+	// The `featureCtx` is not used by this implementation, so we test that it doesn't affect the result.
+	t.Run("with feature context", func(t *testing.T) {
+		ctx := map[string]any{"user_id": "123", "plan": "premium"}
+		result := client.Boolean("enabled-flag", ctx)
+		require.True(t, result)
+
+		result = client.Boolean("disabled-flag", ctx)
+		require.False(t, result)
+	})
+}

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openfga/openfga/internal/utils/apimethod"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/telemetry"
 )
@@ -169,7 +170,7 @@ func (s *Server) getCheckResolverBuilder() *graph.CheckResolverOrderedBuilder {
 	return graph.NewOrderedCheckResolvers([]graph.CheckResolverOrderedBuilderOpt{
 		graph.WithLocalCheckerOpts([]graph.LocalCheckerOption{
 			graph.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
-			graph.WithOptimizations(s.IsExperimentallyEnabled(ExperimentalCheckOptimizations)),
+			graph.WithOptimizations(s.featureFlagClient.Boolean(serverconfig.ExperimentalCheckOptimizations, nil)),
 			graph.WithMaxResolutionDepth(s.resolveNodeLimit),
 			graph.WithPlanner(s.planner),
 			graph.WithUpstreamTimeout(s.requestTimeout),
@@ -177,7 +178,7 @@ func (s *Server) getCheckResolverBuilder() *graph.CheckResolverOrderedBuilder {
 		}...),
 		graph.WithLocalShadowCheckerOpts([]graph.LocalCheckerOption{
 			graph.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
-			graph.WithOptimizations(true),
+			graph.WithOptimizations(true), // shadow checker always uses optimizations
 			graph.WithMaxResolutionDepth(s.resolveNodeLimit),
 			graph.WithPlanner(s.planner),
 		}...),

--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -8,12 +8,14 @@ import (
 	"google.golang.org/grpc/status"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/featureflags"
 )
 
 func TestCheck_Validation(t *testing.T) {
 	t.Parallel()
 
-	testServer := &Server{}
+	testServer := &Server{featureFlagClient: featureflags.NewNoopFeatureFlagClient()}
 	ctx := t.Context()
 
 	tests := []struct {

--- a/pkg/server/commands/list_objects_shadow_test.go
+++ b/pkg/server/commands/list_objects_shadow_test.go
@@ -42,7 +42,6 @@ func TestNewShadowedListObjectsQuery(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		query := result.(*shadowedListObjectsQuery)
-		assert.False(t, query.main.(*ListObjectsQuery).optimizationsEnabled)
 		assert.False(t, query.main.(*ListObjectsQuery).useShadowCache)
 		assert.False(t, query.main.(*ListObjectsQuery).pipelineEnabled)
 		assert.False(t, query.shadow.(*ListObjectsQuery).optimizationsEnabled)

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/internal/shared"
 	"github.com/openfga/openfga/internal/throttler/threshold"
+	"github.com/openfga/openfga/pkg/featureflags"
 	"github.com/openfga/openfga/pkg/logger"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/storage"
@@ -896,10 +897,8 @@ func runOneBenchmark(
 ) {
 	if optimizationsEnabled {
 		name += "_with_optimization"
-		query.optimizationsEnabled = true
-	} else {
-		query.optimizationsEnabled = false
 	}
+	query.ff = featureflags.NewHardcodedBooleanClient(optimizationsEnabled)
 
 	if pipelineEnabled {
 		name += "_with_pipeline"
@@ -970,7 +969,7 @@ func BenchmarkListObjects(b *testing.B) {
 	query, err := NewListObjectsQuery(
 		datastore,
 		checkResolver,
-		WithListObjectsOptimizationsEnabled(true),
+		WithFeatureFlagClient(featureflags.NewHardcodedBooleanClient(true)),
 
 		// unlimited results, these tests are designed to return `n` results per iteration
 		WithListObjectsMaxResults(0),

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
@@ -2113,6 +2113,7 @@ func TestReverseExpandWithWeightedGraph(t *testing.T) {
 		// intersection with ttu recursive
 		// intersection with userset recursive
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			defer goleak.VerifyNone(t)
@@ -2564,6 +2565,7 @@ func TestIntersectionHandler(t *testing.T) {
 			// turn on weighted graph functionality
 			WithListObjectOptimizationsEnabled(true),
 		)
+
 		q.localCheckResolver = mockCheckResolver
 
 		node, ok := typesys.GetNode("document#admin")

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -101,6 +101,10 @@ const (
 
 	DefaultPlannerEvictionThreshold = 0
 	DefaultPlannerCleanupInterval   = 0
+
+	ExperimentalCheckOptimizations       = "enable-check-optimizations"
+	ExperimentalListObjectsOptimizations = "enable-list-objects-optimizations"
+	ExperimentalAccessControlParams      = "enable-access-control"
 )
 
 type DatastoreMetricsConfig struct {

--- a/pkg/server/list_objects.go
+++ b/pkg/server/list_objects.go
@@ -20,6 +20,7 @@ import (
 	"github.com/openfga/openfga/internal/utils/apimethod"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/telemetry"
 	"github.com/openfga/openfga/pkg/typesystem"
@@ -96,7 +97,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 		commands.WithMaxConcurrentReads(s.maxConcurrentReadsForListObjects),
 		commands.WithListObjectsCache(s.sharedDatastoreResources, s.cacheSettings),
 		commands.WithListObjectsDatastoreThrottler(s.listObjectsDatastoreThrottleThreshold, s.listObjectsDatastoreThrottleDuration),
-		commands.WithListObjectsOptimizationsEnabled(s.IsExperimentallyEnabled(ExperimentalListObjectsOptimizations)),
+		commands.WithFeatureFlagClient(s.featureFlagClient),
 	)
 	if err != nil {
 		return nil, serverErrors.NewInternalError("", err)
@@ -236,6 +237,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 		commands.WithResolveNodeLimit(s.resolveNodeLimit),
 		commands.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
 		commands.WithMaxConcurrentReads(s.maxConcurrentReadsForListObjects),
+		commands.WithFeatureFlagClient(s.featureFlagClient),
 	)
 	if err != nil {
 		return serverErrors.NewInternalError("", err)
@@ -292,7 +294,7 @@ func (s *Server) getListObjectsCheckResolverBuilder() *graph.CheckResolverOrdere
 	return graph.NewOrderedCheckResolvers([]graph.CheckResolverOrderedBuilderOpt{
 		graph.WithLocalCheckerOpts([]graph.LocalCheckerOption{
 			graph.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
-			graph.WithOptimizations(s.IsExperimentallyEnabled(ExperimentalCheckOptimizations)),
+			graph.WithOptimizations(s.featureFlagClient.Boolean(serverconfig.ExperimentalCheckOptimizations, nil)),
 			graph.WithMaxResolutionDepth(s.resolveNodeLimit),
 		}...),
 		graph.WithCachedCheckResolverOpts(s.cacheSettings.ShouldCacheCheckQueries(), checkCacheOptions...),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"sort"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/openfga/openfga/internal/utils/apimethod"
 	"github.com/openfga/openfga/pkg/authclaims"
 	"github.com/openfga/openfga/pkg/encoder"
+	"github.com/openfga/openfga/pkg/featureflags"
 	"github.com/openfga/openfga/pkg/gateway"
 	"github.com/openfga/openfga/pkg/logger"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
@@ -41,16 +41,11 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-type ExperimentalFeatureFlag string
-
 const (
 	AuthorizationModelIDHeader = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey    = "authorization_model_id"
 
-	ExperimentalCheckOptimizations       ExperimentalFeatureFlag = "enable-check-optimizations"
-	ExperimentalListObjectsOptimizations ExperimentalFeatureFlag = "enable-list-objects-optimizations"
-	ExperimentalAccessControlParams      ExperimentalFeatureFlag = "enable-access-control"
-	allowedLabel                                                 = "allowed"
+	allowedLabel = "allowed"
 )
 
 var tracer = otel.Tracer("openfga/pkg/server")
@@ -172,10 +167,11 @@ type Server struct {
 	maxConcurrentReadsForListUsers   uint32
 	maxAuthorizationModelCacheSize   int
 	maxAuthorizationModelSizeInBytes int
-	experimentals                    []ExperimentalFeatureFlag
+	experimentals                    []string
 	AccessControl                    serverconfig.AccessControlConfig
 	AuthnMethod                      string
 	serviceName                      string
+	featureFlagClient                featureflags.Client
 
 	// NOTE don't use this directly, use function resolveTypesystem. See https://github.com/openfga/openfga/issues/1527
 	typesystemResolver     typesystem.TypesystemResolverFunc
@@ -392,9 +388,20 @@ func WithMaxConcurrentReadsForListUsers(maxConcurrentReadsForListUsers uint32) O
 	}
 }
 
-func WithExperimentals(experimentals ...ExperimentalFeatureFlag) OpenFGAServiceV1Option {
+func WithExperimentals(experimentals ...string) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.experimentals = experimentals
+	}
+}
+
+func WithFeatureFlagClient(client featureflags.Client) OpenFGAServiceV1Option {
+	return func(s *Server) {
+		if client != nil {
+			s.featureFlagClient = client
+			return
+		}
+
+		s.featureFlagClient = featureflags.NewNoopFeatureFlagClient()
 	}
 }
 
@@ -587,13 +594,10 @@ func MustNewServerWithOpts(opts ...OpenFGAServiceV1Option) *Server {
 	return s
 }
 
-func (s *Server) IsExperimentallyEnabled(flag ExperimentalFeatureFlag) bool {
-	return slices.Contains(s.experimentals, flag)
-}
-
 // IsAccessControlEnabled returns true if the access control feature is enabled.
 func (s *Server) IsAccessControlEnabled() bool {
-	return s.IsExperimentallyEnabled(ExperimentalAccessControlParams) && s.AccessControl.Enabled
+	isEnabled := s.featureFlagClient.Boolean(serverconfig.ExperimentalAccessControlParams, nil)
+	return isEnabled && s.AccessControl.Enabled
 }
 
 // WithListObjectsDispatchThrottlingEnabled sets whether dispatch throttling is enabled for List Objects requests.
@@ -829,7 +833,7 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		maxConcurrentReadsForListUsers:   serverconfig.DefaultMaxConcurrentReadsForListUsers,
 		maxAuthorizationModelSizeInBytes: serverconfig.DefaultMaxAuthorizationModelSizeInBytes,
 		maxAuthorizationModelCacheSize:   serverconfig.DefaultMaxAuthorizationModelCacheSize,
-		experimentals:                    make([]ExperimentalFeatureFlag, 0, 10),
+		experimentals:                    make([]string, 0, 10),
 		AccessControl:                    serverconfig.AccessControlConfig{Enabled: false, StoreID: "", ModelID: ""},
 
 		cacheSettings: serverconfig.NewDefaultCacheSettings(),
@@ -905,6 +909,10 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 
 	if s.listUsersDispatchThrottlingMaxThreshold != 0 && s.listUsersDispatchDefaultThreshold > s.listUsersDispatchThrottlingMaxThreshold {
 		return nil, fmt.Errorf("ListUsers default dispatch throttling threshold must be equal or smaller than max dispatch threshold for ListUsers")
+	}
+
+	if s.featureFlagClient == nil {
+		s.featureFlagClient = featureflags.NewDefaultClient(s.experimentals)
 	}
 
 	err := s.validateAccessControlEnabled()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/openfga/openfga/internal/cachecontroller"
 	"github.com/openfga/openfga/internal/graph"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/pkg/featureflags"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/test"
@@ -196,7 +197,7 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 			_ = MustNewServerWithOpts(
 				WithDatastore(mockDatastore),
-				WithExperimentals(ExperimentalAccessControlParams),
+				WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 				WithAccessControlParams(true, "", "", ""),
 			)
 		})
@@ -209,7 +210,7 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 			_ = MustNewServerWithOpts(
 				WithDatastore(mockDatastore),
-				WithExperimentals(ExperimentalAccessControlParams),
+				WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 				WithAccessControlParams(true, ulid.Make().String(), ulid.Make().String(), ""),
 			)
 		})
@@ -222,7 +223,7 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 			_ = MustNewServerWithOpts(
 				WithDatastore(mockDatastore),
-				WithExperimentals(ExperimentalAccessControlParams),
+				WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 				WithAccessControlParams(true, "not-a-valid-ulid", ulid.Make().String(), "oidc"),
 			)
 		})
@@ -235,7 +236,7 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 			_ = MustNewServerWithOpts(
 				WithDatastore(mockDatastore),
-				WithExperimentals(ExperimentalAccessControlParams),
+				WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 				WithAccessControlParams(true, ulid.Make().String(), "not-a-valid-ulid", "oidc"),
 			)
 		})
@@ -383,7 +384,6 @@ func TestServerPanicIfDefaultListUsersThresholdGreaterThanMaxDispatchThreshold(t
 		)
 	})
 }
-
 func TestServerWithPostgresDatastore(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
@@ -1917,45 +1917,32 @@ func TestDelegateCheckResolver(t *testing.T) {
 	})
 }
 
-func TestIsExperimentallyEnabled(t *testing.T) {
+func TestWithFeatureFlagClient(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
 	})
 	ds := memory.New() // Datastore required for server instantiation
-	someExperimentalFlag := ExperimentalFeatureFlag("some-experimental-feature-to-enable")
 	t.Cleanup(ds.Close)
 
-	t.Run("returns_false_if_experimentals_is_empty", func(t *testing.T) {
-		s := MustNewServerWithOpts(WithDatastore(ds))
-		t.Cleanup(s.Close)
-		require.False(t, s.IsExperimentallyEnabled(someExperimentalFlag))
-	})
-
-	t.Run("returns_true_if_experimentals_has_matching_element", func(t *testing.T) {
+	t.Run("it_initializes_a_noop_client_if_no_client_passed", func(t *testing.T) {
 		s := MustNewServerWithOpts(
 			WithDatastore(ds),
-			WithExperimentals(someExperimentalFlag),
+			WithFeatureFlagClient(nil),
 		)
 		t.Cleanup(s.Close)
-		require.True(t, s.IsExperimentallyEnabled(someExperimentalFlag))
+		// NoopClient() always false
+		require.False(t, s.featureFlagClient.Boolean("should-be-false", nil))
 	})
 
-	t.Run("returns_true_if_experimentals_has_matching_element_and_other_matching_element", func(t *testing.T) {
-		s := MustNewServerWithOpts(
-			WithDatastore(ds),
-			WithExperimentals(someExperimentalFlag, ExperimentalFeatureFlag("some-other-feature")),
-		)
-		t.Cleanup(s.Close)
-		require.True(t, s.IsExperimentallyEnabled(someExperimentalFlag))
-	})
-
-	t.Run("returns_false_if_experimentals_has_no_matching_element", func(t *testing.T) {
-		s := MustNewServerWithOpts(
-			WithDatastore(ds),
-			WithExperimentals(ExperimentalFeatureFlag("some-other-feature")),
-		)
-		t.Cleanup(s.Close)
-		require.False(t, s.IsExperimentallyEnabled(someExperimentalFlag))
+	t.Run("if_a_client_is_provided", func(t *testing.T) {
+		t.Run("it_uses_it", func(t *testing.T) {
+			s := MustNewServerWithOpts(
+				WithDatastore(ds),
+				WithFeatureFlagClient(featureflags.NewHardcodedBooleanClient(true)),
+			)
+			t.Cleanup(s.Close)
+			require.True(t, s.featureFlagClient.Boolean("should-be-true", nil))
+		})
 	})
 }
 
@@ -1969,7 +1956,7 @@ func TestIsAccessControlEnabled(t *testing.T) {
 	t.Run("returns_false_if_experimentals_does_not_have_access_control", func(t *testing.T) {
 		s := MustNewServerWithOpts(
 			WithDatastore(ds),
-			WithExperimentals(ExperimentalFeatureFlag("some-other-feature")),
+			WithExperimentals("some-other-feature"),
 			WithAccessControlParams(true, "some-model-id", "some-store-id", ""),
 		)
 		t.Cleanup(s.Close)
@@ -1979,7 +1966,7 @@ func TestIsAccessControlEnabled(t *testing.T) {
 	t.Run("returns_false_if_access_control_is_disabled", func(t *testing.T) {
 		s := MustNewServerWithOpts(
 			WithDatastore(ds),
-			WithExperimentals(ExperimentalAccessControlParams),
+			WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 			WithAccessControlParams(false, "some-model-id", "some-store-id", ""),
 		)
 		t.Cleanup(s.Close)
@@ -1989,7 +1976,7 @@ func TestIsAccessControlEnabled(t *testing.T) {
 	t.Run("returns_true_if_access_control_is_enabled", func(t *testing.T) {
 		s := MustNewServerWithOpts(
 			WithDatastore(ds),
-			WithExperimentals(ExperimentalAccessControlParams),
+			WithExperimentals(serverconfig.ExperimentalAccessControlParams),
 			WithAccessControlParams(true, ulid.Make().String(), ulid.Make().String(), "oidc"),
 		)
 		t.Cleanup(s.Close)

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openfga/openfga/cmd/run"
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/logger"
-	"github.com/openfga/openfga/pkg/server"
 	"github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -52,7 +51,7 @@ func runMatrixWithEngine(t *testing.T, engine string) {
 		goleak.VerifyNone(t)
 	})
 
-	clientWithExperimentals := tests.BuildClientInterface(t, engine, []string{string(server.ExperimentalCheckOptimizations)})
+	clientWithExperimentals := tests.BuildClientInterface(t, engine, []string{config.ExperimentalCheckOptimizations})
 	RunMatrixTests(t, engine, true, clientWithExperimentals)
 
 	clientWithoutExperimentals := tests.BuildClientInterface(t, engine, []string{})
@@ -331,7 +330,7 @@ func testRunAll(t *testing.T, engine string) {
 		goleak.VerifyNone(t)
 	})
 	cfg := config.MustDefaultConfig()
-	cfg.Experimentals = append(cfg.Experimentals, string(server.ExperimentalCheckOptimizations))
+	cfg.Experimentals = append(cfg.Experimentals, config.ExperimentalCheckOptimizations)
 	cfg.Log.Level = "error"
 	cfg.Datastore.Engine = engine
 	// extend the timeout for the tests, coverage makes them slower


### PR DESCRIPTION
Reverts openfga/openfga#2759

We added FF support yesterday and then reverted it shortly thereafter.

This PR is a revert of the revert, which means it's the same as applying [the original PR](https://github.com/openfga/openfga/pull/2708)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a feature flags system for managing experimental features, with ability to inject custom feature flag clients.
  * Added three new experimental feature flags: Check Optimizations, List Objects Optimizations, and Access Control Parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->