### PR TITLE
feat: add jitter to internal cache TTLs to prevent thundering herd effects

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -640,6 +640,14 @@
                 }
             }
         },
+        "cacheTTLJitterPercentage": {
+            "description": "A percentage (0-100) of the base TTL added as random jitter to each cache entry's TTL, spreading out expirations to prevent thundering herd effects. For example, a value of 10 with a base TTL of 10s means each entry gets a TTL between 10s and 11s.",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "default": 0,
+            "x-env-variable": "OPENFGA_CACHE_TTL_JITTER_PERCENTAGE"
+        },
         "checkDispatchThrottling": {
             "type": "object",
             "properties": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Made some minor changes in ListObjects to reduce heap allocations. Results in minor latency reduction. [#3043](https://github.com/openfga/openfga/pull/3043)
 - Improve cache key generation performance by removing `fmt` usage and extend control-character sanitization to all cache key inputs (tuples, conditions, context). [#3006](https://github.com/openfga/openfga/pull/3006)
+- Add jitter to internal cache TTLs to spread expirations and reduce thundering herd effects. [#3033](https://github.com/openfga/openfga/pull/3033)
 
 ### Security
 - Fixed AuthZEN discovery metadata to publish endpoint URLs from the configured `authzen.baseURL` instead of request-supplied host headers, preventing host-header poisoning of `/.well-known/authzen-configuration/{store_id}`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.14.1] - 2026-04-10
 ### Added
 - Added configuration for the server shutdown timeout. [#2976](https://github.com/openfga/openfga/pull/2976)
+- Add jitter to internal cache TTLs to spread expirations and reduce thundering herd effects. [#3033](https://github.com/openfga/openfga/pull/3033)
 
 ### Changed
 - Made some minor changes in ListObjects to reduce heap allocations. Results in minor latency reduction. [#3043](https://github.com/openfga/openfga/pull/3043)
 - Improve cache key generation performance by removing `fmt` usage and extend control-character sanitization to all cache key inputs (tuples, conditions, context). [#3006](https://github.com/openfga/openfga/pull/3006)
-- Add jitter to internal cache TTLs to spread expirations and reduce thundering herd effects. [#3033](https://github.com/openfga/openfga/pull/3033)
 
 ### Security
 - Fixed AuthZEN discovery metadata to publish endpoint URLs from the configured `authzen.baseURL` instead of request-supplied host headers, preventing host-header poisoning of `/.well-known/authzen-configuration/{store_id}`.

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -258,6 +258,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("cacheController.ttl", flags.Lookup("cache-controller-ttl"))
 		util.MustBindEnv("cacheController.ttl", "OPENFGA_CACHE_CONTROLLER_TTL")
 
+		util.MustBindPFlag("cacheTTLJitterPercentage", flags.Lookup("cache-ttl-jitter-percentage"))
+		util.MustBindEnv("cacheTTLJitterPercentage", "OPENFGA_CACHE_TTL_JITTER_PERCENTAGE")
+
 		util.MustBindPFlag("checkIteratorCache.enabled", flags.Lookup("check-iterator-cache-enabled"))
 		util.MustBindEnv("checkIteratorCache.enabled", "OPENFGA_CHECK_ITERATOR_CACHE_ENABLED")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -316,6 +316,8 @@ func NewRunCommand() *cobra.Command {
 
 	flags.Duration("cache-controller-ttl", defaultConfig.CacheController.TTL, "if cache controller is enabled, this is the minimum time interval for Check requests to trigger cache invalidation. List Objects requests may trigger invalidation even sooner if list objects iterator cache is enabled.")
 
+	flags.Uint32("cache-ttl-jitter-percentage", defaultConfig.CacheTTLJitterPercentage, "a percentage (0-100) of the base TTL added as random jitter to each cache entry's TTL, spreading out expirations to prevent thundering herd effects. For example, a value of 10 with a base TTL of 10s means each entry gets a TTL between 10s and 11s. Default is 0 (no jitter).")
+
 	// Unfortunately UintSlice/IntSlice does not work well when used as environment variable, we need to stick with string slice and convert back to integer
 	flags.StringSlice("request-duration-datastore-query-count-buckets", defaultConfig.RequestDurationDatastoreQueryCountBuckets, "datastore query count buckets used in labelling request_duration_ms.")
 
@@ -1022,6 +1024,7 @@ func (s *ServerContext) Run(ctx context.Context, config *serverconfig.Config) er
 		server.WithListObjectsIteratorCacheEnabled(config.ListObjectsIteratorCache.Enabled),
 		server.WithListObjectsIteratorCacheMaxResults(config.ListObjectsIteratorCache.MaxResults),
 		server.WithListObjectsIteratorCacheTTL(config.ListObjectsIteratorCache.TTL),
+		server.WithCacheTTLJitterPercentage(config.CacheTTLJitterPercentage),
 		server.WithMaxChecksPerBatchCheck(config.MaxChecksPerBatchCheck),
 		server.WithMaxConcurrentChecksPerBatchCheck(config.MaxConcurrentChecksPerBatchCheck),
 		server.WithSharedIteratorEnabled(config.SharedIterator.Enabled),

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1568,6 +1568,47 @@ requestDurationDispatchCountBuckets: [32,42]
 	require.Equal(t, []string{"32", "42"}, cfg.RequestDurationDispatchCountBuckets)
 }
 
+func TestParseConfigCacheTTLJitterPercentageFromFlag(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	util.PrepareTempConfigDir(t)
+
+	runCmd := NewRunCommand()
+	runCmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		return nil
+	}
+
+	rootCmd := cmd.NewRootCommand()
+	rootCmd.AddCommand(runCmd)
+	rootCmd.SetArgs([]string{"run", "--cache-ttl-jitter-percentage", "17"})
+	require.NoError(t, rootCmd.Execute())
+
+	cfg, err := ReadConfig()
+	require.NoError(t, err)
+	require.Equal(t, uint32(17), cfg.CacheTTLJitterPercentage)
+}
+
+func TestParseConfigCacheTTLJitterPercentageFromEnv(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	util.PrepareTempConfigDir(t)
+	t.Setenv("OPENFGA_CACHE_TTL_JITTER_PERCENTAGE", "18")
+
+	runCmd := NewRunCommand()
+	runCmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		return nil
+	}
+
+	rootCmd := cmd.NewRootCommand()
+	rootCmd.AddCommand(runCmd)
+	rootCmd.SetArgs([]string{"run"})
+	require.NoError(t, rootCmd.Execute())
+
+	cfg, err := ReadConfig()
+	require.NoError(t, err)
+	require.Equal(t, uint32(18), cfg.CacheTTLJitterPercentage)
+}
+
 func TestRunCommandConfigIsMerged(t *testing.T) {
 	config := `datastore:
     engine: postgres

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -60,10 +60,11 @@ func (c *CheckResponseCacheEntry) CacheEntityType() string {
 // CachedCheckResolver attempts to resolve check sub-problems via prior computations before
 // delegating the request to some underlying CheckResolver.
 type CachedCheckResolver struct {
-	delegate CheckResolver
-	cache    storage.InMemoryCache[any]
-	cacheTTL time.Duration
-	logger   logger.Logger
+	delegate         CheckResolver
+	cache            storage.InMemoryCache[any]
+	cacheTTL         time.Duration
+	jitterPercentage uint32
+	logger           logger.Logger
 	// allocatedCache is used to denote whether the cache is allocated by this struct.
 	// If so, CachedCheckResolver is responsible for cleaning up.
 	allocatedCache bool
@@ -88,6 +89,15 @@ func WithCacheTTL(ttl time.Duration) CachedCheckResolverOpt {
 func WithExistingCache(cache storage.InMemoryCache[any]) CachedCheckResolverOpt {
 	return func(ccr *CachedCheckResolver) {
 		ccr.cache = cache
+	}
+}
+
+// WithJitterPercentage sets the jitter percentage for cache TTLs.
+// A value of 10 means up to 10% of the base TTL is added as random jitter
+// to each cache entry, spreading out expirations.
+func WithJitterPercentage(pct uint32) CachedCheckResolverOpt {
+	return func(ccr *CachedCheckResolver) {
+		ccr.jitterPercentage = pct
 	}
 }
 
@@ -207,7 +217,7 @@ func (c *CachedCheckResolver) ResolveCheck(
 
 	clonedResp := resp.clone()
 
-	c.cache.Set(cacheKey, &CheckResponseCacheEntry{LastModified: time.Now(), CheckResponse: clonedResp}, c.cacheTTL)
+	c.cache.Set(cacheKey, &CheckResponseCacheEntry{LastModified: time.Now(), CheckResponse: clonedResp}, storage.JitteredTTL(c.cacheTTL, c.jitterPercentage))
 	return resp, nil
 }
 

--- a/pkg/server/config/cache_settings.go
+++ b/pkg/server/config/cache_settings.go
@@ -20,6 +20,15 @@ type CacheSettings struct {
 	SharedIteratorEnabled              bool
 	SharedIteratorLimit                uint32
 	SharedIteratorTTL                  time.Duration
+
+	// CacheTTLJitterPercentage is a percentage (0-100) of the base TTL that is used
+	// as the upper bound for a random jitter added to each cache entry's TTL.
+	// This spreads out cache expirations to prevent thundering herd effects
+	// where many entries expire and refresh simultaneously.
+	// For example, a value of 10 with a base TTL of 10s means each entry
+	// gets a TTL between 10s and 11s.
+	// A value of 0 disables jitter (default, for backward compatibility).
+	CacheTTLJitterPercentage uint32
 }
 
 func NewDefaultCacheSettings() CacheSettings {
@@ -39,6 +48,7 @@ func NewDefaultCacheSettings() CacheSettings {
 		SharedIteratorEnabled:              DefaultSharedIteratorEnabled,
 		SharedIteratorLimit:                DefaultSharedIteratorLimit,
 		SharedIteratorTTL:                  DefaultSharedIteratorTTL,
+		CacheTTLJitterPercentage:           DefaultCacheTTLJitterPercentage,
 	}
 }
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -96,6 +96,8 @@ const (
 	DefaultSharedIteratorMaxAdmissionTime = 10 * time.Second
 	DefaultSharedIteratorMaxIdleTime      = 1 * time.Second
 
+	DefaultCacheTTLJitterPercentage = 0
+
 	DefaultPlannerEvictionThreshold = 0
 	DefaultPlannerCleanupInterval   = 0
 
@@ -457,6 +459,7 @@ type Config struct {
 	CheckIteratorCache            IteratorCacheConfig
 	CheckQueryCache               CheckQueryCache
 	CacheController               CacheControllerConfig
+	CacheTTLJitterPercentage      uint32
 	CheckDispatchThrottling       DispatchThrottlingConfig
 	ListObjectsDispatchThrottling DispatchThrottlingConfig
 	ListUsersDispatchThrottling   DispatchThrottlingConfig
@@ -740,6 +743,9 @@ func (cfg *Config) verifyCacheConfig() error {
 	if cfg.CacheController.Enabled && cfg.CacheController.TTL <= 0 {
 		return errors.New("'cacheController.ttl' must be greater than zero")
 	}
+	if cfg.CacheTTLJitterPercentage > 100 {
+		return errors.New("'cacheTTLJitterPercentage' must be between 0 and 100")
+	}
 	return nil
 }
 
@@ -902,6 +908,7 @@ func DefaultConfig() *Config {
 			Enabled: DefaultCacheControllerConfigEnabled,
 			TTL:     DefaultCacheControllerConfigTTL,
 		},
+		CacheTTLJitterPercentage: DefaultCacheTTLJitterPercentage,
 		CheckDispatchThrottling: DispatchThrottlingConfig{
 			Enabled:      DefaultCheckDispatchThrottlingEnabled,
 			Frequency:    DefaultCheckDispatchThrottlingFrequency,

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -569,6 +569,33 @@ func TestVerifyConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("cache_ttl_jitter_percentage", func(t *testing.T) {
+		t.Run("valid_zero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheTTLJitterPercentage = 0
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+		t.Run("valid_nonzero", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheTTLJitterPercentage = 10
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+		t.Run("valid_max", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheTTLJitterPercentage = 100
+			err := cfg.Verify()
+			require.NoError(t, err)
+		})
+		t.Run("invalid_over_100", func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.CacheTTLJitterPercentage = 101
+			err := cfg.Verify()
+			require.Error(t, err)
+		})
+	})
+
 	t.Run("prints_warning_when_log_level_is_none", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Log.Level = "none"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -558,8 +558,12 @@ func WithListObjectsIteratorCacheTTL(ttl time.Duration) OpenFGAServiceV1Option {
 // WithCacheTTLJitterPercentage sets the jitter percentage applied to cache TTLs.
 // A value of 10 means up to 10% of the base TTL is added as random jitter to each
 // cache entry, spreading out expirations and preventing thundering herd effects.
+// Values above 100 are capped to 100.
 func WithCacheTTLJitterPercentage(pct uint32) OpenFGAServiceV1Option {
 	return func(s *Server) {
+		if pct > 100 {
+			pct = 100
+		}
 		s.cacheSettings.CacheTTLJitterPercentage = pct
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -562,6 +562,8 @@ func WithListObjectsIteratorCacheTTL(ttl time.Duration) OpenFGAServiceV1Option {
 func WithCacheTTLJitterPercentage(pct uint32) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		if pct > 100 {
+			s.logger.Warn("cache TTL jitter percentage exceeded 100, capping to 100",
+				zap.Uint32("requested", pct))
 			pct = 100
 		}
 		s.cacheSettings.CacheTTLJitterPercentage = pct

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -562,7 +562,7 @@ func WithListObjectsIteratorCacheTTL(ttl time.Duration) OpenFGAServiceV1Option {
 func WithCacheTTLJitterPercentage(pct uint32) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		if pct > 100 {
-			s.logger.Warn("cache TTL jitter percentage exceeded 100, capping to 100",
+			s.logger.Warn("cacheTTLJitterPercentage exceeded 100, capping to 100",
 				zap.Uint32("requested", pct))
 			pct = 100
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -555,6 +555,15 @@ func WithListObjectsIteratorCacheTTL(ttl time.Duration) OpenFGAServiceV1Option {
 	}
 }
 
+// WithCacheTTLJitterPercentage sets the jitter percentage applied to cache TTLs.
+// A value of 10 means up to 10% of the base TTL is added as random jitter to each
+// cache entry, spreading out expirations and preventing thundering herd effects.
+func WithCacheTTLJitterPercentage(pct uint32) OpenFGAServiceV1Option {
+	return func(s *Server) {
+		s.cacheSettings.CacheTTLJitterPercentage = pct
+	}
+}
+
 // WithRequestDurationByQueryHistogramBuckets sets the buckets used in labelling the requestDurationByQueryAndDispatchHistogram.
 func WithRequestDurationByQueryHistogramBuckets(buckets []uint) OpenFGAServiceV1Option {
 	return func(s *Server) {
@@ -1162,6 +1171,7 @@ func (s *Server) getCheckResolverOptions() ([]graph.CachedCheckResolverOpt, []gr
 			graph.WithExistingCache(s.sharedDatastoreResources.CheckCache),
 			graph.WithLogger(s.logger),
 			graph.WithCacheTTL(s.cacheSettings.CheckQueryCacheTTL),
+			graph.WithJitterPercentage(s.cacheSettings.CacheTTLJitterPercentage),
 		)
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -33,6 +35,7 @@ import (
 	"github.com/openfga/openfga/internal/graph"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/featureflags"
+	"github.com/openfga/openfga/pkg/logger"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/server/test"
@@ -2148,6 +2151,40 @@ func TestServerListObjectsCache(t *testing.T) {
 		t.Cleanup(s.Close)
 
 		require.Nil(t, s.sharedDatastoreResources.CheckCache)
+	})
+}
+
+func TestWithCacheTTLJitterPercentage(t *testing.T) {
+	t.Run("keeps values within range without warning", func(t *testing.T) {
+		core, logs := observer.New(zap.WarnLevel)
+		testLogger := &logger.ZapLogger{Logger: zap.New(core)}
+
+		s := MustNewServerWithOpts(
+			WithDatastore(memory.New()),
+			WithLogger(testLogger),
+			WithCacheTTLJitterPercentage(10),
+		)
+		t.Cleanup(s.Close)
+
+		require.EqualValues(t, 10, s.cacheSettings.CacheTTLJitterPercentage)
+		require.Zero(t, logs.Len())
+	})
+
+	t.Run("caps values above 100 and logs the requested value", func(t *testing.T) {
+		core, logs := observer.New(zap.WarnLevel)
+		testLogger := &logger.ZapLogger{Logger: zap.New(core)}
+
+		s := MustNewServerWithOpts(
+			WithDatastore(memory.New()),
+			WithLogger(testLogger),
+			WithCacheTTLJitterPercentage(101),
+		)
+		t.Cleanup(s.Close)
+
+		require.EqualValues(t, 100, s.cacheSettings.CacheTTLJitterPercentage)
+		require.Equal(t, 1, logs.Len())
+		require.Equal(t, "cacheTTLJitterPercentage exceeded 100, capping to 100", logs.All()[0].Message)
+		require.EqualValues(t, 101, logs.All()[0].ContextMap()["requested"])
 	})
 }
 

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"sort"
 	"strconv"
 	"sync"
@@ -451,6 +452,19 @@ func writeTuples(w io.StringWriter, tuples ...*openfgav1.TupleKey) (err error) {
 		}
 	}
 	return
+}
+
+// JitteredTTL returns a TTL with random jitter added. The jitter is a random duration
+// in the range [0, baseTTL * jitterPercentage / 100]. If jitterPercentage is 0 the
+// base TTL is returned unchanged.
+func JitteredTTL(baseTTL time.Duration, jitterPercentage uint32) time.Duration {
+	if jitterPercentage == 0 || baseTTL <= 0 {
+		return baseTTL
+	}
+	maxJitter := time.Duration(float64(baseTTL) * float64(jitterPercentage) / 100.0)
+	//nolint:gosec // G404: no security implications, jitter is for load distribution
+	jitter := time.Duration(rand.Int63n(int64(maxJitter) + 1))
+	return baseTTL + jitter
 }
 
 // CheckCacheKeyParams is all the necessary pieces to create a unique-per-check cache key.

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/rand"
 	"sort"
 	"strconv"
@@ -455,15 +456,34 @@ func writeTuples(w io.StringWriter, tuples ...*openfgav1.TupleKey) (err error) {
 }
 
 // JitteredTTL returns a TTL with random jitter added. The jitter is a random duration
-// in the range [0, baseTTL * jitterPercentage / 100]. If jitterPercentage is 0 the
-// base TTL is returned unchanged.
+// in the range [0, baseTTL * jitterPercentage / 100]. Values above 100 are treated as
+// 100. If jitterPercentage is 0 the base TTL is returned unchanged.
 func JitteredTTL(baseTTL time.Duration, jitterPercentage uint32) time.Duration {
-	if jitterPercentage == 0 || baseTTL <= 0 {
+	if baseTTL <= 0 || jitterPercentage == 0 {
 		return baseTTL
 	}
-	maxJitter := time.Duration(float64(baseTTL) * float64(jitterPercentage) / 100.0)
-	//nolint:gosec // G404: no security implications, jitter is for load distribution
-	jitter := time.Duration(rand.Int63n(int64(maxJitter) + 1))
+
+	if jitterPercentage > 100 {
+		jitterPercentage = 100
+	}
+
+	quotient := baseTTL / 100
+	remainder := baseTTL % 100
+	maxJitter := quotient*time.Duration(jitterPercentage) + remainder*time.Duration(jitterPercentage)/100
+
+	var jitter time.Duration
+	if maxJitter == time.Duration(math.MaxInt64) {
+		//nolint:gosec // G404: no security implications, jitter is for load distribution
+		jitter = time.Duration(rand.Uint64() & uint64(math.MaxInt64))
+	} else {
+		//nolint:gosec // G404: no security implications, jitter is for load distribution
+		jitter = time.Duration(rand.Int63n(int64(maxJitter) + 1))
+	}
+
+	if jitter > time.Duration(math.MaxInt64)-baseTTL {
+		return time.Duration(math.MaxInt64)
+	}
+
 	return baseTTL + jitter
 }
 

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -39,6 +39,15 @@ var (
 	}, []string{"entity", "reason"})
 )
 
+// jitterRng is a locally-seeded random source used exclusively by JitteredTTL
+// so that each process gets an independent jitter sequence.
+//
+//nolint:gosec // G404: no security implications, jitter is for load distribution
+var jitterRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// jitterMu protects jitterRng which is not safe for concurrent use.
+var jitterMu sync.Mutex
+
 const (
 	SubproblemCachePrefix      = "sp."
 	iteratorCachePrefix        = "ic."
@@ -471,14 +480,14 @@ func JitteredTTL(baseTTL time.Duration, jitterPercentage uint32) time.Duration {
 	remainder := baseTTL % 100
 	maxJitter := quotient*time.Duration(jitterPercentage) + remainder*time.Duration(jitterPercentage)/100
 
+	jitterMu.Lock()
 	var jitter time.Duration
 	if maxJitter == time.Duration(math.MaxInt64) {
-		//nolint:gosec // G404: no security implications, jitter is for load distribution
-		jitter = time.Duration(rand.Uint64() & uint64(math.MaxInt64))
+		jitter = time.Duration(jitterRng.Uint64() & uint64(math.MaxInt64))
 	} else {
-		//nolint:gosec // G404: no security implications, jitter is for load distribution
-		jitter = time.Duration(rand.Int63n(int64(maxJitter) + 1))
+		jitter = time.Duration(jitterRng.Int63n(int64(maxJitter) + 1))
 	}
+	jitterMu.Unlock()
 
 	if jitter > time.Duration(math.MaxInt64)-baseTTL {
 		return time.Duration(math.MaxInt64)

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -39,15 +39,6 @@ var (
 	}, []string{"entity", "reason"})
 )
 
-// jitterRng is a locally-seeded random source used exclusively by JitteredTTL
-// so that each process gets an independent jitter sequence.
-//
-//nolint:gosec // G404: no security implications, jitter is for load distribution
-var jitterRng = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-// jitterMu protects jitterRng which is not safe for concurrent use.
-var jitterMu sync.Mutex
-
 const (
 	SubproblemCachePrefix      = "sp."
 	iteratorCachePrefix        = "ic."
@@ -480,14 +471,12 @@ func JitteredTTL(baseTTL time.Duration, jitterPercentage uint32) time.Duration {
 	remainder := baseTTL % 100
 	maxJitter := quotient*time.Duration(jitterPercentage) + remainder*time.Duration(jitterPercentage)/100
 
-	jitterMu.Lock()
 	var jitter time.Duration
 	if maxJitter == time.Duration(math.MaxInt64) {
-		jitter = time.Duration(jitterRng.Uint64() & uint64(math.MaxInt64))
+		jitter = time.Duration(rand.Int63())
 	} else {
-		jitter = time.Duration(jitterRng.Int63n(int64(maxJitter) + 1))
+		jitter = time.Duration(rand.Int63n(int64(maxJitter) + 1))
 	}
-	jitterMu.Unlock()
 
 	if jitter > time.Duration(math.MaxInt64)-baseTTL {
 		return time.Duration(math.MaxInt64)

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -1253,6 +1253,13 @@ func TestJitteredTTL(t *testing.T) {
 			expectedMin:      10 * time.Second,
 			expectedMax:      20 * time.Second,
 		},
+		{
+			name:             "jitter_percentage_over_hundred_is_capped",
+			baseTTL:          10 * time.Second,
+			jitterPercentage: 150,
+			expectedMin:      10 * time.Second,
+			expectedMax:      20 * time.Second,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1275,5 +1282,13 @@ func TestJitteredTTL(t *testing.T) {
 		}
 		// With 50% jitter on a 10s TTL (5s range), we should see multiple distinct values
 		require.Greater(t, len(results), 1, "expected variation in jittered TTL values")
+	})
+
+	t.Run("does_not_overflow_for_max_duration", func(t *testing.T) {
+		var result time.Duration
+		require.NotPanics(t, func() {
+			result = JitteredTTL(time.Duration(math.MaxInt64), 100)
+		})
+		require.Equal(t, time.Duration(math.MaxInt64), result)
 	})
 }

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -1209,3 +1209,71 @@ func BenchmarkGetInvalidIteratorByUserObjectTypeCacheKeys(b *testing.B) {
 		_ = GetInvalidIteratorByUserObjectTypeCacheKeys(storeID, users, objectType)
 	}
 }
+
+func TestJitteredTTL(t *testing.T) {
+	tests := []struct {
+		name             string
+		baseTTL          time.Duration
+		jitterPercentage uint32
+		expectedMin      time.Duration
+		expectedMax      time.Duration
+	}{
+		{
+			name:             "zero_jitter_returns_base_ttl",
+			baseTTL:          10 * time.Second,
+			jitterPercentage: 0,
+			expectedMin:      10 * time.Second,
+			expectedMax:      10 * time.Second,
+		},
+		{
+			name:             "zero_base_ttl_returns_zero",
+			baseTTL:          0,
+			jitterPercentage: 10,
+			expectedMin:      0,
+			expectedMax:      0,
+		},
+		{
+			name:             "negative_base_ttl_returns_base",
+			baseTTL:          -5 * time.Second,
+			jitterPercentage: 10,
+			expectedMin:      -5 * time.Second,
+			expectedMax:      -5 * time.Second,
+		},
+		{
+			name:             "ten_percent_jitter",
+			baseTTL:          10 * time.Second,
+			jitterPercentage: 10,
+			expectedMin:      10 * time.Second,
+			expectedMax:      11 * time.Second,
+		},
+		{
+			name:             "hundred_percent_jitter",
+			baseTTL:          10 * time.Second,
+			jitterPercentage: 100,
+			expectedMin:      10 * time.Second,
+			expectedMax:      20 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Run multiple times to verify the range
+			for i := 0; i < 100; i++ {
+				result := JitteredTTL(tt.baseTTL, tt.jitterPercentage)
+				require.GreaterOrEqual(t, result, tt.expectedMin, "result %v is less than minimum %v", result, tt.expectedMin)
+				require.LessOrEqual(t, result, tt.expectedMax, "result %v is greater than maximum %v", result, tt.expectedMax)
+			}
+		})
+	}
+
+	t.Run("produces_variation", func(t *testing.T) {
+		baseTTL := 10 * time.Second
+		jitterPct := uint32(50)
+		results := make(map[time.Duration]struct{})
+		for i := 0; i < 1000; i++ {
+			results[JitteredTTL(baseTTL, jitterPct)] = struct{}{}
+		}
+		// With 50% jitter on a 10s TTL (5s range), we should see multiple distinct values
+		require.Greater(t, len(results), 1, "expected variation in jittered TTL values")
+	})
+}

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -84,6 +84,13 @@ func WithCachedDatastoreMethodName(method string) CachedDatastoreOpt {
 	}
 }
 
+// WithCachedDatastoreJitterPercentage sets the jitter percentage for cache TTLs.
+func WithCachedDatastoreJitterPercentage(pct uint32) CachedDatastoreOpt {
+	return func(b *CachedDatastore) {
+		b.jitterPercentage = pct
+	}
+}
+
 // CachedDatastore is a wrapper over a datastore that caches iterators in memory.
 type CachedDatastore struct {
 	storage.RelationshipTupleReader
@@ -92,6 +99,10 @@ type CachedDatastore struct {
 	cache         storage.InMemoryCache[any]
 	maxResultSize int
 	ttl           time.Duration
+
+	// jitterPercentage is the percentage of the base TTL added as random jitter
+	// to each cache entry's TTL to spread out expirations.
+	jitterPercentage uint32
 
 	// sf is used to prevent draining the same iterator
 	// across multiple requests.
@@ -391,6 +402,7 @@ func (c *CachedDatastore) newCachedIterator(
 		cache:             c.cache,
 		maxResultSize:     c.maxResultSize,
 		ttl:               c.ttl,
+		jitterPercentage:  c.jitterPercentage,
 		initializedAt:     time.Now(),
 		sf:                c.sf,
 		objectType:        objectType,
@@ -413,6 +425,7 @@ type cachedIterator struct {
 	invalidEntityKeys []string
 	cache             storage.InMemoryCache[any]
 	ttl               time.Duration
+	jitterPercentage  uint32
 	initializedAt     time.Time
 
 	objectID   string
@@ -642,7 +655,7 @@ func (c *cachedIterator) flush() {
 	c.records = nil
 
 	c.logger.Debug("cachedIterator flush and update cache for ", zap.String("cacheKey", c.cacheKey))
-	c.cache.Set(c.cacheKey, &storage.TupleIteratorCacheEntry{Tuples: records, LastModified: time.Now()}, c.ttl)
+	c.cache.Set(c.cacheKey, &storage.TupleIteratorCacheEntry{Tuples: records, LastModified: time.Now()}, storage.JitteredTTL(c.ttl, c.jitterPercentage))
 	for _, k := range c.invalidEntityKeys {
 		c.cache.Delete(k)
 	}

--- a/pkg/storage/storagewrappers/request.go
+++ b/pkg/storage/storagewrappers/request.go
@@ -59,6 +59,7 @@ func NewRequestStorageWrapperWithCache(
 			dataResourceConfiguration.Resources.WaitGroup,
 			WithCachedDatastoreLogger(dataResourceConfiguration.Resources.Logger),
 			WithCachedDatastoreMethodName(string(op.Method)),
+			WithCachedDatastoreJitterPercentage(dataResourceConfiguration.CacheSettings.CacheTTLJitterPercentage),
 		)
 	} else if op.Method == apimethod.ListObjects && dataResourceConfiguration.CacheSettings.ShouldCacheListObjectsIterators() {
 		checkCache := dataResourceConfiguration.Resources.CheckCache
@@ -75,6 +76,7 @@ func NewRequestStorageWrapperWithCache(
 			dataResourceConfiguration.Resources.WaitGroup,
 			WithCachedDatastoreLogger(dataResourceConfiguration.Resources.Logger),
 			WithCachedDatastoreMethodName(string(op.Method)),
+			WithCachedDatastoreJitterPercentage(dataResourceConfiguration.CacheSettings.CacheTTLJitterPercentage),
 		)
 	}
 	if dataResourceConfiguration.CacheSettings.SharedIteratorEnabled {

--- a/pkg/storage/storagewrappers/request_test.go
+++ b/pkg/storage/storagewrappers/request_test.go
@@ -39,6 +39,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 				CacheSettings: config.CacheSettings{
 					CheckIteratorCacheEnabled: true,
 					CheckCacheLimit:           1,
+					CacheTTLJitterPercentage:  7,
 				},
 			},
 		)
@@ -54,6 +55,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 		// require.Equal(t, 1000, c.maxResultSize)
 		// require.Equal(t, 10*time.Second, c.ttl)
 		require.True(t, ok)
+		require.EqualValues(t, 7, c.jitterPercentage)
 
 		d, ok := c.RelationshipTupleReader.(*BoundedTupleReader)
 		require.Equal(t, maxConcurrentReads, cap(d.limiter))
@@ -180,6 +182,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 					ListObjectsIteratorCacheEnabled:    true,
 					CheckCacheLimit:                    1,
 					ListObjectsIteratorCacheMaxResults: 1,
+					CacheTTLJitterPercentage:           9,
 				},
 			},
 		)
@@ -191,6 +194,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 
 		c, ok := a.RelationshipTupleReader.(*CachedDatastore)
 		require.True(t, ok)
+		require.EqualValues(t, 9, c.jitterPercentage)
 
 		d, ok := c.RelationshipTupleReader.(*BoundedTupleReader)
 		require.Equal(t, maxConcurrentReads, cap(d.limiter))
@@ -220,6 +224,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 					ListObjectsIteratorCacheEnabled:    true,
 					CheckCacheLimit:                    1,
 					ListObjectsIteratorCacheMaxResults: 1,
+					CacheTTLJitterPercentage:           11,
 				},
 				UseShadowCache: true,
 			},
@@ -232,6 +237,7 @@ func TestRequestStorageWrapper(t *testing.T) {
 
 		c, ok := a.RelationshipTupleReader.(*CachedDatastore)
 		require.True(t, ok)
+		require.EqualValues(t, 11, c.jitterPercentage)
 
 		d, ok := c.RelationshipTupleReader.(*BoundedTupleReader)
 		require.Equal(t, maxConcurrentReads, cap(d.limiter))


### PR DESCRIPTION
## Description

#### What problem is being solved?

During load testing, periodic latency spikes are observed that correlate with the expiration and subsequent synchronous refreshing of internal application caches. When many cached items share the same fixed TTL, they expire and refresh at the exact same moment, causing a "thundering herd" effect that penalizes tail latency (P95/P99) and puts unnecessary periodic stress on the underlying storage layer.

#### How is it being solved?

A configurable jitter percentage is introduced that adds a random offset to each cache entry's TTL at write time:

```
TTL_effective = TTL_base + random(0, TTL_base * jitter_percentage / 100)
```

For example, with a base TTL of 10s and jitter percentage of 10, each cache entry gets a TTL between 10s and 11s. This spreads out expirations over a window, eliminating the synchronized refresh spike.

The jitter defaults to 0 (no jitter) for backward compatibility. A small value like 5-10% is recommended for production environments with caching enabled.

#### What changes are made to solve it?

- **`pkg/storage/cache.go`**: Added `JitteredTTL()` utility function that computes a TTL with random jitter applied.
- **`pkg/server/config/cache_settings.go`**: Added `CacheTTLJitterPercentage` field to `CacheSettings` struct.
- **`pkg/server/config/config.go`**: Added `DefaultCacheTTLJitterPercentage` constant (0), `CacheTTLJitterPercentage` field to `Config`, and validation (0-100).
- **`internal/graph/cached_resolver.go`**: Added `jitterPercentage` field to `CachedCheckResolver` and `WithJitterPercentage()` option. Applied jitter at the `cache.Set()` call in `ResolveCheck()`.
- **`pkg/storage/storagewrappers/cached_datastore.go`**: Added `jitterPercentage` field to `CachedDatastore` and `cachedIterator`, `WithCachedDatastoreJitterPercentage()` option. Applied jitter at the `cache.Set()` call in `flush()`.
- **`pkg/storage/storagewrappers/request.go`**: Passed jitter percentage from `CacheSettings` when constructing `CachedDatastore` instances.
- **`pkg/server/server.go`**: Added `WithCacheTTLJitterPercentage()` server option and passed it when building check resolver options.
- **`cmd/run/run.go`**: Added `--cache-ttl-jitter-percentage` CLI flag.
- **`.config-schema.json`**: Added `cacheTTLJitterPercentage` schema entry with env var `OPENFGA_CACHE_TTL_JITTER_PERCENTAGE`.

## References

* Closes https://github.com/openfga/openfga/issues/3029
* Follows the existing jitter pattern used in the PostgreSQL connection pool: `ConnMaxLifetimeJitter = ConnMaxLifetime / 10`

## Review Checklist
- [x] I have clicked on "allow edits by maintainers"
- [x] I have added documentation for new/changed functionality
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a cache TTL jitter percentage (0–100, default 0) to randomize individual cache entry expirations. Configurable via OPENFGA_CACHE_TTL_JITTER_PERCENTAGE or --cache-ttl-jitter-percentage; 0 disables jitter for backward compatibility. Value is validated at startup.
* **Tests**
  * Added unit and integration tests covering jitter behavior and config parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->