### PR TITLE
fix: ensure the count of datastore throttled requests is accurately reported

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -665,6 +665,7 @@ func (q *ListObjectsQuery) Execute(
 		}
 
 		dsMeta := ds.GetMetadata()
+		res.ResolutionMetadata.DatastoreThrottled.Store(dsMeta.WasThrottled)
 		res.ResolutionMetadata.DatastoreQueryCount.Add(dsMeta.DatastoreQueryCount)
 		res.ResolutionMetadata.DatastoreItemCount.Add(dsMeta.DatastoreItemCount)
 		return &res, nil
@@ -867,6 +868,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 		}
 
 		dsMeta := ds.GetMetadata()
+		resolutionMetadata.DatastoreThrottled.Store(dsMeta.WasThrottled)
 		resolutionMetadata.DatastoreQueryCount.Add(dsMeta.DatastoreQueryCount)
 		resolutionMetadata.DatastoreItemCount.Add(dsMeta.DatastoreItemCount)
 		return &resolutionMetadata, nil


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
This PR fixes a bug where datastore throttled requests are not accurately accounted for when using the list objects pipeline algorithm.

#### What problem is being solved?
Currently, the count of datastore throttled requests is not properly reported for the list objects pipeline algorithm.

#### How is it being solved?
The appropriate signal from the datastore request metadata is now propagated up to the list objects response when using the pipeline algorithm.

#### What changes are made to solve it?
The `WasThrottled` field of the `storagewrappers.Metadata` type is not propagated to the list objects response metadata through the `DatastoreThrottled` field.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced datastore throttling information tracking across list object query execution paths for improved monitoring and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->