### PR TITLE
Revert "fix: if LastInvalidationTime.IsZero(), ignore cache"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - **Breaking**: Update PostgreSQL to use [pgxpool](https://pkg.go.dev/github.com/jackc/pgx/v5/pgxpool) instead of `database/sql` to allow for finer PostgreSQL connection control. [#2734](https://github.com/openfga/openfga/pull/2734), [#2789](https://github.com/openfga/openfga/pull/2789).
 
-### Fixed
-- Adjusted for missing or expired ChangelogCache entry in CacheController. [#2779](https://github.com/openfga/openfga/pull/2779)
-
 ## [1.10.5] - 2025-11-05
 ### Added
 - Added `datastore_throttling` feature flag to enable/disable new throttling mechanism. [#2780](https://github.com/openfga/openfga/pull/2780), [#2781](https://github.com/openfga/openfga/pull/2781)

--- a/internal/cachecontroller/cache_controller.go
+++ b/internal/cachecontroller/cache_controller.go
@@ -67,12 +67,10 @@ type CacheController interface {
 	InvalidateIfNeeded(context.Context, string)
 }
 
-type NoopCacheController struct {
-	InvalidationTime time.Time // only passed in tests
-}
+type NoopCacheController struct{}
 
 func (c *NoopCacheController) DetermineInvalidationTime(_ context.Context, _ string) time.Time {
-	return c.InvalidationTime
+	return time.Time{}
 }
 
 func (c *NoopCacheController) InvalidateIfNeeded(_ context.Context, _ string) {

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -158,7 +158,7 @@ func (c *CachedCheckResolver) ResolveCheck(
 
 	tryCache := req.Consistency != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 
-	if tryCache && !req.LastCacheInvalidationTime.IsZero() {
+	if tryCache {
 		checkCacheTotalCounter.Inc()
 		if cachedResp := c.cache.Get(cacheKey); cachedResp != nil {
 			res := cachedResp.(*CheckResponseCacheEntry)

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -453,12 +453,7 @@ func TestResolveCheckFromCache(t *testing.T) {
 				require.Equal(t, result.Allowed, actualResult.Allowed)
 			}
 
-			subsequentParams := *test.subsequentReqParams
-
-			// Ensure cached entry is newer than the most recent non-zero invalidation time
-			subsequentParams.LastCacheInvalidationTime = time.Now().Add(-1 * time.Minute)
-
-			subsequentRequest, err := NewResolveCheckRequest(subsequentParams)
+			subsequentRequest, err := NewResolveCheckRequest(*test.subsequentReqParams)
 			require.NoError(t, err)
 
 			test.setTestExpectations(mockResolver, subsequentRequest)
@@ -503,12 +498,12 @@ func TestResolveCheck_ConcurrentCachedReadsAndWrites(t *testing.T) {
 		var err1, err2 error
 		go func() {
 			defer wg.Done()
-			resp1, err1 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{LastCacheInvalidationTime: time.Now().Add(-1 * time.Minute)})
+			resp1, err1 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
 		}()
 
 		go func() {
 			defer wg.Done()
-			resp2, err2 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{LastCacheInvalidationTime: time.Now().Add(-1 * time.Minute)})
+			resp2, err2 = dut.ResolveCheck(context.Background(), &ResolveCheckRequest{})
 		}()
 
 		wg.Wait()

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -415,7 +415,6 @@ func (q *ListObjectsQuery) evaluate(
 					resp, checkRequestMetadata, err := NewCheckCommand(q.datastore, q.checkResolver, typesys,
 						WithCheckCommandLogger(q.logger),
 						WithCheckCommandMaxConcurrentReads(q.maxConcurrentReads),
-						WithCheckCommandCache(q.sharedDatastoreResources, q.cacheSettings),
 						WithCheckDatastoreThrottler(
 							q.datastoreThrottlingEnabled,
 							q.datastoreThrottleThreshold,

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -18,7 +18,6 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 
-	"github.com/openfga/openfga/internal/cachecontroller"
 	internalErrors "github.com/openfga/openfga/internal/errors"
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/internal/mocks"
@@ -389,26 +388,10 @@ func TestDoesNotUseCacheWhenHigherConsistencyEnabled(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(checkResolverCloser)
 
-	cacheSettings := serverconfig.CacheSettings{
-		CacheControllerEnabled: true,
-		CacheControllerTTL:     1 * time.Minute,
-		CheckCacheLimit:        1000,
-	}
-
-	sharedResources, err := shared.NewSharedDatastoreResources(
-		ctx,
-		&singleflight.Group{},
-		ds,
-		cacheSettings,
-		shared.WithCacheController(&cachecontroller.NoopCacheController{InvalidationTime: time.Now().Add(-1 * time.Second)}),
-	)
-	require.NoError(t, err)
-
 	q, _ := NewListObjectsQuery(
 		ds,
 		checkResolver,
 		fakeStoreID,
-		WithListObjectsCache(sharedResources, cacheSettings),
 	)
 
 	// Run a check with MINIMIZE_LATENCY that will use the cache we added with 2 tuples
@@ -550,12 +533,10 @@ func TestAttemptsToInvalidateWhenIteratorCacheIsEnabled(t *testing.T) {
 
 		// Need to make sure list objects attempts to invalidate when cache is enabled
 		mockCacheController := mocks.NewMockCacheController(ctrl)
-		mockCacheController.EXPECT().DetermineInvalidationTime(gomock.Any(), gomock.Any()).AnyTimes()
-		mockCacheController.EXPECT().InvalidateIfNeeded(gomock.Any(), gomock.Any()).AnyTimes()
+		mockCacheController.EXPECT().InvalidateIfNeeded(gomock.Any(), gomock.Any()).Times(1)
 
 		mockShadowCacheController := mocks.NewMockCacheController(ctrl)
-		mockShadowCacheController.EXPECT().DetermineInvalidationTime(gomock.Any(), gomock.Any()).AnyTimes()
-		mockShadowCacheController.EXPECT().InvalidateIfNeeded(gomock.Any(), gomock.Any()).AnyTimes()
+		mockShadowCacheController.EXPECT().InvalidateIfNeeded(gomock.Any(), gomock.Any()).Times(1)
 
 		cacheSettings := serverconfig.CacheSettings{
 			ListObjectsIteratorCacheEnabled:    true,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1207,172 +1207,54 @@ func TestCheckWithCachedResolution(t *testing.T) {
 	tk := tuple.NewCheckRequestTupleKey("repo:openfga", "reader", "user:mike")
 	returnedTuple := &openfgav1.Tuple{Key: tuple.ConvertCheckRequestTupleKeyToTupleKey(tk)}
 
-	t.Run("when last invalidation time is non-zero and before cache entry, cache is used", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
 
-		mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+	mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
 
-		mockDatastore.EXPECT().
-			ReadAuthorizationModel(gomock.Any(), storeID, modelID).
-			AnyTimes().
-			Return(&openfgav1.AuthorizationModel{
-				SchemaVersion:   typesystem.SchemaVersion1_1,
-				TypeDefinitions: typedefs,
-				Id:              modelID,
-			}, nil)
+	mockDatastore.EXPECT().
+		ReadAuthorizationModel(gomock.Any(), storeID, modelID).
+		AnyTimes().
+		Return(&openfgav1.AuthorizationModel{
+			SchemaVersion:   typesystem.SchemaVersion1_1,
+			TypeDefinitions: typedefs,
+			Id:              modelID,
+		}, nil)
 
-		mockDatastore.EXPECT().
-			ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Times(1).
-			Return(returnedTuple, nil)
+	mockDatastore.EXPECT().
+		ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+		Times(1).
+		Return(returnedTuple, nil)
 
-		s := MustNewServerWithOpts(
-			WithDatastore(mockDatastore),
-			WithCheckQueryCacheEnabled(true),
-			WithCheckCacheLimit(10),
-			WithCheckQueryCacheTTL(1*time.Minute),
-		)
-
-		s.sharedDatastoreResources.CacheController = &cachecontroller.NoopCacheController{
-			InvalidationTime: time.Now(), // This will be before check caches anything, so cache will be valid
-		}
-
-		t.Cleanup(func() {
-			mockDatastore.EXPECT().Close().Times(1)
-			s.Close()
-		})
-
-		checkResponse, err := s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
-
-		// If we check for the same request, data should come from cache and number of ReadUserTuple should still be 1
-		checkResponse, err = s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
+	s := MustNewServerWithOpts(
+		WithDatastore(mockDatastore),
+		WithCheckQueryCacheEnabled(true),
+		WithCheckCacheLimit(10),
+		WithCheckQueryCacheTTL(1*time.Minute),
+	)
+	t.Cleanup(func() {
+		mockDatastore.EXPECT().Close().Times(1)
+		s.Close()
 	})
 
-	t.Run("when last invalidation time is after cache entry's timestamp, cache is not used", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
-
-		mockDatastore.EXPECT().
-			ReadAuthorizationModel(gomock.Any(), storeID, modelID).
-			AnyTimes().
-			Return(&openfgav1.AuthorizationModel{
-				SchemaVersion:   typesystem.SchemaVersion1_1,
-				TypeDefinitions: typedefs,
-				Id:              modelID,
-			}, nil)
-
-		mockDatastore.EXPECT().
-			ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Times(2). // both requests should read from the DB
-			Return(returnedTuple, nil)
-
-		s := MustNewServerWithOpts(
-			WithDatastore(mockDatastore),
-			WithCheckQueryCacheEnabled(true),
-			WithCheckCacheLimit(10),
-			WithCheckQueryCacheTTL(1*time.Minute),
-		)
-
-		s.sharedDatastoreResources.CacheController = &cachecontroller.NoopCacheController{
-			InvalidationTime: time.Now().Add(10 * time.Second),
-		}
-
-		t.Cleanup(func() {
-			mockDatastore.EXPECT().Close().Times(1)
-			s.Close()
-		})
-
-		checkResponse, err := s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
-
-		// If we check for the same request, data should come from cache and number of ReadUserTuple should still be 1
-		checkResponse, err = s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
+	checkResponse, err := s.Check(ctx, &openfgav1.CheckRequest{
+		StoreId:              storeID,
+		TupleKey:             tk,
+		AuthorizationModelId: modelID,
 	})
 
-	t.Run("when last invalidation time.IsZero(), cache is skipped", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
+	require.NoError(t, err)
+	require.True(t, checkResponse.GetAllowed())
 
-		mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
-
-		mockDatastore.EXPECT().
-			ReadAuthorizationModel(gomock.Any(), storeID, modelID).
-			AnyTimes().
-			Return(&openfgav1.AuthorizationModel{
-				SchemaVersion:   typesystem.SchemaVersion1_1,
-				TypeDefinitions: typedefs,
-				Id:              modelID,
-			}, nil)
-
-		mockDatastore.EXPECT().
-			ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Times(2). // both requests should read from the DB
-			Return(returnedTuple, nil)
-
-		s := MustNewServerWithOpts(
-			WithDatastore(mockDatastore),
-			WithCheckQueryCacheEnabled(true),
-			WithCheckCacheLimit(10),
-			WithCheckQueryCacheTTL(1*time.Minute),
-		)
-
-		// Defaults to returning time zero, check should bypass the cache and read from the DB both times
-		s.sharedDatastoreResources.CacheController = &cachecontroller.NoopCacheController{}
-
-		t.Cleanup(func() {
-			mockDatastore.EXPECT().Close().Times(1)
-			s.Close()
-		})
-
-		checkResponse, err := s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
-
-		// If we check for the same request, data should come from cache and number of ReadUserTuple should still be 1
-		checkResponse, err = s.Check(ctx, &openfgav1.CheckRequest{
-			StoreId:              storeID,
-			TupleKey:             tk,
-			AuthorizationModelId: modelID,
-		})
-
-		require.NoError(t, err)
-		require.True(t, checkResponse.GetAllowed())
+	// If we check for the same request, data should come from cache and number of ReadUserTuple should still be 1
+	checkResponse, err = s.Check(ctx, &openfgav1.CheckRequest{
+		StoreId:              storeID,
+		TupleKey:             tk,
+		AuthorizationModelId: modelID,
 	})
+
+	require.NoError(t, err)
+	require.True(t, checkResponse.GetAllowed())
 }
 
 func TestResolveAuthorizationModel(t *testing.T) {


### PR DESCRIPTION
Reverts openfga/openfga#2779

That PR has an implicit assumption that the CacheController will always be used, which is incorrect, and could lead to an entirely unused check cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved caching logic to attempt cache lookups more broadly, removing dependency on specific invalidation timestamp requirements.

* **Tests**
  * Simplified cache-related tests to reflect updated caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->