### PR TITLE
new: add selected stategy counter for visibility into dynamic query t…

### DIFF
--- a/internal/planner/plan.go
+++ b/internal/planner/plan.go
@@ -76,7 +76,10 @@ func (kp *keyPlan) Select(resolvers map[string]*PlanConfig) *PlanConfig {
 	}
 
 	selected := resolvers[bestResolver]
-	strategySelectedCounter.WithLabelValues(selected.Name).Inc()
+	if selected != nil {
+		strategySelectedCounter.WithLabelValues(selected.Name).Inc()
+	}
+
 	return selected
 }
 

--- a/internal/planner/plan.go
+++ b/internal/planner/plan.go
@@ -5,7 +5,18 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/openfga/openfga/internal/build"
 )
+
+var strategySelectedCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: build.ProjectName,
+	Name:      "planner_strategy_selected_count",
+	Help:      "The total number of times each traversal strategy was selected by the query planner.",
+}, []string{"strategy"})
 
 // keyPlan manages the statistics for a single key and makes decisions about its resolvers.
 // This struct is now entirely lock-free, using a sync.Map to manage its stats.
@@ -64,7 +75,9 @@ func (kp *keyPlan) Select(resolvers map[string]*PlanConfig) *PlanConfig {
 		}
 	}
 
-	return resolvers[bestResolver]
+	selected := resolvers[bestResolver]
+	strategySelectedCounter.WithLabelValues(selected.Name).Inc()
+	return selected
 }
 
 // UpdateStats performs the Bayesian update for the given resolver's statistics.


### PR DESCRIPTION

## Description

Add a new prom metric `planner_strategy_selected_count` for visibility into the dynamic query tuning behavior. It simply increments on every planner selection with a dimension `{strategy=selectedPlan.Name}`

#### What problem is being solved?

There is currently no visibility into the dynamic query tuning behavior.

## References
- https://auth0.com/blog/self-tuning-strategy-planner-openfga/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced planner observability with metric tracking for strategy selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->