### PR TITLE
observability: set proper errors on storage layer spans

### DIFF
--- a/internal/telemetry/tracing.go
+++ b/internal/telemetry/tracing.go
@@ -17,6 +17,8 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+
+	"github.com/openfga/openfga/pkg/storage"
 )
 
 type TracerOption func(d *customTracer)
@@ -159,4 +161,14 @@ func TraceError(span trace.Span, err error) {
 	}
 	span.RecordError(err)
 	span.SetStatus(codes.Error, err.Error())
+}
+
+// TraceStorageError marks the span as having an error only for genuine storage failures.
+// Expected storage outcomes such as not found, collision, and invalid write input are skipped.
+func TraceStorageError(span trace.Span, err error) {
+	if storage.SuccessLabel(err) {
+		return
+	}
+
+	TraceError(span, err)
 }

--- a/internal/telemetry/tracing_test.go
+++ b/internal/telemetry/tracing_test.go
@@ -1,7 +1,16 @@
 package telemetry
 
 import (
+	"context"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/openfga/openfga/pkg/storage"
 )
 
 func TestResolveOTLPSecurity(t *testing.T) {
@@ -143,6 +152,56 @@ func TestParseOTLPEndpoint(t *testing.T) {
 			if secure != tt.expectedSecure {
 				t.Errorf("ParseOTLPEndpoint(%q) secure = %v, want %v", tt.input, secure, tt.expectedSecure)
 			}
+		})
+	}
+}
+
+func TestTraceStorageError(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantCode   codes.Code
+		wantEvents int
+	}{
+		{
+			name:       "storage_not_found_is_not_traced",
+			err:        storage.ErrNotFound,
+			wantCode:   codes.Unset,
+			wantEvents: 0,
+		},
+		{
+			name:       "storage_collision_is_not_traced",
+			err:        storage.ErrCollision,
+			wantCode:   codes.Unset,
+			wantEvents: 0,
+		},
+		{
+			name:       "context_canceled_is_not_traced",
+			err:        context.Canceled,
+			wantCode:   codes.Unset,
+			wantEvents: 0,
+		},
+		{
+			name:       "infrastructure_error_is_traced",
+			err:        errors.New("db connection reset"),
+			wantCode:   codes.Error,
+			wantEvents: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := tracetest.NewSpanRecorder()
+			tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+			_, span := tp.Tracer("test").Start(context.Background(), "trace-storage-error")
+
+			TraceStorageError(span, tt.err)
+			span.End()
+
+			ended := recorder.Ended()
+			require.Len(t, ended, 1)
+			require.Equal(t, tt.wantCode, ended[0].Status().Code)
+			require.Len(t, ended[0].Events(), tt.wantEvents)
 		})
 	}
 }

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -22,6 +22,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
+	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
@@ -141,7 +142,13 @@ func (s *Datastore) Read(
 	ctx, span := startTrace(ctx, "Read")
 	defer span.End()
 
-	return s.read(ctx, store, filter, nil)
+	iter, err := s.read(ctx, store, filter, nil)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+
+	return iter, nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -151,11 +158,18 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
-	return iter.ToArray(ctx, options.Pagination)
+	tuples, token, err := iter.ToArray(ctx, options.Pagination)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, "", err
+	}
+
+	return tuples, token, nil
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*sqlcommon.SQLTupleIterator, error) {
@@ -222,13 +236,19 @@ func (s *Datastore) Write(
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()
 
-	return sqlcommon.Write(ctx, s.dbInfo, s.db, store,
+	err := sqlcommon.Write(ctx, s.dbInfo, s.db, store,
 		sqlcommon.WriteData{
 			Deletes: deletes,
 			Writes:  writes,
 			Opts:    storage.NewTupleWriteOptions(opts...),
 			Now:     time.Now().UTC(),
 		})
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return err
+	}
+
+	return nil
 }
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
@@ -273,7 +293,9 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 			&conditionContext,
 		)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	if conditionName.String != "" {
@@ -282,6 +304,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+				telemetry.TraceError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -396,7 +419,13 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 	ctx, span := startTrace(ctx, "ReadAuthorizationModel")
 	defer span.End()
 
-	return sqlcommon.ReadAuthorizationModel(ctx, s.dbInfo, store, modelID)
+	model, err := sqlcommon.ReadAuthorizationModel(ctx, s.dbInfo, store, modelID)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+
+	return model, nil
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
@@ -421,7 +450,9 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -431,14 +462,18 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for rows.Next() {
 		err = rows.Scan(&modelID)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		modelIDs = append(modelIDs, modelID)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	var token string
@@ -455,6 +490,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for i := 0; i < numModelIDs; i++ {
 		model, err := s.ReadAuthorizationModel(ctx, store, modelIDs[i])
 		if err != nil {
+			telemetry.TraceError(span, err)
 			return nil, "", err
 		}
 		models = append(models, model)
@@ -468,7 +504,13 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 	ctx, span := startTrace(ctx, "FindLatestAuthorizationModel")
 	defer span.End()
 
-	return sqlcommon.FindLatestAuthorizationModel(ctx, s.dbInfo, store)
+	model, err := sqlcommon.FindLatestAuthorizationModel(ctx, s.dbInfo, store)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+
+	return model, nil
 }
 
 // MaxTypesPerAuthorizationModel see [storage.TypeDefinitionWriteBackend].MaxTypesPerAuthorizationModel.
@@ -481,7 +523,13 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 	ctx, span := startTrace(ctx, "WriteAuthorizationModel")
 	defer span.End()
 
-	return sqlcommon.WriteAuthorizationModel(ctx, s.dbInfo, store, model)
+	err := sqlcommon.WriteAuthorizationModel(ctx, s.dbInfo, store, model)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return err
+	}
+
+	return nil
 }
 
 // CreateStore adds a new store to storage.
@@ -494,7 +542,9 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 	txn, err := s.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 	defer func() {
 		_ = txn.Rollback()
@@ -507,7 +557,9 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 		RunWith(txn).
 		ExecContext(ctx)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	err = s.stbl.
@@ -518,12 +570,16 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 		QueryRowContext(ctx).
 		Scan(&id, &name, &createdAt, &updatedAt)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	return &openfgav1.Store{
@@ -553,9 +609,12 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	err := row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			telemetry.TraceError(span, storage.ErrNotFound)
 			return nil, storage.ErrNotFound
 		}
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	return &openfgav1.Store{
@@ -599,7 +658,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -610,7 +671,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		var createdAt, updatedAt time.Time
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		stores = append(stores, &openfgav1.Store{
@@ -622,7 +685,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	if len(stores) > options.Pagination.PageSize {
@@ -643,7 +708,9 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		Where(sq.Eq{"id": id}).
 		ExecContext(ctx)
 	if err != nil {
-		return HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return sqlErr
 	}
 
 	return nil
@@ -656,6 +723,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return err
 	}
 
@@ -666,7 +734,9 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 		Suffix("ON DUPLICATE KEY UPDATE assertions = ?", marshalledAssertions).
 		ExecContext(ctx)
 	if err != nil {
-		return HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return sqlErr
 	}
 
 	return nil
@@ -691,12 +761,15 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 		if errors.Is(err, sql.ErrNoRows) {
 			return []*openfgav1.Assertion{}, nil
 		}
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, err
 	}
 
@@ -740,7 +813,9 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -765,13 +840,16 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 			&insertedAt,
 		)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		var conditionContextStruct structpb.Struct
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+					telemetry.TraceError(span, err)
 					return nil, "", err
 				}
 			}
@@ -793,6 +871,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	}
 
 	if len(changes) == 0 {
+		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -870,8 +870,13 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		})
 	}
 
+	if err := rows.Err(); err != nil {
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
+	}
+
 	if len(changes) == 0 {
-		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -144,7 +144,7 @@ func (s *Datastore) Read(
 
 	iter, err := s.read(ctx, store, filter, nil)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -158,14 +158,14 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
 	tuples, token, err := iter.ToArray(ctx, options.Pagination)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 
@@ -244,7 +244,7 @@ func (s *Datastore) Write(
 			Now:     time.Now().UTC(),
 		})
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -294,7 +294,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -304,7 +304,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-				telemetry.TraceError(span, err)
+				telemetry.TraceStorageError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -421,7 +421,7 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 
 	model, err := sqlcommon.ReadAuthorizationModel(ctx, s.dbInfo, store, modelID)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -451,7 +451,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -463,7 +463,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 		err = rows.Scan(&modelID)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -472,7 +472,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -490,7 +490,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for i := 0; i < numModelIDs; i++ {
 		model, err := s.ReadAuthorizationModel(ctx, store, modelIDs[i])
 		if err != nil {
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 		models = append(models, model)
@@ -506,7 +506,7 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 
 	model, err := sqlcommon.FindLatestAuthorizationModel(ctx, s.dbInfo, store)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -525,7 +525,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	err := sqlcommon.WriteAuthorizationModel(ctx, s.dbInfo, store, model)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -543,7 +543,7 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 	txn, err := s.db.BeginTx(ctx, &sql.TxOptions{})
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 	defer func() {
@@ -558,7 +558,7 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 		ExecContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -571,14 +571,14 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 		Scan(&id, &name, &createdAt, &updatedAt)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
 	err = txn.Commit()
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -609,11 +609,11 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	err := row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			telemetry.TraceError(span, storage.ErrNotFound)
+			telemetry.TraceStorageError(span, storage.ErrNotFound)
 			return nil, storage.ErrNotFound
 		}
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -659,7 +659,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -672,7 +672,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -686,7 +686,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -709,7 +709,7 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		ExecContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return sqlErr
 	}
 
@@ -723,7 +723,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -735,7 +735,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 		ExecContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return sqlErr
 	}
 
@@ -762,14 +762,14 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 			return []*openfgav1.Assertion{}, nil
 		}
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -814,7 +814,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -841,7 +841,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -849,7 +849,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-					telemetry.TraceError(span, err)
+					telemetry.TraceStorageError(span, err)
 					return nil, "", err
 				}
 			}
@@ -872,7 +872,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -1404,8 +1404,13 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		})
 	}
 
+	if err := rows.Err(); err != nil {
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
+	}
+
 	if len(changes) == 0 {
-		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -341,7 +341,7 @@ func (s *Datastore) Read(
 	readPool := s.getPgxPool(options.Consistency.Preference)
 	iter, err := s.read(ctx, store, filter, nil, readPool)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	return iter, nil
@@ -355,14 +355,14 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 	readPool := s.getPgxPool(options.Consistency.Preference)
 	iter, err := s.read(ctx, store, filter, &options, readPool)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
 	tuples, token, err := iter.ToArray(ctx, options.Pagination)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	return tuples, token, nil
@@ -420,7 +420,7 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 	poolGetRows, err := NewPgxTxnGetRows(db, sb)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -440,7 +440,7 @@ func (s *Datastore) Write(
 
 	err := s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 	return nil
@@ -699,7 +699,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 	stmt, args, err := stbl.ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	db := s.getPgxPool(options.Consistency.Preference)
@@ -716,7 +716,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -726,7 +726,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-				telemetry.TraceError(span, err)
+				telemetry.TraceStorageError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -790,7 +790,7 @@ func (s *Datastore) ReadUsersetTuples(
 	poolGetRows, err := NewPgxTxnGetRows(db, sb)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -841,7 +841,7 @@ func (s *Datastore) ReadStartingWithUser(
 	poolGetRows, err := NewPgxTxnGetRows(db, builder)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
@@ -867,21 +867,21 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 		}).ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	defer rows.Close()
 	ret, err := sqlcommon.ConstructAuthorizationModelFromSQLRows(&pgxRowsWrapper{rows})
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -912,14 +912,14 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	stmt, args, err := sb.ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 
@@ -932,7 +932,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 		err = rows.Scan(&modelID)
 		if err != nil {
 			err = HandleSQLError(err)
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 
@@ -941,7 +941,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -959,7 +959,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for i := 0; i < numModelIDs; i++ {
 		model, err := s.ReadAuthorizationModel(ctx, store, modelIDs[i])
 		if err != nil {
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 		models = append(models, model)
@@ -981,20 +981,20 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 		OrderBy("authorization_model_id desc").ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	defer rows.Close()
 	ret, err := sqlcommon.ConstructAuthorizationModelFromSQLRows(&pgxRowsWrapper{rows})
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1020,7 +1020,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := proto.Marshal(model)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1031,13 +1031,13 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 	_, err = s.primaryDB.Exec(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1060,7 +1060,7 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1069,7 +1069,7 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1097,7 +1097,7 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1108,7 +1108,7 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	err = row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1155,14 +1155,14 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	stmt, args, err := sb.ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	defer rows.Close()
@@ -1175,7 +1175,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
 			err = HandleSQLError(err)
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 
@@ -1189,7 +1189,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -1212,14 +1212,14 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		Where(sq.Eq{"id": id}).ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
 	_, err = db.Exec(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1233,7 +1233,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1247,13 +1247,13 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 		ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 	_, err = db.Exec(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1278,7 +1278,7 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1288,14 +1288,14 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 			return []*openfgav1.Assertion{}, nil
 		}
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1341,14 +1341,14 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	stmt, args, err := sb.ToSql()
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
 		err = HandleSQLError(err)
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	defer rows.Close()
@@ -1375,7 +1375,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		)
 		if err != nil {
 			err = HandleSQLError(err)
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 
@@ -1383,7 +1383,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-					telemetry.TraceError(span, err)
+					telemetry.TraceStorageError(span, err)
 					return nil, "", err
 				}
 			}
@@ -1406,7 +1406,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -32,6 +32,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
+	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
@@ -338,7 +339,12 @@ func (s *Datastore) Read(
 	defer span.End()
 
 	readPool := s.getPgxPool(options.Consistency.Preference)
-	return s.read(ctx, store, filter, nil, readPool)
+	iter, err := s.read(ctx, store, filter, nil, readPool)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+	return iter, nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -349,11 +355,17 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 	readPool := s.getPgxPool(options.Consistency.Preference)
 	iter, err := s.read(ctx, store, filter, &options, readPool)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
-	return iter.ToArray(ctx, options.Pagination)
+	tuples, token, err := iter.ToArray(ctx, options.Pagination)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, "", err
+	}
+	return tuples, token, nil
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions, db *pgxpool.Pool) (*sqlcommon.SQLTupleIterator, error) {
@@ -407,7 +419,9 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 
 	poolGetRows, err := NewPgxTxnGetRows(db, sb)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
@@ -423,7 +437,13 @@ func (s *Datastore) Write(
 ) error {
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()
-	return s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
+
+	err := s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return err
+	}
+	return nil
 }
 
 // execute SELECT … FOR UPDATE statement for all the rows indicated by the lockKeys
@@ -678,7 +698,9 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 	}
 	stmt, args, err := stbl.ToSql()
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 	db := s.getPgxPool(options.Consistency.Preference)
 	row := db.QueryRow(ctx, stmt, args...)
@@ -693,7 +715,9 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 	)
 
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	if conditionName.String != "" {
@@ -702,6 +726,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+				telemetry.TraceError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -764,7 +789,9 @@ func (s *Datastore) ReadUsersetTuples(
 
 	poolGetRows, err := NewPgxTxnGetRows(db, sb)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
@@ -813,7 +840,9 @@ func (s *Datastore) ReadStartingWithUser(
 	}
 	poolGetRows, err := NewPgxTxnGetRows(db, builder)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
 }
@@ -837,17 +866,23 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 			"authorization_model_id": modelID,
 		}).ToSql()
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 	defer rows.Close()
 	ret, err := sqlcommon.ConstructAuthorizationModelFromSQLRows(&pgxRowsWrapper{rows})
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return ret, nil
@@ -876,12 +911,16 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	stmt, args, err := sb.ToSql()
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 
 	defer rows.Close()
@@ -892,14 +931,18 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for rows.Next() {
 		err = rows.Scan(&modelID)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			err = HandleSQLError(err)
+			telemetry.TraceError(span, err)
+			return nil, "", err
 		}
 
 		modelIDs = append(modelIDs, modelID)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	var token string
@@ -916,6 +959,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for i := 0; i < numModelIDs; i++ {
 		model, err := s.ReadAuthorizationModel(ctx, store, modelIDs[i])
 		if err != nil {
+			telemetry.TraceError(span, err)
 			return nil, "", err
 		}
 		models = append(models, model)
@@ -936,16 +980,22 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 		Where(sq.Eq{"store": store}).
 		OrderBy("authorization_model_id desc").ToSql()
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 	defer rows.Close()
 	ret, err := sqlcommon.ConstructAuthorizationModelFromSQLRows(&pgxRowsWrapper{rows})
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return ret, nil
@@ -970,6 +1020,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := proto.Marshal(model)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return err
 	}
 
@@ -979,11 +1030,15 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		Values(store, model.GetId(), schemaVersion, "", nil, pbdata).
 		ToSql()
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 	_, err = s.primaryDB.Exec(ctx, stmt, args...)
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 
 	return nil
@@ -1004,14 +1059,18 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 		Suffix("returning id, name, created_at, updated_at").ToSql()
 
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	row := s.primaryDB.QueryRow(ctx, stmt, args...)
 	err = row.Scan(&id, &name, &createdAt, &updatedAt)
 
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return &openfgav1.Store{
@@ -1037,7 +1096,9 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 		}).ToSql()
 
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	row := db.QueryRow(ctx, stmt, args...)
@@ -1046,7 +1107,9 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	var createdAt, updatedAt time.Time
 	err = row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	return &openfgav1.Store{
@@ -1091,12 +1154,16 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	stmt, args, err := sb.ToSql()
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 	defer rows.Close()
 
@@ -1107,7 +1174,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		var createdAt, updatedAt time.Time
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			err = HandleSQLError(err)
+			telemetry.TraceError(span, err)
+			return nil, "", err
 		}
 
 		stores = append(stores, &openfgav1.Store{
@@ -1119,7 +1188,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	if len(stores) > options.Pagination.PageSize {
@@ -1140,12 +1211,16 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		Set("deleted_at", sq.Expr("NOW()")).
 		Where(sq.Eq{"id": id}).ToSql()
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 
 	_, err = db.Exec(ctx, stmt, args...)
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 
 	return nil
@@ -1158,6 +1233,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return err
 	}
 
@@ -1170,11 +1246,15 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 		Suffix("ON CONFLICT (store, authorization_model_id) DO UPDATE SET assertions = ?", marshalledAssertions).
 		ToSql()
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 	_, err = db.Exec(ctx, stmt, args...)
 	if err != nil {
-		return HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return err
 	}
 
 	return nil
@@ -1197,7 +1277,9 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 		}).ToSql()
 
 	if err != nil {
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	err = db.QueryRow(ctx, stmt, args...).Scan(&marshalledAssertions)
@@ -1205,12 +1287,15 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 		if errors.Is(err, pgx.ErrNoRows) {
 			return []*openfgav1.Assertion{}, nil
 		}
-		return nil, HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, err
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, err
 	}
 
@@ -1255,12 +1340,16 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	stmt, args, err := sb.ToSql()
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 
 	rows, err := db.Query(ctx, stmt, args...)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		err = HandleSQLError(err)
+		telemetry.TraceError(span, err)
+		return nil, "", err
 	}
 	defer rows.Close()
 
@@ -1285,13 +1374,16 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 			&insertedAt,
 		)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			err = HandleSQLError(err)
+			telemetry.TraceError(span, err)
+			return nil, "", err
 		}
 
 		var conditionContextStruct structpb.Struct
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+					telemetry.TraceError(span, err)
 					return nil, "", err
 				}
 			}
@@ -1313,6 +1405,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	}
 
 	if len(changes) == 0 {
+		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -332,7 +332,7 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 	elapsed := time.Since(start)
 	if err != nil {
 		storageErr := t.handleSQLError(err)
-		telemetry.TraceError(span, storageErr)
+		telemetry.TraceStorageError(span, storageErr)
 		storage.ObserveIterQueryDuration(storage.SuccessLabel(storageErr), elapsed)
 		return storageErr
 	}

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -22,6 +22,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"github.com/openfga/openfga/internal/build"
+	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/encoder"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
@@ -331,6 +332,7 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 	elapsed := time.Since(start)
 	if err != nil {
 		storageErr := t.handleSQLError(err)
+		telemetry.TraceError(span, storageErr)
 		storage.ObserveIterQueryDuration(storage.SuccessLabel(storageErr), elapsed)
 		return storageErr
 	}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -24,6 +24,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
+	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
@@ -157,7 +158,12 @@ func (s *Datastore) Read(
 	ctx, span := startTrace(ctx, "Read")
 	defer span.End()
 
-	return s.read(ctx, store, filter, nil)
+	iter, err := s.read(ctx, store, filter, nil)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+	return iter, nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -167,11 +173,17 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
-	return iter.ToArray(ctx, options.Pagination)
+	tuples, token, err := iter.ToArray(ctx, options.Pagination)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, "", err
+	}
+	return tuples, token, nil
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*SQLTupleIterator, error) {
@@ -248,7 +260,12 @@ func (s *Datastore) Write(
 	ctx, span := startTrace(ctx, "Write")
 	defer span.End()
 
-	return s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
+	err := s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return err
+	}
+	return nil
 }
 
 // tupleLockKey represents the composite key we lock on.
@@ -730,7 +747,9 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 			&conditionContext,
 		)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	if conditionName.String != "" {
@@ -739,6 +758,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+				telemetry.TraceError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -897,11 +917,18 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 		}).
 		QueryContext(ctx)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 	defer rows.Close()
 
-	return constructAuthorizationModelFromSQLRows(rows)
+	model, err := constructAuthorizationModelFromSQLRows(rows)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+	return model, nil
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
@@ -924,7 +951,9 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -938,7 +967,9 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	for rows.Next() {
 		err = rows.Scan(&modelID, &schemaVersion, &marshalledModel)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		if options.Pagination.PageSize > 0 && len(models) >= options.Pagination.PageSize {
@@ -947,6 +978,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 		var model openfgav1.AuthorizationModel
 		if err := proto.Unmarshal(marshalledModel, &model); err != nil {
+			telemetry.TraceError(span, err)
 			return nil, "", err
 		}
 
@@ -954,7 +986,9 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	return models, token, nil
@@ -973,11 +1007,18 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 		Limit(1).
 		QueryContext(ctx)
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 	defer rows.Close()
 
-	return constructAuthorizationModelFromSQLRows(rows)
+	model, err := constructAuthorizationModelFromSQLRows(rows)
+	if err != nil {
+		telemetry.TraceError(span, err)
+		return nil, err
+	}
+	return model, nil
 }
 
 // MaxTypesPerAuthorizationModel see [storage.TypeDefinitionWriteBackend].MaxTypesPerAuthorizationModel.
@@ -999,6 +1040,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := proto.Marshal(model)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return err
 	}
 
@@ -1011,7 +1053,9 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		return err
 	})
 	if err != nil {
-		return HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return sqlErr
 	}
 
 	return nil
@@ -1035,7 +1079,9 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 			Scan(&id, &name, &createdAt, &updatedAt)
 	})
 	if err != nil {
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	return &openfgav1.Store{
@@ -1065,9 +1111,12 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	err := row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			telemetry.TraceError(span, storage.ErrNotFound)
 			return nil, storage.ErrNotFound
 		}
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	return &openfgav1.Store{
@@ -1111,7 +1160,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -1122,7 +1173,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		var createdAt, updatedAt time.Time
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		stores = append(stores, &openfgav1.Store{
@@ -1134,7 +1187,9 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 
 	if len(stores) > options.Pagination.PageSize {
@@ -1155,7 +1210,9 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		Where(sq.Eq{"id": id}).
 		ExecContext(ctx)
 	if err != nil {
-		return HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return sqlErr
 	}
 
 	return nil
@@ -1168,6 +1225,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return err
 	}
 
@@ -1181,7 +1239,9 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 		return err
 	})
 	if err != nil {
-		return HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return sqlErr
 	}
 
 	return nil
@@ -1206,12 +1266,15 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 		if errors.Is(err, sql.ErrNoRows) {
 			return []*openfgav1.Assertion{}, nil
 		}
-		return nil, HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, sqlErr
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, err
 	}
 
@@ -1255,7 +1318,9 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
-		return nil, "", HandleSQLError(err)
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
 	}
 	defer rows.Close()
 
@@ -1282,13 +1347,16 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 			&insertedAt,
 		)
 		if err != nil {
-			return nil, "", HandleSQLError(err)
+			sqlErr := HandleSQLError(err)
+			telemetry.TraceError(span, sqlErr)
+			return nil, "", sqlErr
 		}
 
 		var conditionContextStruct structpb.Struct
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+					telemetry.TraceError(span, err)
 					return nil, "", err
 				}
 			}
@@ -1310,6 +1378,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	}
 
 	if len(changes) == 0 {
+		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -1377,8 +1377,13 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		})
 	}
 
+	if err := rows.Err(); err != nil {
+		sqlErr := HandleSQLError(err)
+		telemetry.TraceError(span, sqlErr)
+		return nil, "", sqlErr
+	}
+
 	if len(changes) == 0 {
-		telemetry.TraceError(span, storage.ErrNotFound)
 		return nil, "", storage.ErrNotFound
 	}
 

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -160,7 +160,7 @@ func (s *Datastore) Read(
 
 	iter, err := s.read(ctx, store, filter, nil)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	return iter, nil
@@ -173,14 +173,14 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	defer iter.Stop()
 
 	tuples, token, err := iter.ToArray(ctx, options.Pagination)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, "", err
 	}
 	return tuples, token, nil
@@ -262,7 +262,7 @@ func (s *Datastore) Write(
 
 	err := s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 	return nil
@@ -748,7 +748,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -758,7 +758,7 @@ func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter stor
 		if conditionContext != nil {
 			var conditionContextStruct structpb.Struct
 			if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-				telemetry.TraceError(span, err)
+				telemetry.TraceStorageError(span, err)
 				return nil, err
 			}
 			record.ConditionContext = &conditionContextStruct
@@ -918,14 +918,14 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 		QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 	defer rows.Close()
 
 	model, err := constructAuthorizationModelFromSQLRows(rows)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	return model, nil
@@ -952,7 +952,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -968,7 +968,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 		err = rows.Scan(&modelID, &schemaVersion, &marshalledModel)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -978,7 +978,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 		var model openfgav1.AuthorizationModel
 		if err := proto.Unmarshal(marshalledModel, &model); err != nil {
-			telemetry.TraceError(span, err)
+			telemetry.TraceStorageError(span, err)
 			return nil, "", err
 		}
 
@@ -987,7 +987,7 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -1008,14 +1008,14 @@ func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store stri
 		QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 	defer rows.Close()
 
 	model, err := constructAuthorizationModelFromSQLRows(rows)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 	return model, nil
@@ -1040,7 +1040,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := proto.Marshal(model)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1054,7 +1054,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 	})
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return sqlErr
 	}
 
@@ -1080,7 +1080,7 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 	})
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -1111,11 +1111,11 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 	err := row.Scan(&storeID, &name, &createdAt, &updatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			telemetry.TraceError(span, storage.ErrNotFound)
+			telemetry.TraceStorageError(span, storage.ErrNotFound)
 			return nil, storage.ErrNotFound
 		}
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
@@ -1161,7 +1161,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -1174,7 +1174,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 		err := rows.Scan(&id, &name, &createdAt, &updatedAt)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -1188,7 +1188,7 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 
@@ -1211,7 +1211,7 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 		ExecContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return sqlErr
 	}
 
@@ -1225,7 +1225,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return err
 	}
 
@@ -1240,7 +1240,7 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 	})
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return sqlErr
 	}
 
@@ -1267,14 +1267,14 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 			return []*openfgav1.Assertion{}, nil
 		}
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, sqlErr
 	}
 
 	var assertions openfgav1.Assertions
 	err = proto.Unmarshal(marshalledAssertions, &assertions)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		telemetry.TraceStorageError(span, err)
 		return nil, err
 	}
 
@@ -1319,7 +1319,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 	rows, err := sb.QueryContext(ctx)
 	if err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 	defer rows.Close()
@@ -1348,7 +1348,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		)
 		if err != nil {
 			sqlErr := HandleSQLError(err)
-			telemetry.TraceError(span, sqlErr)
+			telemetry.TraceStorageError(span, sqlErr)
 			return nil, "", sqlErr
 		}
 
@@ -1356,7 +1356,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 		if conditionName.String != "" {
 			if conditionContext != nil {
 				if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-					telemetry.TraceError(span, err)
+					telemetry.TraceStorageError(span, err)
 					return nil, "", err
 				}
 			}
@@ -1379,7 +1379,7 @@ func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storag
 
 	if err := rows.Err(); err != nil {
 		sqlErr := HandleSQLError(err)
-		telemetry.TraceError(span, sqlErr)
+		telemetry.TraceStorageError(span, sqlErr)
 		return nil, "", sqlErr
 	}
 

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -14,6 +14,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
+	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/storage"
 )
 
@@ -56,6 +57,7 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 	elapsed := time.Since(start)
 	if err != nil {
 		storageErr := t.handleSQLError(err)
+		telemetry.TraceError(span, storageErr)
 		storage.ObserveIterQueryDuration(storage.SuccessLabel(storageErr), elapsed)
 		return storageErr
 	}

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -57,7 +57,7 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 	elapsed := time.Since(start)
 	if err != nil {
 		storageErr := t.handleSQLError(err)
-		telemetry.TraceError(span, storageErr)
+		telemetry.TraceStorageError(span, storageErr)
 		storage.ObserveIterQueryDuration(storage.SuccessLabel(storageErr), elapsed)
 		return storageErr
 	}


### PR DESCRIPTION
## Description

#### What problem is being solved?

When individual storage requests within a batch fail (e.g., due to `SQLITE_BUSY`, connection errors, or query failures), the errors are returned to callers but are **not recorded on the OpenTelemetry spans** associated with those storage operations. This makes it difficult to diagnose storage-level failures using distributed tracing.

For example, in BatchCheck, if a global error occurs (validation/authorization), it is properly set on the span. However, if individual storage requests fail, the errors are only exposed in the check response but not on the trace spans. This means observability tools cannot surface which specific storage operations failed or why.

The memory backend already uses `telemetry.TraceError` in some error paths, but the SQL backends (postgres, mysql, sqlite) and `sqlcommon.fetchBuffer` do not record any errors on their spans.

#### How is it being solved?

`telemetry.TraceError(span, err)` calls are added before every error return in storage methods that create OTel spans. The `TraceError` function (already defined in `internal/telemetry/tracing.go`) calls `span.RecordError()` and `span.SetStatus(codes.Error, ...)` to properly mark the span as errored, while skipping `context.Canceled` errors to avoid noise from normal request cancellations.

#### What changes are made to solve it?

All four storage backends are updated:

- **`pkg/storage/postgres/postgres.go`**: 45 error return paths across 18 methods instrumented with `telemetry.TraceError`.
- **`pkg/storage/mysql/mysql.go`**: 31 error return paths across 16 methods instrumented.
- **`pkg/storage/sqlite/sqlite.go`**: 31 error return paths across 15 methods instrumented.
- **`pkg/storage/sqlite/tuple_iterator.go`**: 1 error return path in `fetchBuffer` instrumented.
- **`pkg/storage/sqlcommon/sqlcommon.go`**: 1 error return path in `fetchBuffer` instrumented.

For error paths that use `HandleSQLError()` to wrap the error, the *wrapped* error (what the caller sees) is what gets recorded on the span.

## References

* Closes https://github.com/openfga/openfga/issues/3024
* Follows the existing pattern established in `pkg/storage/memory/memory.go` and `internal/graph/cached_resolver.go`

## Review Checklist
- [x] I have clicked on "allow edits by maintainers"
- [x] I have added documentation for new/changed functionality
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a telemetry helper to selectively mark storage errors on traces.

* **Improvements**
  * Enhanced error tracing across all SQL backends so read, page, write, list, decode, and iteration failures are consistently recorded.
  * Read/page operations now return errors more predictably; write operations reliably surface failures.

* **Tests**
  * Added tests validating storage-error tracing behavior and span status/events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->