### PR TITLE
feat: reuse MySQL container across tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.15.0] - 2026-04-27
 ### Changed
 - Implemented edge pruning in the list objects pipeline algorithm. This introduces a measurable improvement to request latency for larger, more complex authorization models. [#3075](https://github.com/openfga/openfga/pull/3075)
+- Reuse a single MySQL container across tests by replacing the test fixture implementation, improving test performance and reducing resource usage. [#3042](https://github.com/openfga/openfga/pull/3042)
 
 ### Fixed
 - Fixed experimental `weighted_graph_check` query cache being skipped when the cache controller returns a zero invalidation time (e.g., on cold start or when disabled), despite the cache controller documenting that zero time should allow cache use. [#3086](https://github.com/openfga/openfga/pull/3086)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Reuse a single MySQL container across tests by replacing the test fixture implementation, improving test performance and reducing resource usage. [#3042](https://github.com/openfga/openfga/pull/3042)
+
 ### Fixed
 - Fixed a potential panic within command error handling. [#3091](https://github.com/openfga/openfga/pull/3091)
 - Fixed a bug that propagated expected errors from list objects when a path short-circuits. [#3096](https://github.com/openfga/openfga/pull/3096)
@@ -17,7 +20,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.15.0] - 2026-04-27
 ### Changed
 - Implemented edge pruning in the list objects pipeline algorithm. This introduces a measurable improvement to request latency for larger, more complex authorization models. [#3075](https://github.com/openfga/openfga/pull/3075)
-- Reuse a single MySQL container across tests by replacing the test fixture implementation, improving test performance and reducing resource usage. [#3042](https://github.com/openfga/openfga/pull/3042)
 
 ### Fixed
 - Fixed experimental `weighted_graph_check` query cache being skipped when the cache controller returns a zero invalidation time (e.g., on cold start or when disabled), despite the cache controller documenting that zero time should allow cache use. [#3086](https://github.com/openfga/openfga/pull/3086)

--- a/assets/migrations/sqlite/006_add_store_ulid_index.sql
+++ b/assets/migrations/sqlite/006_add_store_ulid_index.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+CREATE INDEX idx_store_ulid ON tuple (store, ulid);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_store_ulid;

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -67,6 +67,7 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }
 

--- a/pkg/server/testmain_test.go
+++ b/pkg/server/testmain_test.go
@@ -10,5 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }

--- a/pkg/storage/migrate/testmain_test.go
+++ b/pkg/storage/migrate/testmain_test.go
@@ -10,5 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }

--- a/pkg/storage/mysql/testmain_test.go
+++ b/pkg/storage/mysql/testmain_test.go
@@ -1,4 +1,4 @@
-package validatemodels
+package mysql
 
 import (
 	"os"
@@ -9,7 +9,6 @@ import (
 
 func TestMain(m *testing.M) {
 	code := m.Run()
-	storagefixtures.CleanupPostgresContainer()
 	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -600,8 +600,7 @@ func TestNewDB(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("cannot_ping_primary_uri", func(t *testing.T) {
-		uri :=
-			"postgres://abc:passwd@localhost:5346/dbname"
+		uri := "postgres://abc:passwd@localhost:5346/dbname"
 		cfg := sqlcommon.Config{
 			Username:        "override_user",
 			Password:        "override_passwd",

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -118,9 +118,10 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 
 		mysqlCond.Wait()
 	}
+	dockerCont := mysqlDockerCont
 	mysqlCond.L.Unlock()
 
-	port, err := docker.GetHostPort(mysqlDockerCont, mysqlPort)
+	port, err := docker.GetHostPort(dockerCont, mysqlPort)
 	require.NoError(t, err)
 
 	version, err := latestMigrationVersion(assets.MySQLMigrationDir)
@@ -142,7 +143,7 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 		Cmd: []string{"mysql", "-u", testCont.username, "-e", fmt.Sprintf("CREATE DATABASE `%s`;", testCont.database)},
 		Env: []string{"MYSQL_PWD=" + testCont.password},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), mysqlDockerCont.ID, createExec))
+	require.NoError(t, docker.ExecCommand(t.Context(), dockerCont.ID, createExec))
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -153,7 +154,7 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 			Cmd: []string{"mysql", "-u", testCont.username, "-e", dropQuery},
 			Env: []string{"MYSQL_PWD=" + testCont.password},
 		}
-		if err := docker.ExecCommand(ctx, mysqlDockerCont.ID, dropExec); err != nil {
+		if err := docker.ExecCommand(ctx, dockerCont.ID, dropExec); err != nil {
 			t.Errorf("drop test database in the mysql container: %v", err)
 		}
 	})
@@ -163,13 +164,15 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 		Cmd: []string{"sh", "-ec", copyShell},
 		Env: []string{"MYSQL_PWD=" + testCont.password},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), mysqlDockerCont.ID, copyExec))
+	require.NoError(t, docker.ExecCommand(t.Context(), dockerCont.ID, copyExec))
 
 	require.NoError(t, waitForMigrationVersion("mysql", testCont.GetConnectionURI(true), testCont.version))
 
 	return testCont
 }
 
+// CleanupMysqlContainer removes the shared mysql test container.
+// It should be called from TestMain after all tests in a package have finished.
 func CleanupMysqlContainer() {
 	_ = cleanupDatastoreTestContainer(mysqlContainerName)
 }

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -34,7 +34,9 @@ var (
 	mysqlContainerName = "openfga-test-mysql-" + ulid.Make().String()
 	mysqlPort          = network.MustParsePort("3306/tcp")
 	mysqlDockerCont    *container.InspectResponse
-	mysqlOnce          sync.Once
+
+	mysqlBootstrapping bool
+	mysqlCond          = sync.NewCond(&sync.Mutex{})
 )
 
 type mysqlTestContainer struct {
@@ -87,9 +89,36 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 		docker.Close()
 	})
 
-	mysqlOnce.Do(func() {
-		mysqlDockerCont = bootstrapMysqlContainer(t, docker)
-	})
+	// Shared MySQL container bootstrap for concurrent tests using sync.Cond.
+	// Only one test bootstraps the shared container at a time, while others wait efficiently using sync.Cond.
+	// If bootstrap fails, waiting tests are awakened so another test can retry without being affected by the failure.
+	mysqlCond.L.Lock()
+	for mysqlDockerCont == nil {
+		if !mysqlBootstrapping {
+			mysqlBootstrapping = true
+			mysqlCond.L.Unlock()
+
+			dockerCont, err := bootstrapMysqlContainer(t.Context(), docker)
+			mysqlCond.L.Lock()
+			mysqlBootstrapping = false
+			if err == nil {
+				mysqlDockerCont = dockerCont
+			}
+
+			mysqlCond.Broadcast()
+
+			if err != nil {
+				// Unlock before failing the test to allow waiting tests to proceed with bootstrapping.
+				mysqlCond.L.Unlock()
+				require.NoError(t, err)
+			}
+
+			continue
+		}
+
+		mysqlCond.Wait()
+	}
+	mysqlCond.L.Unlock()
 
 	port, err := docker.GetHostPort(mysqlDockerCont, mysqlPort)
 	require.NoError(t, err)
@@ -145,10 +174,10 @@ func CleanupMysqlContainer() {
 	_ = cleanupDatastoreTestContainer(mysqlContainerName)
 }
 
-func bootstrapMysqlContainer(t testing.TB, docker *testutils.DockerClient) *container.InspectResponse {
-	t.Logf("No running container found for %s, creating a new one", mysqlImage)
-
-	require.NoError(t, docker.PullImage(t.Context(), mysqlImage), "pull mysql image")
+func bootstrapMysqlContainer(ctx context.Context, docker *testutils.DockerClient) (*container.InspectResponse, error) {
+	if err := docker.PullImage(ctx, mysqlImage); err != nil {
+		return nil, fmt.Errorf("pull mysql image: %w", err)
+	}
 
 	contCfg := &container.Config{
 		Env: []string{
@@ -167,20 +196,40 @@ func bootstrapMysqlContainer(t testing.TB, docker *testutils.DockerClient) *cont
 		Tmpfs:           map[string]string{"/var/lib/mysql": "", "/tmp": ""},
 	}
 
-	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, mysqlContainerName)
-	require.NoError(t, err, "run mysql container")
+	cont, err := docker.RunContainer(ctx, contCfg, hostCfg, mysqlContainerName)
+	if err != nil {
+		return nil, fmt.Errorf("run mysql container: %w", err)
+	}
+
+	needsCleanup := true
+	defer func() {
+		if needsCleanup {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_ = docker.RemoveContainer(cleanupCtx, cont.ID)
+		}
+	}()
 
 	port, err := docker.GetHostPort(cont, mysqlPort)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("get mysql host port: %w", err)
+	}
 
 	dbURI := mysqlConnectionURI("localhost", port, mysqlTemplateDB, mysqlUsername, mysqlPassword)
-	require.NoError(t, waitForDatabase("mysql", dbURI))
+	if err := waitForDatabase("mysql", dbURI); err != nil {
+		return nil, fmt.Errorf("wait for mysql database: %w", err)
+	}
 
 	db, err := goose.OpenDBWithDriver("mysql", dbURI)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("open mysql database: %w", err)
+	}
 	defer db.Close()
 
-	require.NoError(t, goose.Up(db, assets.MySQLMigrationDir))
+	if err := goose.Up(db, assets.MySQLMigrationDir); err != nil {
+		return nil, fmt.Errorf("apply mysql migrations: %w", err)
+	}
 
 	// Append goose_db_version last so it is restored after all schema tables.
 	dumpShell := fmt.Sprintf(
@@ -192,9 +241,12 @@ func bootstrapMysqlContainer(t testing.TB, docker *testutils.DockerClient) *cont
 		Cmd: []string{"sh", "-ec", dumpShell},
 		Env: []string{"MYSQL_PWD=" + mysqlPassword},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, dumpExec))
+	if err := docker.ExecCommand(ctx, cont.ID, dumpExec); err != nil {
+		return nil, fmt.Errorf("dump mysql template database: %w", err)
+	}
 
-	return cont
+	needsCleanup = false
+	return cont, nil
 }
 
 func mysqlConnectionURI(host, port, database, username, password string) string {

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -193,7 +193,10 @@ func bootstrapMysqlContainer(ctx context.Context, docker *testutils.DockerClient
 	hostCfg := &container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
-		Tmpfs:           map[string]string{"/var/lib/mysql": "", "/tmp": ""},
+		Tmpfs: map[string]string{
+			"/var/lib/mysql": "size=2g",
+			"/tmp":           "size=512m",
+		},
 	}
 
 	cont, err := docker.RunContainer(ctx, contCfg, hostCfg, mysqlContainerName)

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ var (
 
 	mysqlContainerName = "openfga-test-mysql-" + ulid.Make().String()
 	mysqlPort          = network.MustParsePort("3306/tcp")
-	mysqlDockerCont    *container.InspectResponse
+	mysqlDockerCont    atomic.Pointer[container.InspectResponse]
 
 	mysqlBootstrapping bool
 	mysqlCond          = sync.NewCond(&sync.Mutex{})
@@ -93,7 +94,7 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 	// Only one test bootstraps the shared container at a time, while others wait efficiently using sync.Cond.
 	// If bootstrap fails, waiting tests are awakened so another test can retry without being affected by the failure.
 	mysqlCond.L.Lock()
-	for mysqlDockerCont == nil {
+	for mysqlDockerCont.Load() == nil {
 		if !mysqlBootstrapping {
 			mysqlBootstrapping = true
 			mysqlCond.L.Unlock()
@@ -102,7 +103,7 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 			mysqlCond.L.Lock()
 			mysqlBootstrapping = false
 			if err == nil {
-				mysqlDockerCont = dockerCont
+				mysqlDockerCont.Store(dockerCont)
 			}
 
 			mysqlCond.Broadcast()
@@ -118,9 +119,9 @@ func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
 
 		mysqlCond.Wait()
 	}
-	dockerCont := mysqlDockerCont
 	mysqlCond.L.Unlock()
 
+	dockerCont := mysqlDockerCont.Load()
 	port, err := docker.GetHostPort(dockerCont, mysqlPort)
 	require.NoError(t, err)
 

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
@@ -21,13 +20,12 @@ import (
 )
 
 const (
-	mysqlImage                 = "mysql:8"
-	mysqlDBPrefix              = "openfga-test-db-"
-	mysqlTemplateDB            = mysqlDBPrefix + "template"
-	mysqlTemplateDBDump        = "/tmp/" + mysqlTemplateDB + ".sql"
-	mysqlTemplateDBPartialDump = mysqlTemplateDBDump + ".partial"
-	mysqlUsername              = "root"
-	mysqlPassword              = "secret"
+	mysqlImage          = "mysql:8"
+	mysqlDBPrefix       = "openfga-test-db-"
+	mysqlTemplateDB     = mysqlDBPrefix + "template"
+	mysqlTemplateDBDump = "/tmp/" + mysqlTemplateDB + ".sql"
+	mysqlUsername       = "root"
+	mysqlPassword       = "secret"
 )
 
 var (
@@ -187,37 +185,16 @@ func bootstrapMysqlContainer(t testing.TB, docker *testutils.DockerClient) *cont
 	// Append goose_db_version last so it is restored after all schema tables.
 	dumpShell := fmt.Sprintf(
 		"mysqldump -u %[1]s --ignore-table=%[2]s.goose_db_version %[2]s > %[3]s "+
-			"&& mysqldump -u %[1]s %[2]s goose_db_version >> %[3]s "+
-			"&& mv %[3]s %[4]s",
-		mysqlUsername, mysqlTemplateDB, mysqlTemplateDBPartialDump, mysqlTemplateDBDump,
+			"&& mysqldump -u %[1]s %[2]s goose_db_version >> %[3]s ",
+		mysqlUsername, mysqlTemplateDB, mysqlTemplateDBDump,
 	)
 	dumpExec := client.ExecCreateOptions{
 		Cmd: []string{"sh", "-ec", dumpShell},
 		Env: []string{"MYSQL_PWD=" + mysqlPassword},
 	}
 	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, dumpExec))
-	require.NoError(t, waitForMysqlDumpFile(t.Context(), docker, cont.ID))
 
 	return cont
-}
-
-// waitForMysqlDumpFile waits until the template database dump is present and non-empty.
-func waitForMysqlDumpFile(ctx context.Context, docker *testutils.DockerClient, containerID string) error {
-	backoffPolicy := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(100*time.Millisecond),
-		backoff.WithMaxElapsedTime(30*time.Second),
-	)
-
-	return backoff.Retry(func() error {
-		checkExec := client.ExecCreateOptions{
-			Cmd: []string{"test", "-s", mysqlTemplateDBDump},
-		}
-		if err := docker.ExecCommand(ctx, containerID, checkExec); err != nil {
-			return fmt.Errorf("mysql template dump not ready: %w", err)
-		}
-
-		return nil
-	}, backoff.WithContext(backoffPolicy, ctx))
 }
 
 func mysqlConnectionURI(host, port, database, username, password string) string {

--- a/pkg/testfixtures/storage/mysql.go
+++ b/pkg/testfixtures/storage/mysql.go
@@ -2,15 +2,13 @@ package storage
 
 import (
 	"context"
-	"io"
-	"log"
-	"strings"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/containerd/errdefs"
-	"github.com/go-sql-driver/mysql"
+	_ "github.com/go-sql-driver/mysql"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -19,180 +17,214 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/openfga/openfga/assets"
+	"github.com/openfga/openfga/pkg/testutils"
 )
 
 const (
-	mySQLImage = "mysql:8"
+	mysqlImage                 = "mysql:8"
+	mysqlDBPrefix              = "openfga-test-db-"
+	mysqlTemplateDB            = mysqlDBPrefix + "template"
+	mysqlTemplateDBDump        = "/tmp/" + mysqlTemplateDB + ".sql"
+	mysqlTemplateDBPartialDump = mysqlTemplateDBDump + ".partial"
+	mysqlUsername              = "root"
+	mysqlPassword              = "secret"
 )
 
 var (
-	mySQLPort = network.MustParsePort("3306/tcp")
+	_ DatastoreTestContainer = (*mysqlTestContainer)(nil)
+
+	mysqlContainerName = "openfga-test-mysql-" + ulid.Make().String()
+	mysqlPort          = network.MustParsePort("3306/tcp")
+	mysqlDockerCont    *container.InspectResponse
+	mysqlOnce          sync.Once
 )
 
-type mySQLTestContainer struct {
-	addr     string
-	version  int64
+type mysqlTestContainer struct {
+	host string
+	port string
+
+	database string
 	username string
 	password string
-}
 
-// NewMySQLTestContainer returns an implementation of the DatastoreTestContainer interface
-// for MySQL.
-func NewMySQLTestContainer() *mySQLTestContainer {
-	return &mySQLTestContainer{}
-}
-
-func (m *mySQLTestContainer) GetDatabaseSchemaVersion() int64 {
-	return m.version
-}
-
-// RunMySQLTestContainer runs a MySQL container, connects to it, and returns a
-// bootstrapped implementation of the DatastoreTestContainer interface wired up for the
-// MySQL datastore engine.
-func (m *mySQLTestContainer) RunMySQLTestContainer(t testing.TB) DatastoreTestContainer {
-	dockerClient, err := client.New(client.FromEnv)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		dockerClient.Close()
-	})
-
-	imageListResult, err := dockerClient.ImageList(context.Background(), client.ImageListOptions{
-		All: true,
-	})
-	require.NoError(t, err)
-
-	foundMysqlImage := false
-
-AllImages:
-	for _, image := range imageListResult.Items {
-		for _, tag := range image.RepoTags {
-			if strings.Contains(tag, mySQLImage) {
-				foundMysqlImage = true
-				break AllImages
-			}
-		}
-	}
-
-	if !foundMysqlImage {
-		t.Logf("Pulling image %s", mySQLImage)
-		reader, err := dockerClient.ImagePull(context.Background(), mySQLImage, client.ImagePullOptions{})
-		require.NoError(t, err)
-		defer reader.Close()
-
-		_, err = io.Copy(io.Discard, reader) // consume the image pull output to make sure it's done
-		require.NoError(t, err)
-	}
-
-	containerCfg := container.Config{
-		Env: []string{
-			"MYSQL_DATABASE=defaultdb",
-			"MYSQL_ROOT_PASSWORD=secret",
-		},
-		ExposedPorts: network.PortSet{
-			mySQLPort: {},
-		},
-		Image: mySQLImage,
-	}
-
-	hostCfg := container.HostConfig{
-		AutoRemove:      true,
-		PublishAllPorts: true,
-		Tmpfs:           map[string]string{"/var/lib/mysql": ""},
-	}
-
-	name := "mysql-" + ulid.Make().String()
-
-	cont, err := dockerClient.ContainerCreate(context.Background(), client.ContainerCreateOptions{
-		Name:       name,
-		Config:     &containerCfg,
-		HostConfig: &hostCfg,
-	})
-	require.NoError(t, err, "failed to create mysql docker container")
-
-	t.Cleanup(func() {
-		t.Logf("stopping container %s", name)
-		timeoutSec := 5
-
-		_, err := dockerClient.ContainerStop(context.Background(), cont.ID, client.ContainerStopOptions{Timeout: &timeoutSec})
-		if err != nil && !errdefs.IsNotFound(err) {
-			t.Logf("failed to stop mysql container: %v", err)
-		}
-		t.Logf("stopped container %s", name)
-	})
-
-	_, err = dockerClient.ContainerStart(context.Background(), cont.ID, client.ContainerStartOptions{})
-	require.NoError(t, err, "failed to start mysql container")
-
-	inspectResult, err := dockerClient.ContainerInspect(context.Background(), cont.ID, client.ContainerInspectOptions{})
-	require.NoError(t, err)
-
-	p, ok := inspectResult.Container.NetworkSettings.Ports[mySQLPort]
-	if !ok || len(p) == 0 {
-		require.Fail(t, "failed to get host port mapping from mysql container")
-	}
-
-	mySQLTestContainer := &mySQLTestContainer{
-		addr:     "localhost:" + p[0].HostPort,
-		username: "root",
-		password: "secret",
-	}
-
-	uri := mySQLTestContainer.username + ":" + mySQLTestContainer.password + "@tcp(" + mySQLTestContainer.addr + ")/defaultdb?parseTime=true"
-
-	err = mysql.SetLogger(log.New(io.Discard, "", 0))
-	require.NoError(t, err)
-
-	goose.SetLogger(goose.NopLogger())
-
-	db, err := goose.OpenDBWithDriver("mysql", uri)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = db.Close()
-	})
-
-	backoffPolicy := backoff.NewExponentialBackOff()
-	backoffPolicy.MaxElapsedTime = 2 * time.Minute
-	err = backoff.Retry(
-		func() error {
-			return db.Ping()
-		},
-		backoffPolicy,
-	)
-	require.NoError(t, err, "failed to connect to mysql container")
-
-	goose.SetBaseFS(assets.EmbedMigrations)
-
-	err = goose.Up(db, assets.MySQLMigrationDir)
-	require.NoError(t, err)
-	version, err := goose.GetDBVersion(db)
-	require.NoError(t, err)
-	mySQLTestContainer.version = version
-
-	return mySQLTestContainer
+	version int64
 }
 
 // GetConnectionURI returns the mysql connection uri for the running mysql test container.
-func (m *mySQLTestContainer) GetConnectionURI(includeCredentials bool) string {
-	creds := ""
+func (m *mysqlTestContainer) GetConnectionURI(includeCredentials bool) string {
+	var username, password string
 	if includeCredentials {
-		creds = m.username + ":" + m.password + "@"
+		username = m.username
+		password = m.password
 	}
 
-	return creds + "tcp(" + m.addr + ")/defaultdb?parseTime=true"
+	return mysqlConnectionURI(m.host, m.port, m.database, username, password)
 }
 
-func (m *mySQLTestContainer) GetUsername() string {
+func (m *mysqlTestContainer) GetDatabaseSchemaVersion() int64 {
+	return m.version
+}
+
+func (m *mysqlTestContainer) GetUsername() string {
 	return m.username
 }
 
-func (m *mySQLTestContainer) GetPassword() string {
+func (m *mysqlTestContainer) GetPassword() string {
 	return m.password
 }
 
-func (m *mySQLTestContainer) CreateSecondary(t testing.TB) error {
+func (m *mysqlTestContainer) CreateSecondary(t testing.TB) error {
 	return nil
 }
 
-func (m *mySQLTestContainer) GetSecondaryConnectionURI(includeCredentials bool) string {
+func (m *mysqlTestContainer) GetSecondaryConnectionURI(includeCredentials bool) string {
 	return ""
+}
+
+func RunMysqlTestContainer(t testing.TB) DatastoreTestContainer {
+	docker, err := testutils.NewDockerClient()
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		docker.Close()
+	})
+
+	mysqlOnce.Do(func() {
+		mysqlDockerCont = bootstrapMysqlContainer(t, docker)
+	})
+
+	port, err := docker.GetHostPort(mysqlDockerCont, mysqlPort)
+	require.NoError(t, err)
+
+	version, err := latestMigrationVersion(assets.MySQLMigrationDir)
+	require.NoError(t, err, "get expected mysql migration version")
+
+	testCont := &mysqlTestContainer{
+		host:     "localhost",
+		port:     port,
+		database: mysqlDBPrefix + ulid.Make().String(),
+		username: mysqlUsername,
+		password: mysqlPassword,
+		version:  version,
+	}
+
+	tplURI := mysqlConnectionURI(testCont.host, testCont.port, mysqlTemplateDB, testCont.username, testCont.password)
+	require.NoError(t, waitForMigrationVersion("mysql", tplURI, testCont.version))
+
+	createExec := client.ExecCreateOptions{
+		Cmd: []string{"mysql", "-u", testCont.username, "-e", fmt.Sprintf("CREATE DATABASE `%s`;", testCont.database)},
+		Env: []string{"MYSQL_PWD=" + testCont.password},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), mysqlDockerCont.ID, createExec))
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		dropQuery := fmt.Sprintf("DROP DATABASE IF EXISTS `%s`;", testCont.database)
+		dropExec := client.ExecCreateOptions{
+			Cmd: []string{"mysql", "-u", testCont.username, "-e", dropQuery},
+			Env: []string{"MYSQL_PWD=" + testCont.password},
+		}
+		if err := docker.ExecCommand(ctx, mysqlDockerCont.ID, dropExec); err != nil {
+			t.Errorf("drop test database in the mysql container: %v", err)
+		}
+	})
+
+	copyShell := fmt.Sprintf("mysql -u %s %s < %s", testCont.username, testCont.database, mysqlTemplateDBDump)
+	copyExec := client.ExecCreateOptions{
+		Cmd: []string{"sh", "-ec", copyShell},
+		Env: []string{"MYSQL_PWD=" + testCont.password},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), mysqlDockerCont.ID, copyExec))
+
+	require.NoError(t, waitForMigrationVersion("mysql", testCont.GetConnectionURI(true), testCont.version))
+
+	return testCont
+}
+
+func CleanupMysqlContainer() {
+	_ = cleanupDatastoreTestContainer(mysqlContainerName)
+}
+
+func bootstrapMysqlContainer(t testing.TB, docker *testutils.DockerClient) *container.InspectResponse {
+	t.Logf("No running container found for %s, creating a new one", mysqlImage)
+
+	require.NoError(t, docker.PullImage(t.Context(), mysqlImage), "pull mysql image")
+
+	contCfg := &container.Config{
+		Env: []string{
+			"MYSQL_DATABASE=" + mysqlTemplateDB,
+			"MYSQL_ROOT_PASSWORD=" + mysqlPassword,
+		},
+		ExposedPorts: network.PortSet{
+			mysqlPort: {},
+		},
+		Image: mysqlImage,
+	}
+
+	hostCfg := &container.HostConfig{
+		AutoRemove:      true,
+		PublishAllPorts: true,
+		Tmpfs:           map[string]string{"/var/lib/mysql": "", "/tmp": ""},
+	}
+
+	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, mysqlContainerName)
+	require.NoError(t, err, "run mysql container")
+
+	port, err := docker.GetHostPort(cont, mysqlPort)
+	require.NoError(t, err)
+
+	dbURI := mysqlConnectionURI("localhost", port, mysqlTemplateDB, mysqlUsername, mysqlPassword)
+	require.NoError(t, waitForDatabase("mysql", dbURI))
+
+	db, err := goose.OpenDBWithDriver("mysql", dbURI)
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.NoError(t, goose.Up(db, assets.MySQLMigrationDir))
+
+	// Append goose_db_version last so it is restored after all schema tables.
+	dumpShell := fmt.Sprintf(
+		"mysqldump -u %[1]s --ignore-table=%[2]s.goose_db_version %[2]s > %[3]s "+
+			"&& mysqldump -u %[1]s %[2]s goose_db_version >> %[3]s "+
+			"&& mv %[3]s %[4]s",
+		mysqlUsername, mysqlTemplateDB, mysqlTemplateDBPartialDump, mysqlTemplateDBDump,
+	)
+	dumpExec := client.ExecCreateOptions{
+		Cmd: []string{"sh", "-ec", dumpShell},
+		Env: []string{"MYSQL_PWD=" + mysqlPassword},
+	}
+	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, dumpExec))
+	require.NoError(t, waitForMysqlDumpFile(t.Context(), docker, cont.ID))
+
+	return cont
+}
+
+// waitForMysqlDumpFile waits until the template database dump is present and non-empty.
+func waitForMysqlDumpFile(ctx context.Context, docker *testutils.DockerClient, containerID string) error {
+	backoffPolicy := backoff.NewExponentialBackOff(
+		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithMaxElapsedTime(30*time.Second),
+	)
+
+	return backoff.Retry(func() error {
+		checkExec := client.ExecCreateOptions{
+			Cmd: []string{"test", "-s", mysqlTemplateDBDump},
+		}
+		if err := docker.ExecCommand(ctx, containerID, checkExec); err != nil {
+			return fmt.Errorf("mysql template dump not ready: %w", err)
+		}
+
+		return nil
+	}, backoff.WithContext(backoffPolicy, ctx))
+}
+
+func mysqlConnectionURI(host, port, database, username, password string) string {
+	creds := ""
+	if username != "" && password != "" {
+		creds = fmt.Sprintf("%s:%s@", username, password)
+	}
+
+	return fmt.Sprintf("%stcp(%s:%s)/%s?parseTime=true", creds, host, port, database)
 }

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -143,9 +143,10 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 
 		postgresCond.Wait()
 	}
+	dockerCont := postgresDockerCont
 	postgresCond.L.Unlock()
 
-	port, err := docker.GetHostPort(postgresDockerCont, postgresPort)
+	port, err := docker.GetHostPort(dockerCont, postgresPort)
 	require.NoError(t, err)
 
 	version, err := latestMigrationVersion(assets.PostgresMigrationDir)
@@ -167,7 +168,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		Cmd: []string{"createdb", "-U", testCont.username, "-T", postgresTemplateDB, testCont.database},
 		Env: []string{"PGPASSWORD=" + testCont.password},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), postgresDockerCont.ID, createExec))
+	require.NoError(t, docker.ExecCommand(t.Context(), dockerCont.ID, createExec))
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -178,7 +179,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 			Cmd: []string{"psql", "-U", testCont.username, "-c", dropQuery},
 			Env: []string{"PGPASSWORD=" + testCont.password},
 		}
-		if err := docker.ExecCommand(ctx, postgresDockerCont.ID, dropExec); err != nil {
+		if err := docker.ExecCommand(ctx, dockerCont.ID, dropExec); err != nil {
 			t.Errorf("drop test database in the postgres container: %v", err)
 		}
 	})
@@ -188,6 +189,8 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 	return testCont
 }
 
+// CleanupPostgresContainer removes the shared postgres test container.
+// It should be called from TestMain after all tests in a package have finished.
 func CleanupPostgresContainer() {
 	_ = cleanupDatastoreTestContainer(postgresContainerName)
 }

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -35,7 +36,7 @@ var (
 
 	postgresContainerName = "openfga-test-postgres-" + ulid.Make().String()
 	postgresPort          = network.MustParsePort("5432/tcp")
-	postgresDockerCont    *container.InspectResponse
+	postgresDockerCont    atomic.Pointer[container.InspectResponse]
 
 	postgresBootstrapping bool
 	postgresCond          = sync.NewCond(&sync.Mutex{})
@@ -119,7 +120,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 	// Only one test bootstraps the shared container at a time, while others wait efficiently using sync.Cond.
 	// If bootstrap fails, waiting tests are awakened so another test can retry without being affected by the failure.
 	postgresCond.L.Lock()
-	for postgresDockerCont == nil {
+	for postgresDockerCont.Load() == nil {
 		if !postgresBootstrapping {
 			postgresBootstrapping = true
 			postgresCond.L.Unlock()
@@ -128,7 +129,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 			postgresCond.L.Lock()
 			postgresBootstrapping = false
 			if err == nil {
-				postgresDockerCont = dockerCont
+				postgresDockerCont.Store(dockerCont)
 			}
 
 			postgresCond.Broadcast()
@@ -143,9 +144,9 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 
 		postgresCond.Wait()
 	}
-	dockerCont := postgresDockerCont
 	postgresCond.L.Unlock()
 
+	dockerCont := postgresDockerCont.Load()
 	port, err := docker.GetHostPort(dockerCont, postgresPort)
 	require.NoError(t, err)
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,9 +23,7 @@ import (
 )
 
 const (
-	postgresImage     = "postgres:17-alpine"
-	postgresContainer = "openfga-test-postgres"
-
+	postgresImage      = "postgres:17-alpine"
 	postgresDBPrefix   = "openfga-test-db-"
 	postgresTemplateDB = postgresDBPrefix + "template"
 	postgresUsername   = "postgres"
@@ -36,18 +33,11 @@ const (
 var (
 	_ DatastoreTestContainer = (*postgresTestContainer)(nil)
 
-	containerName = postgresContainer + ulid.MustNewDefault(time.Now()).String()
-
-	postgresPort = network.MustParsePort("5432/tcp")
-
-	mu            sync.Mutex
-	cond          sync.Cond
-	bootstrapping atomic.Bool
+	postgresContainerName = "openfga-test-postgres-" + ulid.Make().String()
+	postgresPort          = network.MustParsePort("5432/tcp")
+	postgresDockerCont    *container.InspectResponse
+	postgresOnce          sync.Once
 )
-
-func init() {
-	cond.L = &mu
-}
 
 type (
 	postgresTestContainer struct {
@@ -115,24 +105,6 @@ func (p *postgresTestContainer) GetSecondaryConnectionURI(includeCredentials boo
 	return postgresConnectionURI(p.replica.host, p.replica.port, p.database, username, password)
 }
 
-// CleanupPostgresContainer removes the shared postgres test container.
-// It should be called from TestMain after all tests in a package have finished.
-func CleanupPostgresContainer() {
-	docker, err := testutils.NewDockerClient()
-	if err != nil {
-		return
-	}
-	defer docker.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	if err := docker.RemoveContainer(ctx, containerName); err != nil {
-		// Container may not exist or already be removed; ignore errors.
-		return
-	}
-}
-
 func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 	docker, err := testutils.NewDockerClient()
 	require.NoError(t, err)
@@ -141,39 +113,11 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		docker.Close()
 	})
 
-	var dockerCont *container.InspectResponse
+	postgresOnce.Do(func() {
+		postgresDockerCont = bootstrapPostgresContainer(t, docker)
+	})
 
-	mu.Lock()
-	for {
-		var found bool
-		dockerCont, found, err = docker.FindRunningContainer(t.Context(), containerName, postgresImage)
-		if err != nil {
-			mu.Unlock()
-			require.NoError(t, err, "find running postgres container")
-		}
-
-		if !found {
-			if !bootstrapping.Swap(true) {
-				var err error
-				dockerCont, err = bootstrapPostgresContainer(t, docker)
-				if err != nil {
-					bootstrapping.Store(false)
-					cond.Broadcast()
-					mu.Unlock()
-					require.NoError(t, err, "bootstrapping postgres container")
-				}
-				bootstrapping.Store(false)
-				cond.Broadcast()
-				break
-			}
-			cond.Wait()
-			continue
-		}
-		break
-	}
-	mu.Unlock()
-
-	port, err := docker.GetHostPort(dockerCont, postgresPort)
+	port, err := docker.GetHostPort(postgresDockerCont, postgresPort)
 	require.NoError(t, err)
 
 	version, err := latestMigrationVersion(assets.PostgresMigrationDir)
@@ -195,7 +139,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		Cmd: []string{"createdb", "-U", testCont.username, "-T", postgresTemplateDB, testCont.database},
 		Env: []string{"PGPASSWORD=" + testCont.password},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), dockerCont.ID, createExec))
+	require.NoError(t, docker.ExecCommand(t.Context(), postgresDockerCont.ID, createExec))
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -206,7 +150,7 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 			Cmd: []string{"psql", "-U", testCont.username, "-c", dropQuery},
 			Env: []string{"PGPASSWORD=" + testCont.password},
 		}
-		if err := docker.ExecCommand(ctx, dockerCont.ID, dropExec); err != nil {
+		if err := docker.ExecCommand(ctx, postgresDockerCont.ID, dropExec); err != nil {
 			t.Errorf("drop test database in the postgres container: %v", err)
 		}
 	})
@@ -216,15 +160,15 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 	return testCont
 }
 
-func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) (*container.InspectResponse, error) {
+func CleanupPostgresContainer() {
+	_ = cleanupDatastoreTestContainer(postgresContainerName)
+}
+
+func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *container.InspectResponse {
 	t.Logf("No running container found for %s, creating a new one", postgresImage)
 
-	err := docker.PullImage(t.Context(), postgresImage)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, docker.PullImage(t.Context(), postgresImage), "pull postgres image")
 
-	// Run container
 	contCfg := &container.Config{
 		Env: []string{
 			"POSTGRES_DB=" + postgresTemplateDB,
@@ -251,52 +195,33 @@ func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) (*
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, containerName)
-	if err != nil {
-		return nil, err
-	}
+	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, postgresContainerName)
+	require.NoError(t, err, "run postgres container")
 
 	port, err := docker.GetHostPort(cont, postgresPort)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 
 	dbURI := postgresConnectionURI("localhost", port, postgresTemplateDB, postgresUsername, postgresPassword)
-	if err := waitForDatabase("pgx", dbURI); err != nil {
-		return nil, err
-	}
+	require.NoError(t, waitForDatabase("pgx", dbURI))
 
 	allowReplicationExec := client.ExecCreateOptions{
 		Cmd: []string{"sh", "-c", "echo 'host replication postgres all trust' >> /var/lib/postgresql/data/pg_hba.conf"},
 	}
-	err = docker.ExecCommand(t.Context(), cont.ID, allowReplicationExec)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, allowReplicationExec))
 
 	reloadExec := client.ExecCreateOptions{
 		Cmd: []string{"psql", "-U", "postgres", "-c", "SELECT pg_reload_conf();"},
 	}
-	err = docker.ExecCommand(t.Context(), cont.ID, reloadExec)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := waitForDatabase("pgx", dbURI); err != nil {
-		return nil, err
-	}
+	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, reloadExec))
+	require.NoError(t, waitForDatabase("pgx", dbURI))
 
 	db, err := goose.OpenDBWithDriver("pgx", dbURI)
-	if err != nil {
-		return nil, err
-	}
+	require.NoError(t, err)
 	defer db.Close()
 
-	if err := goose.Up(db, assets.PostgresMigrationDir); err != nil {
-		return nil, err
-	}
+	require.NoError(t, goose.Up(db, assets.PostgresMigrationDir))
 
-	return cont, nil
+	return cont
 }
 
 func runPostgresReplica(t testing.TB, primary *postgresTestContainer) *postgresReplicaContainer {
@@ -357,10 +282,11 @@ exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
 	hostCfg := &container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
+		Tmpfs:           map[string]string{"/var/lib/postgresql/data": ""},
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	contName := containerName + "-replica"
+	contName := postgresContainerName + "-replica"
 	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, contName)
 	require.NoError(t, err, "run postgres container")
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -337,7 +337,7 @@ exec docker-entrypoint.sh postgres -c hot_standby=on -c max_connections=200
 	hostCfg := &container.HostConfig{
 		AutoRemove:      true,
 		PublishAllPorts: true,
-		Tmpfs:           map[string]string{"/var/lib/postgresql/data": ""},
+		Tmpfs:           map[string]string{"/var/lib/postgresql/data": "size=2g"},
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 

--- a/pkg/testfixtures/storage/postgres.go
+++ b/pkg/testfixtures/storage/postgres.go
@@ -36,7 +36,9 @@ var (
 	postgresContainerName = "openfga-test-postgres-" + ulid.Make().String()
 	postgresPort          = network.MustParsePort("5432/tcp")
 	postgresDockerCont    *container.InspectResponse
-	postgresOnce          sync.Once
+
+	postgresBootstrapping bool
+	postgresCond          = sync.NewCond(&sync.Mutex{})
 )
 
 type (
@@ -113,9 +115,35 @@ func RunPostgresTestContainer(t testing.TB) DatastoreTestContainer {
 		docker.Close()
 	})
 
-	postgresOnce.Do(func() {
-		postgresDockerCont = bootstrapPostgresContainer(t, docker)
-	})
+	// Shared PostgreSQL container bootstrap for concurrent tests using sync.Cond.
+	// Only one test bootstraps the shared container at a time, while others wait efficiently using sync.Cond.
+	// If bootstrap fails, waiting tests are awakened so another test can retry without being affected by the failure.
+	postgresCond.L.Lock()
+	for postgresDockerCont == nil {
+		if !postgresBootstrapping {
+			postgresBootstrapping = true
+			postgresCond.L.Unlock()
+
+			dockerCont, err := bootstrapPostgresContainer(t.Context(), docker)
+			postgresCond.L.Lock()
+			postgresBootstrapping = false
+			if err == nil {
+				postgresDockerCont = dockerCont
+			}
+
+			postgresCond.Broadcast()
+
+			if err != nil {
+				postgresCond.L.Unlock()
+				require.NoError(t, err)
+			}
+
+			continue
+		}
+
+		postgresCond.Wait()
+	}
+	postgresCond.L.Unlock()
 
 	port, err := docker.GetHostPort(postgresDockerCont, postgresPort)
 	require.NoError(t, err)
@@ -164,10 +192,10 @@ func CleanupPostgresContainer() {
 	_ = cleanupDatastoreTestContainer(postgresContainerName)
 }
 
-func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *container.InspectResponse {
-	t.Logf("No running container found for %s, creating a new one", postgresImage)
-
-	require.NoError(t, docker.PullImage(t.Context(), postgresImage), "pull postgres image")
+func bootstrapPostgresContainer(ctx context.Context, docker *testutils.DockerClient) (*container.InspectResponse, error) {
+	if err := docker.PullImage(ctx, postgresImage); err != nil {
+		return nil, fmt.Errorf("pull postgres image: %w", err)
+	}
 
 	contCfg := &container.Config{
 		Env: []string{
@@ -195,33 +223,60 @@ func bootstrapPostgresContainer(t testing.TB, docker *testutils.DockerClient) *c
 		ExtraHosts:      []string{"host.docker.internal:host-gateway"},
 	}
 
-	cont, err := docker.RunContainer(t.Context(), contCfg, hostCfg, postgresContainerName)
-	require.NoError(t, err, "run postgres container")
+	cont, err := docker.RunContainer(ctx, contCfg, hostCfg, postgresContainerName)
+	if err != nil {
+		return nil, fmt.Errorf("run postgres container: %w", err)
+	}
+
+	needsCleanup := true
+	defer func() {
+		if needsCleanup {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_ = docker.RemoveContainer(cleanupCtx, cont.ID)
+		}
+	}()
 
 	port, err := docker.GetHostPort(cont, postgresPort)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("get postgres host port: %w", err)
+	}
 
 	dbURI := postgresConnectionURI("localhost", port, postgresTemplateDB, postgresUsername, postgresPassword)
-	require.NoError(t, waitForDatabase("pgx", dbURI))
+	if err := waitForDatabase("pgx", dbURI); err != nil {
+		return nil, fmt.Errorf("wait for postgres database: %w", err)
+	}
 
 	allowReplicationExec := client.ExecCreateOptions{
 		Cmd: []string{"sh", "-c", "echo 'host replication postgres all trust' >> /var/lib/postgresql/data/pg_hba.conf"},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, allowReplicationExec))
+	if err := docker.ExecCommand(ctx, cont.ID, allowReplicationExec); err != nil {
+		return nil, fmt.Errorf("allow postgres replication: %w", err)
+	}
 
 	reloadExec := client.ExecCreateOptions{
 		Cmd: []string{"psql", "-U", "postgres", "-c", "SELECT pg_reload_conf();"},
 	}
-	require.NoError(t, docker.ExecCommand(t.Context(), cont.ID, reloadExec))
-	require.NoError(t, waitForDatabase("pgx", dbURI))
+	if err := docker.ExecCommand(ctx, cont.ID, reloadExec); err != nil {
+		return nil, fmt.Errorf("reload postgres config: %w", err)
+	}
+	if err := waitForDatabase("pgx", dbURI); err != nil {
+		return nil, fmt.Errorf("wait for postgres database after config reload: %w", err)
+	}
 
 	db, err := goose.OpenDBWithDriver("pgx", dbURI)
-	require.NoError(t, err)
+	if err != nil {
+		return nil, fmt.Errorf("open postgres database: %w", err)
+	}
 	defer db.Close()
 
-	require.NoError(t, goose.Up(db, assets.PostgresMigrationDir))
+	if err := goose.Up(db, assets.PostgresMigrationDir); err != nil {
+		return nil, fmt.Errorf("apply postgres migrations: %w", err)
+	}
 
-	return cont
+	needsCleanup = false
+	return cont, nil
 }
 
 func runPostgresReplica(t testing.TB, primary *postgresTestContainer) *postgresReplicaContainer {

--- a/pkg/testfixtures/storage/readiness.go
+++ b/pkg/testfixtures/storage/readiness.go
@@ -15,7 +15,7 @@ import (
 func waitForDatabase(driverName, uri string) error { //nolint:unparam
 	backoffPolicy := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(100*time.Millisecond),
-		backoff.WithMaxElapsedTime(30*time.Second),
+		backoff.WithMaxElapsedTime(60*time.Second),
 	)
 
 	err := backoff.Retry(func() error {
@@ -43,7 +43,7 @@ func waitForDatabase(driverName, uri string) error { //nolint:unparam
 func waitForMigrationVersion(driverName, uri string, expectedVersion int64) error {
 	backoffPolicy := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(100*time.Millisecond),
-		backoff.WithMaxElapsedTime(30*time.Second),
+		backoff.WithMaxElapsedTime(60*time.Second),
 	)
 
 	err := backoff.Retry(func() error {

--- a/pkg/testfixtures/storage/readiness.go
+++ b/pkg/testfixtures/storage/readiness.go
@@ -14,8 +14,8 @@ import (
 // and ping it until it's ready or a timeout occurs.
 func waitForDatabase(driverName, uri string) error { //nolint:unparam
 	backoffPolicy := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(10*time.Millisecond),
-		backoff.WithMaxElapsedTime(10*time.Second),
+		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithMaxElapsedTime(30*time.Second),
 	)
 
 	err := backoff.Retry(func() error {
@@ -42,8 +42,8 @@ func waitForDatabase(driverName, uri string) error { //nolint:unparam
 // until it matches the expected version or a timeout occurs.
 func waitForMigrationVersion(driverName, uri string, expectedVersion int64) error {
 	backoffPolicy := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(10*time.Millisecond),
-		backoff.WithMaxElapsedTime(10*time.Second),
+		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithMaxElapsedTime(30*time.Second),
 	)
 
 	err := backoff.Retry(func() error {

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -2,12 +2,15 @@
 package storage
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pressly/goose/v3"
 
 	"github.com/openfga/openfga/assets"
+	"github.com/openfga/openfga/pkg/testutils"
 )
 
 func init() {
@@ -67,11 +70,11 @@ func (m memoryTestContainer) GetSecondaryConnectionURI(includeCredentials bool) 
 // datastore engine. If applicable, it also runs all existing database migrations.
 // The resources used by the test engine will be cleaned up after the test has finished.
 //
-// NOTE: PostgreSQL uses a shared container across tests, so it is not automatically cleaned up after each test.
+// NOTE: The caller is responsible for cleanup.
 func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContainer {
 	switch engine {
 	case "mysql":
-		return NewMySQLTestContainer().RunMySQLTestContainer(t)
+		return RunMysqlTestContainer(t)
 	case "postgres":
 		return RunPostgresTestContainer(t)
 	case "memory":
@@ -82,6 +85,26 @@ func RunDatastoreTestContainer(t testing.TB, engine string) DatastoreTestContain
 		t.Fatalf("unsupported datastore engine: %q", engine)
 		return nil
 	}
+}
+
+// cleanupDatastoreTestContainer removes the shared datastore test container used by the package.
+// Call it from TestMain after all package tests have completed.
+func cleanupDatastoreTestContainer(containerName string) error {
+	docker, err := testutils.NewDockerClient()
+	if err != nil {
+		return fmt.Errorf("docker client creation: %w", err)
+	}
+	defer docker.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Best-effort cleanup: container may already be removed.
+	if err := docker.RemoveContainer(ctx, containerName); err != nil {
+		return fmt.Errorf("remove container %s: %w", containerName, err)
+	}
+
+	return nil
 }
 
 // latestMigrationVersion returns the latest goose migration version in migrationDir.

--- a/pkg/testfixtures/storage/storage.go
+++ b/pkg/testfixtures/storage/storage.go
@@ -99,7 +99,6 @@ func cleanupDatastoreTestContainer(containerName string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	// Best-effort cleanup: container may already be removed.
 	if err := docker.RemoveContainer(ctx, containerName); err != nil {
 		return fmt.Errorf("remove container %s: %w", containerName, err)
 	}

--- a/pkg/testutils/dockerclient.go
+++ b/pkg/testutils/dockerclient.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/containerd/errdefs"
+	"github.com/moby/moby/api/pkg/stdcopy"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -147,6 +149,9 @@ func (d *DockerClient) RemoveContainer(ctx context.Context, containerID string) 
 
 // ExecCommand executes a command in the specified container and waits for it to complete.
 func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, execConfig client.ExecCreateOptions) error {
+	execConfig.AttachStdout = true
+	execConfig.AttachStderr = true
+
 	exec, err := d.client.ExecCreate(ctx, containerID, execConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create exec for command %v: %w", execConfig.Cmd, err)
@@ -158,7 +163,9 @@ func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, exec
 	}
 	defer resp.Close()
 
-	if _, err := io.Copy(io.Discard, resp.Reader); err != nil {
+	var stdout, stderr bytes.Buffer
+	_, err = stdcopy.StdCopy(&stdout, &stderr, resp.Reader)
+	if err != nil {
 		return fmt.Errorf("failed to read exec output for command %v: %w", execConfig.Cmd, err)
 	}
 
@@ -168,7 +175,13 @@ func (d *DockerClient) ExecCommand(ctx context.Context, containerID string, exec
 	}
 
 	if inspect.ExitCode != 0 {
-		return fmt.Errorf("command %v completed with exit code %d", execConfig.Cmd, inspect.ExitCode)
+		return fmt.Errorf(
+			"command %v completed with exit code %d: stdout=%q stderr=%q",
+			execConfig.Cmd,
+			inspect.ExitCode,
+			stdout.String(),
+			stderr.String(),
+		)
 	}
 
 	return nil

--- a/pkg/testutils/dockerclient.go
+++ b/pkg/testutils/dockerclient.go
@@ -65,7 +65,7 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string) error {
 func (d *DockerClient) RunContainer(
 	ctx context.Context, containerCfg *container.Config, hostCfg *container.HostConfig, containerName string,
 ) (*container.InspectResponse, error) {
-	_, err := d.client.ContainerCreate(ctx, client.ContainerCreateOptions{
+	createResult, err := d.client.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Name:       containerName,
 		Config:     containerCfg,
 		HostConfig: hostCfg,
@@ -80,11 +80,11 @@ func (d *DockerClient) RunContainer(
 			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
 
-			_ = d.RemoveContainer(cleanupCtx, containerName)
+			_ = d.RemoveContainer(cleanupCtx, createResult.ID)
 		}
 	}()
 
-	if _, err = d.client.ContainerStart(ctx, containerName, client.ContainerStartOptions{}); err != nil {
+	if _, err = d.client.ContainerStart(ctx, createResult.ID, client.ContainerStartOptions{}); err != nil {
 		return nil, fmt.Errorf("start %s container: %w", containerName, err)
 	}
 
@@ -95,7 +95,7 @@ func (d *DockerClient) RunContainer(
 
 	var cont *container.InspectResponse
 	err = backoff.Retry(func() error {
-		inspectResult, err := d.client.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
+		inspectResult, err := d.client.ContainerInspect(ctx, createResult.ID, client.ContainerInspectOptions{})
 		if err != nil {
 			if errdefs.IsNotFound(err) {
 				return err

--- a/pkg/testutils/dockerclient.go
+++ b/pkg/testutils/dockerclient.go
@@ -59,37 +59,7 @@ func (d *DockerClient) PullImage(ctx context.Context, imageName string) error {
 	return nil
 }
 
-// FindRunningContainer returns the inspection data of a running container
-// matching the given name and image, or nil/false if not found.
-func (d *DockerClient) FindRunningContainer(
-	ctx context.Context, containerName, imageName string,
-) (*container.InspectResponse, bool, error) {
-	containerListResult, err := d.client.ContainerList(ctx, client.ContainerListOptions{
-		Limit: 1,
-		Filters: make(client.Filters).
-			Add("name", "^"+containerName+"$").
-			Add("ancestor", imageName).
-			Add("status", "running"),
-	})
-	if err != nil {
-		return nil, false, fmt.Errorf("list containers: %w", err)
-	}
-
-	if len(containerListResult.Items) == 0 {
-		return nil, false, nil
-	}
-
-	inspectResult, err := d.client.ContainerInspect(ctx, containerListResult.Items[0].ID, client.ContainerInspectOptions{})
-	if err != nil {
-		return nil, false, fmt.Errorf("inspect %s container: %w", containerName, err)
-	}
-
-	return &inspectResult.Container, true, nil
-}
-
-// RunContainer starts a container, then returns its inspection data.
-// If Docker reports a conflict because a container with the same name already
-// exists, the existing container is reused and started instead.
+// RunContainer creates and starts a new container.
 func (d *DockerClient) RunContainer(
 	ctx context.Context, containerCfg *container.Config, hostCfg *container.HostConfig, containerName string,
 ) (*container.InspectResponse, error) {
@@ -98,39 +68,44 @@ func (d *DockerClient) RunContainer(
 		Config:     containerCfg,
 		HostConfig: hostCfg,
 	})
-	createdContainer := err == nil
-	if err != nil && !errdefs.IsConflict(err) {
+
+	if err != nil {
 		return nil, fmt.Errorf("create %s container: %w", containerName, err)
 	}
 
 	defer func() {
-		if err == nil || !createdContainer {
-			return
+		if err != nil {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			_ = d.RemoveContainer(cleanupCtx, containerName)
 		}
-
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-
-		_ = d.RemoveContainer(cleanupCtx, containerName)
 	}()
 
-	_, err = d.client.ContainerStart(ctx, containerName, client.ContainerStartOptions{})
-	if err != nil {
+	if _, err = d.client.ContainerStart(ctx, containerName, client.ContainerStartOptions{}); err != nil {
 		return nil, fmt.Errorf("start %s container: %w", containerName, err)
 	}
 
 	backoffPolicy := backoff.NewExponentialBackOff(
 		backoff.WithInitialInterval(100*time.Millisecond),
-		backoff.WithMaxElapsedTime(5*time.Second),
+		backoff.WithMaxElapsedTime(30*time.Second),
 	)
 
-	var cont container.InspectResponse
+	var cont *container.InspectResponse
 	err = backoff.Retry(func() error {
 		inspectResult, err := d.client.ContainerInspect(ctx, containerName, client.ContainerInspectOptions{})
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				return err
+			}
+
 			return backoff.Permanent(fmt.Errorf("inspect %s container: %w", containerName, err))
 		}
-		cont = inspectResult.Container
+		cont = &inspectResult.Container
+
+		if cont.State == nil || !cont.State.Running {
+			return fmt.Errorf("container %s is not running yet", containerName)
+		}
 
 		if len(containerCfg.ExposedPorts) == 0 {
 			return nil
@@ -153,7 +128,7 @@ func (d *DockerClient) RunContainer(
 		return nil, fmt.Errorf("inspect %s container: %w", containerName, err)
 	}
 
-	return &cont, nil
+	return cont, nil
 }
 
 // RemoveContainer kills and removes a container.

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -225,7 +225,7 @@ func TestRunContainer_Fail(t *testing.T) {
 		require.ErrorContains(t, err, "inspect container-name")
 	})
 
-	t.Run("conflict_and_inspect_container", func(t *testing.T) {
+	t.Run("name_conflict", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Error: "conflict", Status: http.StatusConflict},
 		})

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -115,8 +115,8 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 	t.Run("ports_ready_immediately", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
 		})
 
 		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
@@ -128,9 +128,9 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 		noPortsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{}}, "State":{"Running":true}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: noPortsBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: noPortsBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
 		})
 
 		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
@@ -142,9 +142,9 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 		emptyBindingsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[]}}, "State":{"Running":true}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: emptyBindingsBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: emptyBindingsBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
 		})
 
 		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
@@ -156,9 +156,9 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 		emptyStateBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: emptyStateBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: emptyStateBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
 		})
 
 		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
@@ -169,9 +169,9 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 	t.Run("not_found_inspect_at_start", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Error: "not found", Status: http.StatusNotFound},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "not found", Status: http.StatusNotFound},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Body: portsReadyBody},
 		})
 
 		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
@@ -201,8 +201,8 @@ func TestRunContainer_Fail(t *testing.T) {
 	t.Run("start_container", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Error: "start failed"},
-			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Error: "start failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
 		})
 
 		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
@@ -214,9 +214,9 @@ func TestRunContainer_Fail(t *testing.T) {
 	t.Run("inspect_container", func(t *testing.T) {
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
-			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: emptyBody},
-			{Method: http.MethodGet, Path: "/containers/container-name/json", Error: "inspect failed"},
-			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
+			{Method: http.MethodPost, Path: "/containers/container-id/start", Body: emptyBody},
+			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "inspect failed"},
+			{Method: http.MethodDelete, Path: "/containers/container-id", Body: emptyBody},
 		})
 
 		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -248,7 +248,7 @@ func TestRemoveContainer_Fail(t *testing.T) {
 }
 
 func TestExecCommand_Fail(t *testing.T) {
-	t.Run("bad_cmd", func(t *testing.T) {
+	t.Run("command_failure_includes_output", func(t *testing.T) {
 		dc, err := NewDockerClient()
 		require.NoError(t, err)
 		t.Cleanup(func() { require.NoError(t, dc.Close()) })
@@ -265,10 +265,12 @@ func TestExecCommand_Fail(t *testing.T) {
 		t.Cleanup(func() { _ = dc.RemoveContainer(context.Background(), cont.ID) })
 
 		err = dc.ExecCommand(t.Context(), cont.ID, client.ExecCreateOptions{
-			Cmd: []string{"badcommand"},
+			Cmd: []string{"sh", "-c", "echo stdout-message; echo stderr-message >&2; exit 42"},
 		})
 		require.Error(t, err)
-		require.ErrorContains(t, err, "command [badcommand] completed with exit code 127")
+		require.ErrorContains(t, err, "command [sh -c echo stdout-message; echo stderr-message >&2; exit 42] completed with exit code 42")
+		require.ErrorContains(t, err, `stdout="stdout-message\n"`)
+		require.ErrorContains(t, err, `stderr="stderr-message\n"`)
 	})
 
 	t.Run("create_exec", func(t *testing.T) {

--- a/pkg/testutils/dockerclient_test.go
+++ b/pkg/testutils/dockerclient_test.go
@@ -84,66 +84,28 @@ func TestContainerLifecycle_PullAndExec(t *testing.T) {
 	hostCfg := &container.HostConfig{}
 	containerName := "test-dc-client-" + ulid.Make().String()
 
-	inspect, err := dc.RunContainer(t.Context(), containerCfg, hostCfg, containerName)
+	cont, err := dc.RunContainer(t.Context(), containerCfg, hostCfg, containerName)
 	require.NoError(t, err)
-	require.NotEmpty(t, inspect.ID)
+	require.NotEmpty(t, cont.ID)
 
 	t.Cleanup(func() {
-		_ = dc.RemoveContainer(context.Background(), inspect.ID)
+		_ = dc.RemoveContainer(context.Background(), cont.ID)
 	})
 
-	foundInspect, running, err := dc.FindRunningContainer(t.Context(), containerName, alpineImage)
-	require.NoError(t, err)
-	require.True(t, running)
-	require.Equal(t, inspect.ID, foundInspect.ID)
-
-	err = dc.ExecCommand(t.Context(), inspect.ID, client.ExecCreateOptions{
+	err = dc.ExecCommand(t.Context(), cont.ID, client.ExecCreateOptions{
 		Cmd: []string{"echo", "hello!"},
 	})
 	require.NoError(t, err)
 }
 
-func TestFindRunningContainer_Fail(t *testing.T) {
-	t.Run("not_found", func(t *testing.T) {
-		dc := newDockerClientMock(t, []dockerMockStep{
-			{Method: http.MethodGet, Path: "/containers/json", Body: []byte(`[]`)},
-		})
-
-		_, found, err := dc.FindRunningContainer(t.Context(), "does-not-exist", alpineImage)
-		require.NoError(t, err)
-		require.False(t, found)
-	})
-
-	t.Run("list_containers", func(t *testing.T) {
-		dc := newDockerClientMock(t, []dockerMockStep{
-			{Method: http.MethodGet, Path: "/containers/json", Error: "list failed"},
-		})
-
-		inspect, found, err := dc.FindRunningContainer(t.Context(), "test", alpineImage)
-		require.Nil(t, inspect)
-		require.False(t, found)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "list containers")
-	})
-
-	t.Run("inspect_container", func(t *testing.T) {
-		dc := newDockerClientMock(t, []dockerMockStep{
-			{Method: http.MethodGet, Path: "/containers/json", Body: []byte(`[{"Id":"container-id"}]`)},
-			{Method: http.MethodGet, Path: "/containers/container-id/json", Error: "inspect failed"},
-		})
-
-		inspect, found, err := dc.FindRunningContainer(t.Context(), "test", alpineImage)
-		require.Nil(t, inspect)
-		require.False(t, found)
-		require.Error(t, err)
-		require.ErrorContains(t, err, "inspect test container")
-	})
-}
-
 func TestRunContainer_WithExposedPorts(t *testing.T) {
 	createBody := []byte(`{"Id":"container-id"}`)
 	startBody := []byte(`{}`)
-	portsReadyBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}}}`)
+	portsReadyBody := []byte(`{
+		"Id":"container-id",
+		"NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}},
+		"State":{"Running":true}
+	}`)
 
 	exposedCfg := &container.Config{
 		Image:        alpineImage,
@@ -157,13 +119,13 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
+		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
-		require.NotNil(t, inspect)
+		require.NotNil(t, cont)
 	})
 
 	t.Run("empty_ports_map_then_ready", func(t *testing.T) {
-		noPortsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{}}}`)
+		noPortsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{}}, "State":{"Running":true}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
 			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
@@ -171,13 +133,13 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
+		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
-		require.NotNil(t, inspect)
+		require.NotNil(t, cont)
 	})
 
 	t.Run("empty_port_bindings_then_ready", func(t *testing.T) {
-		emptyBindingsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[]}}}`)
+		emptyBindingsBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[]}}, "State":{"Running":true}}`)
 		dc := newDockerClientMock(t, []dockerMockStep{
 			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
 			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
@@ -185,9 +147,36 @@ func TestRunContainer_WithExposedPorts(t *testing.T) {
 			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
+		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
 		require.NoError(t, err)
-		require.NotNil(t, inspect)
+		require.NotNil(t, cont)
+	})
+
+	t.Run("empty_state_then_running", func(t *testing.T) {
+		emptyStateBody := []byte(`{"Id":"container-id","NetworkSettings":{"Ports":{"5432/tcp":[{"HostIp":"0.0.0.0","HostPort":"54321"}]}}}`)
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: emptyStateBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+		})
+
+		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
+		require.NoError(t, err)
+		require.NotNil(t, cont)
+	})
+
+	t.Run("not_found_inspect_at_start", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Body: createBody},
+			{Method: http.MethodPost, Path: "/containers/container-name/start", Body: startBody},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Error: "not found", Status: http.StatusNotFound},
+			{Method: http.MethodGet, Path: "/containers/container-name/json", Body: portsReadyBody},
+		})
+
+		cont, err := dc.RunContainer(t.Context(), exposedCfg, &container.HostConfig{}, "container-name")
+		require.NoError(t, err)
+		require.NotNil(t, cont)
 	})
 }
 
@@ -203,8 +192,8 @@ func TestRunContainer_Fail(t *testing.T) {
 			{Method: http.MethodPost, Path: "/containers/create", Error: "create failed"},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "test")
-		require.Nil(t, inspect)
+		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "test")
+		require.Nil(t, runResult)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "create test container")
 	})
@@ -216,8 +205,8 @@ func TestRunContainer_Fail(t *testing.T) {
 			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
-		require.Nil(t, inspect)
+		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
+		require.Nil(t, runResult)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "start container-name")
 	})
@@ -230,10 +219,21 @@ func TestRunContainer_Fail(t *testing.T) {
 			{Method: http.MethodDelete, Path: "/containers/container-name", Body: emptyBody},
 		})
 
-		inspect, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
-		require.Nil(t, inspect)
+		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
+		require.Nil(t, runResult)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "inspect container-name")
+	})
+
+	t.Run("conflict_and_inspect_container", func(t *testing.T) {
+		dc := newDockerClientMock(t, []dockerMockStep{
+			{Method: http.MethodPost, Path: "/containers/create", Error: "conflict", Status: http.StatusConflict},
+		})
+
+		runResult, err := dc.RunContainer(t.Context(), containerCfg, &container.HostConfig{}, "container-name")
+		require.Nil(t, runResult)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "conflict")
 	})
 }
 
@@ -260,14 +260,15 @@ func TestExecCommand_Fail(t *testing.T) {
 			Image: alpineImage,
 			Cmd:   []string{"sleep", "30"},
 		}
-		inspect, err := dc.RunContainer(t.Context(), contConf, &container.HostConfig{}, containerName)
+		cont, err := dc.RunContainer(t.Context(), contConf, &container.HostConfig{}, containerName)
 		require.NoError(t, err)
-		t.Cleanup(func() { _ = dc.RemoveContainer(context.Background(), inspect.ID) })
+		t.Cleanup(func() { _ = dc.RemoveContainer(context.Background(), cont.ID) })
 
-		err = dc.ExecCommand(t.Context(), inspect.ID, client.ExecCreateOptions{
+		err = dc.ExecCommand(t.Context(), cont.ID, client.ExecCreateOptions{
 			Cmd: []string{"badcommand"},
 		})
 		require.Error(t, err)
+		require.ErrorContains(t, err, "command [badcommand] completed with exit code 127")
 	})
 
 	t.Run("create_exec", func(t *testing.T) {
@@ -350,6 +351,7 @@ type dockerMockStep struct {
 	Path   string
 	Body   []byte
 	Error  string
+	Status int
 }
 
 // newDockerClientMock wires a Docker client to a httptest server for unit tests.
@@ -387,6 +389,13 @@ func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
 
+		switch {
+		case step.Status == 0 && step.Error != "":
+			w.WriteHeader(http.StatusInternalServerError)
+		case step.Status != 0:
+			w.WriteHeader(step.Status)
+		}
+
 		if step.Body != nil {
 			_, _ = w.Write(step.Body)
 			return
@@ -394,7 +403,6 @@ func newDockerClientMock(t *testing.T, steps []dockerMockStep) *DockerClient {
 
 		if step.Error != "" {
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]string{
 				"message": step.Error,
 			})

--- a/tests/check/testmain_test.go
+++ b/tests/check/testmain_test.go
@@ -10,5 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }

--- a/tests/listobjects/testmain_test.go
+++ b/tests/listobjects/testmain_test.go
@@ -10,5 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }

--- a/tests/listusers/testmain_test.go
+++ b/tests/listusers/testmain_test.go
@@ -10,5 +10,6 @@ import (
 func TestMain(m *testing.M) {
 	code := m.Run()
 	storagefixtures.CleanupPostgresContainer()
+	storagefixtures.CleanupMysqlContainer()
 	os.Exit(code)
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

The `RunDatastoreTestContainer` storage fixture currently creates a new container on each invocation, which can result in more than 10 containers being started during a single test run per storage. Each container initialization involves startup and running migrations, increasing execution time and resource usage in CI. This added overhead can negatively impact overall test performance.

#### How is it being solved?

I started with [PostgreSQL](https://github.com/openfga/openfga/pull/3018) and in this PR continue with MySQL.
The approach the same - reusing a single container across tests, while maintaining isolation through per-test databases. For MySQL this much more significantly reduces the overhead of container creation and migration execution.

This PR continues the work started in #3018 and #3062￼, now applied to MySQL.

The approach is the same: we reuse a single MySQL container across tests while maintaining isolation via per-test databases. For MySQL, this change significantly reduces the overhead of container creation and migration execution.

As a result, the execution time for `storage/mysql/mysql_test.go` is reduced by ~3×:
- Before: `github.com/openfga/openfga/pkg/storage/mysql	226.366s`
- After:    `github.com/openfga/openfga/pkg/storage/mysql	71.786s`

Also was reduces execution time of SQLite storage tests by ~2x. It was achieved by adding the `idx_store_ulid` index.

- Before: `github.com/openfga/openfga/pkg/storage/sqlite	315.027s`
- After:    `github.com/openfga/openfga/pkg/storage/sqlite	150.331s`

#### What changes are made to solve it?
- Updated the `MySQL` test fixture to reuse a single container.
- Simplified `MySQL` and `Postgres` test fixtures by introducing `sync.Once` for shared container lifecycle management, which also simplifies `Docker` client.
- Improved SQLite test performance by adding an index, reducing execution time by 2x.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

followup https://github.com/openfga/openfga/pull/3018
followup https://github.com/openfga/openfga/pull/3062

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test suite now reuses shared MySQL and PostgreSQL containers with isolated per-test databases, using coordinated bootstrapping, stronger readiness/backoff, and improved container startup checks; Docker client utilities and test coverage for container readiness and command execution were strengthened.

* **Chores**
  * Test harnesses now perform explicit shared-container cleanup during teardown.

* **New Features**
  * Added a DB migration to add an index on (store, ulid) to improve query performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->