### PR TITLE
feat(log): add configurable cloud trace context fields for log correlation

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -488,7 +488,7 @@
                     "x-env-variable": "OPENFGA_LOG_TIMESTAMP_FORMAT"
                 },
                 "cloudTraceFields": {
-                    "description": "Add cloud-provider-specific trace correlation fields to structured logs. When set to 'gcp', adds logging.googleapis.com/trace, logging.googleapis.com/spanId and logging.googleapis.com/trace_sampled fields (requires the GOOGLE_CLOUD_PROJECT environment variable to be set).",
+                    "description": "Add cloud-provider-specific trace correlation fields to structured logs. When set to 'gcp', adds logging.googleapis.com/trace, logging.googleapis.com/spanId and logging.googleapis.com/trace_sampled fields (requires 'log.format' to be 'json' and the GOOGLE_CLOUD_PROJECT environment variable to be set).",
                     "type": "string",
                     "enum": ["", "gcp"],
                     "default": "",

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -486,6 +486,12 @@
                     "enum": ["Unix", "ISO8601"],
                     "default": "Unix",
                     "x-env-variable": "OPENFGA_LOG_TIMESTAMP_FORMAT"
+                },
+                "cloudTraceFields": {
+                    "description": "Add cloud-provider-specific trace correlation fields to structured logs. When set to 'gcp', adds logging.googleapis.com/trace, logging.googleapis.com/spanId and logging.googleapis.com/trace_sampled fields (requires the GOOGLE_CLOUD_PROJECT environment variable to be set).",
+                    "type": "string",
+                    "enum": ["gcp"],
+                    "x-env-variable": "OPENFGA_LOG_CLOUD_TRACE_FIELDS"
                 }
             }
         },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -490,7 +490,8 @@
                 "cloudTraceFields": {
                     "description": "Add cloud-provider-specific trace correlation fields to structured logs. When set to 'gcp', adds logging.googleapis.com/trace, logging.googleapis.com/spanId and logging.googleapis.com/trace_sampled fields (requires the GOOGLE_CLOUD_PROJECT environment variable to be set).",
                     "type": "string",
-                    "enum": ["gcp"],
+                    "enum": ["", "gcp"],
+                    "default": "",
                     "x-env-variable": "OPENFGA_LOG_CLOUD_TRACE_FIELDS"
                 }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Added
+- Added a `log.cloudTraceFields` config option (`OPENFGA_LOG_CLOUD_TRACE_FIELDS`) that adds cloud-provider-specific trace correlation fields to structured logs. When set to `gcp`, request logs include `logging.googleapis.com/trace`, `logging.googleapis.com/spanId`, and `logging.googleapis.com/trace_sampled`, which Cloud Run's logging agent promotes to top-level `LogEntry` fields so logs are correlated with traces and request logs in Cloud Logging. Requires the `GOOGLE_CLOUD_PROJECT` environment variable. [#3049](https://github.com/openfga/openfga/pull/3049)
 
 ## [1.18.1] - 2026-06-29
 ### Added

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -164,6 +164,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("log.timestampFormat", flags.Lookup("log-timestamp-format"))
 		util.MustBindEnv("log.timestampFormat", "OPENFGA_LOG_TIMESTAMP_FORMAT")
 
+		util.MustBindPFlag("log.cloudTraceFields", flags.Lookup("log-cloud-trace-fields"))
+		util.MustBindEnv("log.cloudTraceFields", "OPENFGA_LOG_CLOUD_TRACE_FIELDS")
+
 		util.MustBindPFlag("trace.enabled", flags.Lookup("trace-enabled"))
 		util.MustBindEnv("trace.enabled", "OPENFGA_TRACE_ENABLED")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -240,6 +240,8 @@ func NewRunCommand() *cobra.Command {
 
 	flags.String("log-timestamp-format", defaultConfig.Log.TimestampFormat, "the timestamp format to use for log messages")
 
+	flags.String("log-cloud-trace-fields", defaultConfig.Log.CloudTraceFields, "add cloud-provider-specific trace correlation fields to structured logs. Supported: 'gcp'")
+
 	flags.Bool("trace-enabled", defaultConfig.Trace.Enabled, "enable tracing")
 
 	flags.String("trace-otlp-endpoint", defaultConfig.Trace.OTLP.Endpoint, "the endpoint of the trace collector")
@@ -562,6 +564,10 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 }
 
 func (s *ServerContext) buildServerOpts(ctx context.Context, config *serverconfig.Config, authenticator authn.Authenticator) ([]grpc.ServerOption, *grpc_prometheus.ServerMetrics, error) {
+	if config.Log.CloudTraceFields == "gcp" && os.Getenv("GOOGLE_CLOUD_PROJECT") == "" {
+		s.Logger.Warn("config 'log.cloudTraceFields' is set to 'gcp' but the GOOGLE_CLOUD_PROJECT environment variable is not set; the 'logging.googleapis.com/trace' field will be omitted and logs will not be correlated with traces in Cloud Logging")
+	}
+
 	serverOpts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(config.GRPC.MaxRecvMsgBytes),
 		grpc.ChainUnaryInterceptor(
@@ -598,8 +604,8 @@ func (s *ServerContext) buildServerOpts(ctx context.Context, config *serverconfi
 	serverOpts = append(serverOpts,
 		grpc.ChainUnaryInterceptor(
 			[]grpc.UnaryServerInterceptor{
-				storeid.NewUnaryInterceptor(),           // if available, add store_id to ctxtags
-				logging.NewLoggingInterceptor(s.Logger), // needed to log invalid requests
+				storeid.NewUnaryInterceptor(), // if available, add store_id to ctxtags
+				logging.NewLoggingInterceptor(s.Logger, logging.WithCloudTraceFields(config.Log.CloudTraceFields)), // needed to log invalid requests
 				validator.UnaryServerInterceptor(),
 			}...,
 		),
@@ -639,7 +645,7 @@ func (s *ServerContext) buildServerOpts(ctx context.Context, config *serverconfi
 				// The following interceptors wrap the server stream with our own
 				// wrapper and must come last.
 				storeid.NewStreamingInterceptor(),
-				logging.NewStreamingLoggingInterceptor(s.Logger),
+				logging.NewStreamingLoggingInterceptor(s.Logger, logging.WithCloudTraceFields(config.Log.CloudTraceFields)),
 			}...,
 		),
 	)

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -40,14 +42,32 @@ const (
 	healthCheckService     string = "grpc.health.v1.Health"
 )
 
+type interceptorOptions struct {
+	cloudTraceFields string
+}
+
+// InterceptorOption configures the logging interceptors.
+type InterceptorOption func(*interceptorOptions)
+
+// WithCloudTraceFields adds cloud-provider-specific trace correlation fields
+// to each request log's structured output. The provider "gcp" emits the
+// logging.googleapis.com/trace, logging.googleapis.com/spanId, and
+// logging.googleapis.com/trace_sampled fields; an empty provider disables
+// the extra fields.
+func WithCloudTraceFields(provider string) InterceptorOption {
+	return func(o *interceptorOptions) {
+		o.cloudTraceFields = provider
+	}
+}
+
 // NewLoggingInterceptor creates a new logging interceptor for gRPC unary server requests.
-func NewLoggingInterceptor(logger logger.Logger) grpc.UnaryServerInterceptor {
-	return interceptors.UnaryServerInterceptor(reportable(logger))
+func NewLoggingInterceptor(logger logger.Logger, opts ...InterceptorOption) grpc.UnaryServerInterceptor {
+	return interceptors.UnaryServerInterceptor(reportable(logger, opts...))
 }
 
 // NewStreamingLoggingInterceptor creates a new streaming logging interceptor for gRPC stream server requests.
-func NewStreamingLoggingInterceptor(logger logger.Logger) grpc.StreamServerInterceptor {
-	return interceptors.StreamServerInterceptor(reportable(logger))
+func NewStreamingLoggingInterceptor(logger logger.Logger, opts ...InterceptorOption) grpc.StreamServerInterceptor {
+	return interceptors.StreamServerInterceptor(reportable(logger, opts...))
 }
 
 type reporter struct {
@@ -133,7 +153,14 @@ func userAgentFromContext(ctx context.Context) (string, bool) {
 	return "", false
 }
 
-func reportable(l logger.Logger) interceptors.CommonReportableFunc {
+func reportable(l logger.Logger, opts ...InterceptorOption) interceptors.CommonReportableFunc {
+	var o interceptorOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	traceFieldsFn := cloudTraceFieldsFn(o.cloudTraceFields)
+
 	return func(ctx context.Context, c interceptors.CallMeta) (interceptors.Reporter, context.Context) {
 		fields := []zap.Field{
 			zap.String(grpcServiceKey, c.Service),
@@ -144,6 +171,7 @@ func reportable(l logger.Logger) interceptors.CommonReportableFunc {
 		spanCtx := trace.SpanContextFromContext(ctx)
 		if spanCtx.HasTraceID() {
 			fields = append(fields, zap.String(traceIDKey, spanCtx.TraceID().String()))
+			fields = append(fields, traceFieldsFn(spanCtx)...)
 		}
 
 		if userAgent, ok := userAgentFromContext(ctx); ok {
@@ -158,4 +186,36 @@ func reportable(l logger.Logger) interceptors.CommonReportableFunc {
 			serviceName:    c.Service,
 		}, ctx
 	}
+}
+
+// cloudTraceFieldsFn returns a function that produces cloud-provider-specific
+// trace correlation fields for a request's span context. GOOGLE_CLOUD_PROJECT
+// is read once here rather than on every request.
+func cloudTraceFieldsFn(provider string) func(trace.SpanContext) []zap.Field {
+	switch provider {
+	case "gcp":
+		gcpProject := os.Getenv("GOOGLE_CLOUD_PROJECT")
+		return func(spanCtx trace.SpanContext) []zap.Field {
+			return gcpTraceFields(spanCtx, gcpProject)
+		}
+	default:
+		return func(trace.SpanContext) []zap.Field { return nil }
+	}
+}
+
+// gcpTraceFields returns GCP Cloud Logging trace correlation fields.
+// Cloud Run's log agent promotes these JSON fields to top-level LogEntry
+// fields, enabling log-trace correlation in Cloud Logging.
+// See https://cloud.google.com/run/docs/logging#writing_structured_logs
+func gcpTraceFields(spanCtx trace.SpanContext, gcpProject string) []zap.Field {
+	var fields []zap.Field
+	if gcpProject != "" {
+		fields = append(fields, zap.String("logging.googleapis.com/trace",
+			fmt.Sprintf("projects/%s/traces/%s", gcpProject, spanCtx.TraceID().String())))
+	}
+	if spanCtx.HasSpanID() {
+		fields = append(fields, zap.String("logging.googleapis.com/spanId", spanCtx.SpanID().String()))
+	}
+	fields = append(fields, zap.Bool("logging.googleapis.com/trace_sampled", spanCtx.IsSampled()))
+	return fields
 }

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -194,9 +193,12 @@ func reportable(l logger.Logger, opts ...InterceptorOption) interceptors.CommonR
 func cloudTraceFieldsFn(provider string) func(trace.SpanContext) []zap.Field {
 	switch provider {
 	case "gcp":
-		gcpProject := os.Getenv("GOOGLE_CLOUD_PROJECT")
+		var tracePrefix string
+		if gcpProject := os.Getenv("GOOGLE_CLOUD_PROJECT"); gcpProject != "" {
+			tracePrefix = "projects/" + gcpProject + "/traces/"
+		}
 		return func(spanCtx trace.SpanContext) []zap.Field {
-			return gcpTraceFields(spanCtx, gcpProject)
+			return gcpTraceFields(spanCtx, tracePrefix)
 		}
 	default:
 		return func(trace.SpanContext) []zap.Field { return nil }
@@ -207,11 +209,13 @@ func cloudTraceFieldsFn(provider string) func(trace.SpanContext) []zap.Field {
 // Cloud Run's log agent promotes these JSON fields to top-level LogEntry
 // fields, enabling log-trace correlation in Cloud Logging.
 // See https://cloud.google.com/run/docs/logging#writing_structured_logs
-func gcpTraceFields(spanCtx trace.SpanContext, gcpProject string) []zap.Field {
-	var fields []zap.Field
-	if gcpProject != "" {
-		fields = append(fields, zap.String("logging.googleapis.com/trace",
-			fmt.Sprintf("projects/%s/traces/%s", gcpProject, spanCtx.TraceID().String())))
+//
+// tracePrefix is the precomputed "projects/<project>/traces/" prefix; when
+// empty, the trace field is omitted.
+func gcpTraceFields(spanCtx trace.SpanContext, tracePrefix string) []zap.Field {
+	fields := make([]zap.Field, 0, 3)
+	if tracePrefix != "" {
+		fields = append(fields, zap.String("logging.googleapis.com/trace", tracePrefix+spanCtx.TraceID().String()))
 	}
 	if spanCtx.HasSpanID() {
 		fields = append(fields, zap.String("logging.googleapis.com/spanId", spanCtx.SpanID().String()))

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -11,6 +11,7 @@ import (
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
@@ -104,6 +105,48 @@ func TestNewLoggingInterceptor_concrete(t *testing.T) {
 
 	srv.Stop()
 	wg.Wait()
+}
+
+func TestGCPTraceFields(t *testing.T) {
+	traceID, _ := trace.TraceIDFromHex("4bf92f3577b34da6a3ce929d0e0e4736")
+	spanID, _ := trace.SpanIDFromHex("00f067aa0ba902b7")
+	spanCtx := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+
+	t.Run("returns_nil_when_not_gcp", func(t *testing.T) {
+		fn := cloudTraceFieldsFn("")
+		fields := fn(spanCtx)
+		assert.Nil(t, fields)
+	})
+
+	t.Run("returns_gcp_fields", func(t *testing.T) {
+		fields := gcpTraceFields(spanCtx, "my-project")
+
+		fieldMap := make(map[string]interface{})
+		for _, f := range fields {
+			switch f.Type {
+			case zapcore.StringType:
+				fieldMap[f.Key] = f.String
+			case zapcore.BoolType:
+				fieldMap[f.Key] = f.Integer == 1
+			}
+		}
+
+		assert.Equal(t, "projects/my-project/traces/4bf92f3577b34da6a3ce929d0e0e4736", fieldMap["logging.googleapis.com/trace"])
+		assert.Equal(t, "00f067aa0ba902b7", fieldMap["logging.googleapis.com/spanId"])
+		assert.Equal(t, true, fieldMap["logging.googleapis.com/trace_sampled"])
+	})
+
+	t.Run("omits_trace_field_when_no_project", func(t *testing.T) {
+		fields := gcpTraceFields(spanCtx, "")
+
+		for _, f := range fields {
+			assert.NotEqual(t, "logging.googleapis.com/trace", f.Key)
+		}
+	})
 }
 
 type fgaServer struct {

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -122,8 +122,21 @@ func TestGCPTraceFields(t *testing.T) {
 		assert.Nil(t, fields)
 	})
 
+	t.Run("builds_trace_prefix_from_project_env", func(t *testing.T) {
+		t.Setenv("GOOGLE_CLOUD_PROJECT", "my-project")
+		fn := cloudTraceFieldsFn("gcp")
+
+		var traceValue string
+		for _, f := range fn(spanCtx) {
+			if f.Key == "logging.googleapis.com/trace" {
+				traceValue = f.String
+			}
+		}
+		assert.Equal(t, "projects/my-project/traces/4bf92f3577b34da6a3ce929d0e0e4736", traceValue)
+	})
+
 	t.Run("returns_gcp_fields", func(t *testing.T) {
-		fields := gcpTraceFields(spanCtx, "my-project")
+		fields := gcpTraceFields(spanCtx, "projects/my-project/traces/")
 
 		fieldMap := make(map[string]interface{})
 		for _, f := range fields {
@@ -140,7 +153,7 @@ func TestGCPTraceFields(t *testing.T) {
 		assert.Equal(t, true, fieldMap["logging.googleapis.com/trace_sampled"])
 	})
 
-	t.Run("omits_trace_field_when_no_project", func(t *testing.T) {
+	t.Run("omits_trace_field_when_no_prefix", func(t *testing.T) {
 		fields := gcpTraceFields(spanCtx, "")
 
 		for _, f := range fields {

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -250,8 +250,8 @@ type LogConfig struct {
 	// fields are added to structured log output. Supported values:
 	//   - "" (empty/default): no additional trace correlation fields
 	//   - "gcp": adds logging.googleapis.com/trace, logging.googleapis.com/spanId,
-	//     and logging.googleapis.com/trace_sampled fields. Requires GOOGLE_CLOUD_PROJECT
-	//     env var to be set.
+	//     and logging.googleapis.com/trace_sampled fields. Requires Format "json"
+	//     and the GOOGLE_CLOUD_PROJECT env var to be set.
 	CloudTraceFields string
 }
 
@@ -606,6 +606,10 @@ func (cfg *Config) VerifyBinarySettings() error {
 
 	if cfg.Log.CloudTraceFields != "" && cfg.Log.CloudTraceFields != "gcp" {
 		return fmt.Errorf("config 'log.cloudTraceFields' must be one of ['', 'gcp']")
+	}
+
+	if cfg.Log.CloudTraceFields != "" && cfg.Log.Format != "json" {
+		return fmt.Errorf("config 'log.cloudTraceFields' requires 'log.format' to be 'json'")
 	}
 
 	if cfg.Trace.Enabled {

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -245,6 +245,14 @@ type LogConfig struct {
 
 	// Format of the timestamp in the log output (e.g. 'Unix'(default) or 'ISO8601')
 	TimestampFormat string
+
+	// CloudTraceFields controls whether cloud-provider-specific trace correlation
+	// fields are added to structured log output. Supported values:
+	//   - "" (empty/default): no additional trace correlation fields
+	//   - "gcp": adds logging.googleapis.com/trace, logging.googleapis.com/spanId,
+	//     and logging.googleapis.com/trace_sampled fields. Requires GOOGLE_CLOUD_PROJECT
+	//     env var to be set.
+	CloudTraceFields string
 }
 
 type TraceConfig struct {
@@ -594,6 +602,10 @@ func (cfg *Config) VerifyBinarySettings() error {
 
 	if cfg.Log.TimestampFormat != "Unix" && cfg.Log.TimestampFormat != "ISO8601" {
 		return fmt.Errorf("config 'log.TimestampFormat' must be one of ['Unix', 'ISO8601']")
+	}
+
+	if cfg.Log.CloudTraceFields != "" && cfg.Log.CloudTraceFields != "gcp" {
+		return fmt.Errorf("config 'log.cloudTraceFields' must be one of ['', 'gcp']")
 	}
 
 	if cfg.Trace.Enabled {

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -1132,12 +1132,21 @@ func TestVerifyBinarySettings(t *testing.T) {
 		require.EqualError(t, err, "config 'log.cloudTraceFields' must be one of ['', 'gcp']")
 	})
 
-	t.Run("valid_log_cloud_trace_fields", func(t *testing.T) {
+	t.Run("log_cloud_trace_fields_with_json_format", func(t *testing.T) {
 		cfg := DefaultConfig()
+		cfg.Log.Format = "json"
 		cfg.Log.CloudTraceFields = "gcp"
 
 		err := cfg.VerifyBinarySettings()
 		require.NoError(t, err)
+	})
+
+	t.Run("log_cloud_trace_fields_without_json_format", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.CloudTraceFields = "gcp"
+
+		err := cfg.VerifyBinarySettings()
+		require.EqualError(t, err, "config 'log.cloudTraceFields' requires 'log.format' to be 'json'")
 	})
 
 	t.Run("playground_enabled_without_http", func(t *testing.T) {

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -1132,6 +1132,14 @@ func TestVerifyBinarySettings(t *testing.T) {
 		require.EqualError(t, err, "config 'log.cloudTraceFields' must be one of ['', 'gcp']")
 	})
 
+	t.Run("empty_log_cloud_trace_fields", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.CloudTraceFields = ""
+
+		err := cfg.VerifyBinarySettings()
+		require.NoError(t, err)
+	})
+
 	t.Run("log_cloud_trace_fields_with_json_format", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Log.Format = "json"

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -1124,6 +1124,22 @@ func TestVerifyBinarySettings(t *testing.T) {
 		require.Contains(t, err.Error(), "config 'log.level' must be one of ['none', 'debug', 'info', 'warn', 'error', 'panic', 'fatal']")
 	})
 
+	t.Run("invalid_log_cloud_trace_fields", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.CloudTraceFields = "aws"
+
+		err := cfg.VerifyBinarySettings()
+		require.EqualError(t, err, "config 'log.cloudTraceFields' must be one of ['', 'gcp']")
+	})
+
+	t.Run("valid_log_cloud_trace_fields", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.CloudTraceFields = "gcp"
+
+		err := cfg.VerifyBinarySettings()
+		require.NoError(t, err)
+	})
+
 	t.Run("playground_enabled_without_http", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Playground.Enabled = true


### PR DESCRIPTION
## Why?

OpenFGA writes `trace_id` and `span_id` to structured JSON logs, but cloud logging agents (e.g. Cloud Run on GCP) only promote fields with specific key names to top-level LogEntry fields for trace correlation.

Enriching the existing stdout logs is the simplest way to get correlation on Cloud Run - the platform's log agent ingests stdout directly, and rerouting logs through a collector instead would duplicate or bypass that path.

Relates to #3022. A vendor-neutral OTLP log export approach is explored separately in #3048; this PR is independent of it.

## What?

Introduces a `log.cloudTraceFields` configuration option (`OPENFGA_LOG_CLOUD_TRACE_FIELDS` env var) to add cloud-provider-specific trace correlation fields to structured log output.

**Key features:**

- When set to `"gcp"`, emits `logging.googleapis.com/trace`, `logging.googleapis.com/spanId`, and `logging.googleapis.com/trace_sampled` fields
- Cloud Run's log agent promotes these to top-level `LogEntry` fields, enabling log-trace correlation
- New config: `log.cloudTraceFields` / `OPENFGA_LOG_CLOUD_TRACE_FIELDS` (supported values: `""` for default, `"gcp"`)
- Invalid values are rejected at startup, consistent with `log.format`/`log.level` validation
- `GOOGLE_CLOUD_PROJECT` environment variable is read once at startup
- Default behavior remains unchanged
- The logging interceptor constructors take functional options (`WithCloudTraceFields`), so their exported signatures remain backward compatible
- Extensible to other cloud providers via the provider enum

## Notes

- Requires `GOOGLE_CLOUD_PROJECT` env var when using GCP mode - it is *not* set automatically on Cloud Run. If missing, OpenFGA logs a startup warning and omits the `logging.googleapis.com/trace` field (correlation will not work)
- Only the gRPC logging interceptor's request logs (`grpc_req_complete` and error logs) carry these fields. Logs emitted elsewhere via the logger's `*WithContext` methods are not enriched yet; extending this into `pkg/logger` could be a follow-up
- Reference: [GCP Cloud Run logging documentation](https://cloud.google.com/run/docs/logging#writing_structured_logs)
- **Design question for maintainers:** this PR hardcodes provider-specific field names behind a provider enum (`"gcp"`). Alternatives are (a) a generic field-injection mechanism - a configurable map of field name → template, e.g. `"logging.googleapis.com/trace": "projects/my-project/traces/{trace_id}"` - which would serve any backend without vendor-specific code in core, at the cost of a small template syntax; or (b) OTLP log export (#3022/#3048), which is vendor-neutral but requires a collector pipeline and doesn't help deployments that rely on stdout ingestion.


**Deployment example:**

```
OPENFGA_LOG_CLOUD_TRACE_FIELDS=gcp
GOOGLE_CLOUD_PROJECT=my-project-id
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `log.cloudTraceFields` support for structured gRPC request logs via `log-cloud-trace-fields` (CLI) and `OPENFGA_LOG_CLOUD_TRACE_FIELDS` (enable with `gcp`).
* **Bug Fixes**
  * Validates allowed values and requires JSON log format when `gcp` is selected; warns and omits cloud trace fields if the required Google Cloud project context isn’t available.
* **Tests**
  * Added unit coverage for GCP trace correlation field generation.
* **Documentation**
  * Updated `CHANGELOG.md` with the new configuration setting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->