### PR TITLE
test: fix flaky condition test

### DIFF
--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -685,7 +685,7 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 			require.NoError(t, err)
 
 			evalCtx, cancel := context.WithCancel(ctx)
-			cancel() // cancel immediately so ctx.Done() is closed before Evaluate
+			cancel() // cancel immediately so evalCtx.Done() is closed before Evaluate
 
 			result, err := condition.Evaluate(evalCtx, contextStruct.GetFields())
 

--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -558,9 +557,9 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 		return items
 	}
 
-	// numLoops is the number of loops being evaluated by a CEL
-	// expression. This number needs to be large enough to not
-	// be resolved before the 1 microsecond context timeout.
+	// numLoops is used as both the list size and the interrupt check
+	// frequency. With N items and checkFrequency=N, the interrupt fires
+	// exactly at the last iteration; with N-1 items it never fires.
 	numLoops := 500
 
 	var tests = []struct {
@@ -685,8 +684,8 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 			contextStruct, err := structpb.NewStruct(test.context)
 			require.NoError(t, err)
 
-			evalCtx, cancel := context.WithTimeout(ctx, time.Microsecond)
-			defer cancel()
+			evalCtx, cancel := context.WithCancel(ctx)
+			cancel() // cancel immediately so ctx.Done() is closed before Evaluate
 
 			result, err := condition.Evaluate(evalCtx, contextStruct.GetFields())
 


### PR DESCRIPTION

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
TestEvaluateWithInterruptCheckFrequency was flaky in CI. The test expected the error "operation interrupted" from CEL's comprehension interrupt mechanism, but intermittently received "context deadline exceeded" instead. This was caused by a race: the 1μs context.WithTimeout timer fires in a separate goroutine, and on fast machines or loaded CI runners, the Go runtime may not schedule that goroutine before CEL finishes evaluating the comprehension  — so ctx.Done() wasn't closed when the interrupt check ran.


#### How is it being solved?
Replace the timing-dependent timeout with a pre-cancelled context. Calling cancel() immediately after context.WithCancel guarantees ctx.Done() is closed before Evaluate is called. Since CEL's interrupt mechanism only polls ctx.Done() (a channel) and never inspects ctx.Err(), interrupt detection becomes purely a function of iteration count, independent of wall-clock timing or goroutine scheduling.                                                 
                                                                                      
#### What changes are made to solve it?
  - internal/condition/condition_test.go: replace context.WithTimeout(ctx, time.Microsecond) + defer cancel() with context.WithCancel(ctx) + immediate cancel()
  - Remove the now-unused "time" import                                                                                                                                                                                            
  - Update the numLoops comment to describe the actual invariant (list size equals check frequency) rather than the removed timing rationale


## References
CICD failure: https://github.com/openfga/openfga/actions/runs/24194351452/job/70715442530

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test implementation for condition evaluation with updated context handling and test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->