### PR TITLE
Chore: Tidy up git workflow & dependabot configs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "gomod"
     directory: "/tools"
@@ -19,6 +21,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -28,6 +32,8 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -37,3 +43,5 @@ updates:
       dependencies:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/create-release-tag.yaml
+++ b/.github/workflows/create-release-tag.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Check if PR author is a maintainer
         run: |
-          pr_author="${{ github.event.pull_request.user.login }}"
+          pr_author="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
           permission=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "https://api.github.com/repos/${{ github.repository }}/collaborators/$pr_author/permission" | jq -r .permission)
 
@@ -34,6 +34,8 @@ jobs:
             echo "$pr_author is NOT a maintainer. Exiting..."
             exit 1
           fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Create new tag
@@ -59,7 +61,7 @@ jobs:
             tag_name="v$tag_name"
           fi
           echo "Creating a new tag $tag_name..."
-          SHA=${{ github.event.pull_request.merge_commit_sha }}
+          SHA=${GITHUB_EVENT_PULL_REQUEST_MERGE_COMMIT_SHA}
           response=$(curl -s -o response.json -w "%{http_code}" -X POST -H "Authorization: token ${{ secrets.GORELEASER_GITHUB_TOKEN }}" \
             -d "{\"ref\":\"refs/tags/$tag_name\", \"sha\":\"$SHA\"}" \
             https://api.github.com/repos/${{ github.repository }}/git/refs)
@@ -70,3 +72,5 @@ jobs:
           else
             cat response.json
           fi
+        env:
+          GITHUB_EVENT_PULL_REQUEST_MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -67,6 +67,7 @@ jobs:
           go-version-file: './go.mod'
           cache-dependency-path: './go.sum'
           check-latest: true
+          cache: false
 
       - id: go-cache-paths
         name: Get Go cache paths
@@ -138,6 +139,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0 # to be able to retrieve the last commit in main
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0

--- a/.github/workflows/release-nightly.yaml
+++ b/.github/workflows/release-nightly.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -24,6 +25,7 @@ jobs:
           go-version-file: "./go.mod"
           cache-dependency-path: './go.sum'
           check-latest: true
+          cache: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
@@ -37,6 +38,7 @@ jobs:
           go-version-file: './go.mod'
           cache-dependency-path: './go.sum'
           check-latest: true
+          cache: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -170,7 +172,8 @@ jobs:
   verification-with-slsa-verifier:
     needs: [ goreleaser, binary-provenance ]
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions:
+      contents: read # To download assets from a release.
     steps:
       - name: Install the verifier
         uses: slsa-framework/slsa-verifier/actions/installer@ea584f4502babc6f60d9bc799dbbb13c1caa9ee6 # pin@v2.7.1
@@ -197,7 +200,7 @@ jobs:
   verification-with-cosign:
     needs: [ goreleaser, image-provenance ]
     runs-on: ubuntu-latest
-    permissions: read-all
+    permissions: {}
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0


### PR DESCRIPTION
This PR is a small collection of tweaks:
- add a 7-day cooldown period to dependabot so we give upstream releases some time to settle before updating
- pass github-provided variables through environment to prevent injection attacks
- disable persistent credentials and go module cache
- remove unnecessary permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented a 7-day cooldown for automated dependency updates to reduce update frequency
  * Strengthened CI/CD security by disabling credential persistence and restricting workflow permissions
  * Optimized CI/CD workflow efficiency through selective caching adjustments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->