### PR TITLE
fix(cmd/run): dial loopback when gRPC server binds to wildcard address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Dial the loopback when the gRPC server binds to a wildcard address (`""`, `0.0.0.0`, `::`) so the in-process HTTP gateway can connect on platforms where wildcard addresses are not valid dial targets, and so TLS hostname verification works against issued IP/DNS SANs. [#3083](https://github.com/openfga/openfga/pull/3083)
 
 ## [1.14.2] - 2026-04-14
 ### Fixed

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -656,16 +656,31 @@ func (s *ServerContext) dialGrpc(config *serverconfig.Config) *grpc.ClientConn {
 	if config.Trace.Enabled {
 		dialOpts = append(dialOpts, grpc.WithStatsHandler(otelgrpc.NewClientHandler()))
 	}
-	if config.GRPC.TLS.Enabled {
-		// Resolve just the hostname portion of the gRPC address for use in
-		// peer certificate verification (InsecureSkipVerify suppresses Go's
-		// automatic hostname check, so we must do it ourselves).
-		grpcHost, _, err := net.SplitHostPort(config.GRPC.Addr)
-		if err != nil {
-			// Fall back to the raw address if it has no port component.
-			grpcHost = config.GRPC.Addr
-		}
 
+	// The gRPC server usually binds to a wildcard address (":8081", "0.0.0.0:8081"
+	// or "[::]:8081"), which isn't a valid dial target for a client: on Linux
+	// it happens to route to the loopback, on other platforms it fails, and in
+	// all cases it breaks TLS SAN verification because server certificates
+	// aren't issued for 0.0.0.0 / ::. Rewrite wildcard hosts to 127.0.0.1
+	// before dialing the local gRPC server from the in-process HTTP gateway.
+	// See https://github.com/openfga/openfga/issues/2871.
+	grpcHost, grpcPort, err := net.SplitHostPort(config.GRPC.Addr)
+	if err != nil {
+		// Fall back to the raw address if it has no port component.
+		grpcHost = config.GRPC.Addr
+		grpcPort = ""
+	}
+	dialHost := grpcHost
+	switch dialHost {
+	case "", "0.0.0.0", "::":
+		dialHost = "127.0.0.1"
+	}
+	dialAddr := config.GRPC.Addr
+	if grpcPort != "" && dialHost != grpcHost {
+		dialAddr = net.JoinHostPort(dialHost, grpcPort)
+	}
+
+	if config.GRPC.TLS.Enabled {
 		creds := credentials.NewTLS(&tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec // Hostname and cert are verified manually via VerifyPeerCertificate.
 			VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
@@ -681,9 +696,11 @@ func (s *ServerContext) dialGrpc(config *serverconfig.Config) *grpc.ClientConn {
 				// Verify the leaf certificate against the global pinned pool
 				// and check the hostname in a single call. The pool is
 				// updated atomically by the watcher callback on cert rotation.
+				// dialHost (not the original wildcard grpcHost) is what the
+				// cert has to cover as an IP SAN or DNS name.
 				_, err = peerCert.Verify(x509.VerifyOptions{
 					Roots:   grpcTLSCertPool.Load(),
-					DNSName: grpcHost,
+					DNSName: dialHost,
 				})
 				if err != nil {
 					return fmt.Errorf("peer certificate verification failed: %w", err)
@@ -696,7 +713,7 @@ func (s *ServerContext) dialGrpc(config *serverconfig.Config) *grpc.ClientConn {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 
-	conn, err := grpc.NewClient(config.GRPC.Addr, dialOpts...)
+	conn, err := grpc.NewClient(dialAddr, dialOpts...)
 	if err != nil {
 		s.Logger.Fatal("failed to create gRPC client connection", zap.Error(err))
 	}


### PR DESCRIPTION
Closes #2871.

## Problem

The in-process HTTP gateway in \`cmd/run/run.go\` opens a gRPC client to the local gRPC server using \`config.GRPC.Addr\` verbatim. When the server binds to a wildcard address, \`\":8081\"\`, \`\"0.0.0.0:8081\"\`, \`\"[::]:8081\"\`, the client ends up dialing \`0.0.0.0:8081\`. That address isn't a valid dial target on most platforms:

- On Linux it happens to route to the loopback, so it works by accident.
- On other platforms the dial fails outright.
- With \`grpc.tls.enabled=true\` it always fails, because server certs aren't issued for \`0.0.0.0\` / \`::\`; the SAN mismatch surfaces as \`peer certificate verification failed\`.

## Fix

Rewrite \`\"\"\`, \`\"0.0.0.0\"\` and \`\"::\"\` host parts to \`127.0.0.1\` before dialing, and use the rewritten host as the \`DNSName\` for \`peerCert.Verify\`. Go's x509 verifier treats IP-literal \`DNSName\` strings as IP-SAN lookups, so certs carrying \`IP:127.0.0.1\` SANs keep verifying cleanly.

Before:

\`\`\`go
grpcHost, _, err := net.SplitHostPort(config.GRPC.Addr)
// ... Verify uses grpcHost (\"0.0.0.0\"), SAN match fails
conn, err := grpc.NewClient(config.GRPC.Addr, dialOpts...) // dials 0.0.0.0
\`\`\`

After:

\`\`\`go
grpcHost, grpcPort, err := net.SplitHostPort(config.GRPC.Addr)
...
dialHost := grpcHost
switch dialHost {
case \"\", \"0.0.0.0\", \"::\":
    dialHost = \"127.0.0.1\"
}
dialAddr := config.GRPC.Addr
if grpcPort != \"\" && dialHost != grpcHost {
    dialAddr = net.JoinHostPort(dialHost, grpcPort)
}
// ... Verify uses dialHost (\"127.0.0.1\"), SAN match succeeds
conn, err := grpc.NewClient(dialAddr, dialOpts...)
\`\`\`

## Testing

- \`go build ./cmd/run/...\`, clean.
- \`go vet ./cmd/run/...\`, clean.
- \`go test -count=1 -v -run TestBuildServer ./cmd/run/...\`, PASS (all sub-tests, including the TLS and OIDC variants).
- \`go test -count=1 ./cmd/run/...\`, only \`TestServerMetricsReporting/mysql\` and \`.../postgres\` fail, both because my local doesn't have those datastores running; \`.../sqlite\` passes. Unrelated to this change.

## Follow-ups

The issue mentions a unix-domain-socket option as a cleaner alternative. Out of scope for this PR, it would change the config surface and deserves its own discussion, but happy to open a follow-up if maintainers want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed gRPC loopback handling when the server binds to wildcard addresses so the local gateway can connect and TLS hostname verification works with IP/DNS SANs.

* **Chores**
  * Optimized internal gRPC connection establishment to consistently use the adjusted dial target for in-process clients.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->