### PR TITLE
chore: update NewPgxTxnGetRows to allow for more flexible statement builder

### DIFF
--- a/pkg/storage/postgres/pgxpool_iter_query.go
+++ b/pkg/storage/postgres/pgxpool_iter_query.go
@@ -34,7 +34,7 @@ type PgxTxnIterQuery struct {
 
 var _ sqlcommon.SQLIteratorRowGetter = (*PgxTxnIterQuery)(nil)
 
-// NewPgxTxnGetRows creates a PgxPoolIterQuery which allows the GetRows functionality via the specified PgxQuery txn.
+// NewPgxTxnGetRows creates a PgxTxnIterQuery which allows the GetRows functionality via the specified PgxQuery txn.
 func NewPgxTxnGetRows(txn PgxQuery, sb SQLBuilder) (*PgxTxnIterQuery, error) {
 	stmt, args, err := sb.ToSql()
 	if err != nil {


### PR DESCRIPTION
## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Chore of update postgres.NewPgxTxnGetRows to allow for more flexible squirrel statement builder (not just select) 

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal query handling updated to use a generic SQL-capable interface and remove a legacy SQL builder dependency.
  * Public-facing function signatures adjusted to accept the new interface (no behavioral changes at runtime).
  * No user-visible functionality changes; this simplifies internal SQL generation while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->