### PR TITLE
fix: bind playground to 0.0.0.0 in Docker and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,24 +181,21 @@ Disable it with:
 ./openfga run --playground-enabled=false
 ```
 
-Change port:
+Change address:
 
 ```shell
-./openfga run --playground-enabled --playground-port 3001
+./openfga run --playground-enabled --playground-addr 0.0.0.0:3001
 ```
 
-> [!TIP]
-> The `OPENFGA_HTTP_ADDR` environment variable can be used to configure the address at which the Playground expects the OpenFGA server to be.
->
-> For example:
+> [!IMPORTANT]
+> When running in Docker, the Playground binds to `127.0.0.1` by default, making it unreachable from outside the container.
+> Set `OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000` to bind to all interfaces:
 >
 > ```shell
 > docker run -e OPENFGA_PLAYGROUND_ENABLED=true \
-> -e OPENFGA_HTTP_ADDR=0.0.0.0:4000 \
-> -p 4000:4000 -p 3000:3000 openfga/openfga run
+> -e OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000 \
+> -p 8080:8080 -p 3000:3000 openfga/openfga run
 > ```
->
-> This starts OpenFGA on port 4000 and configures the Playground accordingly.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -174,24 +174,21 @@ Disable it with:
 ./openfga run --playground-enabled=false
 ```
 
-Change port:
+Change address:
 
 ```shell
-./openfga run --playground-enabled --playground-port 3001
+./openfga run --playground-enabled --playground-addr 0.0.0.0:3001
 ```
 
-> [!TIP]
-> The `OPENFGA_HTTP_ADDR` environment variable can be used to configure the address at which the Playground expects the OpenFGA server to be.
->
-> For example:
+> [!IMPORTANT]
+> When running in Docker, the Playground binds to `127.0.0.1` by default, making it unreachable from outside the container.
+> Set `OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000` to bind to all interfaces:
 >
 > ```shell
 > docker run -e OPENFGA_PLAYGROUND_ENABLED=true \
-> -e OPENFGA_HTTP_ADDR=0.0.0.0:4000 \
-> -p 4000:4000 -p 3000:3000 openfga/openfga run
+> -e OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000 \
+> -p 8080:8080 -p 3000:3000 openfga/openfga run
 > ```
->
-> This starts OpenFGA on port 4000 and configures the Playground accordingly.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ It helps developers easily model and enforce fine-grained access control in thei
 Run OpenFGA with in-memory storage (⚠️ **not for production**):
 
 ```shell
-docker run -p 8080:8080 -p 3000:3000 openfga/openfga run
+docker run -p 8080:8080 -p 127.0.0.1:3000:3000 openfga/openfga run
 ```
 
 Once running, create a store:
@@ -88,7 +88,7 @@ in-memory datastore by running the following commands:
 
 ```shell
 docker pull openfga/openfga
-docker run -p 8080:8080 -p 3000:3000 openfga/openfga run
+docker run -p 8080:8080 -p 127.0.0.1:3000:3000 openfga/openfga run
 ```
 
 > [!NOTE]
@@ -184,7 +184,7 @@ Disable it with:
 Change address:
 
 ```shell
-./openfga run --playground-enabled --playground-addr 0.0.0.0:3001
+./openfga run --playground-enabled --playground-addr 192.168.1.1:3001
 ```
 
 > [!IMPORTANT]
@@ -194,7 +194,7 @@ Change address:
 > ```shell
 > docker run -e OPENFGA_PLAYGROUND_ENABLED=true \
 > -e OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000 \
-> -p 8080:8080 -p 3000:3000 openfga/openfga run
+> -p 8080:8080 -p 127.0.0.1:3000:3000 openfga/openfga run
 > ```
 
 ## Next Steps

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,7 @@ services:
       - OPENFGA_DATASTORE_URI=postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       - OPENFGA_DATASTORE_MAX_OPEN_CONNS=100 #see postgres container
       - OPENFGA_PLAYGROUND_ENABLED=true
+      - OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000
     networks:
       - default
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,7 @@ services:
     ports:
       - "8080:8080" #http
       - "8081:8081" #grpc
-      - "3000:3000" #playground
+      - "127.0.0.1:3000:3000" #playground
       - "2112:2112" #prometheus metrics
     healthcheck:
       test:


### PR DESCRIPTION
## Summary

- Add `OPENFGA_PLAYGROUND_ADDR=0.0.0.0:3000` to `docker-compose.yaml` so the playground server is reachable outside the container (default `127.0.0.1` binds only to loopback, making it unreachable in Docker)
- Update README playground section: replace deprecated `--playground-port` with `--playground-addr` and add an `[!IMPORTANT]` callout documenting the Docker binding requirement
- Remove incorrect tip that `OPENFGA_HTTP_ADDR` controls the playground address

## Test plan

- [ ] Run `docker compose up` and verify `http://localhost:3000/playground` is accessible
- [ ] Verify playground can connect to the OpenFGA API at `http://localhost:8080`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Playground setup to use bind-address settings instead of the old port-only flag.
  * Clarified that the Playground defaults to localhost (127.0.0.1) and how to expose it externally.
  * Revised Docker and compose examples to demonstrate the new bind/address environment variable and adjusted port publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->