### PR TITLE
feat: reuse PostgreSQL container across tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Made some minor changes in ListObjects to reduce heap allocations. Results in minor latency reduction. [#3043](https://github.com/openfga/openfga/pull/3043)
 - Improve cache key generation performance by removing `fmt` usage and extend control-character sanitization to all cache key inputs (tuples, conditions, context). [#3006](https://github.com/openfga/openfga/pull/3006)
+- Reuse a single PostgreSQL container across tests by replacing the test fixture implementation, improving test performance and reducing resource usage. [#3018](https://github.com/openfga/openfga/pull/3018)
 
 ### Fixed
 - Fixed AuthZEN discovery metadata to publish endpoint URLs from the configured `authzen.baseURL` instead of request-supplied host headers, preventing host-header poisoning of `/.well-known/authzen-configuration/{store_id}`. Thanks to [@Jvr2022](https://github.com/Jvr2022) for reporting this. [#3057](https://github.com/openfga/openfga/pull/3057)

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ test: generate-mocks ## Run all tests. To run a specific test, pass the FILTER v
 			${GO_PACKAGES}
 	@cat coverageunit.tmp.out | grep -v "mock" > coverageunit.out
 	@rm coverageunit.tmp.out
+	@docker ps -q --filter "name=openfga-test-*" | xargs -r docker rm -f >/dev/null
 	
 test-docker: ## Run tests requiring Docker
 	${call print, "Running docker tests"}

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ test: generate-mocks ## Run all tests. To run a specific test, pass the FILTER v
 			${GO_PACKAGES}
 	@cat coverageunit.tmp.out | grep -v "mock" > coverageunit.out
 	@rm coverageunit.tmp.out
-	@docker ps -q --filter "name=openfga-test-*" | xargs -r docker rm -f >/dev/null
 	
 test-docker: ## Run tests requiring Docker
 	${call print, "Running docker tests"}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -240,8 +240,7 @@ func New(uri string, cfg *sqlcommon.Config) (*Datastore, error) {
 }
 
 func configureDB(db *pgxpool.Pool, cfg *sqlcommon.Config, dbName string) (prometheus.Collector, error) {
-	policy := backoff.NewExponentialBackOff()
-	policy.MaxElapsedTime = 1 * time.Minute
+	policy := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(1 * time.Minute))
 	attempt := 1
 	err := backoff.Retry(func() error {
 		err := db.Ping(context.Background())

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -283,7 +283,7 @@ exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	contName := "secondary-" + postgresContainer
+	contName := postgresContainer + "-replica"
 	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, contName)
 	require.NoError(t, err, "run postgres container")
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -2,202 +2,72 @@ package storage
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
-	"io"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/errdefs"
-	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver.
-	"github.com/moby/moby/api/types/container"
-	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/client"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/oklog/ulid/v2"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/openfga/openfga/assets"
+	"github.com/openfga/openfga/pkg/testutils"
 )
 
 const (
-	postgresImage = "postgres:17"
+	postgresImage           = "postgres:17-alpine"
+	postgresContainerPrefix = "openfga-test-postgres-"
+	postgresPort            = nat.Port("5432/tcp")
+
+	postgresDBPrefix   = "openfga-test-db-"
+	postgresTemplateDB = postgresDBPrefix + "template"
+	postgresUsername   = "postgres"
+	postgresPassword   = "secret"
 )
 
-var (
-	postgresPort = network.MustParsePort("5432/tcp")
+var _ DatastoreTestContainer = (*postgresTestContainer)(nil)
+
+type (
+	postgresTestContainer struct {
+		host string
+		port string
+
+		database string
+		username string
+		password string
+
+		version int64
+		replica *postgresReplicaContainer
+	}
+
+	postgresReplicaContainer struct {
+		host string
+		port string
+
+		username string
+		password string
+	}
 )
 
-type postgresTestContainer struct {
-	addr     string
-	version  int64
-	username string
-	password string
-	replica  *postgresReplicaContainer
-}
+// GetConnectionURI returns the postgres connection uri for the running postgres test container.
+func (p *postgresTestContainer) GetConnectionURI(includeCredentials bool) string {
+	var username, password string
+	if includeCredentials {
+		username = p.username
+		password = p.password
+	}
 
-type postgresReplicaContainer struct {
-	addr     string
-	username string
-	password string
-}
-
-// NewPostgresTestContainer returns an implementation of the DatastoreTestContainer interface
-// for Postgres.
-func NewPostgresTestContainer() *postgresTestContainer {
-	return &postgresTestContainer{}
+	return postgresConnectionURI(p.host, p.port, p.database, username, password)
 }
 
 func (p *postgresTestContainer) GetDatabaseSchemaVersion() int64 {
 	return p.version
-}
-
-// RunPostgresTestContainer runs a Postgres container, connects to it, and returns a
-// bootstrapped implementation of the DatastoreTestContainer interface wired up for the
-// Postgres datastore engine.
-func (p *postgresTestContainer) RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
-	dockerClient, err := client.New(client.FromEnv)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		dockerClient.Close()
-	})
-
-	imageListResult, err := dockerClient.ImageList(context.Background(), client.ImageListOptions{
-		All: true,
-	})
-	require.NoError(t, err)
-
-	foundPostgresImage := false
-
-AllImages:
-	for _, image := range imageListResult.Items {
-		for _, tag := range image.RepoTags {
-			if strings.Contains(tag, postgresImage) {
-				foundPostgresImage = true
-				break AllImages
-			}
-		}
-	}
-
-	if !foundPostgresImage {
-		t.Logf("Pulling image %s", postgresImage)
-		reader, err := dockerClient.ImagePull(context.Background(), postgresImage, client.ImagePullOptions{})
-		require.NoError(t, err)
-		defer reader.Close()
-
-		_, err = io.Copy(io.Discard, reader) // consume the image pull output to make sure it's done
-		require.NoError(t, err)
-	}
-
-	containerCfg := container.Config{
-		Env: []string{
-			"POSTGRES_DB=defaultdb",
-			"POSTGRES_PASSWORD=secret",
-		},
-		ExposedPorts: network.PortSet{
-			postgresPort: {},
-		},
-		Image: postgresImage,
-		Cmd: []string{
-			"postgres",
-			"-c", "wal_level=replica",
-			"-c", "max_wal_senders=3",
-			"-c", "max_replication_slots=3",
-			"-c", "wal_keep_size=64MB",
-			"-c", "hot_standby=on",
-		},
-	}
-
-	hostCfg := container.HostConfig{
-		AutoRemove:      true,
-		PublishAllPorts: true,
-		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
-	}
-
-	name := "postgres-" + ulid.Make().String()
-
-	cont, err := dockerClient.ContainerCreate(context.Background(), client.ContainerCreateOptions{
-		Name:       name,
-		Config:     &containerCfg,
-		HostConfig: &hostCfg,
-	})
-	require.NoError(t, err, "failed to create postgres docker container")
-
-	t.Cleanup(func() {
-		t.Logf("stopping container %s", name)
-		timeoutSec := 5
-
-		_, err := dockerClient.ContainerStop(context.Background(), cont.ID, client.ContainerStopOptions{Timeout: &timeoutSec})
-		if err != nil && !errdefs.IsNotFound(err) {
-			t.Logf("failed to stop postgres container: %v", err)
-		}
-
-		t.Logf("stopped container %s", name)
-	})
-
-	_, err = dockerClient.ContainerStart(context.Background(), cont.ID, client.ContainerStartOptions{})
-	require.NoError(t, err, "failed to start postgres container")
-
-	inspectResult, err := dockerClient.ContainerInspect(context.Background(), cont.ID, client.ContainerInspectOptions{})
-	require.NoError(t, err)
-
-	m, ok := inspectResult.Container.NetworkSettings.Ports[postgresPort]
-	if !ok || len(m) == 0 {
-		require.Fail(t, "failed to get host port mapping from postgres container")
-	}
-
-	pgTestContainer := &postgresTestContainer{
-		addr:     "localhost:" + m[0].HostPort,
-		username: "postgres",
-		password: "secret",
-	}
-
-	uri := fmt.Sprintf("postgres://%s:%s@%s/defaultdb?sslmode=disable", pgTestContainer.username, pgTestContainer.password, pgTestContainer.addr)
-
-	goose.SetLogger(goose.NopLogger())
-
-	db, err := goose.OpenDBWithDriver("pgx", uri)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
-
-	backoffPolicy := backoff.NewExponentialBackOff()
-	backoffPolicy.MaxElapsedTime = 30 * time.Second
-	err = backoff.Retry(
-		func() error {
-			return db.Ping()
-		},
-		backoffPolicy,
-	)
-	require.NoError(t, err, "failed to connect to postgres container")
-
-	goose.SetBaseFS(assets.EmbedMigrations)
-
-	err = goose.Up(db, assets.PostgresMigrationDir)
-	require.NoError(t, err)
-
-	version, err := goose.GetDBVersion(db)
-	require.NoError(t, err)
-	pgTestContainer.version = version
-
-	return pgTestContainer
-}
-
-// GetConnectionURI returns the postgres connection uri for the running postgres test container.
-func (p *postgresTestContainer) GetConnectionURI(includeCredentials bool) string {
-	creds := ""
-	if includeCredentials {
-		creds = fmt.Sprintf("%s:%s@", p.username, p.password)
-	}
-
-	return fmt.Sprintf(
-		"postgres://%s%s/%s?sslmode=disable",
-		creds,
-		p.addr,
-		"defaultdb",
-	)
 }
 
 func (p *postgresTestContainer) GetUsername() string {
@@ -210,37 +80,166 @@ func (p *postgresTestContainer) GetPassword() string {
 
 // CreateSecondary creates a secondary PostgreSQL container.
 func (p *postgresTestContainer) CreateSecondary(t testing.TB) error {
-	dockerClient, err := client.New(client.FromEnv)
+	p.replica = runPostgresReplica(t, p)
+	return nil
+}
+
+// GetSecondaryConnectionURI returns the connection URI for the read replica.
+func (p *postgresTestContainer) GetSecondaryConnectionURI(includeCredentials bool) string {
+	if p.replica == nil {
+		return ""
+	}
+
+	var username, password string
+	if includeCredentials {
+		username = p.replica.username
+		password = p.replica.password
+	}
+
+	return postgresConnectionURI(p.replica.host, p.replica.port, p.database, username, password)
+}
+
+func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
+	docker, err := testutils.NewDockerClient()
 	require.NoError(t, err)
+
 	t.Cleanup(func() {
-		dockerClient.Close()
+		docker.Close()
 	})
 
-	// Configure the master for replication.
-	masterContainerID, err := p.getMasterContainerID(dockerClient)
+	dockerCont, found, err := docker.FindRunningContainer(t.Context(), "^"+postgresContainerPrefix, postgresImage)
+	require.NoError(t, err, "find running postgres container")
+
+	if !found {
+		dockerCont = bootstrapPostgresContainer(t, docker)
+	}
+
+	port, err := docker.GetHostPort(dockerCont, postgresPort)
 	require.NoError(t, err)
 
-	err = p.configureMasterForReplication(t, dockerClient, masterContainerID)
+	version, err := latestMigrationVersion(assets.PostgresMigrationDir)
+	require.NoError(t, err, "get expected postgres migration version")
+
+	testCont := &postgresTestContainer{
+		host:     "localhost",
+		port:     port,
+		database: postgresDBPrefix + ulid.Make().String(),
+		username: postgresUsername,
+		password: postgresPassword,
+		version:  version,
+	}
+
+	tplURI := postgresConnectionURI(testCont.host, testCont.port, postgresTemplateDB, testCont.username, testCont.password)
+	require.NoError(t, waitForMigrationVersion("pgx", tplURI, testCont.version))
+
+	createExec := container.ExecOptions{
+		Cmd: []string{"createdb", "-U", testCont.username, "-T", postgresTemplateDB, testCont.database},
+		Env: []string{"PGPASSWORD=" + testCont.password},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), dockerCont.ID, createExec))
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		dropQuery := fmt.Sprintf("DROP DATABASE IF EXISTS \"%s\" WITH (FORCE);", testCont.database)
+		dropExec := container.ExecOptions{
+			Cmd: []string{"psql", "-U", testCont.username, "-c", dropQuery},
+			Env: []string{"PGPASSWORD=" + testCont.password},
+		}
+		if err := docker.ExecCommand(ctx, dockerCont.ID, dropExec); err != nil {
+			t.Errorf("drop test database in the postgres container: %v", err)
+		}
+	})
+
+	require.NoError(t, waitForMigrationVersion("pgx", testCont.GetConnectionURI(true), testCont.version))
+
+	return testCont
+}
+
+func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *container.InspectResponse {
+	t.Logf("No running container found for %s, creating a new one", postgresImage)
+
+	require.NoError(t, docker.PullImage(t.Context(), postgresImage), "pull postgres image")
+
+	// Run container
+	contCfg := &container.Config{
+		Env: []string{
+			"POSTGRES_DB=" + postgresTemplateDB,
+			"POSTGRES_PASSWORD=" + postgresPassword,
+		},
+		ExposedPorts: nat.PortSet{
+			postgresPort: {},
+		},
+		Image: postgresImage,
+		Cmd: []string{
+			"postgres",
+			"-c", "wal_level=replica",
+			"-c", "max_wal_senders=3",
+			"-c", "max_replication_slots=3",
+			"-c", "max_connections=200",
+			"-c", "wal_keep_size=64MB",
+			"-c", "hot_standby=on",
+		},
+	}
+
+	hostCfg := &container.HostConfig{
+		AutoRemove:      true,
+		PublishAllPorts: true,
+		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
+	}
+
+	containerName := postgresContainerPrefix + ulid.Make().String()
+	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, containerName)
+	require.NoError(t, err, "run postgres container")
+
+	port, err := docker.GetHostPort(cont, postgresPort)
 	require.NoError(t, err)
 
-	// Wait for the master to be configured.
-	time.Sleep(3 * time.Second)
+	dbURI := postgresConnectionURI("localhost", port, postgresTemplateDB, postgresUsername, postgresPassword)
+	require.NoError(t, waitForDatabase("pgx", dbURI))
 
-	// Extract host and port from master for basebackup.
-	masterHost := "host.docker.internal"
-	masterPort := strings.Split(p.addr, ":")[1]
+	allowReplicationExec := container.ExecOptions{
+		Cmd: []string{"sh", "-c", "echo 'host replication postgres all trust' >> /var/lib/postgresql/data/pg_hba.conf"},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, allowReplicationExec))
+
+	reloadExec := container.ExecOptions{
+		Cmd: []string{"psql", "-U", "postgres", "-c", "SELECT pg_reload_conf();"},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, reloadExec))
+	require.NoError(t, waitForDatabase("pgx", dbURI))
+
+	db, err := goose.OpenDBWithDriver("pgx", dbURI)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, goose.Up(db, assets.PostgresMigrationDir))
+
+	return cont
+}
+
+func runPostgresReplica(t testing.TB, primary *postgresTestContainer) *postgresReplicaContainer {
+	docker, err := testutils.NewDockerClient()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		docker.Close()
+	})
+
+	primaryHost := "host.docker.internal"
 
 	// Use standard PostgreSQL approach with docker-entrypoint-initdb.d.
-	containerCfg := container.Config{
+	contCfg := &container.Config{
 		Env: []string{
-			"POSTGRES_DB=defaultdb",
-			"POSTGRES_PASSWORD=secret",
-			"PGPASSWORD=secret",
+			"POSTGRES_DB=" + primary.database,
+			"POSTGRES_PASSWORD=" + postgresPassword,
+			"PGPASSWORD=" + postgresPassword,
 			"POSTGRES_INITDB_ARGS=--auth-host=trust",
-			"POSTGRES_MASTER_HOST=" + masterHost,
-			"POSTGRES_MASTER_PORT=" + masterPort,
+			"POSTGRES_MASTER_HOST=" + primaryHost,
+			"POSTGRES_MASTER_PORT=" + primary.port,
 		},
-		ExposedPorts: network.PortSet{
+		ExposedPorts: nat.PortSet{
 			postgresPort: {},
 		},
 		Image:      postgresImage,
@@ -248,7 +247,7 @@ func (p *postgresTestContainer) CreateSecondary(t testing.TB) error {
 		Cmd: []string{fmt.Sprintf(`
 set -e
 
-export PGPASSWORD=secret
+export PGPASSWORD=%s
 
 echo "Initializing PostgreSQL replica..."
 
@@ -264,124 +263,60 @@ echo "Master ready, creating base backup..."
 rm -rf $PGDATA/*
 
 # Create base backup
-pg_basebackup -h %s -p %s -U postgres -D $PGDATA -Fp -Xs -P -R
+pg_basebackup -h %s -p %s -U postgres -D $PGDATA -Fp -Xs -P -R -c fast
 
 # Configure as replica
 echo "hot_standby = on" >> $PGDATA/postgresql.conf
 touch $PGDATA/standby.signal
 
 echo "Starting PostgreSQL replica..."
-exec docker-entrypoint.sh postgres -c hot_standby=on -c wal_level=replica
-`, masterHost, masterPort, masterHost, masterPort)},
+exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
+`, postgresPassword, primaryHost, primary.port, primaryHost, primary.port)},
 	}
 
-	hostCfg := container.HostConfig{
+	hostCfg := &container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	name := "postgres-replica-" + ulid.Make().String()
-
-	cont, err := dockerClient.ContainerCreate(context.Background(), client.ContainerCreateOptions{
-		Name:       name,
-		Config:     &containerCfg,
-		HostConfig: &hostCfg,
-	})
-	require.NoError(t, err, "failed to create postgres replica docker container")
+	contName := "secondary-" + postgresContainerPrefix + ulid.Make().String()
+	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, contName)
+	require.NoError(t, err, "run postgres container")
 
 	t.Cleanup(func() {
-		t.Logf("stopping replica container %s", name)
-		timeoutSec := 5
+		t.Logf("stopping replica container %s", contName)
 
-		_, err := dockerClient.ContainerStop(context.Background(), cont.ID, client.ContainerStopOptions{Timeout: &timeoutSec})
-		if err != nil && !errdefs.IsNotFound(err) {
-			t.Logf("failed to stop postgres replica container: %v", err)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		if err := docker.RemoveContainer(ctx, cont.ID); err != nil && !errdefs.IsNotFound(err) {
+			t.Errorf("failed to stop postgres replica container: %v", err)
 		}
 
-		t.Logf("stopped replica container %s", name)
+		t.Logf("stopped replica container %s", contName)
 	})
 
-	_, err = dockerClient.ContainerStart(context.Background(), cont.ID, client.ContainerStartOptions{})
-	require.NoError(t, err, "failed to start postgres replica container")
-
-	inspectResult, err := dockerClient.ContainerInspect(context.Background(), cont.ID, client.ContainerInspectOptions{})
+	port, err := docker.GetHostPort(cont, postgresPort)
 	require.NoError(t, err)
 
-	m, ok := inspectResult.Container.NetworkSettings.Ports[postgresPort]
-	if !ok || len(m) == 0 {
-		require.Fail(t, "failed to get host port mapping from postgres replica container")
-	}
-
-	p.replica = &postgresReplicaContainer{
-		addr:     "localhost:" + m[0].HostPort,
-		username: "postgres",
-		password: "secret",
+	replicaCont := &postgresReplicaContainer{
+		host:     "localhost",
+		port:     port,
+		username: postgresUsername,
+		password: postgresPassword,
 	}
 
 	// Wait for replica to be ready and synchronized.
-	err = p.waitForReplicaSync(t)
+	dbURI := postgresConnectionURI(replicaCont.host, replicaCont.port, primary.database, replicaCont.username, replicaCont.password)
+	err = waitForPostgresReplicaSync(t, dbURI)
 	require.NoError(t, err, "failed to sync replica")
 
-	return nil
-}
-
-// getMasterContainerID finds the master container ID.
-func (p *postgresTestContainer) getMasterContainerID(dockerClient *client.Client) (string, error) {
-	containerListResult, err := dockerClient.ContainerList(context.Background(), client.ContainerListOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	for _, cont := range containerListResult.Items {
-		for _, name := range cont.Names {
-			if strings.Contains(name, "postgres-") && !strings.Contains(name, "replica") && !strings.Contains(name, "basebackup") {
-				return cont.ID, nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("master container not found")
-}
-
-// configureMasterForReplication configures the master to accept replication connections.
-func (p *postgresTestContainer) configureMasterForReplication(t testing.TB, dockerClient *client.Client, masterContainerID string) error {
-	// Configuration for streaming replication - only pg_hba.conf and reload.
-	commands := [][]string{
-		{"sh", "-c", "echo 'host replication postgres all trust' >> /var/lib/postgresql/data/pg_hba.conf"},
-		{"psql", "-U", "postgres", "-d", "defaultdb", "-c", "SELECT pg_reload_conf()"},
-	}
-
-	for _, cmd := range commands {
-		execConfig := client.ExecCreateOptions{Cmd: cmd}
-		exec, err := dockerClient.ExecCreate(context.Background(), masterContainerID, execConfig)
-		if err != nil {
-			return fmt.Errorf("failed to create exec for command %v: %w", cmd, err)
-		}
-
-		_, err = dockerClient.ExecStart(context.Background(), exec.ID, client.ExecStartOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to execute command %v: %w", cmd, err)
-		}
-
-		// Wait for command to complete.
-		inspect, err := dockerClient.ExecInspect(context.Background(), exec.ID, client.ExecInspectOptions{})
-		if err != nil {
-			return fmt.Errorf("failed to inspect exec %v: %w", cmd, err)
-		}
-
-		if inspect.ExitCode != 0 {
-			t.Logf("Command %v completed with exit code %d", cmd, inspect.ExitCode)
-		}
-	}
-
-	return nil
+	return replicaCont
 }
 
 // waitForReplicaSync waits for the replica to be synchronized with the master.
-func (p *postgresTestContainer) waitForReplicaSync(t testing.TB) error {
-	uri := fmt.Sprintf("postgres://%s:%s@%s/defaultdb?sslmode=disable", p.replica.username, p.replica.password, p.replica.addr)
-
+func waitForPostgresReplicaSync(t testing.TB, uri string) error {
 	backoffPolicy := backoff.NewExponentialBackOff()
 	backoffPolicy.MaxElapsedTime = 120 * time.Second // Increase to 2 minutes for initialization.
 	backoffPolicy.InitialInterval = 2 * time.Second  // Start with 2 seconds.
@@ -398,8 +333,7 @@ func (p *postgresTestContainer) waitForReplicaSync(t testing.TB) error {
 
 			// Check that replica is in recovery mode (standby)
 			var inRecovery bool
-			err = db.QueryRow("SELECT pg_is_in_recovery()").Scan(&inRecovery)
-			if err != nil {
+			if err = db.QueryRow("SELECT pg_is_in_recovery()").Scan(&inRecovery); err != nil {
 				t.Logf("Failed to check recovery status (replica may still be initializing): %v", err)
 				return fmt.Errorf("failed to check recovery status: %w", err)
 			}
@@ -409,39 +343,34 @@ func (p *postgresTestContainer) waitForReplicaSync(t testing.TB) error {
 			}
 
 			// Check that replica is receiving WAL
-			var replicaLSN *string
-			err = db.QueryRow("SELECT pg_last_wal_receive_lsn()").Scan(&replicaLSN)
-			if err != nil {
+			var replicaLSN sql.NullString
+			if err = db.QueryRow("SELECT pg_last_wal_receive_lsn()").Scan(&replicaLSN); err != nil {
 				t.Logf("Failed to get replica LSN: %v", err)
 				return fmt.Errorf("failed to get replica LSN: %w", err)
 			}
 
-			if replicaLSN == nil || *replicaLSN == "" {
+			if !replicaLSN.Valid || replicaLSN.String == "" {
 				return fmt.Errorf("replica has not received any WAL yet")
 			}
 
-			t.Logf("Replica is synchronized and receiving WAL at LSN: %s", *replicaLSN)
+			t.Logf("Replica is synchronized and receiving WAL at LSN: %s", replicaLSN.String)
 			return nil
 		},
 		backoffPolicy,
 	)
 }
 
-// GetSecondaryConnectionURI returns the connection URI for the read replica.
-func (p *postgresTestContainer) GetSecondaryConnectionURI(includeCredentials bool) string {
-	if p.replica == nil {
-		return ""
-	}
-
+func postgresConnectionURI(host, port, database, username, password string) string {
 	creds := ""
-	if includeCredentials {
-		creds = fmt.Sprintf("%s:%s@", p.replica.username, p.replica.password)
+	if username != "" && password != "" {
+		creds = fmt.Sprintf("%s:%s@", username, password)
 	}
 
 	return fmt.Sprintf(
-		"postgres://%s%s/%s?sslmode=disable",
+		"postgres://%s%s:%s/%s?sslmode=disable",
 		creds,
-		p.replica.addr,
-		"defaultdb",
+		host,
+		port,
+		database,
 	)
 }

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -317,10 +317,11 @@ exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
 
 // waitForReplicaSync waits for the replica to be synchronized with the master.
 func waitForPostgresReplicaSync(t testing.TB, uri string) error {
-	backoffPolicy := backoff.NewExponentialBackOff()
-	backoffPolicy.MaxElapsedTime = 120 * time.Second // Increase to 2 minutes for initialization.
-	backoffPolicy.InitialInterval = 2 * time.Second  // Start with 2 seconds.
-	backoffPolicy.MaxInterval = 10 * time.Second     // Cap at 10 seconds.
+	backoffPolicy := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(2*time.Second),
+		backoff.WithMaxInterval(10*time.Second),
+		backoff.WithMaxElapsedTime(120*time.Second),
+	)
 
 	return backoff.Retry(
 		func() error {

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -9,9 +9,10 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/errdefs"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/go-connections/nat"
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/oklog/ulid/v2"
 	"github.com/pressly/goose/v3"
 	"github.com/stretchr/testify/require"
@@ -21,9 +22,8 @@ import (
 )
 
 const (
-	postgresImage           = "postgres:17-alpine"
-	postgresContainerPrefix = "openfga-test-postgres-"
-	postgresPort            = nat.Port("5432/tcp")
+	postgresImage     = "postgres:17-alpine"
+	postgresContainer = "openfga-test-postgres"
 
 	postgresDBPrefix   = "openfga-test-db-"
 	postgresTemplateDB = postgresDBPrefix + "template"
@@ -31,7 +31,11 @@ const (
 	postgresPassword   = "secret"
 )
 
-var _ DatastoreTestContainer = (*postgresTestContainer)(nil)
+var (
+	_ DatastoreTestContainer = (*postgresTestContainer)(nil)
+
+	postgresPort = network.MustParsePort("5432/tcp")
+)
 
 type (
 	postgresTestContainer struct {
@@ -107,7 +111,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		docker.Close()
 	})
 
-	dockerCont, found, err := docker.FindRunningContainer(t.Context(), "^"+postgresContainerPrefix, postgresImage)
+	dockerCont, found, err := docker.FindRunningContainer(t.Context(), postgresContainer, postgresImage)
 	require.NoError(t, err, "find running postgres container")
 
 	if !found {
@@ -132,7 +136,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 	tplURI := postgresConnectionURI(testCont.host, testCont.port, postgresTemplateDB, testCont.username, testCont.password)
 	require.NoError(t, waitForMigrationVersion("pgx", tplURI, testCont.version))
 
-	createExec := container.ExecOptions{
+	createExec := client.ExecCreateOptions{
 		Cmd: []string{"createdb", "-U", testCont.username, "-T", postgresTemplateDB, testCont.database},
 		Env: []string{"PGPASSWORD=" + testCont.password},
 	}
@@ -143,7 +147,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		defer cancel()
 
 		dropQuery := fmt.Sprintf("DROP DATABASE IF EXISTS \"%s\" WITH (FORCE);", testCont.database)
-		dropExec := container.ExecOptions{
+		dropExec := client.ExecCreateOptions{
 			Cmd: []string{"psql", "-U", testCont.username, "-c", dropQuery},
 			Env: []string{"PGPASSWORD=" + testCont.password},
 		}
@@ -168,7 +172,7 @@ func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *c
 			"POSTGRES_DB=" + postgresTemplateDB,
 			"POSTGRES_PASSWORD=" + postgresPassword,
 		},
-		ExposedPorts: nat.PortSet{
+		ExposedPorts: network.PortSet{
 			postgresPort: {},
 		},
 		Image: postgresImage,
@@ -189,8 +193,7 @@ func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *c
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	containerName := postgresContainerPrefix + ulid.Make().String()
-	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, containerName)
+	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, postgresContainer)
 	require.NoError(t, err, "run postgres container")
 
 	port, err := docker.GetHostPort(cont, postgresPort)
@@ -199,12 +202,12 @@ func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *c
 	dbURI := postgresConnectionURI("localhost", port, postgresTemplateDB, postgresUsername, postgresPassword)
 	require.NoError(t, waitForDatabase("pgx", dbURI))
 
-	allowReplicationExec := container.ExecOptions{
+	allowReplicationExec := client.ExecCreateOptions{
 		Cmd: []string{"sh", "-c", "echo 'host replication postgres all trust' >> /var/lib/postgresql/data/pg_hba.conf"},
 	}
 	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, allowReplicationExec))
 
-	reloadExec := container.ExecOptions{
+	reloadExec := client.ExecCreateOptions{
 		Cmd: []string{"psql", "-U", "postgres", "-c", "SELECT pg_reload_conf();"},
 	}
 	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, reloadExec))
@@ -239,7 +242,7 @@ func runPostgresReplica(t testing.TB, primary *postgresTestContainer) *postgresR
 			"POSTGRES_MASTER_HOST=" + primaryHost,
 			"POSTGRES_MASTER_PORT=" + primary.port,
 		},
-		ExposedPorts: nat.PortSet{
+		ExposedPorts: network.PortSet{
 			postgresPort: {},
 		},
 		Image:      postgresImage,
@@ -280,7 +283,7 @@ exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	contName := "secondary-" + postgresContainerPrefix + ulid.Make().String()
+	contName := "secondary-" + postgresContainer
 	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, contName)
 	require.NoError(t, err, "run postgres container")
 

--- a/pkg/testfixtures/storage/readiness.go
+++ b/pkg/testfixtures/storage/readiness.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pressly/goose/v3"
+)
+
+// waitForDatabase attempts to establish a connection to the database
+// and ping it until it's ready or a timeout occurs.
+func waitForDatabase(driverName, uri string) error { //nolint:unparam
+	db, err := sql.Open(driverName, uri)
+	if err != nil {
+		return fmt.Errorf("open connection to %s: %w", driverName, err)
+	}
+	defer db.Close()
+
+	backoffPolicy := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(10*time.Millisecond),
+		backoff.WithMaxElapsedTime(30*time.Second),
+	)
+
+	if err := backoff.Retry(db.Ping, backoffPolicy); err != nil {
+		return fmt.Errorf("ping %s database: %w", driverName, err)
+	}
+
+	return nil
+}
+
+// waitForMigrationVersion attempts to read the database migration version
+// until it matches the expected version or a timeout occurs.
+func waitForMigrationVersion(driverName, uri string, expectedVersion int64) error {
+	backoffPolicy := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithMaxElapsedTime(1*time.Minute),
+	)
+
+	err := backoff.Retry(func() error {
+		db, err := goose.OpenDBWithDriver(driverName, uri)
+		if err != nil {
+			return fmt.Errorf("open connection: %w", err)
+		}
+		defer db.Close()
+
+		version, err := goose.GetDBVersion(db)
+		if err != nil {
+			return fmt.Errorf("get database version: %w", err)
+		}
+
+		if version != expectedVersion {
+			return fmt.Errorf("database version %d does not match expected version %d", version, expectedVersion)
+		}
+
+		return nil
+	}, backoffPolicy)
+
+	if err != nil {
+		return fmt.Errorf("%s migration version: %w", driverName, err)
+	}
+
+	return nil
+}

--- a/pkg/testfixtures/storage/readiness.go
+++ b/pkg/testfixtures/storage/readiness.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
@@ -12,18 +13,25 @@ import (
 // waitForDatabase attempts to establish a connection to the database
 // and ping it until it's ready or a timeout occurs.
 func waitForDatabase(driverName, uri string) error { //nolint:unparam
-	db, err := sql.Open(driverName, uri)
-	if err != nil {
-		return fmt.Errorf("open connection to %s: %w", driverName, err)
-	}
-	defer db.Close()
-
 	backoffPolicy := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(10*time.Millisecond),
-		backoff.WithMaxElapsedTime(30*time.Second),
+		backoff.WithMaxElapsedTime(10*time.Second),
 	)
 
-	if err := backoff.Retry(db.Ping, backoffPolicy); err != nil {
+	err := backoff.Retry(func() error {
+		db, err := sql.Open(driverName, uri)
+		if err != nil {
+			return fmt.Errorf("open connection to %s: %w", driverName, err)
+		}
+		defer db.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		return db.PingContext(ctx)
+	}, backoffPolicy)
+
+	if err != nil {
 		return fmt.Errorf("ping %s database: %w", driverName, err)
 	}
 
@@ -34,14 +42,14 @@ func waitForDatabase(driverName, uri string) error { //nolint:unparam
 // until it matches the expected version or a timeout occurs.
 func waitForMigrationVersion(driverName, uri string, expectedVersion int64) error {
 	backoffPolicy := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(100*time.Millisecond),
-		backoff.WithMaxElapsedTime(1*time.Minute),
+		backoff.WithInitialInterval(10*time.Millisecond),
+		backoff.WithMaxElapsedTime(10*time.Second),
 	)
 
 	err := backoff.Retry(func() error {
 		db, err := goose.OpenDBWithDriver(driverName, uri)
 		if err != nil {
-			return fmt.Errorf("open connection: %w", err)
+			return fmt.Errorf("open connection to %s: %w", driverName, err)
 		}
 		defer db.Close()
 

--- a/pkg/testfixtures/storage/sqlite.go
+++ b/pkg/testfixtures/storage/sqlite.go
@@ -40,13 +40,9 @@ func (m *sqliteTestContainer) RunSqliteTestDatabase(t testing.TB) DatastoreTestC
 
 	uri := m.GetConnectionURI(true)
 
-	goose.SetLogger(goose.NopLogger())
-
 	db, err := goose.OpenDBWithDriver("sqlite", uri)
 	require.NoError(t, err)
 	defer db.Close()
-
-	goose.SetBaseFS(assets.EmbedMigrations)
 
 	err = goose.Up(db, assets.SqliteMigrationDir)
 	require.NoError(t, err)

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -2,8 +2,18 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/openfga/openfga/assets"
 )
+
+func init() {
+	goose.SetLogger(goose.NopLogger())
+	goose.SetBaseFS(assets.EmbedMigrations)
+}
 
 // DatastoreTestContainer represents a runnable container for testing specific datastore engines.
 type DatastoreTestContainer interface {
@@ -56,12 +66,14 @@ func (m memoryTestContainer) GetSecondaryConnectionURI(includeCredentials bool) 
 // RunDatastoreTestContainer constructs and runs a specific DatastoreTestContainer for the provided
 // datastore engine. If applicable, it also runs all existing database migrations.
 // The resources used by the test engine will be cleaned up after the test has finished.
+//
+// NOTE: PostgreSQL uses a shared container across tests, so it is not automatically cleaned up after each test.
 func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContainer {
 	switch engine {
 	case "mysql":
 		return NewMySQLTestContainer().RunMySQLTestContainer(t)
 	case "postgres":
-		return NewPostgresTestContainer().RunPostgresTestContainer(t)
+		return RunPostgresTestContainer(t)
 	case "memory":
 		return memoryTestContainer{}
 	case "sqlite":
@@ -70,4 +82,17 @@ func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContain
 		t.Fatalf("unsupported datastore engine: %q", engine)
 		return nil
 	}
+}
+
+// latestMigrationVersion returns the latest goose migration version in migrationDir.
+func latestMigrationVersion(migrationDir string) (int64, error) {
+	migrations, err := goose.CollectMigrations(migrationDir, 0, goose.MaxVersion)
+	if err != nil {
+		return 0, err
+	}
+	if len(migrations) == 0 {
+		return 0, fmt.Errorf("no migrations found in %s", migrationDir)
+	}
+
+	return migrations[len(migrations)-1].Version, nil
 }

--- a/pkg/testutils/dockerclient.go
+++ b/pkg/testutils/dockerclient.go
@@ -1,0 +1,206 @@
+package testutils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+)
+
+// DockerClient is a simple wrapper around the Docker client
+// to provide utility methods for managing containers and images in tests.
+type DockerClient struct {
+	client *client.Client
+}
+
+// NewDockerClient creates a new instance of DockerClient.
+func NewDockerClient() (*DockerClient, error) {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return nil, fmt.Errorf("create docker client: %w", err)
+	}
+
+	return &DockerClient{client: cli}, nil
+}
+
+// Close calls the underlying Docker client's Close method, releasing its transport resources.
+func (d *DockerClient) Close() error {
+	return d.client.Close()
+}
+
+// PullImage checks if the specified image is already present locally, and if not, it pulls it from the registry.
+func (d *DockerClient) PullImage(ctx context.Context, imageName string) error {
+	images, err := d.client.ImageList(ctx, image.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("reference", imageName),
+		),
+	})
+	if err != nil {
+		return fmt.Errorf("list images: %w", err)
+	}
+
+	if len(images) == 0 {
+		reader, err := d.client.ImagePull(ctx, imageName, image.PullOptions{})
+		if err != nil {
+			return fmt.Errorf("pull image: %w", err)
+		}
+		defer reader.Close()
+
+		// consume the image pull output to make sure it's done
+		if _, err := io.Copy(io.Discard, reader); err != nil {
+			return fmt.Errorf("consume image pull output: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// FindRunningContainer returns the inspection data of a running container
+// matching the given name and image, or nil/false if not found.
+func (d *DockerClient) FindRunningContainer(
+	ctx context.Context, containerName, imageName string,
+) (*container.InspectResponse, bool, error) {
+	filterArgs := filters.NewArgs(
+		filters.Arg("name", containerName),
+		filters.Arg("ancestor", imageName),
+		filters.Arg("status", "running"),
+	)
+
+	containers, err := d.client.ContainerList(ctx, container.ListOptions{
+		Filters: filterArgs,
+		Limit:   1,
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("list containers: %w", err)
+	}
+
+	if len(containers) == 0 {
+		return nil, false, nil
+	}
+
+	inspect, err := d.client.ContainerInspect(ctx, containers[0].ID)
+	if err != nil {
+		return nil, false, fmt.Errorf("inspect %s container: %w", containerName, err)
+	}
+
+	return &inspect, true, nil
+}
+
+// RunContainer starts a container and returns its inspection data.
+func (d *DockerClient) RunContainer(
+	ctx context.Context, containerCfg *container.Config, hostCfg *container.HostConfig, containerName string,
+) (*container.InspectResponse, error) {
+	cont, err := d.client.ContainerCreate(ctx, containerCfg, hostCfg, nil, nil, containerName)
+	if err != nil {
+		return nil, fmt.Errorf("create %s container: %w", containerName, err)
+	}
+
+	defer func() {
+		if err != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			d.RemoveContainer(ctx, cont.ID)
+		}
+	}()
+
+	err = d.client.ContainerStart(ctx, cont.ID, container.StartOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("start %s container: %w", containerName, err)
+	}
+
+	backoffPolicy := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithMaxElapsedTime(5*time.Second),
+	)
+
+	var inspect container.InspectResponse
+	err = backoff.Retry(func() error {
+		inspect, err = d.client.ContainerInspect(ctx, cont.ID)
+		if err != nil {
+			return backoff.Permanent(fmt.Errorf("inspect %s container: %w", containerName, err))
+		}
+
+		if len(containerCfg.ExposedPorts) == 0 {
+			return nil
+		}
+
+		if len(inspect.NetworkSettings.Ports) == 0 {
+			return fmt.Errorf("port bindings not yet available for container %s", containerName)
+		}
+
+		for _, portBindings := range inspect.NetworkSettings.Ports {
+			if len(portBindings) == 0 {
+				return fmt.Errorf("port bindings not yet available for container %s", containerName)
+			}
+		}
+
+		return nil
+	}, backoff.WithContext(backoffPolicy, ctx))
+
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s container: %w", containerName, err)
+	}
+
+	return &inspect, nil
+}
+
+// RemoveContainer kills and removes a container.
+func (d *DockerClient) RemoveContainer(ctx context.Context, containerID string) error {
+	removeOpts := container.RemoveOptions{
+		Force:         true,
+		RemoveVolumes: true,
+	}
+
+	if err := d.client.ContainerRemove(ctx, containerID, removeOpts); err != nil {
+		return fmt.Errorf("remove container %s: %w", containerID, err)
+	}
+
+	return nil
+}
+
+// ExecCommand executes a command in the specified container and waits for it to complete.
+func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, execConfig container.ExecOptions) error {
+	exec, err := d.client.ContainerExecCreate(ctx, containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec for command %v: %w", execConfig.Cmd, err)
+	}
+
+	resp, err := d.client.ContainerExecAttach(ctx, exec.ID, container.ExecAttachOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to execute command %v: %w", execConfig.Cmd, err)
+	}
+	defer resp.Close()
+
+	if _, err := io.Copy(io.Discard, resp.Reader); err != nil {
+		return fmt.Errorf("failed to read exec output for command %v: %w", execConfig.Cmd, err)
+	}
+
+	inspect, err := d.client.ContainerExecInspect(ctx, exec.ID)
+	if err != nil {
+		return fmt.Errorf("failed to inspect exec %v: %w", execConfig.Cmd, err)
+	}
+
+	if inspect.ExitCode != 0 {
+		return fmt.Errorf("command %v completed with exit code %d", execConfig.Cmd, inspect.ExitCode)
+	}
+
+	return nil
+}
+
+// GetHostPort returns the published host port for the given container port.
+func (d *DockerClient) GetHostPort(inspect *container.InspectResponse, containerPort nat.Port) (string, error) {
+	m, ok := inspect.NetworkSettings.Ports[containerPort]
+	if !ok || len(m) == 0 {
+		return "", fmt.Errorf("port bindings not available for container port %s", containerPort)
+	}
+
+	return m[0].HostPort, nil
+}

--- a/pkg/testutils/dockerclient.go
+++ b/pkg/testutils/dockerclient.go
@@ -7,11 +7,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
+	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 )
 
 // DockerClient is a simple wrapper around the Docker client
@@ -22,7 +21,7 @@ type DockerClient struct {
 
 // NewDockerClient creates a new instance of DockerClient.
 func NewDockerClient() (*DockerClient, error) {
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		return nil, fmt.Errorf("create docker client: %w", err)
 	}
@@ -37,17 +36,15 @@ func (d *DockerClient) Close() error {
 
 // PullImage checks if the specified image is already present locally, and if not, it pulls it from the registry.
 func (d *DockerClient) PullImage(ctx context.Context, imageName string) error {
-	images, err := d.client.ImageList(ctx, image.ListOptions{
-		Filters: filters.NewArgs(
-			filters.Arg("reference", imageName),
-		),
+	imageListResult, err := d.client.ImageList(ctx, client.ImageListOptions{
+		Filters: make(client.Filters).Add("reference", imageName),
 	})
 	if err != nil {
 		return fmt.Errorf("list images: %w", err)
 	}
 
-	if len(images) == 0 {
-		reader, err := d.client.ImagePull(ctx, imageName, image.PullOptions{})
+	if len(imageListResult.Items) == 0 {
+		reader, err := d.client.ImagePull(ctx, imageName, client.ImagePullOptions{})
 		if err != nil {
 			return fmt.Errorf("pull image: %w", err)
 		}
@@ -67,38 +64,41 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string) error {
 func (d *DockerClient) FindRunningContainer(
 	ctx context.Context, containerName, imageName string,
 ) (*container.InspectResponse, bool, error) {
-	filterArgs := filters.NewArgs(
-		filters.Arg("name", containerName),
-		filters.Arg("ancestor", imageName),
-		filters.Arg("status", "running"),
-	)
-
-	containers, err := d.client.ContainerList(ctx, container.ListOptions{
-		Filters: filterArgs,
-		Limit:   1,
+	containerListResult, err := d.client.ContainerList(ctx, client.ContainerListOptions{
+		Limit: 1,
+		Filters: make(client.Filters).
+			Add("name", "^"+containerName+"$").
+			Add("ancestor", imageName).
+			Add("status", "running"),
 	})
 	if err != nil {
 		return nil, false, fmt.Errorf("list containers: %w", err)
 	}
 
-	if len(containers) == 0 {
+	if len(containerListResult.Items) == 0 {
 		return nil, false, nil
 	}
 
-	inspect, err := d.client.ContainerInspect(ctx, containers[0].ID)
+	inspectResult, err := d.client.ContainerInspect(ctx, containerListResult.Items[0].ID, client.ContainerInspectOptions{})
 	if err != nil {
 		return nil, false, fmt.Errorf("inspect %s container: %w", containerName, err)
 	}
 
-	return &inspect, true, nil
+	return &inspectResult.Container, true, nil
 }
 
-// RunContainer starts a container and returns its inspection data.
+// RunContainer starts a container, then returns its inspection data.
+// If Docker reports a conflict because a container with the same name already
+// exists, the existing container is reused and started instead.
 func (d *DockerClient) RunContainer(
 	ctx context.Context, containerCfg *container.Config, hostCfg *container.HostConfig, containerName string,
 ) (*container.InspectResponse, error) {
-	cont, err := d.client.ContainerCreate(ctx, containerCfg, hostCfg, nil, nil, containerName)
-	if err != nil {
+	_, err := d.client.ContainerCreate(ctx, client.ContainerCreateOptions{
+		Name:       containerName,
+		Config:     containerCfg,
+		HostConfig: hostCfg,
+	})
+	if err != nil && !errdefs.IsConflict(err) {
 		return nil, fmt.Errorf("create %s container: %w", containerName, err)
 	}
 
@@ -107,11 +107,11 @@ func (d *DockerClient) RunContainer(
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			d.RemoveContainer(ctx, cont.ID)
+			d.RemoveContainer(ctx, containerName)
 		}
 	}()
 
-	err = d.client.ContainerStart(ctx, cont.ID, container.StartOptions{})
+	_, err = d.client.ContainerStart(ctx, containerName, client.ContainerStartOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("start %s container: %w", containerName, err)
 	}
@@ -121,22 +121,23 @@ func (d *DockerClient) RunContainer(
 		backoff.WithMaxElapsedTime(5*time.Second),
 	)
 
-	var inspect container.InspectResponse
+	var cont container.InspectResponse
 	err = backoff.Retry(func() error {
-		inspect, err = d.client.ContainerInspect(ctx, cont.ID)
+		inspectResult, err := d.client.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
 		if err != nil {
 			return backoff.Permanent(fmt.Errorf("inspect %s container: %w", containerName, err))
 		}
+		cont = inspectResult.Container
 
 		if len(containerCfg.ExposedPorts) == 0 {
 			return nil
 		}
 
-		if len(inspect.NetworkSettings.Ports) == 0 {
+		if len(cont.NetworkSettings.Ports) == 0 {
 			return fmt.Errorf("port bindings not yet available for container %s", containerName)
 		}
 
-		for _, portBindings := range inspect.NetworkSettings.Ports {
+		for _, portBindings := range cont.NetworkSettings.Ports {
 			if len(portBindings) == 0 {
 				return fmt.Errorf("port bindings not yet available for container %s", containerName)
 			}
@@ -149,17 +150,17 @@ func (d *DockerClient) RunContainer(
 		return nil, fmt.Errorf("inspect %s container: %w", containerName, err)
 	}
 
-	return &inspect, nil
+	return &cont, nil
 }
 
 // RemoveContainer kills and removes a container.
 func (d *DockerClient) RemoveContainer(ctx context.Context, containerID string) error {
-	removeOpts := container.RemoveOptions{
+	removeOpts := client.ContainerRemoveOptions{
 		Force:         true,
 		RemoveVolumes: true,
 	}
 
-	if err := d.client.ContainerRemove(ctx, containerID, removeOpts); err != nil {
+	if _, err := d.client.ContainerRemove(ctx, containerID, removeOpts); err != nil {
 		return fmt.Errorf("remove container %s: %w", containerID, err)
 	}
 
@@ -167,13 +168,13 @@ func (d *DockerClient) RemoveContainer(ctx context.Context, containerID string) 
 }
 
 // ExecCommand executes a command in the specified container and waits for it to complete.
-func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, execConfig container.ExecOptions) error {
-	exec, err := d.client.ContainerExecCreate(ctx, containerID, execConfig)
+func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, execConfig client.ExecCreateOptions) error {
+	exec, err := d.client.ExecCreate(ctx, containerID, execConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create exec for command %v: %w", execConfig.Cmd, err)
 	}
 
-	resp, err := d.client.ContainerExecAttach(ctx, exec.ID, container.ExecAttachOptions{})
+	resp, err := d.client.ExecAttach(ctx, exec.ID, client.ExecAttachOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to execute command %v: %w", execConfig.Cmd, err)
 	}
@@ -183,7 +184,7 @@ func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, exec
 		return fmt.Errorf("failed to read exec output for command %v: %w", execConfig.Cmd, err)
 	}
 
-	inspect, err := d.client.ContainerExecInspect(ctx, exec.ID)
+	inspect, err := d.client.ExecInspect(ctx, exec.ID, client.ExecInspectOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to inspect exec %v: %w", execConfig.Cmd, err)
 	}
@@ -196,7 +197,7 @@ func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, exec
 }
 
 // GetHostPort returns the published host port for the given container port.
-func (d *DockerClient) GetHostPort(inspect *container.InspectResponse, containerPort nat.Port) (string, error) {
+func (d *DockerClient) GetHostPort(inspect *container.InspectResponse, containerPort network.Port) (string, error) {
 	m, ok := inspect.NetworkSettings.Ports[containerPort]
 	if !ok || len(m) == 0 {
 		return "", fmt.Errorf("port bindings not available for container port %s", containerPort)

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -1,0 +1,406 @@
+package testutils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	alpineImage = "alpine:3"
+)
+
+func TestNewDockerClient_InvalidHost(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "foobar")
+
+	dc, err := NewDockerClient()
+	require.Nil(t, dc)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "create docker client")
+}
+
+func TestPullImage(t *testing.T) {
+	dc, err := NewDockerClient()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, dc.Close())
+	})
+
+	require.NoError(t, dc.PullImage(t.Context(), alpineImage))
+}
+
+func TestPullImage_Fail(t *testing.T) {
+	t.Run("list_images", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodGet, Path: "/images/json", Error: "list failed"},
+		})
+		err := dc.PullImage(t.Context(), alpineImage)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "list images")
+	})
+
+	t.Run("image_nonexistent", func(t *testing.T) {
+		dc, err := NewDockerClient()
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			require.NoError(t, dc.Close())
+		})
+
+		err = dc.PullImage(t.Context(), "image:nonexistent")
+		require.Error(t, err)
+		require.ErrorContains(t, err, "pull image")
+	})
+}
+
+func TestContainerLifecycle_PullAndExec(t *testing.T) {
+	dc, err := NewDockerClient()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, dc.Close())
+	})
+
+	require.NoError(t, dc.PullImage(t.Context(), alpineImage))
+
+	containerCfg := &container.Config{
+		Image: alpineImage,
+		Cmd:   []string{"sh", "-c", "sleep 30"},
+	}
+	hostCfg := &container.HostConfig{}
+	containerName := "test-dc-client-" + ulid.Make().String()
+
+	inspect, err := dc.RunContainer(t.Context(), containerCfg, hostCfg, containerName)
+	require.NoError(t, err)
+	require.NotEmpty(t, inspect.ID)
+
+	t.Cleanup(func() {
+		_ = dc.RemoveContainer(context.Background(), inspect.ID)
+	})
+
+	foundInspect, running, err := dc.FindRunningContainer(t.Context(), containerName, alpineImage)
+	require.NoError(t, err)
+	require.True(t, running)
+	require.Equal(t, inspect.ID, foundInspect.ID)
+
+	err = dc.ExecCommand(t.Context(), inspect.ID, container.ExecOptions{
+		Cmd: []string{"echo", "hello!"},
+	})
+	require.NoError(t, err)
+}
+
+func TestFindRunningContainer_Fail(t *testing.T) {
+	t.Run("not_found", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodGet, Path: "/containers/json", Body: []byte(`[]`)},
+		})
+
+		_, found, err := dc.FindRunningContainer(t.Context(), "does-not-exist", alpineImage)
+		require.NoError(t, err)
+		require.False(t, found)
+	})
+
+	t.Run("list_containers", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodGet, Path: "/containers/json", Error: "list failed"},
+		})
+
+		inspect, found, err := dc.FindRunningContainer(t.Context(), "test", alpineImage)
+		require.Nil(t, inspect)
+		require.False(t, found)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "list containers")
+	})
+
+	t.Run("inspect_container", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodGet, Path: "/containers/json", Body: []byte(`[{"Id":"container-id"}]`)},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "inspect failed"},
+		})
+
+		inspect, found, err := dc.FindRunningContainer(t.Context(), "test", alpineImage)
+		require.Nil(t, inspect)
+		require.False(t, found)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "inspect test container")
+	})
+}
+
+func TestRunContainer_WithExposedPorts(t *testing.T) {
+	createBody := []byte(`{"Id":"container-id"}`)
+	startBody := []byte(`{}`)
+	portsReadyBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}}}`)
+
+	exposedCfg := &container.Config{
+		ExposedPorts: nat.PortSet{"5432/tcp": struct{}{}},
+	}
+
+	t.Run("ports_ready_immediately", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		require.NoError(t, err)
+		require.NotNil(t, inspect)
+	})
+
+	t.Run("empty_ports_map_then_ready", func(t *testing.T) {
+		noPortsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{}}}`)
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: noPortsBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		require.NoError(t, err)
+		require.NotNil(t, inspect)
+	})
+
+	t.Run("empty_port_bindings_then_ready", func(t *testing.T) {
+		emptyBindingsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[]}}}`)
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: emptyBindingsBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		require.NoError(t, err)
+		require.NotNil(t, inspect)
+	})
+}
+
+func TestRunContainer_Fail(t *testing.T) {
+	createBody := []byte(`{"Id":"container-id"}`)
+	emptyBody := []byte(`{}`)
+
+	t.Run("create_container", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Error: "create failed"},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		require.Nil(t, inspect)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "create test container")
+	})
+
+	t.Run("start_container", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Error: "start failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		require.Nil(t, inspect)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "start test container")
+	})
+
+	t.Run("inspect_container", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: emptyBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "inspect failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
+		})
+
+		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		require.Nil(t, inspect)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "inspect test container")
+	})
+}
+
+func TestRemoveContainer_Fail(t *testing.T) {
+	dc := newDockerClientMock(t, []dockerMockStep{
+		{Method: http.MethodDelete, Path: "/containers/container-id", Error: "remove failed"},
+	})
+
+	err := dc.RemoveContainer(context.Background(), "container-id")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "remove container container-id")
+}
+
+func TestExecCommand_Fail(t *testing.T) {
+	t.Run("bad_cmd", func(t *testing.T) {
+		dc, err := NewDockerClient()
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, dc.Close()) })
+
+		require.NoError(t, dc.PullImage(t.Context(), alpineImage))
+
+		containerName := "exec-bad-cmd-" + ulid.Make().String()
+		contConf := &container.Config{
+			Image: alpineImage,
+			Cmd:   []string{"sleep", "30"},
+		}
+		inspect, err := dc.RunContainer(t.Context(), contConf, &container.HostConfig{}, containerName)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = dc.RemoveContainer(context.Background(), inspect.ID) })
+
+		err = dc.ExecCommand(t.Context(), inspect.ID, container.ExecOptions{
+			Cmd: []string{"badcommand"},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "command [badcommand] completed with exit code 127")
+	})
+
+	t.Run("create_exec", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/container-id/exec", Error: "create exec failed"},
+		})
+
+		err := dc.ExecCommand(t.Context(), "container-id", container.ExecOptions{
+			Cmd: []string{"echo", "hello"},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to create exec")
+	})
+
+	t.Run("start_exec", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/container-id/exec", Body: []byte(`{"Id":"exec-id"}`)},
+			{Method: http.MethodPost, Path: "/exec/exec-id/start", Error: "start exec failed"},
+		})
+
+		err := dc.ExecCommand(t.Context(), "container-id", container.ExecOptions{
+			Cmd: []string{"echo", "hello"},
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to execute command")
+	})
+}
+
+func TestGetHostPort(t *testing.T) {
+	t.Run("returns_host_port", func(t *testing.T) {
+		dc := &DockerClient{}
+		networkSettings := &container.NetworkSettings{}
+		networkSettings.Ports = nat.PortMap{
+			"5432/tcp": []nat.PortBinding{
+				{HostIP: "0.0.0.0", HostPort: "54321"},
+			},
+		}
+		inspect := &container.InspectResponse{
+			NetworkSettings: networkSettings,
+		}
+
+		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		require.NoError(t, err)
+		require.Equal(t, "54321", port)
+	})
+
+	t.Run("returns_error_when_port_missing", func(t *testing.T) {
+		dc := &DockerClient{}
+		networkSettings := &container.NetworkSettings{}
+		networkSettings.Ports = nat.PortMap{}
+		inspect := &container.InspectResponse{
+			NetworkSettings: networkSettings,
+		}
+
+		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		require.Empty(t, port)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "port bindings not available for container port 5432/tcp")
+	})
+
+	t.Run("returns_error_when_binding_empty", func(t *testing.T) {
+		dc := &DockerClient{}
+		networkSettings := &container.NetworkSettings{}
+		networkSettings.Ports = nat.PortMap{
+			"5432/tcp": []nat.PortBinding{},
+		}
+		inspect := &container.InspectResponse{
+			NetworkSettings: networkSettings,
+		}
+
+		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		require.Empty(t, port)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "port bindings not available for container port 5432/tcp")
+	})
+}
+
+type dockerMockStep struct {
+	Method string
+	Path   string
+	Body   []byte
+	Error  string
+}
+
+// newDockerClientMock wires a Docker client to a httptest server for unit tests.
+func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
+	t.Helper()
+
+	t.Cleanup(func() {
+		if len(steps) != 0 {
+			t.Errorf("%d mock step(s) were not consumed", len(steps))
+		}
+	})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(steps) == 0 {
+			t.Fatalf("no more steps left for request %s %s", r.Method, r.URL.Path)
+		}
+		step := steps[0]
+		steps = steps[1:]
+
+		if r.Method != step.Method {
+			t.Fatalf("expected method %s, got %s", step.Method, r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, step.Path) {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+
+		if step.Body != nil {
+			_, _ = w.Write(step.Body)
+			return
+		}
+
+		if step.Error != "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"message": step.Error,
+			})
+
+			return
+		}
+	})
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	cli, err := client.NewClientWithOpts(
+		client.WithHost("tcp://"+serverURL.Host),
+		client.WithHTTPClient(server.Client()),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, cli.Close())
+	})
+
+	return &DockerClient{client: cli}
+}

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/docker/docker/api/types/container"
@@ -350,18 +351,23 @@ type dockerMockStep struct {
 func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
 	t.Helper()
 
+	var stepIndex atomic.Int32
+
 	t.Cleanup(func() {
-		if len(steps) != 0 {
-			t.Errorf("%d mock step(s) were not consumed", len(steps))
+		remaining := len(steps) - int(stepIndex.Load())
+		if remaining != 0 {
+			t.Errorf("%d mock step(s) were not consumed", remaining)
 		}
 	})
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if len(steps) == 0 {
+		currentIndex := int(stepIndex.Add(1)) - 1
+
+		if currentIndex >= len(steps) {
 			t.Fatalf("no more steps left for request %s %s", r.Method, r.URL.Path)
 		}
-		step := steps[0]
-		steps = steps[1:]
+
+		step := steps[currentIndex]
 
 		if r.Method != step.Method {
 			t.Fatalf("expected method %s, got %s", step.Method, r.Method)

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -52,14 +52,11 @@ func TestPullImage_Fail(t *testing.T) {
 	})
 
 	t.Run("image_nonexistent", func(t *testing.T) {
-		dc, err := NewDockerClient()
-		require.NoError(t, err)
-
-		t.Cleanup(func() {
-			require.NoError(t, dc.Close())
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodGet, Path: "/images/json", Body: []byte(`[]`)},
+			{Method: http.MethodPost, Path: "/images/create", Error: "pull failed"},
 		})
-
-		err = dc.PullImage(t.Context(), "image:nonexistent")
+		err := dc.PullImage(t.Context(), "image:nonexistent")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "pull image")
 	})

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -5,20 +5,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
 
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
-	"github.com/docker/go-connections/nat"
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	"github.com/moby/moby/client"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
 
 const (
 	alpineImage = "alpine:3"
+)
+
+var (
+	testPort = network.MustParsePort("5432/tcp")
 )
 
 func TestNewDockerClient_InvalidHost(t *testing.T) {
@@ -92,7 +97,7 @@ func TestContainerLifecycle_PullAndExec(t *testing.T) {
 	require.True(t, running)
 	require.Equal(t, inspect.ID, foundInspect.ID)
 
-	err = dc.ExecCommand(t.Context(), inspect.ID, container.ExecOptions{
+	err = dc.ExecCommand(t.Context(), inspect.ID, client.ExecCreateOptions{
 		Cmd: []string{"echo", "hello!"},
 	})
 	require.NoError(t, err)
@@ -141,17 +146,18 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 	portsReadyBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}}}`)
 
 	exposedCfg := &container.Config{
-		ExposedPorts: nat.PortSet{"5432/tcp": struct{}{}},
+		Image:        alpineImage,
+		ExposedPorts: network.PortSet{testPort: struct{}{}},
 	}
 
 	t.Run("ports_ready_immediately", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
 		require.NotNil(t, inspect)
 	})
@@ -160,12 +166,12 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 		noPortsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{}}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: noPortsBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: noPortsBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
 		require.NotNil(t, inspect)
 	})
@@ -174,12 +180,12 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 		emptyBindingsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[]}}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: emptyBindingsBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: emptyBindingsBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
 		require.NotNil(t, inspect)
 	})
@@ -188,13 +194,16 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 func TestRunContainer_Fail(t *testing.T) {
 	createBody := []byte(`{"Id":"container-id"}`)
 	emptyBody := []byte(`{}`)
+	containerCfg := &container.Config{
+		Image: alpineImage,
+	}
 
 	t.Run("create_container", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Error: "create failed"},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "test")
 		require.Nil(t, inspect)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "create test container")
@@ -203,28 +212,28 @@ func TestRunContainer_Fail(t *testing.T) {
 	t.Run("start_container", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-id/start", Error: "start failed"},
-			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Error: "start failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
 		require.Nil(t, inspect)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "start test container")
+		require.ErrorContains(t, err, "start container-name")
 	})
 
 	t.Run("inspect_container", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: emptyBody},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "inspect failed"},
-			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: emptyBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Error: "inspect failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), &container.Config{}, &container.HostConfig{}, "test")
+		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
 		require.Nil(t, inspect)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "inspect test container")
+		require.ErrorContains(t, err, "inspect container-name")
 	})
 }
 
@@ -255,7 +264,7 @@ func TestExecCommand_Fail(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = dc.RemoveContainer(context.Background(), inspect.ID) })
 
-		err = dc.ExecCommand(t.Context(), inspect.ID, container.ExecOptions{
+		err = dc.ExecCommand(t.Context(), inspect.ID, client.ExecCreateOptions{
 			Cmd: []string{"badcommand"},
 		})
 		require.Error(t, err)
@@ -267,7 +276,7 @@ func TestExecCommand_Fail(t *testing.T) {
 			{Method: http.MethodPost, Path: "/containers/container-id/exec", Error: "create exec failed"},
 		})
 
-		err := dc.ExecCommand(t.Context(), "container-id", container.ExecOptions{
+		err := dc.ExecCommand(t.Context(), "container-id", client.ExecCreateOptions{
 			Cmd: []string{"echo", "hello"},
 		})
 		require.Error(t, err)
@@ -280,7 +289,7 @@ func TestExecCommand_Fail(t *testing.T) {
 			{Method: http.MethodPost, Path: "/exec/exec-id/start", Error: "start exec failed"},
 		})
 
-		err := dc.ExecCommand(t.Context(), "container-id", container.ExecOptions{
+		err := dc.ExecCommand(t.Context(), "container-id", client.ExecCreateOptions{
 			Cmd: []string{"echo", "hello"},
 		})
 		require.Error(t, err)
@@ -292,16 +301,16 @@ func TestGetHostPort(t *testing.T) {
 	t.Run("returns_host_port", func(t *testing.T) {
 		dc := &DockerClient{}
 		networkSettings := &container.NetworkSettings{}
-		networkSettings.Ports = nat.PortMap{
-			"5432/tcp": []nat.PortBinding{
-				{HostIP: "0.0.0.0", HostPort: "54321"},
+		networkSettings.Ports = network.PortMap{
+			testPort: []network.PortBinding{
+				{HostIP: netip.MustParseAddr("0.0.0.0"), HostPort: "54321"},
 			},
 		}
 		inspect := &container.InspectResponse{
 			NetworkSettings: networkSettings,
 		}
 
-		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		port, err := dc.GetHostPort(inspect, testPort)
 		require.NoError(t, err)
 		require.Equal(t, "54321", port)
 	})
@@ -309,12 +318,12 @@ func TestGetHostPort(t *testing.T) {
 	t.Run("returns_error_when_port_missing", func(t *testing.T) {
 		dc := &DockerClient{}
 		networkSettings := &container.NetworkSettings{}
-		networkSettings.Ports = nat.PortMap{}
+		networkSettings.Ports = network.PortMap{}
 		inspect := &container.InspectResponse{
 			NetworkSettings: networkSettings,
 		}
 
-		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		port, err := dc.GetHostPort(inspect, testPort)
 		require.Empty(t, port)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "port bindings not available for container port 5432/tcp")
@@ -323,14 +332,14 @@ func TestGetHostPort(t *testing.T) {
 	t.Run("returns_error_when_binding_empty", func(t *testing.T) {
 		dc := &DockerClient{}
 		networkSettings := &container.NetworkSettings{}
-		networkSettings.Ports = nat.PortMap{
-			"5432/tcp": []nat.PortBinding{},
+		networkSettings.Ports = network.PortMap{
+			testPort: []network.PortBinding{},
 		}
 		inspect := &container.InspectResponse{
 			NetworkSettings: networkSettings,
 		}
 
-		port, err := dc.GetHostPort(inspect, nat.Port("5432/tcp"))
+		port, err := dc.GetHostPort(inspect, testPort)
 		require.Empty(t, port)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "port bindings not available for container port 5432/tcp")
@@ -358,6 +367,12 @@ func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
 	})
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// ignore HEAD requests since the Docker client may send them
+		// to check if the server is alive before sending the actual request
+		if r.Method == http.MethodHead {
+			return
+		}
+
 		currentIndex := int(stepIndex.Add(1)) - 1
 
 		if currentIndex >= len(steps) {
@@ -395,7 +410,7 @@ func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
 	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
 
-	cli, err := client.NewClientWithOpts(
+	cli, err := client.New(
 		client.WithHost("tcp://"+serverURL.Host),
 		client.WithHTTPClient(server.Client()),
 	)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc"
 
@@ -92,7 +91,7 @@ func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *r
 
 // BuildClientInterface sets up test client interface to be used for matrix test.
 func BuildClientInterface(t *testing.T, engine string, experimentals []string) ClientInterface {
-	cfg := testutils.MustDefaultConfig()
+	cfg := testutils.MustDefaultConfigForParallelTests()
 	if len(experimentals) > 0 {
 		cfg.Experimentals = append(cfg.Experimentals, experimentals...)
 	}
@@ -100,8 +99,6 @@ func BuildClientInterface(t *testing.T, engine string, experimentals []string) C
 	cfg.Datastore.Engine = engine
 	cfg.ListUsersDeadline = 0   // no deadline
 	cfg.ListObjectsDeadline = 0 // no deadline
-	// extend the timeout for the tests, coverage makes them slower
-	cfg.RequestTimeout = 10 * time.Second
 	cfg.SharedIterator.Enabled = true
 
 	cfg.CheckIteratorCache.Enabled = true


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

The `RunDatastoreTestContainer` storage fixture currently creates a new container on each invocation, which can result in more than 10 containers being started during a single test run per storage. Each container initialization involves startup and running migrations, increasing execution time and resource usage in CI. This added overhead can negatively impact overall test performance.

#### How is it being solved?

I started with `PostgreSQL` by updating its test fixture to reuse a single container across tests, while maintaining isolation through per-test databases. This significantly reduces the overhead of container creation and migration execution.

As a result, the execution time of `storage/postgres/postgres_test.go` decreased by ~30%:
- Before: `github.com/openfga/openfga/pkg/storage/postgres	159.219s`
- After:    `github.com/openfga/openfga/pkg/storage/postgres	108.411s`

> [!WARNING]
> The current implementation does not remove the `PostgreSQL` container after tests complete. Instead, it is cleaned up along with the `CI` worker. As an improvement, this cleanup step could be added to the `make test` command.

#### What changes are made to solve it?

- Added an improved `Docker` client in `testutils`, used by the `PostgreSQL` fixture and ready for `MySQL` reuse.
- Updated the PostgreSQL test fixture to reuse a single container.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

followup https://github.com/openfga/openfga/pull/2912

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tests now reuse a shared PostgreSQL container and create per-test databases, speeding runs and reducing resource use.
* **Tests**
  * Added a Docker client wrapper with comprehensive container lifecycle tests and updated test harness to use a parallel-ready default config.
* **Refactor**
  * Improved database readiness, retry/backoff, replica sync, and migration/version wait logic to stabilize test startup.
* **Documentation**
  * CHANGELOG updated describing the testing infrastructure changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->