### PR TITLE
list objects pipeline edge pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Implemented edge pruning in the list objects pipeline algorithm. This introduces a measurable improvement to request latency for larger, more complex authorization models. [#3075](https://github.com/openfga/openfga/pull/3075)
+
 ### Security
 - Update toolchain Go version to 1.26.2 to address the Go standard library vulnerabilities documented in the [Go 1.26.2 release notes](https://go.dev/doc/devel/release#go1.26.2). [#3084](https://github.com/openfga/openfga/pull/3084)
 

--- a/internal/containers/mpsc/accumulator.go
+++ b/internal/containers/mpsc/accumulator.go
@@ -138,7 +138,7 @@ PopLoop:
 // next value and true if one is immediately available, or the zero value
 // and false if the queue is empty. Unlike [Accumulator.Recv], it never
 // blocks waiting for a producer.
-func (a *Accumulator[T]) TryRecv(ctx context.Context) (T, bool) {
+func (a *Accumulator[T]) TryRecv() (T, bool) {
 	var value T
 	var ok bool
 

--- a/internal/containers/mpsc/accumulator.go
+++ b/internal/containers/mpsc/accumulator.go
@@ -134,6 +134,25 @@ PopLoop:
 	return value, ok
 }
 
+// TryRecv attempts a non-blocking receive from the queue. It returns the
+// next value and true if one is immediately available, or the zero value
+// and false if the queue is empty. Unlike [Accumulator.Recv], it never
+// blocks waiting for a producer.
+func (a *Accumulator[T]) TryRecv(ctx context.Context) (T, bool) {
+	var value T
+	var ok bool
+
+	currentTail := a.tail
+	nextNode := currentTail.Next.Load()
+
+	if nextNode != nil && nextNode.Kind != end {
+		value = nextNode.Value
+		ok = true
+		a.tail = nextNode
+	}
+	return value, ok
+}
+
 // Seq returns an iter.Seq[T] that yields elements in insertion order,
 // blocking until new nodes appear and terminating when it encounters
 // a sentinel terminal node produced by Close().

--- a/internal/listobjects/pipeline/config.go
+++ b/internal/listobjects/pipeline/config.go
@@ -1,6 +1,6 @@
 package pipeline
 
-// Option configures a [Pipeline].
+// Option configures a [Builder].
 type Option func(*Config)
 
 // WithBufferCapacity sets the capacity of pipes between workers.

--- a/internal/listobjects/pipeline/config_test.go
+++ b/internal/listobjects/pipeline/config_test.go
@@ -1,7 +1,6 @@
 package pipeline_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,12 +100,4 @@ func TestWithConfig(t *testing.T) {
 	custom := pipeline.Config{BufferCapacity: 10, ChunkSize: 5, NumProcs: 2}
 	pipeline.WithConfig(custom)(&config)
 	assert.Equal(t, custom, config)
-}
-
-func TestWithConfig_InvalidConfig_ReturnsError(t *testing.T) {
-	invalid := pipeline.Config{BufferCapacity: -1, ChunkSize: 0, NumProcs: 0}
-	pl := pipeline.New(nil, nil, pipeline.WithConfig(invalid))
-	_, err := pl.Expand(context.Background(), pipeline.Spec{ObjectType: "x", Relation: "y", User: "u:1"})
-	// Validate runs before resolveObjectNode, so we get config error first.
-	require.ErrorIs(t, err, pipeline.ErrInvalidBufferCapacity)
 }

--- a/internal/listobjects/pipeline/doc.go
+++ b/internal/listobjects/pipeline/doc.go
@@ -11,10 +11,10 @@
 // authorization graph. Workers communicate through message passing,
 // processing tuples and propagating results toward the query origin.
 //
-//	Pipeline.Expand()
+//	Builder.Build(ctx, graph, spec)
 //	       │
 //	       ▼
-//	  resolve() ─── builds worker graph from authorization model
+//	  DFS walk ─── builds worker graph from authorization model
 //	       │
 //	       ▼
 //	  ┌─────────┐     ┌─────────┐     ┌─────────┐
@@ -23,7 +23,7 @@
 //	  └─────────┘     └─────────┘     └─────────┘
 //	       │
 //	       ▼
-//	  iter.Seq[Object] ─── results streamed to caller
+//	  Pipeline.Recv() ─── results streamed to caller
 //
 // # Trade-offs
 //
@@ -34,7 +34,7 @@
 //
 // Streaming Results:
 //   - Memory usage remains constant regardless of result set size
-//   - Enables early termination when caller stops iteration
+//   - Enables early termination when caller calls Close
 //
 // Cycle Handling:
 //   - Cycles require input deduplication to prevent infinite loops
@@ -42,22 +42,35 @@
 //
 // # Usage
 //
-//	p := pipeline.New(graph, reader,
+//	builder, err := pipeline.NewBuilder(store,
 //	    pipeline.WithNumProcs(4),
 //	    pipeline.WithChunkSize(100),
 //	)
+//	if err != nil {
+//	    return err
+//	}
 //
-//	seq, err := p.Expand(ctx, pipeline.Spec{
-//	    ObjectType: "document",
-//	    Relation:   "viewer",
-//	    User:       "user:alice",
+//	p, err := builder.Build(ctx, graph, pipeline.Spec{
+//	    ObjectType:     "document",
+//	    ObjectRelation: "viewer",
+//	    SubjectType:    "user",
+//	    SubjectID:      "alice",
 //	})
+//	if err != nil {
+//	    return err
+//	}
+//	defer p.Close()
 //
-//	for obj := range seq {
-//	    id, err := obj.Object()
-//	    if err != nil {
-//	        // handle error
+//	for {
+//	    id, ok := p.Recv(ctx)
+//	    if !ok {
+//	        break
 //	    }
 //	    // id is an object ID like "document:readme"
+//	}
+//
+//	if err := p.Err(); err != nil {
+//	    // handle error (e.g. storage failure, context cancellation)
+//	    return err
 //	}
 package pipeline

--- a/internal/listobjects/pipeline/edge.go
+++ b/internal/listobjects/pipeline/edge.go
@@ -11,7 +11,7 @@ import (
 
 // directEdgeHandler queries objects via the edge's relation definition.
 type directEdgeHandler struct {
-	reader ObjectReader
+	reader ObjectStore
 }
 
 // Handle queries storage for objects related to the given items through
@@ -53,7 +53,7 @@ func (h *directEdgeHandler) Handle(
 
 // ttuEdgeHandler queries objects via the edge's tupleset relation.
 type ttuEdgeHandler struct {
-	reader ObjectReader
+	reader ObjectStore
 	graph  *Graph
 }
 

--- a/internal/listobjects/pipeline/internal/worker/core.go
+++ b/internal/listobjects/pipeline/internal/worker/core.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -14,6 +15,7 @@ import (
 	weightedGraph "github.com/openfga/language/pkg/go/graph"
 
 	"github.com/openfga/openfga/internal/concurrency"
+	"github.com/openfga/openfga/internal/containers/mpsc"
 )
 
 var tracer = otel.Tracer("openfga/internal/listobjects/pipeline/internal/worker")
@@ -151,7 +153,7 @@ type Core struct {
 	MediumFunc  func(*Edge, int) Medium
 	MsgFunc     func(*Message, *Edge)
 	Label       string
-	Errors      chan<- error
+	Errors      *mpsc.Accumulator[error]
 	Interpreter Interpreter
 	ChunkSize   int
 	NumProcs    int
@@ -176,14 +178,10 @@ func (c *Core) instrument(span trace.Span) {
 	span.SetAttributes(attrs...)
 }
 
-// error sends a non-nil *err to the shared error channel. If the channel
-// is full, the error is silently dropped to avoid blocking the caller.
+// error sends a non-nil *err to the shared error accumulator.
 func (c *Core) error(err *error) {
 	if err != nil && *err != nil {
-		select {
-		case c.Errors <- *err:
-		default:
-		}
+		c.Errors.Send(*err)
 	}
 }
 
@@ -265,8 +263,10 @@ func (c *Core) ProcessSender(ctx context.Context, index int, processor MessagePr
 			for msg = range input {
 				if processor != nil {
 					if e := processor.ProcessMessage(ctx, index, msg); e != nil {
-						errCount.Add(1)
-						c.error(&e)
+						if !errors.Is(e, context.Canceled) && !errors.Is(e, context.DeadlineExceeded) {
+							errCount.Add(1)
+							c.error(&e)
+						}
 					}
 				}
 				msg.Done()

--- a/internal/listobjects/pipeline/internal/worker/core_test.go
+++ b/internal/listobjects/pipeline/internal/worker/core_test.go
@@ -145,7 +145,7 @@ func TestCore_Message_SendsToListener(t *testing.T) {
 		Pool:      newPool(),
 	}
 	output := core.Subscribe(nil, chunkSize)
-	core.Broadcast(context.Background(), worker.NewValueReceiver("a", "b", "c"))
+	core.Broadcast(context.Background(), worker.NewSliceReceiver([]string{"a", "b", "c"}))
 	core.Cleanup()
 
 	assert.Equal(t, []string{"a", "b", "c"}, collectOutput(output))
@@ -158,7 +158,7 @@ func TestCore_Message_ChunksOutput(t *testing.T) {
 	}
 	output := core.Subscribe(nil, chunkSize)
 
-	core.Broadcast(context.Background(), worker.NewValueReceiver("a", "b", "c", "d", "e"))
+	core.Broadcast(context.Background(), worker.NewSliceReceiver([]string{"a", "b", "c", "d", "e"}))
 	core.Cleanup()
 
 	messages := collectMessages(output)
@@ -176,7 +176,7 @@ func TestCore_Message_BroadcastsToMultipleListeners(t *testing.T) {
 	out1 := core.Subscribe(nil, chunkSize)
 	out2 := core.Subscribe(nil, chunkSize)
 
-	core.Broadcast(context.Background(), worker.NewValueReceiver("x", "y"))
+	core.Broadcast(context.Background(), worker.NewSliceReceiver([]string{"x", "y"}))
 	core.Cleanup()
 
 	assert.Equal(t, []string{"x", "y"}, collectOutput(out1))
@@ -196,7 +196,7 @@ func TestCore_Message_CallsMsgFunc(t *testing.T) {
 	}
 	output := core.Subscribe(nil, chunkSize)
 
-	core.Broadcast(context.Background(), worker.NewValueReceiver("a", "b", "c"))
+	core.Broadcast(context.Background(), worker.NewSliceReceiver([]string{"a", "b", "c"}))
 	core.Cleanup()
 
 	_ = collectOutput(output)
@@ -217,7 +217,7 @@ func TestCore_Message_StopsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	core.Broadcast(ctx, worker.NewValueReceiver("a", "b", "c"))
+	core.Broadcast(ctx, worker.NewSliceReceiver([]string{"a", "b", "c"}))
 	core.Cleanup()
 
 	assert.Empty(t, collectOutput(output))

--- a/internal/listobjects/pipeline/internal/worker/medium.go
+++ b/internal/listobjects/pipeline/internal/worker/medium.go
@@ -29,6 +29,11 @@ type Sender interface {
 
 // Listener is the write end of a [Medium]. A worker writes to its listeners
 // to deliver messages to downstream workers.
+//
+// Send transfers ownership of the message to the listener on success
+// (returns true): the listener is responsible for eventually calling
+// [Message.Done]. On failure (returns false), ownership remains with the
+// caller, who must call [Message.Done] itself to release pooled resources.
 type Listener interface {
 	Close()
 	Key() *Edge
@@ -53,6 +58,52 @@ func NewStandardMedium(edge *Edge, capacity int) Medium {
 func NewCyclicalMedium(edge *Edge, capacity int) Medium {
 	return NewQueueMedium(edge, capacity)
 }
+
+// NoopMedium is a [Medium] that discards all sends and never produces
+// values. It is used to satisfy listener slots for edges that are
+// unreachable in the current query.
+type NoopMedium struct {
+	key   *Edge
+	label string
+}
+
+// String returns a label of the form "source->destination".
+func (m *NoopMedium) String() string {
+	return m.label
+}
+
+// NewNoopMedium returns a NoopMedium for the given edge.
+func NewNoopMedium(edge *Edge) *NoopMedium {
+	src, dst := EdgeLabels(edge)
+	return &NoopMedium{
+		key:   edge,
+		label: src + "->" + dst,
+	}
+}
+
+// Key returns the edge associated with this medium.
+func (m *NoopMedium) Key() *Edge {
+	return m.key
+}
+
+// Recv always returns (nil, false).
+func (m *NoopMedium) Recv(_ context.Context) (*Message, bool) {
+	return nil, false
+}
+
+// Send returns false without consuming the message when the context
+// has been canceled. Otherwise, the message is marked as done and
+// discarded, and Send returns true.
+func (m *NoopMedium) Send(ctx context.Context, msg *Message) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+	msg.Done()
+	return true
+}
+
+// Close is a no-op.
+func (m *NoopMedium) Close() {}
 
 // QueueMedium is a [Medium] backed by an [mpmc.Queue]. Like all
 // [Medium] variants, it is multiple-producer, single-consumer.

--- a/internal/listobjects/pipeline/internal/worker/receiver.go
+++ b/internal/listobjects/pipeline/internal/worker/receiver.go
@@ -3,13 +3,13 @@ package worker
 import (
 	"context"
 	"iter"
-	"sync/atomic"
 )
 
 // Receiver is a pull-based stream of values. Recv blocks until the
 // next value is available, returning false when the stream is exhausted
 // or the context is cancelled. Close releases any resources held by
-// the receiver; it is safe to call multiple times.
+// the receiver; it is safe to call multiple times. A Receiver is not
+// safe for concurrent use.
 type Receiver[T any] interface {
 	Recv(context.Context) (T, bool)
 	Close()
@@ -62,19 +62,45 @@ func (r *MappingReceiver[T, U]) Close() {
 	r.inner.Close()
 }
 
-// SliceReceiver iterates over a fixed slice of values. It is safe for
-// concurrent use: Close may be called from any goroutine to stop iteration.
-type SliceReceiver[T any] struct {
-	inner  []T
-	pos    atomic.Int64
-	closed atomic.Bool
+// ValueReceiver yields a single value and then exhausts itself.
+// It is not safe for concurrent use.
+type ValueReceiver[T any] struct {
+	value  T
+	closed bool
 }
 
-// NewValueReceiver returns a Receiver that yields the given values in order.
-func NewValueReceiver[T any](values ...T) Receiver[T] {
-	return &SliceReceiver[T]{
-		inner: values,
+// NewValueReceiver returns a Receiver that yields value exactly once.
+func NewValueReceiver[T any](value T) *ValueReceiver[T] {
+	return &ValueReceiver[T]{
+		value: value,
 	}
+}
+
+// Recv returns the value on the first call, then (zero, false) on
+// subsequent calls.
+func (r *ValueReceiver[T]) Recv(ctx context.Context) (T, bool) {
+	var value T
+	if r.closed || ctx.Err() != nil {
+		return value, false
+	}
+	value = r.value
+	r.closed = true
+	return value, true
+}
+
+// Close marks the receiver as exhausted and releases the held value.
+func (r *ValueReceiver[T]) Close() {
+	r.closed = true
+	var zero T
+	r.value = zero
+}
+
+// SliceReceiver iterates over a fixed slice of values. It is NOT safe for
+// concurrent use.
+type SliceReceiver[T any] struct {
+	inner  []T
+	pos    int
+	closed bool
 }
 
 // NewSliceReceiver returns a SliceReceiver that yields elements from inner.
@@ -84,24 +110,22 @@ func NewSliceReceiver[T any](inner []T) *SliceReceiver[T] {
 	}
 }
 
-// Recv atomically claims the next position and returns the element at
-// that index. Concurrent callers each receive a distinct element.
+// Recv returns the next element from the slice, advancing the position
+// by one.
 func (r *SliceReceiver[T]) Recv(ctx context.Context) (T, bool) {
 	var value T
-	if ctx.Err() != nil {
+	if r.closed || r.pos >= len(r.inner) || ctx.Err() != nil {
 		return value, false
 	}
-	pos := r.pos.Add(1) - 1
-	if r.closed.Load() || pos >= int64(len(r.inner)) {
-		return value, false
-	}
-	value = r.inner[pos]
+	value = r.inner[r.pos]
+	r.pos++
 	return value, true
 }
 
 // Close marks the receiver as exhausted.
 func (r *SliceReceiver[T]) Close() {
-	r.closed.Store(true)
+	r.closed = true
+	r.inner = nil
 }
 
 // SeqReceiver adapts an [iter.Seq] into a [Receiver] using [iter.Pull].

--- a/internal/listobjects/pipeline/internal/worker/receiver_test.go
+++ b/internal/listobjects/pipeline/internal/worker/receiver_test.go
@@ -102,27 +102,6 @@ func TestValueReceiver_SingleValue(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestValueReceiver_MultipleValues(t *testing.T) {
-	r := worker.NewValueReceiver("x", "y")
-
-	v1, ok := r.Recv(context.Background())
-	assert.True(t, ok)
-	assert.Equal(t, "x", v1)
-
-	v2, ok := r.Recv(context.Background())
-	assert.True(t, ok)
-	assert.Equal(t, "y", v2)
-
-	_, ok = r.Recv(context.Background())
-	assert.False(t, ok)
-}
-
-func TestValueReceiver_NoValuesReturnsNotOk(t *testing.T) {
-	r := worker.NewValueReceiver[string]()
-	_, ok := r.Recv(context.Background())
-	assert.False(t, ok)
-}
-
 func TestMapReceiver_TransformsValues(t *testing.T) {
 	inner := worker.NewSliceReceiver([]int{1, 2, 3})
 	r := worker.MapReceiver(inner, func(i int) string {

--- a/internal/listobjects/pipeline/internal/worker/terminal.go
+++ b/internal/listobjects/pipeline/internal/worker/terminal.go
@@ -1,0 +1,54 @@
+package worker
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/openfga/openfga/internal/concurrency"
+)
+
+// Terminal is a leaf worker for concrete type nodes (e.g. "user").
+// It prepends the type label to each incoming identifier and broadcasts
+// the fully-qualified object strings to listeners.
+type Terminal struct {
+	*Core
+}
+
+// ProcessMessage prepends the worker's type label to each value in msg
+// and broadcasts the results.
+func (w *Terminal) ProcessMessage(ctx context.Context, index int, msg *Message) error {
+	receiver := NewSliceReceiver(msg.Value)
+	values := MapReceiver(receiver, func(value string) string {
+		return w.Label + ":" + value
+	})
+	defer values.Close()
+	w.Broadcast(ctx, values)
+	return nil
+}
+
+// Execute starts a goroutine per sender to drain incoming messages.
+func (w *Terminal) Execute(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "Terminal.Execute", trace.WithAttributes(
+		attribute.String("worker.label", w.String()),
+	))
+	defer span.End()
+
+	defer w.instrument(span)
+	defer w.Cleanup()
+
+	var wg sync.WaitGroup
+
+	for index := range len(w.senders) {
+		wg.Go(func() {
+			var err error
+			defer w.error(&err)
+			defer concurrency.RecoverFromPanic(&err)
+
+			w.ProcessSender(ctx, index, w)
+		})
+	}
+	wg.Wait()
+}

--- a/internal/listobjects/pipeline/internal/worker/wildcard.go
+++ b/internal/listobjects/pipeline/internal/worker/wildcard.go
@@ -1,0 +1,31 @@
+package worker
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Wildcard is a leaf worker for wildcard type nodes (e.g. "user:*").
+// It broadcasts its own label as the sole result, representing the
+// wildcard match for the type.
+type Wildcard struct {
+	*Core
+}
+
+// Execute broadcasts the wildcard label and cleans up.
+func (w *Wildcard) Execute(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "Wildcard.Execute", trace.WithAttributes(
+		attribute.String("worker.label", w.String()),
+	))
+	defer span.End()
+
+	defer w.instrument(span)
+	defer w.Cleanup()
+
+	results := NewValueReceiver(w.Label)
+	defer results.Close()
+
+	w.Broadcast(ctx, results)
+}

--- a/internal/listobjects/pipeline/internal/worker/worker_test.go
+++ b/internal/listobjects/pipeline/internal/worker/worker_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
+	"github.com/openfga/openfga/internal/containers/mpsc"
 	"github.com/openfga/openfga/internal/listobjects/pipeline/internal/worker"
 )
 
@@ -91,7 +92,7 @@ func newPool() *worker.MessagePool {
 	return worker.NewMessagePool(chunkSize, 10)
 }
 
-func newCore(interp worker.Interpreter, errs chan<- error) *worker.Core {
+func newCore(interp worker.Interpreter, errs *mpsc.Accumulator[error]) *worker.Core {
 	return &worker.Core{
 		Label:       "test",
 		Errors:      errs,
@@ -103,6 +104,19 @@ func newCore(interp worker.Interpreter, errs chan<- error) *worker.Core {
 			return worker.NewChannelMedium(edge, capacity)
 		},
 	}
+}
+
+// collectErrors drains all errors from an Accumulator after it has been closed.
+func collectErrors(acc *mpsc.Accumulator[error]) []error {
+	var errs []error
+	for {
+		e, ok := acc.TryRecv(context.Background())
+		if !ok {
+			break
+		}
+		errs = append(errs, e)
+	}
+	return errs
 }
 
 // collectOutput drains all messages from a Sender and returns the combined values.
@@ -190,20 +204,21 @@ func TestDefaultPreprocessor_IsIdentity(t *testing.T) {
 func TestBasic_Execute_NoSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestBasic_Execute_SingleSender(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	output := w.Subscribe(nil, chunkSize)
@@ -211,13 +226,14 @@ func TestBasic_Execute_SingleSender(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestBasic_Execute_DeduplicatesWithinSender(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "a", "b", "c"))
 	output := w.Subscribe(nil, chunkSize)
@@ -225,13 +241,14 @@ func TestBasic_Execute_DeduplicatesWithinSender(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestBasic_Execute_DeduplicatesAcrossSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("b", "c"))
@@ -240,14 +257,15 @@ func TestBasic_Execute_DeduplicatesAcrossSenders(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestBasic_Execute_InterpreterError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	sentinelErr := errors.New("interpret failed")
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 
 	interp := &mockInterpreter{
 		fn: func(_ context.Context, _ *worker.Edge, items []string) worker.Receiver[worker.Item] {
@@ -265,16 +283,18 @@ func TestBasic_Execute_InterpreterError(t *testing.T) {
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
+	errs.Close()
 
 	assert.Nil(t, collectOutput(output))
-	require.Len(t, errs, 1)
-	assert.ErrorIs(t, <-errs, sentinelErr)
+	got := collectErrors(errs)
+	require.Len(t, got, 1)
+	assert.ErrorIs(t, got[0], sentinelErr)
 }
 
 func TestBasic_Execute_ContextCancelled(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	output := w.Subscribe(nil, chunkSize)
@@ -285,7 +305,8 @@ func TestBasic_Execute_ContextCancelled(t *testing.T) {
 	w.Execute(ctx)
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 // --- Intersection Worker Tests ---
@@ -293,20 +314,21 @@ func TestBasic_Execute_ContextCancelled(t *testing.T) {
 func TestIntersection_Execute_NoSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_CommonItems(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	w.Listen(sendItems("b", "c", "d"))
@@ -315,13 +337,14 @@ func TestIntersection_Execute_CommonItems(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_NoOverlap(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("c", "d"))
@@ -330,13 +353,14 @@ func TestIntersection_Execute_NoOverlap(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_OneSenderEmpty(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendNothing())
@@ -345,13 +369,14 @@ func TestIntersection_Execute_OneSenderEmpty(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_IdenticalSets(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("a", "b"))
@@ -360,13 +385,14 @@ func TestIntersection_Execute_IdenticalSets(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_ThreeSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	w.Listen(sendItems("b", "c", "d"))
@@ -376,14 +402,15 @@ func TestIntersection_Execute_ThreeSenders(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_InterpreterError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	sentinelErr := errors.New("interpret failed")
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 
 	interp := &mockInterpreter{
 		fn: func(_ context.Context, _ *worker.Edge, items []string) worker.Receiver[worker.Item] {
@@ -402,16 +429,18 @@ func TestIntersection_Execute_InterpreterError(t *testing.T) {
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
+	errs.Close()
 
 	_ = collectOutput(output)
-	require.NotEmpty(t, errs)
-	assert.ErrorIs(t, <-errs, sentinelErr)
+	got := collectErrors(errs)
+	require.NotEmpty(t, got)
+	assert.ErrorIs(t, got[0], sentinelErr)
 }
 
 func TestIntersection_Execute_ContextCancelled(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("a", "b"))
@@ -421,6 +450,7 @@ func TestIntersection_Execute_ContextCancelled(t *testing.T) {
 	cancel()
 
 	w.Execute(ctx)
+	errs.Close()
 
 	assert.Empty(t, collectOutput(output))
 }
@@ -428,7 +458,7 @@ func TestIntersection_Execute_ContextCancelled(t *testing.T) {
 func TestIntersection_Execute_SingleSender(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	output := w.Subscribe(nil, chunkSize)
@@ -437,7 +467,8 @@ func TestIntersection_Execute_SingleSender(t *testing.T) {
 
 	// With a single sender, all items should pass through (intersection of one set).
 	assert.Equal(t, []string{"a", "b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 // --- Difference Worker Tests ---
@@ -445,7 +476,7 @@ func TestIntersection_Execute_SingleSender(t *testing.T) {
 func TestDifference_Execute_LessThanTwoSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a"))
 	output := w.Subscribe(nil, chunkSize)
@@ -453,13 +484,14 @@ func TestDifference_Execute_LessThanTwoSenders(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_SubtractsFromBase(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	w.Listen(sendItems("b"))
@@ -468,13 +500,14 @@ func TestDifference_Execute_SubtractsFromBase(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_EmptyBase(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendNothing())
 	w.Listen(sendItems("a"))
@@ -483,13 +516,14 @@ func TestDifference_Execute_EmptyBase(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_EmptySubtract(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendNothing())
@@ -498,13 +532,14 @@ func TestDifference_Execute_EmptySubtract(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_CompleteSubtraction(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("a", "b"))
@@ -513,13 +548,14 @@ func TestDifference_Execute_CompleteSubtraction(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_DisjointSets(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("c", "d"))
@@ -528,14 +564,15 @@ func TestDifference_Execute_DisjointSets(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_InterpreterError(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	sentinelErr := errors.New("interpret failed")
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 
 	interp := &mockInterpreter{
 		fn: func(_ context.Context, _ *worker.Edge, items []string) worker.Receiver[worker.Item] {
@@ -554,16 +591,18 @@ func TestDifference_Execute_InterpreterError(t *testing.T) {
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
+	errs.Close()
 
 	_ = collectOutput(output)
-	require.NotEmpty(t, errs)
-	assert.ErrorIs(t, <-errs, sentinelErr)
+	got := collectErrors(errs)
+	require.NotEmpty(t, got)
+	assert.ErrorIs(t, got[0], sentinelErr)
 }
 
 func TestDifference_Execute_ContextCancelled(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b"))
 	w.Listen(sendItems("c"))
@@ -573,6 +612,7 @@ func TestDifference_Execute_ContextCancelled(t *testing.T) {
 	cancel()
 
 	w.Execute(ctx)
+	errs.Close()
 
 	assert.Empty(t, collectOutput(output))
 }
@@ -580,20 +620,21 @@ func TestDifference_Execute_ContextCancelled(t *testing.T) {
 func TestDifference_Execute_NoSenders(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	output := w.Subscribe(nil, chunkSize)
 
 	w.Execute(context.Background())
 
 	assert.Empty(t, collectOutput(output))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestDifference_Execute_DuplicatesInSubtractSet(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Difference{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "b", "c"))
 	w.Listen(sendItems("b", "b", "c", "c"))
@@ -602,13 +643,14 @@ func TestDifference_Execute_DuplicatesInSubtractSet(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestBasic_Execute_MultipleMessagesPerSender(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Basic{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendMultipleMessages([]string{"a", "b"}, []string{"b", "c"}))
 	output := w.Subscribe(nil, chunkSize)
@@ -617,13 +659,14 @@ func TestBasic_Execute_MultipleMessagesPerSender(t *testing.T) {
 
 	// "b" appears in both messages but should be deduplicated.
 	assert.Equal(t, []string{"a", "b", "c"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }
 
 func TestIntersection_Execute_DuplicatesWithinSender(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	errs := make(chan error, 10)
+	errs := mpsc.NewAccumulator[error]()
 	w := &worker.Intersection{Core: newCore(passthroughInterpreter(), errs)}
 	w.Listen(sendItems("a", "a", "b"))
 	w.Listen(sendItems("a", "b", "b"))
@@ -632,5 +675,6 @@ func TestIntersection_Execute_DuplicatesWithinSender(t *testing.T) {
 	w.Execute(context.Background())
 
 	assert.Equal(t, []string{"a", "b"}, sorted(collectOutput(output)))
-	assert.Empty(t, errs)
+	errs.Close()
+	assert.Empty(t, collectErrors(errs))
 }

--- a/internal/listobjects/pipeline/internal/worker/worker_test.go
+++ b/internal/listobjects/pipeline/internal/worker/worker_test.go
@@ -110,7 +110,7 @@ func newCore(interp worker.Interpreter, errs *mpsc.Accumulator[error]) *worker.C
 func collectErrors(acc *mpsc.Accumulator[error]) []error {
 	var errs []error
 	for {
-		e, ok := acc.TryRecv(context.Background())
+		e, ok := acc.TryRecv()
 		if !ok {
 			break
 		}

--- a/internal/listobjects/pipeline/pipeline.go
+++ b/internal/listobjects/pipeline/pipeline.go
@@ -312,7 +312,12 @@ func (b *Builder) Build(
 
 			if _, ok := key.GetWeight(subject); !ok {
 				if _, ok := key.GetWeight(wildcard); !ok {
+					// No path exists from this edge to the subject type, so there
+					// is no possibility of it producing results.
 					if w, ok := workers[key.GetFrom().GetUniqueLabel()]; ok {
+						// The worker still needs a sender for this edge. Workers such as
+						// Difference expect a specific number of senders in order to operate.
+						// Therefore, the worker is subscribed to a noop sender.
 						w.Listen(worker.NewNoopMedium(key))
 					}
 					continue

--- a/internal/listobjects/pipeline/pipeline.go
+++ b/internal/listobjects/pipeline/pipeline.go
@@ -3,14 +3,16 @@ package pipeline
 import (
 	"context"
 	"errors"
-	"iter"
-	"strings"
 	"sync"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	weightedGraph "github.com/openfga/language/pkg/go/graph"
 
+	"github.com/openfga/openfga/internal/concurrency"
+	"github.com/openfga/openfga/internal/containers/mpsc"
 	"github.com/openfga/openfga/internal/listobjects/pipeline/internal/worker"
 )
 
@@ -43,7 +45,6 @@ var (
 	edgeTypeTTULogical    = weightedGraph.TTULogicalEdge
 
 	emptyReceiver = worker.NewEmptyReceiver[Item]()
-	emptySequence = func(func(Item) bool) {}
 
 	nodeTypeLogicalDirectGrouping   = weightedGraph.LogicalDirectGrouping
 	nodeTypeLogicalTTUGrouping      = weightedGraph.LogicalTTUGrouping
@@ -60,11 +61,14 @@ const (
 )
 
 var (
+	ErrInvalidStore          = errors.New("store is nil")
+	ErrInvalidGraph          = errors.New("graph is nil")
 	ErrInvalidBufferCapacity = errors.New("buffer capacity must be a positive number")
 	ErrInvalidChunkSize      = errors.New("chunk size must be greater than zero")
 	ErrInvalidNumProcs       = errors.New("process number must be greater than zero")
 	ErrInvalidObject         = errors.New("invalid object")
-	ErrInvalidUser           = errors.New("invalid user")
+	ErrInvalidSubject        = errors.New("invalid subject")
+	ErrUnreachable           = errors.New("no path exists")
 )
 
 // ObjectQuery describes a reverse lookup: find objects of ObjectType where
@@ -76,46 +80,64 @@ type ObjectQuery struct {
 	Conditions []string
 }
 
-// ObjectReader reads relationship tuples from storage.
-type ObjectReader interface {
+// ObjectStore reads relationship tuples from storage.
+type ObjectStore interface {
 	Read(context.Context, ObjectQuery) Receiver[Item]
 }
 
 // Spec identifies the target of a reverse expansion query.
 type Spec struct {
-	ObjectType string
-	Relation   string
-	User       string
+	ObjectType     string
+	ObjectRelation string
+	SubjectType    string
+	SubjectID      string
 }
 
-// Pipeline holds the dependencies and configuration for reverse expansion queries.
-type Pipeline struct {
-	graph  *Graph
-	reader ObjectReader
+// Builder holds infrastructure configuration for constructing Pipelines.
+// A single Builder can produce multiple Pipelines concurrently.
+type Builder struct {
+	store  ObjectStore
 	config Config
 }
 
-// New creates a Pipeline with the given graph and reader.
-func New(graph *Graph, reader ObjectReader, options ...Option) *Pipeline {
-	var pl Pipeline
-	pl.graph = graph
-	pl.reader = reader
-	pl.config = DefaultConfig()
-
-	for _, o := range options {
-		o(&pl.config)
+// NewBuilder returns a Builder that uses store for tuple reads.
+// Options configure tuning parameters (buffer size, chunk size, concurrency).
+func NewBuilder(store ObjectStore, options ...Option) (*Builder, error) {
+	if store == nil {
+		return nil, ErrInvalidStore
 	}
-	return &pl
+
+	config := DefaultConfig()
+	for _, o := range options {
+		o(&config)
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &Builder{store: store, config: config}, nil
+}
+
+// Pipeline holds the state for a single reverse expansion query.
+type Pipeline struct {
+	output  worker.Sender
+	workers map[string]worker.Worker
+	errs    *mpsc.Accumulator[error]
+	wg      *sync.WaitGroup
+	cancel  context.CancelFunc
+	buffer  []string
+	pos     int
+	err     error
+	closed  bool
 }
 
 // createInterpreter returns an Interpreter that dispatches to the
 // appropriate edge handler (direct, TTU, or identity) based on edge type.
-func (pl *Pipeline) createInterpreter() worker.Interpreter {
-	directEdgeHandler := directEdgeHandler{pl.reader}
+func createInterpreter(graph *Graph, store ObjectStore) worker.Interpreter {
+	directEdgeHandler := directEdgeHandler{store}
 
 	ttuEdgeHandler := ttuEdgeHandler{
-		reader: pl.reader,
-		graph:  pl.graph,
+		reader: store,
+		graph:  graph,
 	}
 
 	var identityEdgeHandler identityEdgeHandler
@@ -127,49 +149,28 @@ func (pl *Pipeline) createInterpreter() worker.Interpreter {
 	}
 }
 
-// path carries state through recursive worker construction.
-type path struct {
-	objectNode     *Node
-	userNode       *Node
-	userIdentifier string
-	cycleGroup     *worker.CycleGroup
-	errors         chan error
-	interpreter    worker.Interpreter
-	pool           *worker.MessagePool
-}
-
-// resolve recursively constructs a worker for the given graph node,
-// wiring it to upstream workers for each outgoing edge. Workers are
-// memoized in the workers map so each node is built at most once.
-func (pl *Pipeline) resolve(p path, workers map[*Node]worker.Worker) worker.Worker {
-	if w, ok := workers[p.objectNode]; ok {
-		return w
-	}
-
-	// Create cycle group on first encounter with a cyclical path.
-	// All workers in the cycle will share this group for coordinated shutdown.
-	if p.cycleGroup == nil {
-		p.cycleGroup = worker.NewCycleGroup()
-	}
-
+// createWorker returns a Worker appropriate for node's type, configured
+// with the given core and cycle group. The core is passed by value so
+// that each worker gets independent listener/sender slices while sharing
+// the pool, error channel, and interpreter via pointers.
+func createWorker(node *Node, core worker.Core, group *worker.CycleGroup) worker.Worker {
 	var w worker.Worker
+	core.Label = node.GetUniqueLabel()
 
-	var core worker.Core
-	core.Label = p.objectNode.GetUniqueLabel()
-	core.Errors = p.errors
-	core.Interpreter = p.interpreter
-	core.ChunkSize = pl.config.ChunkSize
-	core.NumProcs = pl.config.NumProcs
-	core.Pool = p.pool
-
-	switch p.objectNode.GetNodeType() {
-	case nodeTypeSpecificType,
-		nodeTypeSpecificTypeAndRelation,
-		nodeTypeSpecificTypeWildcard,
+	switch node.GetNodeType() {
+	case nodeTypeSpecificType:
+		var terminal worker.Terminal
+		terminal.Core = &core
+		w = &terminal
+	case nodeTypeSpecificTypeWildcard:
+		var wildcard worker.Wildcard
+		wildcard.Core = &core
+		w = &wildcard
+	case nodeTypeSpecificTypeAndRelation,
 		nodeTypeLogicalDirectGrouping,
 		nodeTypeLogicalTTUGrouping:
 		var basic worker.Basic
-		basic.Membership = p.cycleGroup.Join(core.Label)
+		basic.Membership = group.Join(core.Label)
 		basic.Core = &core
 		basic.MsgFunc = func(m *worker.Message, e *worker.Edge) {
 			if worker.IsCyclical(e) {
@@ -185,7 +186,7 @@ func (pl *Pipeline) resolve(p path, workers map[*Node]worker.Worker) worker.Work
 		}
 		w = &basic
 	case nodeTypeOperator:
-		switch p.objectNode.GetLabel() {
+		switch node.GetLabel() {
 		case weightedGraph.IntersectionOperator:
 			var intersection worker.Intersection
 			intersection.Core = &core
@@ -196,7 +197,7 @@ func (pl *Pipeline) resolve(p path, workers map[*Node]worker.Worker) worker.Work
 			w = &difference
 		case weightedGraph.UnionOperator:
 			var basic worker.Basic
-			basic.Membership = p.cycleGroup.Join(core.Label)
+			basic.Membership = group.Join(core.Label)
 			basic.Core = &core
 			basic.MsgFunc = func(m *worker.Message, e *worker.Edge) {
 				if worker.IsCyclical(e) {
@@ -217,312 +218,293 @@ func (pl *Pipeline) resolve(p path, workers map[*Node]worker.Worker) worker.Work
 	default:
 		panic("unsupported node type for pipeline resolver")
 	}
-
-	workers[p.objectNode] = w
-
-	// Leaf nodes matching the query user are seeded with an initial message
-	// containing the user identifier. This bootstraps the pipeline: workers
-	// process this seed and propagate results toward the root.
-	switch p.objectNode.GetNodeType() {
-	case nodeTypeSpecificType, nodeTypeSpecificTypeAndRelation:
-		if p.objectNode == p.userNode {
-			objectType, _, _ := strings.Cut(p.userNode.GetLabel(), "#")
-			var value string
-
-			switch p.userNode.GetNodeType() {
-			case nodeTypeSpecificTypeWildcard:
-				// the ':*' is part of the type
-			case nodeTypeSpecificType, nodeTypeSpecificTypeAndRelation:
-				value = ":" + p.userIdentifier
-			}
-			fullObject := objectType + value
-			items := []string{fullObject}
-			m := worker.Message{
-				Value: items,
-			}
-			medium := worker.NewChannelMedium(nil, 1)
-			medium.Send(context.Background(), &m)
-			medium.Close()
-			w.Listen(medium)
-		}
-	case nodeTypeSpecificTypeWildcard:
-		label := p.objectNode.GetLabel()
-		typePart, _, _ := strings.Cut(label, ":")
-
-		if p.objectNode == p.userNode || typePart == p.userNode.GetLabel() {
-			fullObject := typePart + ":*"
-			items := []string{fullObject}
-			m := worker.Message{
-				Value: items,
-			}
-			medium := worker.NewChannelMedium(nil, 1)
-			medium.Send(context.Background(), &m)
-			medium.Close()
-			w.Listen(medium)
-		}
-	}
-
-	edges, ok := pl.graph.GetEdgesFromNode(p.objectNode)
-	if !ok {
-		return w
-	}
-
-	for _, edge := range edges {
-		nextPath := p
-
-		// Only cyclical edges continue sharing the cycle group.
-		// Non-cyclical edges start fresh, each worker gets its own single-member group.
-		if !worker.IsCyclical(edge) {
-			nextPath.cycleGroup = nil
-		}
-
-		nextPath.objectNode = edge.GetTo()
-
-		to := pl.resolve(nextPath, workers)
-		w.Listen(to.Subscribe(edge, pl.config.BufferCapacity))
-	}
 	return w
 }
 
-// userResolution holds the resolved graph node and identifier for a user
-// string like "user:alice" or "group:eng#member".
-type userResolution struct {
-	userNode       *Node
-	userIdentifier string
+// stacker is an intrusive linked-list node used as the DFS stack during
+// pipeline construction.
+type stacker struct {
+	node  *Node
+	edge  *Edge
+	group *worker.CycleGroup
+	next  *stacker
 }
 
-// resolveUser parses a user string into its graph node and bare identifier.
-// It returns ErrInvalidUser if the user's type is not present in the graph.
-func (pl *Pipeline) resolveUser(u string) (*userResolution, error) {
-	user, userRelation, exists := strings.Cut(u, "#")
-	userType, userIdentifier, _ := strings.Cut(user, ":")
-
-	if exists {
-		userType += "#" + userRelation
+// Build constructs a Pipeline for the given graph and spec, starts all
+// workers, injects the subject identifier, and closes the input stream.
+// The caller must call Close on the returned Pipeline to avoid leaking
+// goroutines.
+func (b *Builder) Build(
+	ctx context.Context,
+	graph *Graph,
+	spec Spec,
+) (*Pipeline, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 
-	userNode, ok := pl.graph.GetNodeByID(userType)
-	if !ok {
-		return nil, ErrInvalidUser
+	if graph == nil {
+		return nil, ErrInvalidGraph
 	}
 
-	return &userResolution{userNode, userIdentifier}, nil
-}
+	config := b.config
 
-// resolveObjectNode looks up the graph node for the given type#relation pair.
-// It returns ErrInvalidObject if the node is not present in the graph.
-func (pl *Pipeline) resolveObjectNode(objectType, objectRelation string) (*Node, error) {
-	nodeID := objectType + "#" + objectRelation
-	node, ok := pl.graph.GetNodeByID(nodeID)
+	_, span := tracer.Start(ctx, "pipeline.Build", trace.WithAttributes(
+		attribute.String("object_type", spec.ObjectType),
+		attribute.String("object_relation", spec.ObjectRelation),
+		attribute.String("subject_type", spec.SubjectType),
+		attribute.String("subject_id", spec.SubjectID),
+		attribute.Int("buffer_capacity", config.BufferCapacity),
+		attribute.Int("chunk_size", config.ChunkSize),
+		attribute.Int("num_procs", config.NumProcs),
+	))
+	defer span.End()
+
+	buffer := make([]string, 0, config.ChunkSize)
+	errs := mpsc.NewAccumulator[error]()
+
+	var core worker.Core
+	core.Interpreter = createInterpreter(graph, b.store)
+	core.Errors = errs
+	core.ChunkSize = config.ChunkSize
+	core.NumProcs = config.NumProcs
+	core.Pool = new(worker.MessagePool)
+
+	workers := make(map[string]worker.Worker)
+	visited := make(map[*Edge]struct{})
+
+	object := spec.ObjectType + "#" + spec.ObjectRelation
+	subject := spec.SubjectType
+	wildcard := spec.SubjectType + ":*"
+
+	n, ok := graph.GetNodeByID(object)
 	if !ok {
 		return nil, ErrInvalidObject
 	}
-	return node, nil
-}
 
-// expansion holds the fully constructed worker graph, the shared error
-// channel, and the root worker's output sender.
-type expansion struct {
-	workers map[*Node]worker.Worker
-	errors  chan error
-	results worker.Sender
-}
-
-// buildExpansion constructs the full worker graph for a reverse expansion
-// query, seeds leaf workers with the user identifier, and returns an
-// expansion ready to be executed.
-func (pl *Pipeline) buildExpansion(objectNode, userNode *Node, userIdentifier string) *expansion {
-	interpreter := pl.createInterpreter()
-	workers := make(map[*Node]worker.Worker)
-	chError := make(chan error, pl.config.BufferCapacity)
-
-	p := path{
-		objectNode:     objectNode,
-		userNode:       userNode,
-		userIdentifier: userIdentifier,
-		errors:         chError,
-		interpreter:    interpreter,
-		pool:           new(worker.MessagePool),
+	_, ok = graph.GetNodeByID(subject)
+	if !ok {
+		return nil, ErrInvalidSubject
 	}
-
-	pl.resolve(p, workers)
 
 	var totalListeners int
-	for _, w := range workers {
-		totalListeners += w.Len()
+
+	var root stacker
+	root.node = n
+
+	stack := &root
+
+	for stack != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		current := stack
+		stack = stack.next
+
+		label := current.node.GetUniqueLabel()
+
+		if current.edge != nil {
+			key := current.edge
+			if _, ok := visited[key]; ok {
+				continue
+			}
+			visited[key] = struct{}{}
+
+			if _, ok := key.GetWeight(subject); !ok {
+				if _, ok := key.GetWeight(wildcard); !ok {
+					if w, ok := workers[key.GetFrom().GetUniqueLabel()]; ok {
+						w.Listen(worker.NewNoopMedium(key))
+					}
+					continue
+				}
+			}
+		}
+
+		var w worker.Worker
+		var ok bool
+
+		w, ok = workers[label]
+		if !ok {
+			if current.group == nil {
+				current.group = worker.NewCycleGroup()
+			}
+			w = createWorker(current.node, core, current.group)
+			workers[label] = w
+		}
+
+		if current.edge != nil {
+			if subscriber, ok := workers[current.edge.GetFrom().GetUniqueLabel()]; ok {
+				subscriber.Listen(w.Subscribe(current.edge, config.BufferCapacity))
+				totalListeners++
+			}
+		}
+
+		edges, ok := graph.GetEdgesFromNode(current.node)
+		if !ok {
+			continue
+		}
+
+		for i := len(edges) - 1; i >= 0; i-- {
+			var newStack stacker
+			newStack.node = edges[i].GetTo()
+			newStack.edge = edges[i]
+			if worker.IsCyclical(edges[i]) {
+				newStack.group = current.group
+			}
+			newStack.next = stack
+			stack = &newStack
+		}
 	}
 
-	worker.InitMessagePool(p.pool, pl.config.ChunkSize, pl.config.BufferCapacity*totalListeners)
+	// Size by buffer capacity multiplied by the number of actual listeners.
+	// The additional one is included for the pipeline's output channel.
+	worker.InitMessagePool(core.Pool, config.ChunkSize, config.BufferCapacity*(totalListeners+1))
 
-	objectWorker, ok := workers[objectNode]
+	objectWorker, ok := workers[object]
 	if !ok {
-		panic("unable to find source worker; if you see this, something is broken in the code.")
+		return nil, ErrInvalidObject
+	}
+	// Bind the pipeline's output to the object worker.
+	output := objectWorker.Subscribe(nil, config.BufferCapacity)
+
+	subjectWorker, canReachSubject := workers[subject]
+	_, canReachWildcard := workers[wildcard]
+
+	if !canReachSubject && !canReachWildcard {
+		return nil, ErrUnreachable
 	}
 
-	return &expansion{
-		workers: workers,
-		errors:  chError,
-		results: objectWorker.Subscribe(nil, pl.config.BufferCapacity),
+	if canReachSubject {
+		input := worker.NewStandardMedium(nil, 1)
+		subjectWorker.Listen(input)
+
+		if spec.SubjectID != "" {
+			msg := worker.Message{Value: []string{spec.SubjectID}}
+			if !input.Send(ctx, &msg) {
+				msg.Done()
+			}
+		}
+		input.Close()
 	}
-}
 
-// workerLifecycle manages the goroutines running each worker's Execute method.
-type workerLifecycle struct {
-	wg *sync.WaitGroup
-}
-
-// Wait blocks until all worker goroutines have returned.
-func (wl *workerLifecycle) Wait() {
-	wl.wg.Wait()
-}
-
-// startWorkerLifecycle launches a goroutine for each worker's Execute method
-// and returns a handle that can be used to wait for all of them to finish.
-func (pl *Pipeline) startWorkerLifecycle(ctx context.Context, workers map[*Node]worker.Worker) *workerLifecycle {
 	var wg sync.WaitGroup
 
-	for _, worker := range workers {
+	ctx, cancel := context.WithCancel(ctx)
+
+	for _, w := range workers {
 		wg.Go(func() {
-			worker.Execute(ctx)
+			var err error
+			defer func(err *error) {
+				if err != nil && *err != nil {
+					errs.Send(*err)
+				}
+			}(&err)
+			defer concurrency.RecoverFromPanic(&err)
+			w.Execute(ctx)
 		})
 	}
 
-	return &workerLifecycle{&wg}
+	return &Pipeline{
+		output:  output,
+		workers: workers,
+		wg:      &wg,
+		cancel:  cancel,
+		errs:    errs,
+		buffer:  buffer,
+	}, nil
 }
 
-// iterateOverResults starts all workers, drains the root worker's output
-// and the error channel into the yield callback, and ensures all
-// goroutines are cleaned up on return.
-func (pl *Pipeline) iterateOverResults(
-	ctx context.Context,
-	p *expansion,
-	yield func(Item) bool,
-) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+// Recv returns the next result from the pipeline. It is nil-safe and
+// returns ("", false) immediately if the pipeline is nil or has already
+// encountered an error. Otherwise it blocks until a value is available,
+// draining any buffered values before checking for new errors or output.
+// When an error is received from a worker, it is stored and the pipeline
+// is automatically closed. When the output stream is exhausted without
+// context cancellation, the pipeline is also closed. On context
+// cancellation, Recv returns ("", false) without closing, leaving that
+// responsibility to the caller. After Recv returns ("", false), call
+// Err to distinguish between clean exhaustion and failure.
+func (p *Pipeline) Recv(ctx context.Context) (string, bool) {
+	if p == nil || p.err != nil {
+		return "", false
+	}
 
-	var wgErr sync.WaitGroup
-	defer wgErr.Wait()
-
-	lifecycle := pl.startWorkerLifecycle(ctx, p.workers)
-
-	var wg sync.WaitGroup
-
-	chOutput := make(chan Item)
-
-	wgErr.Add(1)
-	go func(ch chan Item) {
-		defer wgErr.Done()
-		defer close(ch)
-		defer wg.Wait()
-
-	ErrorLoop:
-		for err := range p.errors {
-			select {
-			case ch <- Item{Err: err}:
-			case <-ctx.Done():
-				break ErrorLoop
-			}
-		}
-	}(chOutput)
-
-	wg.Add(1)
-	go func(ch chan<- Item) {
-		defer wg.Done()
-		defer close(p.errors)
-		defer lifecycle.Wait()
-
-		buffer := make([]string, 0, pl.config.ChunkSize)
-
-	BufferLoop:
-		for {
-			if len(buffer) == 0 {
-				msg, ok := p.results.Recv(ctx)
-				if !ok {
-					break
-				}
-
-				buffer = append(buffer, msg.Value...)
-				msg.Done()
-				continue
-			}
-
-			for _, item := range buffer {
-				select {
-				case ch <- Item{Value: item}:
-				case <-ctx.Done():
-					break BufferLoop
-				}
-			}
-			clear(buffer[:cap(buffer)])
-			buffer = buffer[:0]
-		}
-	}(chOutput)
-
-OutputLoop:
 	for {
-		select {
-		case obj, ok := <-chOutput:
-			if !ok {
-				break OutputLoop
-			}
-
-			if !yield(obj) {
-				cancel()
-				return
-			}
-		case <-ctx.Done():
-			break OutputLoop
-		}
-	}
-
-	// Context cancellation during iteration means results may be incomplete.
-	// Yield an error item to signal partial results to the caller.
-	if ctx.Err() != nil {
-		yield(Item{Err: ctx.Err()})
-	}
-}
-
-// streamResults builds the worker graph and returns an iter.Seq that, when
-// iterated, executes the pipeline and streams results to the caller.
-func (pl *Pipeline) streamResults(ctx context.Context, objectNode, userNode *Node, userIdentifier string) iter.Seq[Item] {
-	return func(yield func(Item) bool) {
-		_, span := tracer.Start(ctx, "pipeline.build")
-		expansion := pl.buildExpansion(objectNode, userNode, userIdentifier)
-		span.End()
-
-		ctx, span := tracer.Start(ctx, "pipeline.iterate")
-		defer span.End()
-
-		// Early exit before any goroutines are created avoids cleanup overhead.
 		if ctx.Err() != nil {
-			yield(Item{Err: ctx.Err()})
-			return
+			return "", false
 		}
 
-		pl.iterateOverResults(ctx, expansion, yield)
+		// Drain buffered values before checking for errors. Values in
+		// the buffer were produced before any concurrently arriving
+		// error, so delivering them first preserves ordering.
+		if p.pos < len(p.buffer) {
+			value := p.buffer[p.pos]
+			p.pos++
+			return value, true
+		}
+		p.pos = 0
+		p.buffer = p.buffer[:0]
+
+		e, ok := p.errs.TryRecv(ctx)
+		if ok {
+			p.err = e
+			p.Close()
+			return "", false
+		}
+
+		msg, ok := p.output.Recv(ctx)
+		if !ok {
+			if ctx.Err() == nil {
+				p.Close()
+			}
+			return "", false
+		}
+		p.buffer = append(p.buffer, msg.Value...)
+		msg.Done()
 	}
 }
 
-// Expand returns a streaming iterator of objects accessible to the user specified in spec.
-// Iteration can be stopped early; the pipeline will clean up resources automatically.
-func (pl *Pipeline) Expand(ctx context.Context, spec Spec) (iter.Seq[Item], error) {
-	if err := pl.config.Validate(); err != nil {
-		return emptySequence, err
+// Err returns the first error encountered during pipeline execution,
+// or nil if the pipeline completed successfully. It should be called
+// after Recv returns ("", false).
+func (p *Pipeline) Err() error {
+	return p.err
+}
+
+// Close cancels the pipeline context, drains any remaining output
+// messages, and waits for all workers to finish. It is nil-safe and
+// idempotent: subsequent calls after the first are no-ops. After
+// workers complete, it closes and drains the error accumulator,
+// storing the first non-context-cancellation error for retrieval
+// via Err. Close must be called to avoid leaking goroutines.
+func (p *Pipeline) Close() {
+	if p == nil || p.closed {
+		return
 	}
+	p.closed = true
 
-	ctx, span := tracer.Start(ctx, "pipeline.Query.Execute")
-	defer span.End()
+	p.cancel()
 
-	objectNode, err := pl.resolveObjectNode(spec.ObjectType, spec.Relation)
-	if err != nil {
-		return emptySequence, err
+	for {
+		msg, ok := p.output.Recv(context.Background())
+		if !ok {
+			break
+		}
+		msg.Done()
 	}
+	p.wg.Wait()
 
-	userRes, err := pl.resolveUser(spec.User)
-	if err != nil {
-		return emptySequence, err
+	p.errs.Close()
+
+	for {
+		e, ok := p.errs.TryRecv(context.Background())
+		if !ok {
+			break
+		}
+		if p.err == nil &&
+			!errors.Is(e, context.Canceled) &&
+			!errors.Is(e, context.DeadlineExceeded) {
+			p.err = e
+		}
 	}
-
-	return pl.streamResults(ctx, objectNode, userRes.userNode, userRes.userIdentifier), nil
 }

--- a/internal/listobjects/pipeline/pipeline.go
+++ b/internal/listobjects/pipeline/pipeline.go
@@ -445,7 +445,7 @@ func (p *Pipeline) Recv(ctx context.Context) (string, bool) {
 		p.pos = 0
 		p.buffer = p.buffer[:0]
 
-		e, ok := p.errs.TryRecv(ctx)
+		e, ok := p.errs.TryRecv()
 		if ok {
 			p.err = e
 			p.Close()
@@ -497,7 +497,7 @@ func (p *Pipeline) Close() {
 	p.errs.Close()
 
 	for {
-		e, ok := p.errs.TryRecv(context.Background())
+		e, ok := p.errs.TryRecv()
 		if !ok {
 			break
 		}

--- a/internal/listobjects/pipeline/pipeline_test.go
+++ b/internal/listobjects/pipeline/pipeline_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"iter"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -70,7 +68,7 @@ func (e *ErrorReader) Read(_ context.Context, _ pipeline.ObjectQuery) pipeline.R
 	return worker.NewValueReceiver(pipeline.Item{Err: e.err})
 }
 
-func TestPipelineShutdown(t *testing.T) {
+func TestPipeline_Shutdown(t *testing.T) {
 	const bufferSize int = 4
 	const chunkSize int = 1
 
@@ -159,67 +157,69 @@ func TestPipelineShutdown(t *testing.T) {
 
 	validator := pipeline.NewValidator(context.Background(), typesys, nil)
 
-	reader := pipeline.NewReader(
+	reader := pipeline.NewValidatingStore(
 		ds,
 		Store,
-		pipeline.WithReaderValidator(validator),
+		pipeline.WithStoreValidator(validator),
 	)
 
-	pl := pipeline.New(g, reader, pipeline.WithBufferCapacity(bufferSize), pipeline.WithChunkSize(chunkSize))
+	builder, err := pipeline.NewBuilder(
+		reader,
+		pipeline.WithBufferCapacity(bufferSize),
+		pipeline.WithChunkSize(chunkSize),
+	)
+	require.NoError(t, err)
 
-	t.Run("exclusive_path", func(t *testing.T) {
+	t.Run("document#viewer", func(t *testing.T) {
 		spec := pipeline.Spec{
-			ObjectType: "document",
-			Relation:   "viewer",
-			User:       "user:bob",
+			ObjectType:     "document",
+			ObjectRelation: "viewer",
+			SubjectType:    "user",
+			SubjectID:      "bob",
 		}
 
-		t.Run("NoAbandon", func(t *testing.T) {
+		t.Run("user:bob fully resolves", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			seq, err := pl.Expand(context.Background(), spec)
+			p, err := builder.Build(context.Background(), g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			values := make([]string, 0, len(documents))
-			for object := range seq {
-				value, err := object.Object()
-				require.NoError(t, err)
+			for {
+				value, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
 				values = append(values, value)
 			}
+			require.NoError(t, p.Err())
 			require.ElementsMatch(t, documents, values)
 		})
 
-		t.Run("AbandonWithoutPull", func(t *testing.T) {
+		t.Run("producing without consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			_, err := pl.Expand(context.Background(), spec)
+			p, err := builder.Build(context.Background(), g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 		})
 
-		t.Run("AbandonAfterPull", func(t *testing.T) {
+		t.Run("closing without fully consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			seq, err := pl.Expand(context.Background(), spec)
+			p, err := builder.Build(context.Background(), g, spec)
 			require.NoError(t, err)
-
-			var value string
-			for objects := range seq {
-				value, err = objects.Object()
-				break
-			}
-			require.NoError(t, err)
-			require.NotEmpty(t, value)
-		})
-
-		t.Run("AbandonMidProcessing", func(t *testing.T) {
-			defer goleak.VerifyNone(t)
-
-			seq, err := pl.Expand(context.Background(), spec)
-			require.NoError(t, err)
+			defer p.Close()
 
 			var count int
 			limit := nestLevel / 2
-			for range seq {
+			for {
+				_, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
+
 				count++
 				if count >= limit {
 					break
@@ -227,227 +227,145 @@ func TestPipelineShutdown(t *testing.T) {
 			}
 		})
 
-		t.Run("CancelWithoutPull", func(t *testing.T) {
+		t.Run("context cancelation without consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
-			_, err := pl.Expand(ctx, spec)
+			p, err := builder.Build(ctx, g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			cancel()
 		})
 
-		t.Run("CancelBeforePull", func(t *testing.T) {
+		t.Run("consuming after context cancelation does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
-			seq, err := pl.Expand(ctx, spec)
+			p, err := builder.Build(ctx, g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			cancel()
-			for item := range seq {
-				_, err := item.Object()
-				require.ErrorIs(t, err, context.Canceled)
-			}
-		})
-
-		t.Run("CancelAfterPull", func(t *testing.T) {
-			defer goleak.VerifyNone(t)
-
-			ctx, cancel := context.WithCancel(context.Background())
-
-			defer cancel()
-
-			seq, err := pl.Expand(ctx, spec)
-			require.NoError(t, err)
-
-			var value string
-			for object := range seq {
-				var v string
-				v, err = object.Object()
-				if err == nil {
-					value = v
+			for {
+				_, ok := p.Recv(context.Background())
+				if !ok {
+					break
 				}
-				cancel()
 			}
-			require.NotEmpty(t, value)
-			require.ErrorIs(t, err, context.Canceled)
 		})
 
-		t.Run("CancelMidProcessing", func(t *testing.T) {
+		t.Run("context cancelation after consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
 			defer cancel()
 
-			seq, err := pl.Expand(ctx, spec)
+			p, err := builder.Build(ctx, g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			var count int
 			limit := nestLevel / 2
-			for object := range seq {
-				_, err = object.Object()
+			for {
+				_, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
+
 				count++
 				if count >= limit {
 					cancel()
 				}
 			}
-			require.ErrorIs(t, err, context.Canceled)
-		})
-
-		t.Run("TimeoutAfterPull", func(t *testing.T) {
-			defer goleak.VerifyNone(t)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-
-			defer cancel()
-
-			seq, err := pl.Expand(ctx, spec)
-			require.NoError(t, err)
-
-			var count int
-			for object := range seq {
-				_, err = object.Object()
-
-				if count == 0 {
-					// wait long enough for timeout to occur
-					time.Sleep(200 * time.Millisecond)
-				}
-				count++
-			}
-			require.Greater(t, len(documents), count) // ensure that we stopped before consuming the full traversal
-			require.ErrorIs(t, err, context.DeadlineExceeded)
-		})
-
-		t.Run("TimeoutBeforePull", func(t *testing.T) {
-			defer goleak.VerifyNone(t)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-
-			seq, err := pl.Expand(ctx, spec)
-			require.NoError(t, err)
-
-			defer cancel()
-
-			// wait long enough for timeout to occur
-			time.Sleep(2 * time.Millisecond)
-
-			for item := range seq {
-				_, err := item.Object()
-				require.ErrorIs(t, err, context.DeadlineExceeded)
-			}
 		})
 	})
 
-	t.Run("mutual_path", func(t *testing.T) {
+	t.Run("document#fault", func(t *testing.T) {
 		spec := pipeline.Spec{
-			ObjectType: "document",
-			Relation:   "fault",
-			User:       "user:bob",
+			ObjectType:     "document",
+			ObjectRelation: "fault",
+			SubjectType:    "user",
+			SubjectID:      "bob",
 		}
 
-		t.Run("NoAbandon", func(t *testing.T) {
+		t.Run("user:bob fully resolves", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			seq, err := pl.Expand(context.Background(), spec)
+			p, err := builder.Build(context.Background(), g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			values := make([]string, 0, len(documents))
-			for object := range seq {
-				value, err := object.Object()
-				require.NoError(t, err)
+			for {
+				value, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
 				values = append(values, value)
 			}
+			require.NoError(t, p.Err())
 			require.Empty(t, values)
 		})
 
-		t.Run("AbandonWithoutPull", func(t *testing.T) {
+		t.Run("producing without consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
-			_, err := pl.Expand(context.Background(), spec)
+			p, err := builder.Build(context.Background(), g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 		})
 
-		t.Run("CancelWithoutPull", func(t *testing.T) {
+		t.Run("context cancelation without consuming does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
-			_, err := pl.Expand(ctx, spec)
+			p, err := builder.Build(ctx, g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			cancel()
 		})
 
-		t.Run("CancelBeforePull", func(t *testing.T) {
+		t.Run("consuming after context cancelation does not deadlock", func(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			ctx, cancel := context.WithCancel(context.Background())
 
-			seq, err := pl.Expand(ctx, spec)
+			p, err := builder.Build(ctx, g, spec)
 			require.NoError(t, err)
+			defer p.Close()
 
 			cancel()
-			for item := range seq {
-				_, err := item.Object()
-				require.ErrorIs(t, err, context.Canceled)
-			}
-		})
-
-		t.Run("TimeoutBeforePull", func(t *testing.T) {
-			defer goleak.VerifyNone(t)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-
-			seq, err := pl.Expand(ctx, spec)
-			require.NoError(t, err)
-
-			defer cancel()
-
-			// wait long enough for timeout to occur
-			time.Sleep(2 * time.Millisecond)
-
-			for item := range seq {
-				_, err := item.Object()
-				require.ErrorIs(t, err, context.DeadlineExceeded)
+			for {
+				_, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
 			}
 		})
 	})
 }
 
-func TestPipelineExpand_InvalidConfig(t *testing.T) {
+func TestPipeline_InvalidConfig(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
-	const dsl = `
-	model
-	  schema 1.1
-	type user
-	type document
-	  relations
-	    define viewer: [user]
-	`
+	reader := pipeline.NewValidatingStore(memory.New(), Store)
 
-	model := testutils.MustTransformDSLToProtoWithID(dsl)
-	typesys, err := typesystem.NewAndValidate(context.Background(), model)
-	require.NoError(t, err)
-
-	g := typesys.GetWeightedGraph()
-	reader := pipeline.NewReader(memory.New(), Store)
-
-	pl := pipeline.New(g, reader, pipeline.WithConfig(pipeline.Config{
-		BufferCapacity: -1, ChunkSize: 1, NumProcs: 1,
-	}))
-
-	_, err = pl.Expand(context.Background(), pipeline.Spec{
-		ObjectType: "document", Relation: "viewer", User: "user:alice",
-	})
+	_, err := pipeline.NewBuilder(
+		reader,
+		pipeline.WithConfig(pipeline.Config{
+			BufferCapacity: -1, ChunkSize: 1, NumProcs: 1,
+		}),
+	)
 	require.ErrorIs(t, err, pipeline.ErrInvalidBufferCapacity)
 }
 
-func TestPipelineExpand_InvalidObjectType(t *testing.T) {
+func TestPipeline_InvalidObjectType(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	const dsl = `
@@ -464,16 +382,22 @@ func TestPipelineExpand_InvalidObjectType(t *testing.T) {
 	require.NoError(t, err)
 
 	g := typesys.GetWeightedGraph()
-	reader := pipeline.NewReader(memory.New(), Store)
-	pl := pipeline.New(g, reader)
+	reader := pipeline.NewValidatingStore(memory.New(), Store)
 
-	_, err = pl.Expand(context.Background(), pipeline.Spec{
-		ObjectType: "nonexistent", Relation: "viewer", User: "user:alice",
-	})
+	builder, err := pipeline.NewBuilder(reader)
+	require.NoError(t, err)
+
+	_, err = builder.Build(
+		context.Background(),
+		g,
+		pipeline.Spec{
+			ObjectType: "nonexistent", ObjectRelation: "viewer", SubjectType: "user",
+		},
+	)
 	require.ErrorIs(t, err, pipeline.ErrInvalidObject)
 }
 
-func TestPipelineExpand_InvalidRelation(t *testing.T) {
+func TestPipeline_InvalidRelation(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	const dsl = `
@@ -490,16 +414,22 @@ func TestPipelineExpand_InvalidRelation(t *testing.T) {
 	require.NoError(t, err)
 
 	g := typesys.GetWeightedGraph()
-	reader := pipeline.NewReader(memory.New(), Store)
-	pl := pipeline.New(g, reader)
+	reader := pipeline.NewValidatingStore(memory.New(), Store)
 
-	_, err = pl.Expand(context.Background(), pipeline.Spec{
-		ObjectType: "document", Relation: "nonexistent", User: "user:alice",
-	})
+	builder, err := pipeline.NewBuilder(reader)
+	require.NoError(t, err)
+
+	_, err = builder.Build(
+		context.Background(),
+		g,
+		pipeline.Spec{
+			ObjectType: "document", ObjectRelation: "nonexistent", SubjectType: "user",
+		},
+	)
 	require.ErrorIs(t, err, pipeline.ErrInvalidObject)
 }
 
-func TestPipelineExpand_InvalidUser(t *testing.T) {
+func TestPipeline_InvalidSubjectType(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	const dsl = `
@@ -516,16 +446,22 @@ func TestPipelineExpand_InvalidUser(t *testing.T) {
 	require.NoError(t, err)
 
 	g := typesys.GetWeightedGraph()
-	reader := pipeline.NewReader(memory.New(), Store)
-	pl := pipeline.New(g, reader)
+	reader := pipeline.NewValidatingStore(memory.New(), Store)
 
-	_, err = pl.Expand(context.Background(), pipeline.Spec{
-		ObjectType: "document", Relation: "viewer", User: "nonexistent:alice",
-	})
-	require.ErrorIs(t, err, pipeline.ErrInvalidUser)
+	builder, err := pipeline.NewBuilder(reader)
+	require.NoError(t, err)
+
+	_, err = builder.Build(
+		context.Background(),
+		g,
+		pipeline.Spec{
+			ObjectType: "document", ObjectRelation: "viewer", SubjectType: "nonexistent",
+		},
+	)
+	require.ErrorIs(t, err, pipeline.ErrInvalidSubject)
 }
 
-func TestPipelineExpand_EmptyResult(t *testing.T) {
+func TestPipeline_EmptyResult(t *testing.T) {
 	defer goleak.VerifyNone(t)
 
 	const dsl = `
@@ -547,28 +483,38 @@ func TestPipelineExpand_EmptyResult(t *testing.T) {
 	require.NoError(t, err)
 
 	g := typesys.GetWeightedGraph()
-	reader := pipeline.NewReader(ds, Store,
-		pipeline.WithReaderValidator(pipeline.NewValidator(context.Background(), typesys, nil)),
+	reader := pipeline.NewValidatingStore(ds, Store,
+		pipeline.WithStoreValidator(pipeline.NewValidator(context.Background(), typesys, nil)),
 	)
-	pl := pipeline.New(g, reader)
 
-	seq, err := pl.Expand(context.Background(), pipeline.Spec{
-		ObjectType: "document", Relation: "viewer", User: "user:alice",
-	})
+	builder, err := pipeline.NewBuilder(reader)
 	require.NoError(t, err)
 
+	p, err := builder.Build(
+		context.Background(),
+		g,
+		pipeline.Spec{
+			ObjectType: "document", ObjectRelation: "viewer", SubjectType: "user", SubjectID: "alice",
+		},
+	)
+	require.NoError(t, err)
+	defer p.Close()
+
 	var results []string
-	for obj := range seq {
-		value, err := obj.Object()
-		require.NoError(t, err)
+	for {
+		value, ok := p.Recv(context.Background())
+		if !ok {
+			break
+		}
 		results = append(results, value)
 	}
+	require.NoError(t, p.Err())
 	require.Empty(t, results)
 }
 
 var ErrSignal = errors.New("signal error")
 
-func TestPipelineError(t *testing.T) {
+func TestPipeline_Error(t *testing.T) {
 	const bufferSize int = 4
 	const chunkSize int = 1
 
@@ -614,44 +560,61 @@ func TestPipelineError(t *testing.T) {
 	g := typesys.GetWeightedGraph()
 
 	spec := pipeline.Spec{
-		ObjectType: "document",
-		Relation:   "viewer",
-		User:       "user:bob",
+		ObjectType:     "document",
+		ObjectRelation: "viewer",
+		SubjectType:    "user",
+		SubjectID:      "bob",
 	}
 
-	pl := pipeline.New(g, ds, pipeline.WithBufferCapacity(bufferSize), pipeline.WithChunkSize(chunkSize))
+	builder, err := pipeline.NewBuilder(
+		ds,
+		pipeline.WithBufferCapacity(bufferSize),
+		pipeline.WithChunkSize(chunkSize),
+	)
+	require.NoError(t, err)
 
-	t.Run("ShouldReturnErrorThenEnd", func(t *testing.T) {
+	t.Run("storage errors propagate to consumer", func(t *testing.T) {
 		defer goleak.VerifyNone(t)
 
-		seq, err := pl.Expand(context.Background(), spec)
+		p, err := builder.Build(context.Background(), g, spec)
 		require.NoError(t, err)
+		defer p.Close()
 
-		for obj := range seq {
-			value, err := obj.Object()
-			require.Empty(t, value)
-			require.ErrorIs(t, err, ErrSignal)
+		for {
+			_, ok := p.Recv(context.Background())
+			if !ok {
+				break
+			}
 		}
+		require.ErrorIs(t, p.Err(), ErrSignal)
 	})
 }
 
 type testcase struct {
-	name       string
-	model      string
-	tuples     []string
-	objectType string
-	relation   string
-	user       string
-	expected   []string
+	name        string
+	model       string
+	tuples      []string
+	objectType  string
+	relation    string
+	subjectType string
+	subjectID   string
+	error       error
+	expected    []string
 }
 
-func evaluate(t *testing.T, tc testcase, seq iter.Seq[pipeline.Item]) {
+func evaluate(t *testing.T, tc testcase, p *pipeline.Pipeline) {
+	t.Helper()
+	defer p.Close()
+
 	var results []string
-	for object := range seq {
-		value, err := object.Object()
-		require.NoError(t, err)
+	for {
+		value, ok := p.Recv(context.Background())
+		if !ok {
+			break
+		}
 		results = append(results, value)
 	}
+	require.NoError(t, p.Err())
 	require.ElementsMatch(t, tc.expected, results)
 }
 
@@ -704,10 +667,11 @@ var cases = []testcase{
 			"resource:document_2#write_policy@policy:document_writer",
 			"resource:document_2#read_policy@policy:document_reader",
 		},
-		objectType: "resource",
-		relation:   "writer",
-		user:       "user:bob",
-		expected:   []string{"resource:document_1", "resource:document_2"},
+		objectType:  "resource",
+		relation:    "writer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"resource:document_1", "resource:document_2"},
 	},
 	{
 		name: "recursive_ttu_intersection",
@@ -734,10 +698,11 @@ var cases = []testcase{
 			"org:2#admin@user:1",
 			"doc:1#viewer@org:2#moderator",
 		},
-		objectType: "doc",
-		relation:   "viewer",
-		user:       "user:1",
-		expected:   []string{"doc:1"},
+		objectType:  "doc",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "1",
+		expected:    []string{"doc:1"},
 	},
 	{
 		name: "recursive_userset_intersection",
@@ -763,10 +728,11 @@ var cases = []testcase{
 			"org:1#member@org:2#member",
 			"doc:1#viewer@org:1#moderator",
 		},
-		objectType: "doc",
-		relation:   "viewer",
-		user:       "user:1",
-		expected:   []string{"doc:1"},
+		objectType:  "doc",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "1",
+		expected:    []string{"doc:1"},
 	},
 	{
 		name: "recursive_recursion",
@@ -794,10 +760,11 @@ var cases = []testcase{
 			"org:3#admin@user:bob",
 			"doc:1#viewer@org:3#moderator",
 		},
-		objectType: "doc",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"doc:1"},
+		objectType:  "doc",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"doc:1"},
 	},
 	{
 		name: "ttu_recursive",
@@ -816,35 +783,14 @@ var cases = []testcase{
 			"org:c#parent@org:b", // org:b is parent of org:c
 			"org:d#parent@org:c", // org:c is parent of org:d
 		},
-		objectType: "org",
-		relation:   "ttu_recursive",
-		user:       "user:justin",
-		expected:   []string{"org:a", "org:b", "org:c", "org:d"},
+		objectType:  "org",
+		relation:    "ttu_recursive",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"org:a", "org:b", "org:c", "org:d"},
 	},
-	{
-		name: "userset_as_user",
-		model: `
-		model
-		schema 1.1
-
-		type user
-
-		type group
-			relations
-				define member: [user]
-		type document
-			relations
-				define viewer: [group#member]
-		`,
-		tuples: []string{
-			"document:1#viewer@group:x#member",
-			"group:x#member@user:aardvark",
-		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "group:x#member",
-		expected:   []string{"document:1"},
-	},
+	// userset_as_user removed: the new pipeline interface does not support
+	// type+relation subject types such as "group#member".
 	{
 		name: "err_and_true_return_err",
 		model: `
@@ -913,10 +859,11 @@ var cases = []testcase{
 			"resource:1#a2@resource:1#a1",
 			"resource:1#a1@user:maria",
 		},
-		objectType: "resource",
-		relation:   "can_view",
-		user:       "user:maria",
-		expected:   []string{"resource:1"},
+		objectType:  "resource",
+		relation:    "can_view",
+		subjectType: "user",
+		subjectID:   "maria",
+		expected:    []string{"resource:1"},
 	},
 	{
 		name: "double_ttu",
@@ -950,40 +897,14 @@ var cases = []testcase{
 			"wrapper:1#parent@usersets-user:1",
 			"wrapper:2#parent@directs:2",
 		},
-		objectType: "wrapper",
-		relation:   "assigned",
-		user:       "user:bob",
-		expected:   []string{"wrapper:2"},
+		objectType:  "wrapper",
+		relation:    "assigned",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"wrapper:2"},
 	},
-	{
-		name: "simple_userset_child_computed_userset",
-		model: `
-		model
-		schema 1.1
-
-		type user
-
-		type group
-			relations
-				define member: [user]
-				define member_c1: member
-				define member_c2: member_c1
-				define member_c3: member_c2
-				define member_c4: member_c3
-
-		type folder
-			relations
-				define viewer: [group#member_c4]
-		`,
-		tuples: []string{
-			"group:fga#member@user:anne",
-			"folder:1#viewer@group:fga#member_c4",
-		},
-		objectType: "folder",
-		relation:   "viewer",
-		user:       "group:fga#member",
-		expected:   []string{"folder:1"},
-	},
+	// simple_userset_child_computed_userset removed: the new pipeline interface
+	// does not support type+relation subject types such as "group#member".
 	{
 		name: "simple_userset_child_wildcard",
 		model: `
@@ -1008,10 +929,11 @@ var cases = []testcase{
 			"folder:1#viewer@group:fga#member",
 			"folder:2#viewer@group:engineering#member",
 		},
-		objectType: "folder",
-		relation:   "viewer",
-		user:       "user2:foo",
-		expected:   []string{},
+		objectType:  "folder",
+		relation:    "viewer",
+		subjectType: "user2",
+		subjectID:   "foo",
+		expected:    []string{},
 	},
 	{
 		name: "ttu_mix_with_userset",
@@ -1048,45 +970,33 @@ var cases = []testcase{
 			"folder:public#viewer@group:public#member",
 			"document:public#parent@folder:public",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:anne",
-		expected:   []string{"document:a", "document:public"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "anne",
+		expected:    []string{"document:a", "document:public"},
 	},
 	{
-		name: "wild_card",
-		model: `model
-				  schema 1.1
-					type user
-				  type group
-					relations
-					  define member: [user, user:*]
-				  type folder
-					relations
-					  define viewer: [user,group#member]
-				  type document
-					relations
-					  define parent: [folder]
-					  define viewer: viewer from parent
+		name: "wildcard_only_reachability",
+		model: `
+		model
+		schema 1.1
+
+		type user
+
+		type document
+			relations
+				define viewer: [user:*]
 		`,
 		tuples: []string{
-			"group:1#member@user:anne",
-			"group:1#member@user:charlie",
-			"group:2#member@user:anne",
-			"group:2#member@user:bob",
-			"group:3#member@user:elle",
-			"group:public#member@user:*",
-			"document:a#parent@folder:a",
-			"document:public#parent@folder:public",
-			"folder:a#viewer@group:1#member",
-			"folder:a#viewer@group:2#member",
-			"folder:a#viewer@user:daemon",
-			"folder:public#viewer@group:public#member",
+			"document:1#viewer@user:*",
+			"document:2#viewer@user:*",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:*",
-		expected:   []string{"document:public"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "alice",
+		expected:    []string{"document:1", "document:2"},
 	},
 	{
 		name: "computed",
@@ -1113,10 +1023,11 @@ var cases = []testcase{
 			"document:2#viewer@team:1#member",
 			"document:3#viewer@team:2#member",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:2"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:2"},
 	},
 	{
 		name: "union",
@@ -1149,10 +1060,11 @@ var cases = []testcase{
 			"document:3#rel2@user:justin",
 			"document:3#rel3@user:justin",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:2", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:2", "document:3"},
 	},
 	{
 		name: "ttu",
@@ -1177,10 +1089,11 @@ var cases = []testcase{
 			"document:2#parent@company:auth0",
 			"document:3#parent@company:fga",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1", "document:2"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1", "document:2"},
 	},
 	{
 		name: "ttu_in_intersection",
@@ -1207,10 +1120,11 @@ var cases = []testcase{
 			"document:2#relative@company:auth0",
 			"document:3#admin@company:auth0",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1"},
 	},
 	{
 		name: "ttu_in_cycle_with_union",
@@ -1246,10 +1160,11 @@ var cases = []testcase{
 			"document:4#parent@company:fga",
 			"document:5#parent@org:fga",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1", "document:2", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1", "document:2", "document:3"},
 	},
 	{
 		name: "ttu_in_cycle_with_intersection",
@@ -1283,10 +1198,11 @@ var cases = []testcase{
 			"document:4#parent@org:fga",
 			"company:fga#employee@user:bob",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1", "document:2"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1", "document:2"},
 	},
 	{
 		name: "ttu_with_two_directs",
@@ -1316,10 +1232,11 @@ var cases = []testcase{
 			"document:2#parent@company:auth0",
 			"document:3#parent@org:fga",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1", "document:2", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1", "document:2", "document:3"},
 	},
 	{
 		name: "ttu_with_complexity",
@@ -1354,10 +1271,11 @@ var cases = []testcase{
 			"document:3#parent@org:fga",
 			"document:4#parent@org:x",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"document:1", "document:2", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"document:1", "document:2", "document:3"},
 	},
 	{
 		name: "intersection",
@@ -1390,10 +1308,11 @@ var cases = []testcase{
 			"document:3#rel2@user:justin",
 			"document:3#rel3@user:justin",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:3"},
 	},
 	{
 		name: "direct_userset",
@@ -1419,10 +1338,11 @@ var cases = []testcase{
 			"document:3#viewer@team:2#member",
 			"document:4#viewer@team:2#member",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:2", "document:3", "document:4"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:2", "document:3", "document:4"},
 	},
 	{
 		name: "beast_mode",
@@ -1491,10 +1411,11 @@ var cases = []testcase{
 			"team:j#member@document:i#viewer",
 			// expect document:h, document:i, document:j
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:3", "document:5", "document:8", "document:a", "document:b", "document:c", "document:d", "document:e", "document:f", "document:g", "document:h", "document:i", "document:j"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:3", "document:5", "document:8", "document:a", "document:b", "document:c", "document:d", "document:e", "document:f", "document:g", "document:h", "document:i", "document:j"},
 	},
 	{
 		name: "mean_tuple_cycle",
@@ -1536,10 +1457,11 @@ var cases = []testcase{
 			"org:00#employee@team:00#member",
 			"team:00#member@document:8#viewer",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:0", "document:1", "document:3", "document:5", "document:8"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:0", "document:1", "document:3", "document:5", "document:8"},
 	},
 	{
 		name: "indirect_userset",
@@ -1583,10 +1505,11 @@ var cases = []testcase{
 			"document:7#viewer@team:0#member",
 			"document:22#viewer@team:22#member",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:2", "document:3", "document:4", "document:5", "document:6", "document:22"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:2", "document:3", "document:4", "document:5", "document:6", "document:22"},
 	},
 	{
 		name: "recursive",
@@ -1622,10 +1545,11 @@ var cases = []testcase{
 			"group:2#member@team:3#member",
 			"document:2#viewer@group:2#member",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:justin",
-		expected:   []string{"document:1", "document:2"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"document:1", "document:2"},
 	},
 	{
 		name: "tuple_cycle",
@@ -1644,10 +1568,11 @@ var cases = []testcase{
 			"team:cncf#member@team:fga#member",
 			"team:lnf#member@team:cncf#member",
 		},
-		objectType: "team",
-		relation:   "member",
-		user:       "user:justin",
-		expected:   []string{"team:fga", "team:cncf", "team:lnf"},
+		objectType:  "team",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "justin",
+		expected:    []string{"team:fga", "team:cncf", "team:lnf"},
 	},
 	{
 		name: "simple_exclusion",
@@ -1665,10 +1590,11 @@ var cases = []testcase{
 			"org:b#member@user:bob",
 			"org:a#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:b"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:b"},
 	},
 	{
 		name: "exclusion_on_itself",
@@ -1684,10 +1610,11 @@ var cases = []testcase{
 		tuples: []string{
 			"org:a#banned@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{},
 	},
 	{
 		name: "exclusion_no_connection_base",
@@ -1706,10 +1633,12 @@ var cases = []testcase{
 			"org:a#member@user:bob",
 			"org:c#banned@user2:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user2:bob",
-		expected:   []string{},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user2",
+		subjectID:   "bob",
+		error:       pipeline.ErrUnreachable,
+		expected:    []string{},
 	},
 	{
 		name: "exclusion_no_connection_exclusion_path",
@@ -1728,10 +1657,11 @@ var cases = []testcase{
 			"org:b#member@user:bob",
 			"org:a#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:b"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:b"},
 	},
 	{
 		name: "simple_exclusion_no_direct_assignment",
@@ -1750,10 +1680,11 @@ var cases = []testcase{
 			"org:b#member@user:bob",
 			"org:a#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "viewer",
-		user:       "user:bob",
-		expected:   []string{"org:b"},
+		objectType:  "org",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:b"},
 	},
 	{
 		name: "simple_exclusion_multiple_direct_assignments",
@@ -1776,10 +1707,11 @@ var cases = []testcase{
 			"org:c#member@team:c#member",
 			"team:c#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:b", "org:c"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:b", "org:c"},
 	},
 	{
 		name: "simple_exclusion_multiple_direct_assignments_not_linked_1",
@@ -1800,10 +1732,11 @@ var cases = []testcase{
 			"org:c#allowed@user:bob",
 			"org:d#member@user2:bob", // bob is user2 and there should be no link
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:b"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:b"},
 	},
 	{
 		name: "ttu_with_exclusion",
@@ -1827,10 +1760,11 @@ var cases = []testcase{
 			"team:2#parent@org:b",
 			"team:2#member@user:bob",
 		},
-		objectType: "team",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"team:2"},
+		objectType:  "team",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"team:2"},
 	},
 	{
 		name: "simple_exclusion_multiple_direct_assignments_not_linked_2",
@@ -1851,10 +1785,11 @@ var cases = []testcase{
 			"org:c#allowed@user:bob",
 			"org:d#member@user2:bob", // even if right side not connected, it should still be good
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user2:bob",
-		expected:   []string{"org:d"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user2",
+		subjectID:   "bob",
+		expected:    []string{"org:d"},
 	},
 	{
 		name: "simple_exclusion_with_double_negative",
@@ -1879,10 +1814,11 @@ var cases = []testcase{
 			"org:b#member@user:bob",
 			"org:b#allowed@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c", "org:d"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c", "org:d"},
 	},
 	{
 		name: "exclusion_has_no_direct_assignment",
@@ -1916,10 +1852,11 @@ var cases = []testcase{
 			"org:b#member@team:b#member",
 			"org:b#allowed@user:bob",
 		},
-		objectType: "org",
-		relation:   "can_access",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c", "org:d"},
+		objectType:  "org",
+		relation:    "can_access",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c", "org:d"},
 	},
 	{
 		name: "complex_exclusion_nested",
@@ -1954,10 +1891,11 @@ var cases = []testcase{
 			"org:b#member@team:b#member",
 			"org:b#also_also_allowed@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c", "org:d"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c", "org:d"},
 	},
 	{
 		name: "complex_exclusion_nested_and_union",
@@ -1991,10 +1929,11 @@ var cases = []testcase{
 			"org:d#granted@user:bob",
 			"org:e#granted@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c"},
 	},
 	{
 		name: "exclusion_intersection_1",
@@ -2026,10 +1965,11 @@ var cases = []testcase{
 			"org:d#allowed@user:bob",
 			"org:d#also_allowed@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:b", "org:c"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:b", "org:c"},
 	},
 	{
 		name: "exclusion_intersection_2",
@@ -2061,10 +2001,11 @@ var cases = []testcase{
 			"org:d#member@team:d#member",
 			"org:d#also_allowed@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:b"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:b"},
 	},
 	{
 		name: "exclusion_lowest_weight_is_TTU",
@@ -2099,10 +2040,11 @@ var cases = []testcase{
 			"org:b#team@team:b",
 			"team:b#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c"},
 	},
 	{
 		name: "exclusion_ttu_multipleparents",
@@ -2133,10 +2075,11 @@ var cases = []testcase{
 			"org:a#parent@subteam:st2",
 			"team:t1#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:c"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:c"},
 	},
 	{
 		name: "lowest_weight_is_TTU_intersection_with_intersections",
@@ -2171,10 +2114,11 @@ var cases = []testcase{
 			"team:c#dept_member@dept:c#member",
 			"dept:c#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a"},
 	},
 	{
 		name: "mix_of_union_intersection_and_exclusion",
@@ -2209,10 +2153,11 @@ var cases = []testcase{
 			"org:d#dept@dept:d",
 			"dept:d#member@user:bob",
 		},
-		objectType: "org",
-		relation:   "member",
-		user:       "user:bob",
-		expected:   []string{"org:a", "org:b"},
+		objectType:  "org",
+		relation:    "member",
+		subjectType: "user",
+		subjectID:   "bob",
+		expected:    []string{"org:a", "org:b"},
 	},
 	{
 		name: "intersection_with_TTU",
@@ -2238,10 +2183,11 @@ var cases = []testcase{
 			"folder:X#viewer@user:b",
 			"document:2#writer@user:c",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:1"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:1"},
 	},
 	{
 		name: "intersection_with_high_weights",
@@ -2273,10 +2219,11 @@ var cases = []testcase{
 			"folder:Y#viewer@user:a",
 			"document:2#other_parent@folder:Z",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:1", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:1", "document:3"},
 	},
 	{
 		name: "exclusion_with_TTU",
@@ -2304,10 +2251,11 @@ var cases = []testcase{
 			"document:1#writer@user:a",
 			"folder:Y#viewer@user:a",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:2", "document:3"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:2", "document:3"},
 	},
 	{
 		name: "exclusion_with_high_weights",
@@ -2343,10 +2291,11 @@ var cases = []testcase{
 			"document:5#other_parent@folder:F",
 			"folder:F#viewer@user:a",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:2", "document:4"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:2", "document:4"},
 	},
 	{
 		name: "tuple_to_userset_intersection",
@@ -2378,10 +2327,11 @@ var cases = []testcase{
 			"and_folder:e#editor@user:e",
 			"and_folder:e#editor@user:e",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:a"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:a"},
 	},
 	{
 		name: "tuple_to_userset_exclusion",
@@ -2411,10 +2361,11 @@ var cases = []testcase{
 			"but_not_folder:c#editor@user:c",
 			"but_not_folder:d#writer@user:d",
 		},
-		objectType: "document",
-		relation:   "viewer",
-		user:       "user:a",
-		expected:   []string{"document:a"},
+		objectType:  "document",
+		relation:    "viewer",
+		subjectType: "user",
+		subjectID:   "a",
+		expected:    []string{"document:a"},
 	},
 	{
 		name: "duplicate_parent_ttu",
@@ -2435,9 +2386,10 @@ var cases = []testcase{
 			"thing:4#parent@account:4",
 			"account:4#super_admin@user:1",
 		},
-		objectType: "thing",
-		relation:   "can_view",
-		user:       "user:1",
+		objectType:  "thing",
+		relation:    "can_view",
+		subjectType: "user",
+		subjectID:   "1",
 		expected: []string{
 			"thing:4",
 		},
@@ -2484,9 +2436,10 @@ var cases = []testcase{
 			"resource:5#also_user@user:1",
 			"resource:5#owner@user:1",
 		},
-		objectType: "thing",
-		relation:   "can_view",
-		user:       "user:1",
+		objectType:  "thing",
+		relation:    "can_view",
+		subjectType: "user",
+		subjectID:   "1",
 		expected: []string{
 			"thing:1",
 			"thing:2",
@@ -2572,9 +2525,10 @@ var cases = []testcase{
 			"resource:8#member@user:1",
 			"document:4#viewer@resource:8#member",
 		},
-		objectType: "thing",
-		relation:   "can_view",
-		user:       "user:1",
+		objectType:  "thing",
+		relation:    "can_view",
+		subjectType: "user",
+		subjectID:   "1",
 		expected: []string{
 			"thing:1",
 			"thing:2",
@@ -2609,27 +2563,39 @@ func BenchmarkPipeline(b *testing.B) {
 
 			validator := pipeline.NewValidator(context.Background(), typesys, nil)
 
-			reader := pipeline.NewReader(
+			reader := pipeline.NewValidatingStore(
 				ds,
 				Store,
-				pipeline.WithReaderValidator(validator),
+				pipeline.WithStoreValidator(validator),
 			)
+
+			builder, err := pipeline.NewBuilder(reader)
+			require.NoError(b, err)
+
+			spec := pipeline.Spec{
+				ObjectType:     tc.objectType,
+				ObjectRelation: tc.relation,
+				SubjectType:    tc.subjectType,
+				SubjectID:      tc.subjectID,
+			}
 
 			b.ResetTimer()
 
 			for b.Loop() {
-				spec := pipeline.Spec{
-					ObjectType: tc.objectType,
-					Relation:   tc.relation,
-					User:       tc.user,
+				p, err := builder.Build(context.Background(), g, spec)
+				if tc.error != nil {
+					require.ErrorIs(b, err, tc.error)
+					continue
 				}
-
-				seq, err := pipeline.New(g, reader).Expand(context.Background(), spec)
-
 				require.NoError(b, err)
 
-				for range seq {
+				for {
+					_, ok := p.Recv(context.Background())
+					if !ok {
+						break
+					}
 				}
+				p.Close()
 			}
 		})
 	}
@@ -2659,28 +2625,35 @@ func TestPipeline(t *testing.T) {
 
 			validator := pipeline.NewValidator(context.Background(), typesys, nil)
 
-			reader := pipeline.NewReader(
+			reader := pipeline.NewValidatingStore(
 				ds,
 				Store,
-				pipeline.WithReaderValidator(validator),
+				pipeline.WithStoreValidator(validator),
 			)
 
-			spec := pipeline.Spec{
-				ObjectType: tc.objectType,
-				Relation:   tc.relation,
-				User:       tc.user,
-			}
-
-			seq, err := pipeline.New(g, reader).Expand(context.Background(), spec)
-
+			builder, err := pipeline.NewBuilder(reader)
 			require.NoError(t, err)
 
-			evaluate(t, tc, seq)
+			spec := pipeline.Spec{
+				ObjectType:     tc.objectType,
+				ObjectRelation: tc.relation,
+				SubjectType:    tc.subjectType,
+				SubjectID:      tc.subjectID,
+			}
+
+			p, err := builder.Build(context.Background(), g, spec)
+			if tc.error != nil {
+				require.ErrorIs(t, err, tc.error)
+				return
+			}
+			require.NoError(t, err)
+
+			evaluate(t, tc, p)
 		})
 	}
 }
 
-func TestPipelineTTUWithCondition(t *testing.T) {
+func TestPipeline_TTUWithCondition(t *testing.T) {
 	const dsl string = `
 	model
 	  schema 1.2
@@ -2713,9 +2686,10 @@ func TestPipelineTTUWithCondition(t *testing.T) {
 	g := typesys.GetWeightedGraph()
 
 	spec := pipeline.Spec{
-		ObjectType: "document",
-		Relation:   "can_edit",
-		User:       "user:alice",
+		ObjectType:     "document",
+		ObjectRelation: "can_edit",
+		SubjectType:    "user",
+		SubjectID:      "alice",
 	}
 
 	tests := []struct {
@@ -2765,21 +2739,28 @@ func TestPipelineTTUWithCondition(t *testing.T) {
 				},
 			}
 
-			reader := pipeline.NewReader(
+			reader := pipeline.NewValidatingStore(
 				ds,
 				storeID,
-				pipeline.WithReaderValidator(pipeline.NewValidator(context.Background(), typesys, reqCtx)),
+				pipeline.WithStoreValidator(pipeline.NewValidator(context.Background(), typesys, reqCtx)),
 			)
 
-			seq, err := pipeline.New(g, reader).Expand(context.Background(), spec)
+			builder, err := pipeline.NewBuilder(reader)
 			require.NoError(t, err)
 
+			p, err := builder.Build(context.Background(), g, spec)
+			require.NoError(t, err)
+			defer p.Close()
+
 			var results []string
-			for object := range seq {
-				value, err := object.Object()
-				require.NoError(t, err)
+			for {
+				value, ok := p.Recv(context.Background())
+				if !ok {
+					break
+				}
 				results = append(results, value)
 			}
+			require.NoError(t, p.Err())
 			require.ElementsMatch(t, tc.expected, results)
 		})
 	}

--- a/internal/listobjects/pipeline/store.go
+++ b/internal/listobjects/pipeline/store.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync/atomic"
 
@@ -18,7 +19,7 @@ import (
 )
 
 // NewValidator returns a validator that combines condition evaluation
-// and type-system filtering for use with [WithReaderValidator].
+// and type-system filtering for use with [WithStoreValidator].
 func NewValidator(
 	ctx context.Context,
 	ts *typesystem.TypeSystem,
@@ -36,40 +37,40 @@ func NewValidator(
 	)
 }
 
-// ReaderOption configures a [Reader].
-type ReaderOption func(o *Reader)
+// StoreOption configures a [ValidatingStore].
+type StoreOption func(o *ValidatingStore)
 
-// NewReader returns a Reader that queries store for relationship tuples.
-func NewReader(
+// NewValidatingStore returns a ValidatingStore that queries store for relationship tuples.
+func NewValidatingStore(
 	store storage.RelationshipTupleReader,
 	storeID string,
-	opts ...ReaderOption,
-) *Reader {
-	r := &Reader{store: store, storeID: storeID}
+	opts ...StoreOption,
+) *ValidatingStore {
+	r := &ValidatingStore{store: store, storeID: storeID}
 	for _, opt := range opts {
 		opt(r)
 	}
 	return r
 }
 
-// WithReaderConsistency sets the consistency preference for storage reads.
-func WithReaderConsistency(pref openfgav1.ConsistencyPreference) ReaderOption {
-	return func(r *Reader) {
+// WithStoreConsistency sets the consistency preference for storage reads.
+func WithStoreConsistency(pref openfgav1.ConsistencyPreference) StoreOption {
+	return func(r *ValidatingStore) {
 		r.consistency = pref
 	}
 }
 
-// WithReaderValidator sets a function that filters tuples during iteration.
+// WithStoreValidator sets a function that filters tuples during iteration.
 // Tuples for which fn returns false are silently skipped.
-func WithReaderValidator(fn func(*openfgav1.TupleKey) (bool, error)) ReaderOption {
-	return func(r *Reader) {
+func WithStoreValidator(fn func(*openfgav1.TupleKey) (bool, error)) StoreOption {
+	return func(r *ValidatingStore) {
 		r.validator = fn
 	}
 }
 
-// Reader implements [ObjectReader] by querying a [storage.RelationshipTupleReader]
+// ValidatingStore implements [ObjectStore] by querying a [storage.RelationshipTupleReader]
 // and optionally filtering results through a validator.
-type Reader struct {
+type ValidatingStore struct {
 	store       storage.RelationshipTupleReader
 	storeID     string
 	consistency openfgav1.ConsistencyPreference
@@ -79,7 +80,7 @@ type Reader struct {
 // createIterator queries the datastore for tuples matching the input parameters.
 // Returns an error iterator if the query fails to preserve error information
 // through the iterator interface.
-func (r *Reader) createIterator(
+func (r *ValidatingStore) createIterator(
 	ctx context.Context,
 	q ObjectQuery,
 ) storage.TupleIterator {
@@ -111,7 +112,7 @@ func (r *Reader) createIterator(
 	)
 
 	if err != nil {
-		return iterator.Error[*openfgav1.Tuple](err)
+		return iterator.Error[*openfgav1.Tuple](fmt.Errorf("datastore: %w", err))
 	}
 	return it
 }
@@ -119,7 +120,7 @@ func (r *Reader) createIterator(
 // applyValidator wraps the iterator with validation to filter invalid tuples.
 // Invalid tuples (wrong type, failing conditions, etc.) are skipped; this prevents
 // them from corrupting pipeline results or causing downstream errors.
-func (r *Reader) applyValidator(it storage.TupleIterator) storage.TupleKeyIterator {
+func (r *ValidatingStore) applyValidator(it storage.TupleIterator) storage.TupleKeyIterator {
 	base := storage.NewTupleKeyIteratorFromTupleIterator(it)
 	base = iterator.Validate(base, r.validator)
 	return base
@@ -150,7 +151,7 @@ func (r *TupleKeyItemReceiver) Recv(ctx context.Context) (Item, bool) {
 			if errors.Is(err, storage.ErrIteratorDone) {
 				return item, false
 			}
-			item.Err = err
+			item.Err = fmt.Errorf("iterator: %w", err)
 			return item, true
 		}
 
@@ -172,7 +173,7 @@ func (r *TupleKeyItemReceiver) Close() {
 
 // Read queries storage for tuples matching q and returns the matching
 // object identifiers as a streaming sequence.
-func (r *Reader) Read(
+func (r *ValidatingStore) Read(
 	ctx context.Context,
 	q ObjectQuery,
 ) Receiver[Item] {

--- a/internal/listobjects/pipeline/store.go
+++ b/internal/listobjects/pipeline/store.go
@@ -122,7 +122,9 @@ func (r *ValidatingStore) createIterator(
 // them from corrupting pipeline results or causing downstream errors.
 func (r *ValidatingStore) applyValidator(it storage.TupleIterator) storage.TupleKeyIterator {
 	base := storage.NewTupleKeyIteratorFromTupleIterator(it)
-	base = iterator.Validate(base, r.validator)
+	if r.validator != nil {
+		base = iterator.Validate(base, r.validator)
+	}
 	return base
 }
 

--- a/internal/listobjects/pipeline/store_test.go
+++ b/internal/listobjects/pipeline/store_test.go
@@ -29,7 +29,7 @@ func TestReaderRead(t *testing.T) {
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		var got []string
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
@@ -65,7 +65,7 @@ func TestReaderRead(t *testing.T) {
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
 			Return(nil, sentinel)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		var gotErr error
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
@@ -96,7 +96,7 @@ func TestReaderRead(t *testing.T) {
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
 			Return(storage.NewStaticTupleIterator(nil), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		count := 0
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
@@ -141,7 +141,7 @@ func TestReaderRead(t *testing.T) {
 			return tk.GetObject() == "document:1" || tk.GetObject() == "document:3", nil
 		}
 
-		reader := pipeline.NewReader(store, "store-1", pipeline.WithReaderValidator(validator))
+		reader := pipeline.NewValidatingStore(store, "store-1", pipeline.WithStoreValidator(validator))
 
 		var got []string
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
@@ -181,7 +181,7 @@ func TestReaderRead(t *testing.T) {
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -225,7 +225,7 @@ func TestReaderRead(t *testing.T) {
 			).
 			Return(storage.NewStaticTupleIterator(nil), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
 			ObjectType: "document",
@@ -258,8 +258,8 @@ func TestReaderRead(t *testing.T) {
 			).
 			Return(storage.NewStaticTupleIterator(nil), nil)
 
-		reader := pipeline.NewReader(store, "store-1",
-			pipeline.WithReaderConsistency(openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY),
+		reader := pipeline.NewValidatingStore(store, "store-1",
+			pipeline.WithStoreConsistency(openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY),
 		)
 
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
@@ -298,7 +298,7 @@ func TestReaderRead(t *testing.T) {
 			).
 			Return(storage.NewStaticTupleIterator(nil), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
 			ObjectType: "document",
@@ -332,7 +332,7 @@ func TestReaderRead(t *testing.T) {
 			).
 			Return(storage.NewStaticTupleIterator(nil), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
 			ObjectType: "document",
@@ -364,7 +364,7 @@ func TestReaderRead(t *testing.T) {
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
 			Return(storage.NewStaticTupleIterator(tuples), nil)
 
-		reader := pipeline.NewReader(store, "store-1")
+		reader := pipeline.NewValidatingStore(store, "store-1")
 
 		var got []string
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -786,7 +786,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 			if errors.Is(err, pipeline.ErrUnreachable) {
 				return &resolutionMetadata, nil
 			}
-			return nil, serverErrors.ValidationError(err)
+			return nil, serverErrors.HandleError("", err)
 		}
 		defer p.Close()
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -584,51 +584,59 @@ func (q *ListObjectsQuery) Execute(
 
 		validator := pipeline.NewValidator(timeoutCtx, typesys, req.GetContext())
 
-		reader := pipeline.NewReader(
+		reader := pipeline.NewValidatingStore(
 			ds,
 			req.GetStoreId(),
-			pipeline.WithReaderConsistency(req.GetConsistency()),
-			pipeline.WithReaderValidator(validator),
+			pipeline.WithStoreConsistency(req.GetConsistency()),
+			pipeline.WithStoreValidator(validator),
 		)
 
-		spec := pipeline.Spec{
-			ObjectType: targetObjectType,
-			Relation:   targetRelation,
-			User:       req.GetUser(),
+		builder, err := pipeline.NewBuilder(reader, pipeline.WithConfig(q.pipelineConfig))
+		if err != nil {
+			return nil, serverErrors.HandleError("", err)
 		}
 
-		seq, err := pipeline.New(
-			wgraph,
-			reader,
-			pipeline.WithConfig(q.pipelineConfig),
-		).Expand(timeoutCtx, spec)
+		subjectType, subjectIdentifier, _ := tuple.ToUserParts(req.GetUser())
 
-		if err != nil {
-			return nil, serverErrors.ValidationError(err)
+		spec := pipeline.Spec{
+			ObjectType:     targetObjectType,
+			ObjectRelation: targetRelation,
+			SubjectType:    subjectType,
+			SubjectID:      subjectIdentifier,
 		}
 
 		var res ListObjectsResponse
 
-		for object := range seq {
-			if timeoutCtx.Err() != nil {
+		res.ResolutionMetadata.WasWeightedGraphUsed.Store(true)
+
+		p, err := builder.Build(timeoutCtx, wgraph, spec)
+		if err != nil {
+			if errors.Is(err, pipeline.ErrUnreachable) {
+				return &res, nil
+			}
+			return nil, serverErrors.ValidationError(err)
+		}
+		defer p.Close()
+
+		for {
+			value, ok := p.Recv(timeoutCtx)
+			if !ok {
 				break
 			}
 
-			value, err := object.Object()
-
-			// If the error is from a context cancelation, the current
-			// behavior for ListObjects is to not report it.
-			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				return nil, serverErrors.HandleError("", err)
-			}
-
-			if err == nil {
-				res.Objects = append(res.Objects, value)
-			}
+			res.Objects = append(res.Objects, value)
 
 			// Check if we've reached the max results limit
 			if maxResults > 0 && uint32(len(res.Objects)) >= maxResults {
 				break
+			}
+		}
+		p.Close() // ensure that the pipeline is closed after any early loop exits
+
+		if err := p.Err(); err != nil {
+			// current list objects behavior is to elide context cancelation errors
+			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+				return nil, serverErrors.HandleError("", err)
 			}
 		}
 
@@ -752,67 +760,74 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 
 		validator := pipeline.NewValidator(timeoutCtx, typesys, req.GetContext())
 
-		reader := pipeline.NewReader(
+		reader := pipeline.NewValidatingStore(
 			ds,
 			req.GetStoreId(),
-			pipeline.WithReaderConsistency(req.GetConsistency()),
-			pipeline.WithReaderValidator(validator),
+			pipeline.WithStoreConsistency(req.GetConsistency()),
+			pipeline.WithStoreValidator(validator),
 		)
 
-		spec := pipeline.Spec{
-			ObjectType: targetObjectType,
-			Relation:   targetRelation,
-			User:       req.GetUser(),
+		builder, err := pipeline.NewBuilder(reader, pipeline.WithConfig(q.pipelineConfig))
+		if err != nil {
+			return nil, serverErrors.HandleError("", err)
 		}
 
-		seq, err := pipeline.New(
-			wgraph,
-			reader,
-			pipeline.WithConfig(q.pipelineConfig),
-		).Expand(timeoutCtx, spec)
+		subjectType, subjectIdentifier, _ := tuple.ToUserParts(req.GetUser())
 
+		spec := pipeline.Spec{
+			ObjectType:     targetObjectType,
+			ObjectRelation: targetRelation,
+			SubjectType:    subjectType,
+			SubjectID:      subjectIdentifier,
+		}
+
+		p, err := builder.Build(timeoutCtx, wgraph, spec)
 		if err != nil {
+			if errors.Is(err, pipeline.ErrUnreachable) {
+				return &resolutionMetadata, nil
+			}
 			return nil, serverErrors.ValidationError(err)
 		}
+		defer p.Close()
 
 		var listObjectsCount uint32 = 0
 
-		for object := range seq {
-			if timeoutCtx.Err() != nil {
+		var errRx error
+
+		for {
+			value, ok := p.Recv(timeoutCtx)
+			if !ok {
+				errRx = p.Err()
 				break
 			}
 
-			value, err := object.Object()
-
-			// If the error is from a context cancelation, the current
-			// behavior for ListObjects is to not report it.
-			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
-				if errors.Is(err, condition.ErrEvaluationFailed) {
-					return nil, serverErrors.ValidationError(err)
-				}
-				return nil, serverErrors.HandleError("", err)
+			if errRx = srv.Send(&openfgav1.StreamedListObjectsResponse{Object: value}); errRx != nil {
+				break
 			}
 
-			if err == nil {
-				if err := srv.Send(&openfgav1.StreamedListObjectsResponse{
-					Object: value,
-				}); err != nil {
-					return nil, serverErrors.HandleError("", err)
-				}
-
-				listObjectsCount++
-			}
+			listObjectsCount++
 
 			// Check if we've reached the max results limit
 			if maxResults > 0 && listObjectsCount >= maxResults {
 				break
 			}
 		}
+		p.Close() // ensure that the pipeline is closed after any early loop exits
+
+		if errRx != nil && !errors.Is(errRx, context.Canceled) && !errors.Is(errRx, context.DeadlineExceeded) {
+			if errors.Is(errRx, condition.ErrEvaluationFailed) {
+				err = serverErrors.ValidationError(errRx)
+			} else {
+				err = serverErrors.HandleError("", errRx)
+			}
+			return nil, err
+		}
 
 		dsMeta := ds.GetMetadata()
 		resolutionMetadata.DatastoreThrottled.Store(dsMeta.WasThrottled)
 		resolutionMetadata.DatastoreQueryCount.Add(dsMeta.DatastoreQueryCount)
 		resolutionMetadata.DatastoreItemCount.Add(dsMeta.DatastoreItemCount)
+		resolutionMetadata.WasWeightedGraphUsed.Store(true)
 		return &resolutionMetadata, nil
 	}
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -760,6 +760,8 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 			},
 		)
 
+		resolutionMetadata.WasWeightedGraphUsed.Store(true)
+
 		validator := pipeline.NewValidator(timeoutCtx, typesys, req.GetContext())
 
 		reader := pipeline.NewValidatingStore(
@@ -827,7 +829,6 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 		resolutionMetadata.DatastoreThrottled.Store(dsMeta.WasThrottled)
 		resolutionMetadata.DatastoreQueryCount.Add(dsMeta.DatastoreQueryCount)
 		resolutionMetadata.DatastoreItemCount.Add(dsMeta.DatastoreItemCount)
-		resolutionMetadata.WasWeightedGraphUsed.Store(true)
 		return &resolutionMetadata, nil
 	}
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -614,7 +614,7 @@ func (q *ListObjectsQuery) Execute(
 			if errors.Is(err, pipeline.ErrUnreachable) {
 				return &res, nil
 			}
-			return nil, serverErrors.ValidationError(err)
+			return nil, serverErrors.HandleError("", err)
 		}
 		defer p.Close()
 

--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -520,6 +520,8 @@ func (q *ListObjectsQuery) Execute(
 	targetObjectType := req.GetType()
 	targetRelation := req.GetRelation()
 
+	subjectType, subjectIdentifier, subjectRelation := tuple.ToUserParts(req.GetUser())
+
 	typesys, ok := typesystem.TypesystemFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
@@ -564,7 +566,7 @@ func (q *ListObjectsQuery) Execute(
 
 	wgraph := typesys.GetWeightedGraph()
 
-	if wgraph != nil && q.pipelineEnabled {
+	if wgraph != nil && subjectRelation == "" && subjectIdentifier != "*" && q.pipelineEnabled {
 		ds := storagewrappers.NewRequestStorageWrapperWithCache(
 			q.datastore,
 			req.GetContextualTuples().GetTupleKeys(),
@@ -595,8 +597,6 @@ func (q *ListObjectsQuery) Execute(
 		if err != nil {
 			return nil, serverErrors.HandleError("", err)
 		}
-
-		subjectType, subjectIdentifier, _ := tuple.ToUserParts(req.GetUser())
 
 		spec := pipeline.Spec{
 			ObjectType:     targetObjectType,
@@ -647,7 +647,7 @@ func (q *ListObjectsQuery) Execute(
 		return &res, nil
 	}
 
-	// --------- OLD STUFF -----------
+	// --------- OLD ALGORITHM FALLBACK -----------
 	resultsChan := make(chan ListObjectsResult, 1)
 	if maxResults > 0 {
 		resultsChan = make(chan ListObjectsResult, maxResults)
@@ -706,6 +706,8 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 	targetObjectType := req.GetType()
 	targetRelation := req.GetRelation()
 
+	subjectType, subjectIdentifier, subjectRelation := tuple.ToUserParts(req.GetUser())
+
 	typesys, ok := typesystem.TypesystemFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("%w: typesystem missing in context", openfgaErrors.ErrUnknown)
@@ -740,7 +742,7 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 
 	wgraph := typesys.GetWeightedGraph()
 
-	if wgraph != nil && q.pipelineEnabled {
+	if wgraph != nil && subjectRelation == "" && subjectIdentifier != "*" && q.pipelineEnabled {
 		ds := storagewrappers.NewRequestStorageWrapperWithCache(
 			q.datastore,
 			req.GetContextualTuples().GetTupleKeys(),
@@ -771,8 +773,6 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 		if err != nil {
 			return nil, serverErrors.HandleError("", err)
 		}
-
-		subjectType, subjectIdentifier, _ := tuple.ToUserParts(req.GetUser())
 
 		spec := pipeline.Spec{
 			ObjectType:     targetObjectType,
@@ -830,6 +830,8 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 		resolutionMetadata.WasWeightedGraphUsed.Store(true)
 		return &resolutionMetadata, nil
 	}
+
+	// --------- OLD ALGORITHM FALLBACK -----------
 
 	// make a buffered channel so that writer goroutines aren't blocked when attempting to send a result
 	resultsChan := make(chan ListObjectsResult, streamedBufferSize)

--- a/pkg/server/list_objects.go
+++ b/pkg/server/list_objects.go
@@ -167,6 +167,9 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	wasDatastoreThrottled := result.ResolutionMetadata.DatastoreThrottled.Load()
 	grpc_ctxtags.Extract(ctx).Set("request.datastore_throttled", wasDatastoreThrottled)
 
+	wasWeightedGraphUsed := result.ResolutionMetadata.WasWeightedGraphUsed.Load()
+	grpc_ctxtags.Extract(ctx).Set("request.weighted_graph", wasWeightedGraphUsed)
+
 	if wasDispatchThrottled {
 		throttledRequestCounter.WithLabelValues(s.serviceName, methodName, throttleTypeDispatch).Inc()
 	}
@@ -310,6 +313,9 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 
 	wasDatastoreThrottled := resolutionMetadata.DatastoreThrottled.Load()
 	grpc_ctxtags.Extract(ctx).Set("request.datastore_throttled", wasDatastoreThrottled)
+
+	wasWeightedGraphUsed := resolutionMetadata.WasWeightedGraphUsed.Load()
+	grpc_ctxtags.Extract(ctx).Set("request.weighted_graph", wasWeightedGraphUsed)
 
 	if wasDispatchThrottled {
 		throttledRequestCounter.WithLabelValues(s.serviceName, methodName, throttleTypeDispatch).Inc()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
The current list objects pipeline algorithm builds the entire authorization model graph into a worker pipeline, regardless of a node's or edge's reachability to the subject type. This creates short-lived but unnecessary goroutines and wastes compute cycles.

The changes in this PR introduce edge pruning for nodes and edges that have no reachability to the subject type. This results in a measurable performance improvement in many, but specific, cases. This is especially beneficial in very large models having many types and relationships.

  - Refactored the pipeline from a single Pipeline type into a Builder/Pipeline split. Builder holds infrastructure config (store, tuning params) and can produce multiple Pipeline instances concurrently. Pipeline is now a stateful object with explicit Recv(ctx) / Close() methods, replacing the previous iter.Seq[Item] streaming interface.
  - Replaced recursive worker graph construction with an iterative DFS. The old resolve() method built the worker graph recursively; it now uses an explicit stacker linked-list as a DFS stack, which is simpler to reason about and avoids deep call stacks on complex models.
  - Edge pruning via weight-based reachability. During DFS construction, edges whose weight map contains neither the subject type nor the wildcard form are pruned with a NoopMedium, avoiding unnecessary worker creation and storage reads for unreachable graph branches.
  - Introduced dedicated Terminal and Wildcard worker types. Leaf nodes for concrete types (e.g. user) and wildcard types (e.g. user:*) are now distinct worker types instead of being handled as special cases inside the generic Basic worker. Terminal prepends the type label; Wildcard broadcasts its label as the sole result.
  - Simplified Receiver types. SliceReceiver and ValueReceiver are no longer safe for concurrent use (no atomics), reflecting that receivers are single-consumer. NewValueReceiver now yields exactly one value; multi-value usage migrated to NewSliceReceiver.
  - Renamed ObjectReader to ObjectStore, Reader to ValidatingStore, and updated option names (WithReaderValidator -> WithStoreValidator, WithReaderConsistency -> WithStoreConsistency).
  - Config validation moved to NewBuilder. Invalid configurations now fail at builder construction time rather than at query execution time.

> [!WARNING]
> To support edge pruning, the pipeline algorithm no longer supports userset or wildcard subject types. The Spec struct now takes explicit SubjectType and SubjectID fields instead of a raw User string. Queries where the subject type contains a relation (e.g. group:x#member) or is a wildcard (user:\*) will fall back to the old algorithm. The guard subjectRelation == "" && subjectIdentifier != "*" is checked before entering the pipeline path in both Execute and ExecuteStreamed.

  Test plan

  - make test FILTER="TestPipeline" — all pipeline unit tests pass (shutdown, error propagation, invalid config/object/relation/subject, empty results, and the full matrix of graph patterns)
  - make test FILTER="TestListObjects" — list objects command tests pass, including fallback to the old algorithm for userset and wildcard subjects
  - make lint — passes with no new warnings
  - goleak.VerifyNone in every pipeline test confirms no goroutine leaks across all lifecycle scenarios (cancel, timeout, partial consumption, close without consuming)
  - Verify the removed test cases (userset_as_user, simple_userset_child_computed_userset) are covered by the old algorithm fallback path
## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Pipeline refactored to a builder + pull-based receiver model; consume results via Recv/Close/Err. Spec fields clarified to object-relation/subject-type/subject-id. Result streaming/documentation updated to use Recv loops with explicit Close and Err checks.
* **New Features**
  * Edge-pruning optimization for ListObjects performance.
  * Pipeline/workers: new terminal/wildcard worker behaviors and a no-op medium; non-blocking accumulator TryRecv for error collection.
* **Changed**
  * ListObjects now records weighted-graph usage in resolution metadata and treats unreachable subjects as empty successful results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->