### PR TITLE
observability: aggregate message statistics for each list-objects sender into a single span

### DIFF
--- a/pkg/server/commands/reverseexpand/pipeline/resolver_core.go
+++ b/pkg/server/commands/reverseexpand/pipeline/resolver_core.go
@@ -141,6 +141,20 @@ func (r *resolverCore) drain(
 		),
 	)
 
+	defer func() {
+		span.SetAttributes(
+			attribute.Int64(labelIdleDurationSum, sumIdleNanoseconds),
+			attribute.Int64(labelIdleDurationMax, maxIdleNanoseconds),
+			attribute.Int64(labelActiveDurationSum, sumActiveNanoseconds),
+			attribute.Int64(labelActiveDurationMax, maxActiveNanoseconds),
+			attribute.Int64(labelMessagesSum, sumMessages),
+			attribute.Int64(labelItemsSum, sumItems),
+			attribute.Int64(labelItemsMax, maxItems),
+		)
+
+		span.End()
+	}()
+
 	idleStart := time.Now()
 	for msg := range snd.C {
 		elapsedIdleNanoseconds := time.Since(idleStart).Nanoseconds()
@@ -167,15 +181,4 @@ func (r *resolverCore) drain(
 		sumActiveNanoseconds += elapsedActiveNanoseconds
 		idleStart = time.Now()
 	}
-
-	span.SetAttributes(
-		attribute.Int64(labelIdleDurationSum, sumIdleNanoseconds),
-		attribute.Int64(labelIdleDurationMax, maxIdleNanoseconds),
-		attribute.Int64(labelActiveDurationSum, sumActiveNanoseconds),
-		attribute.Int64(labelActiveDurationMax, maxActiveNanoseconds),
-		attribute.Int64(labelMessagesSum, sumMessages),
-		attribute.Int64(labelItemsSum, sumItems),
-		attribute.Int64(labelItemsMax, maxItems),
-	)
-	span.End()
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Currently, a span is created for every message that is processed through a sender within the list objects pipeline. It is common for tens of thousands of messages to pass through one or more senders within a pipeline.

We can observe the same information, using far less spans, by using aggregate statistics for each sender.

#### How is it being solved?
The core resolver's drain function is updated to create only a single span per sender, and aggregate statistics for:
- sum of time spent waiting for messages
- max time spent waiting for messages
- sum of time spent processing messages
- max time spent processing a message
- sum of messages that passed through the sender
- sum of items contained within the messages
- max number of items contained within a message

#### What changes are made to solve it?
- The span creation is moved outside of the message loop.
- The span's name is changed.
- New variables are added to track the desired statistics.
- New attributes are added to the span.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced tracing overhead by replacing per-message traces with a single aggregated drain trace; attached computed edge metadata (including a safe fallback for unknown types) and consolidated timing metrics (idle/active sum and max). Aggregated message/item counts and size statistics are now reported at loop completion for clearer, lower-overhead diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->