### PR TITLE
Add tracing to v2 Check planner strategy selection

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -263,6 +263,8 @@ func (r *Resolver) executeStrategy(ctx context.Context, selector planner.Selecto
 	span := trace.SpanFromContext(ctx)
 	start := time.Now()
 	res, err := fn()
+	duration := time.Since(start)
+	span.SetAttributes(attribute.Int64("strategy_duration_ms", duration.Milliseconds()))
 	if err != nil {
 		// penalize plans that timeout from the upstream context
 		if errors.Is(err, context.DeadlineExceeded) {
@@ -271,7 +273,7 @@ func (r *Resolver) executeStrategy(ctx context.Context, selector planner.Selecto
 		telemetry.TraceError(span, err)
 		return nil, err
 	}
-	selector.UpdateStats(strategy, time.Since(start))
+	selector.UpdateStats(strategy, duration)
 	if res.GetAllowed() {
 		span.SetAttributes(attribute.Bool("allowed", true))
 	}
@@ -322,9 +324,14 @@ func (r *Resolver) resolveRecursiveUserset(ctx context.Context, req *Request, ed
 		RecursiveStrategyName: RecursivePlan,
 	}
 
-	keyPlan := r.planner.GetPlanSelector(createRecursiveUsersetPlanKey(req, edge.GetTo().GetUniqueLabel()))
+	planKey := createRecursiveUsersetPlanKey(req, edge.GetTo().GetUniqueLabel())
+	keyPlan := r.planner.GetPlanSelector(planKey)
 	strategy := keyPlan.Select(possibleStrategies)
-	span.SetAttributes(attribute.Bool("allowed", true))
+	span.SetAttributes(
+		attribute.String("plan_key", planKey),
+		attribute.String("strategy", strategy.Name),
+		attribute.Int("candidate_strategies", len(possibleStrategies)),
+	)
 	return r.executeStrategy(ctx, keyPlan, strategy, func() (*Response, error) {
 		return r.strategies[strategy.Name].Userset(ctx, req, edge, iter, visited)
 	})
@@ -386,9 +393,14 @@ func (r *Resolver) resolveRecursiveTTU(ctx context.Context, req *Request, edge *
 		RecursiveStrategyName: RecursivePlan,
 	}
 
-	keyPlan := r.planner.GetPlanSelector(createRecursiveTTUPlanKey(req, edge.GetRecursiveRelation()))
+	planKey := createRecursiveTTUPlanKey(req, edge.GetRecursiveRelation())
+	keyPlan := r.planner.GetPlanSelector(planKey)
 	strategy := keyPlan.Select(possibleStrategies)
-	span.SetAttributes(attribute.String("strategy", strategy.Name))
+	span.SetAttributes(
+		attribute.String("plan_key", planKey),
+		attribute.String("strategy", strategy.Name),
+		attribute.Int("candidate_strategies", len(possibleStrategies)),
+	)
 	return r.executeStrategy(ctx, keyPlan, strategy, func() (*Response, error) {
 		return r.strategies[strategy.Name].TTU(ctx, req, edge, iter, visited)
 	})
@@ -842,7 +854,11 @@ func (r *Resolver) specificTypeAndRelation(ctx context.Context, req *Request, ed
 	usersetKey := createUsersetPlanKey(req, edge.GetTo().GetUniqueLabel())
 	keyPlan := r.planner.GetPlanSelector(usersetKey)
 	strategy := keyPlan.Select(possibleStrategies)
-	span.SetAttributes(attribute.String("strategy", strategy.Name))
+	span.SetAttributes(
+		attribute.String("plan_key", usersetKey),
+		attribute.String("strategy", strategy.Name),
+		attribute.Int("candidate_strategies", len(possibleStrategies)),
+	)
 	return r.executeStrategy(ctx, keyPlan, strategy, func() (*Response, error) {
 		return r.strategies[strategy.Name].Userset(ctx, req, edge, iter, visited)
 	})
@@ -912,7 +928,11 @@ func (r *Resolver) ttu(ctx context.Context, req *Request, edge *authzGraph.Weigh
 	planKey := createTTUPlanKey(req, tuplesetRelation, computedRelation)
 	keyPlan := r.planner.GetPlanSelector(planKey)
 	strategy := keyPlan.Select(possibleStrategies)
-	span.SetAttributes(attribute.String("strategy", strategy.Name))
+	span.SetAttributes(
+		attribute.String("plan_key", planKey),
+		attribute.String("strategy", strategy.Name),
+		attribute.Int("candidate_strategies", len(possibleStrategies)),
+	)
 	return r.executeStrategy(ctx, keyPlan, strategy, func() (*Response, error) {
 		return r.strategies[strategy.Name].TTU(ctx, req, edge, iter, visited)
 	})

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -241,11 +241,24 @@ func (s *Server) v2Check(
 	modelGraphResolver *modelgraph.AuthorizationModelGraphResolver,
 ) (*openfgav1.CheckResponse, error) {
 	storeID := req.GetStoreId()
+	tk := req.GetTupleKey()
+
+	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, trace.WithAttributes(
+		attribute.String("store_id", storeID),
+		attribute.String("object", tk.GetObject()),
+		attribute.String("relation", tk.GetRelation()),
+		attribute.String("user", tk.GetUser()),
+		attribute.String("consistency", req.GetConsistency().String()),
+	))
+	defer span.End()
 
 	cacheInvalidationTime := time.Time{}
 	if req.GetConsistency() != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		cacheInvalidationTime = cacheController.DetermineInvalidationTime(ctx, storeID)
 	}
+	span.SetAttributes(
+		attribute.Bool("cache_invalidation_active", !cacheInvalidationTime.IsZero()),
+	)
 
 	mg, err := modelGraphResolver.Resolve(ctx, storeID, req.GetAuthorizationModelId())
 	if err != nil {
@@ -274,11 +287,11 @@ func (s *Server) v2Check(
 
 	res, metadata, err := q.Execute(ctx, req)
 
+	span.SetAttributes(attribute.Bool("allowed", res.GetAllowed()))
+
 	// Publish metrics from datastore metadata.
 	queryCount := float64(metadata.DatastoreQueryCount)
 	itemCount := float64(metadata.DatastoreItemCount)
-
-	span := trace.SpanFromContext(ctx)
 
 	grpc_ctxtags.Extract(ctx).Set(datastoreQueryCountHistogramName, queryCount)
 	span.SetAttributes(attribute.Float64(datastoreQueryCountHistogramName, queryCount))
@@ -294,8 +307,10 @@ func (s *Server) v2Check(
 	grpc_ctxtags.Extract(ctx).Set("request.datastore_throttled", metadata.WasThrottled)
 
 	if err != nil {
+		telemetry.TraceError(span, err)
 		return nil, commands.CheckCommandErrorToServerError(err)
 	}
+
 	return res, nil
 }
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Adds trace attributes to the v2 Check resolution path to make planner strategy decisions observable. This helps debug slow requests by showing what choices the Thompson Sampling planner is making and how long each chosen strategy takes to execute.

### Changes

At every planner decision point (`specificTypeAndRelation`, `ttu`, `resolveRecursiveUserset`, `resolveRecursiveTTU`), each span now includes:
- `plan_key` — the planner lookup key identifying this decision point (encodes model ID, object type, relation, user type, and edge info)
- `strategy` — the strategy selected by the planner (e.g. `default`, `weight2`, `recursive`)
- `candidate_strategies` — how many strategies were eligible, distinguishing forced defaults (1) from real planner selections (2+)

In `executeStrategy`:
- `strategy_duration_ms` — wall-clock time the chosen strategy took to execute

### Bug fix

Fixed a pre-existing issue in `resolveRecursiveUserset` where `span.SetAttributes(attribute.Bool("allowed", true))` was set unconditionally *before* executing the strategy. Replaced with the correct `plan_key`/`strategy`/`candidate_strategies` attributes.

### How to use

In a trace viewer, filter for spans with `plan_key` to see all planner decisions in a request. To find sub-optimal choices, look for spans where `strategy_duration_ms` is high and compare the `strategy` selected against `candidate_strategies` to see if an alternative was available.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Enhanced observability with improved tracing and monitoring metrics for the check operation system.
* Added performance measurement for strategy execution and expanded tracing attributes for better insight into system operations and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->