### PR TITLE
fix: remove LOCK=NONE from MySQL migration 007 for Percona XtraDB Cluster compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 
+### Fixed
+- MySQL migration 007 now works with Percona XtraDB Cluster by removing unsupported `LOCK=NONE` clauses from index operations. [#2903](https://github.com/openfga/openfga/pull/2903)
+
 ## [1.11.3] - 2026-01-28
 ### Added
 - Add configuration option to limit max type system cache size. [2744](https://github.com/openfga/openfga/pull/2744)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
-
 ### Fixed
 - MySQL migration 007 now works with Percona XtraDB Cluster by removing unsupported `LOCK=NONE` clauses from index operations. [#2903](https://github.com/openfga/openfga/pull/2903)
 

--- a/assets/migrations/mysql/007_collate_object_id.sql
+++ b/assets/migrations/mysql/007_collate_object_id.sql
@@ -2,14 +2,14 @@
 ALTER TABLE tuple MODIFY COLUMN object_id VARCHAR(255) COLLATE utf8mb4_bin,
 LOCK = SHARED;
 
-CREATE INDEX idx_user_lookup ON tuple (store, _user, relation, object_type, object_id) LOCK = NONE;
+CREATE INDEX idx_user_lookup ON tuple (store, _user, relation, object_type, object_id);
 
-DROP INDEX idx_reverse_lookup_user ON tuple LOCK = NONE;
+DROP INDEX idx_reverse_lookup_user ON tuple;
 
 -- +goose Down
-DROP INDEX idx_user_lookup on tuple LOCK = NONE;
+DROP INDEX idx_user_lookup on tuple;
 
 ALTER TABLE tuple MODIFY COLUMN object_id VARCHAR(255),
 LOCK = SHARED;
 
-CREATE INDEX idx_reverse_lookup_user ON tuple (store, object_type, relation, _user) LOCK = NONE;
+CREATE INDEX idx_reverse_lookup_user ON tuple (store, object_type, relation, _user);


### PR DESCRIPTION
## Description

This PR removes `LOCK=NONE` clauses from MySQL migration `007_collate_object_id.sql` to improve compatibility with Percona XtraDB Cluster (PXC).

### Problem

When deploying OpenFGA with a MySQL-compatible backend using Percona XtraDB Cluster, migration 007 fails with:

```
ERROR 1845 (0A000): LOCK=NONE is not supported for this operation. Try LOCK=SHARED.
```

PXC has stricter requirements for DDL operations due to synchronous replication, and explicitly rejects `LOCK=NONE` for certain operations.

### Solution

Remove `LOCK=NONE` from `CREATE INDEX` and `DROP INDEX` statements. This is safe because:

1. **No behavior change for standard MySQL/InnoDB**: MySQL uses `LOCK=NONE` as the default for secondary index operations anyway, so omitting it results in the same online DDL behavior.

2. **Consistent with existing migrations**: Other OpenFGA MySQL migrations (e.g., `003_add_reverse_lookup_index.sql`) already create/drop indexes without specifying `LOCK` clauses.

3. **Improves compatibility**: Works correctly on standard MySQL, MariaDB, and Percona XtraDB Cluster.

### Changes

- Removed `LOCK = NONE` from `CREATE INDEX idx_user_lookup` (goose Up)
- Removed `LOCK = NONE` from `DROP INDEX idx_reverse_lookup_user` (goose Up)
- Removed `LOCK = NONE` from `DROP INDEX idx_user_lookup` (goose Down)
- Removed `LOCK = NONE` from `CREATE INDEX idx_reverse_lookup_user` (goose Down)

Note: `LOCK = SHARED` is retained for `ALTER TABLE` operations as this is supported by PXC.

Fixes #2902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified database migration procedures by removing locking hints from index operations. This streamlines both index creation and removal across forward and rollback migration paths, potentially reducing deployment overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->