### PR TITLE
release: update changelog for release `v1.11.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.11.0] - 2025-11-05
 ### Added
 - **Breaking**: Update PostgreSQL to use [pgxpool](https://pkg.go.dev/github.com/jackc/pgx/v5/pgxpool) instead of `database/sql` to allow for finer PostgreSQL connection control. [#2734](https://github.com/openfga/openfga/pull/2734), [#2789](https://github.com/openfga/openfga/pull/2789).
 
@@ -1469,7 +1471,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.10.5...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/openfga/openfga/compare/v1.10.5...v1.11.0
 [1.10.5]: https://github.com/openfga/openfga/compare/v1.10.4...v1.10.5
 [1.10.4]: https://github.com/openfga/openfga/compare/v1.10.3...v1.10.4
 [1.10.3]: https://github.com/openfga/openfga/compare/v1.10.2...v1.10.3


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.11.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Released version 1.11.0 with updated release information.
  * **Breaking Change:** PostgreSQL dependency upgraded to pgxpool. Users must review upgrade requirements before updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->