### PR TITLE
fix(sqlite): make SQLTupleIterator concurrency-safe for Next and Head

### DIFF
--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -32,6 +32,7 @@ type SQLTupleIterator struct {
 	firstRow       *storage.TupleRecord // GUARDED_BY(mu)
 	mu             sync.Mutex
 	inFlight       sync.Mutex
+	fetched        bool // GUARDED_BY(mu)
 }
 
 // Ensures that SQLTupleIterator implements the TupleIterator interface.
@@ -54,10 +55,12 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 
 	// FIX: prevent duplicate fetch
 	t.mu.Lock()
-	if t.rows != nil {
+	// USE: If we have already attempted a fetch, don't do it again
+	if t.fetched {
 		t.mu.Unlock()
 		return nil
 	}
+	t.fetched = true
 	t.mu.Unlock()
 
 	ctx, span := tracer.Start(ctx, "sqlite.fetchBuffer", trace.WithAttributes())
@@ -93,18 +96,17 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, error) {
 	t.mu.Lock()
 
-	if t.rows == nil {
+	if t.fetched && t.rows == nil && t.firstRow == nil {
 		t.mu.Unlock()
+		return nil, storage.ErrIteratorDone
+	}
 
+	if !t.fetched {
+		t.mu.Unlock()
 		if err := t.fetchBuffer(ctx); err != nil {
 			return nil, err
 		}
-
 		t.mu.Lock()
-		if t.rows == nil {
-			t.mu.Unlock()
-			return nil, ErrIteratorRowsNotInitialized
-		}
 	}
 
 	if t.firstRow != nil {
@@ -114,12 +116,15 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 		return firstRow, nil
 	}
 
+	if t.rows == nil {
+		t.mu.Unlock()
+		return nil, ErrIteratorRowsNotInitialized
+	}
+
 	if !t.rows.Next() {
 		err := t.rows.Err()
-
 		_ = t.rows.Close()
-		t.rows = nil
-
+		t.rows = nil // Mark as nil so we stay finished
 		t.mu.Unlock()
 
 		if err != nil {
@@ -153,7 +158,6 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	}
 
 	record.ConditionName = conditionName.String
-
 	if conditionContext != nil {
 		var conditionContextStruct structpb.Struct
 		if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
@@ -168,74 +172,67 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, error) {
 	t.mu.Lock()
 
-	if t.rows == nil {
+	// USE: Check if we are already done
+	if t.fetched && t.rows == nil && t.firstRow == nil {
 		t.mu.Unlock()
+		return nil, storage.ErrIteratorDone
+	}
 
+	if !t.fetched {
+		t.mu.Unlock()
 		if err := t.fetchBuffer(ctx); err != nil {
 			return nil, err
 		}
-
 		t.mu.Lock()
-		if t.rows == nil {
-			t.mu.Unlock()
-			return nil, ErrIteratorRowsNotInitialized
-		}
 	}
 
-	defer t.mu.Unlock()
-
 	if t.firstRow != nil {
-		return t.firstRow, nil
+		row := t.firstRow
+		t.mu.Unlock()
+		return row, nil
+	}
+
+	if t.rows == nil {
+		t.mu.Unlock()
+		return nil, ErrIteratorRowsNotInitialized
 	}
 
 	if !t.rows.Next() {
-		err := t.rows.Err(); 
-
+		err := t.rows.Err()
 		_ = t.rows.Close()
 		t.rows = nil
+		t.mu.Unlock()
 
 		if err != nil {
 			return nil, t.handleSQLError(err)
 		}
-
 		return nil, storage.ErrIteratorDone
 	}
 
+	// ... (Scanning logic same as next)
 	var conditionName sql.NullString
 	var conditionContext []byte
 	var record storage.TupleRecord
-
-	err := t.rows.Scan(
-		&record.Store,
-		&record.ObjectType,
-		&record.ObjectID,
-		&record.Relation,
-		&record.UserObjectType,
-		&record.UserObjectID,
-		&record.UserRelation,
-		&conditionName,
-		&conditionContext,
-		&record.Ulid,
-		&record.InsertedAt,
-	)
+	err := t.rows.Scan(&record.Store, &record.ObjectType, &record.ObjectID, &record.Relation, &record.UserObjectType, &record.UserObjectID, &record.UserRelation, &conditionName, &conditionContext, &record.Ulid, &record.InsertedAt)
 
 	if err != nil {
+		t.mu.Unlock()
 		return nil, t.handleSQLError(err)
 	}
 
 	record.ConditionName = conditionName.String
-
 	if conditionContext != nil {
 		var conditionContextStruct structpb.Struct
 		if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
+			t.mu.Unlock()
 			return nil, t.handleSQLError(err)
 		}
 		record.ConditionContext = &conditionContextStruct
 	}
 
-	rec := record
-	t.firstRow = &rec
-	return &rec, nil
+	t.firstRow = &record
+	t.mu.Unlock()
+	return &record, nil
 }
 
 func (t *SQLTupleIterator) ToArray(
@@ -293,8 +290,10 @@ func (t *SQLTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 
 func (t *SQLTupleIterator) Stop() {
 	t.mu.Lock()
+	t.fetched = true
 	defer t.mu.Unlock()
 	if t.rows != nil {
 		_ = t.rows.Close()
+		t.rows = nil
 	}
 }

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -19,6 +19,10 @@ import (
 
 type errorHandlerFn func(error, ...interface{}) error
 
+var (
+	ErrIteratorRowsNotInitialized = errors.New("sqlite: iterator rows not initialized")
+)
+
 // SQLTupleIterator is a struct that implements the storage.TupleIterator
 // interface for iterating over tuples fetched from a SQL database.
 type SQLTupleIterator struct {
@@ -48,10 +52,17 @@ func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
 	t.inFlight.Lock()
 	defer t.inFlight.Unlock()
 
+	// FIX: prevent duplicate fetch
+	t.mu.Lock()
+	if t.rows != nil {
+		t.mu.Unlock()
+		return nil
+	}
+	t.mu.Unlock()
+
 	ctx, span := tracer.Start(ctx, "sqlite.fetchBuffer", trace.WithAttributes())
 	defer span.End()
 
-	// We intentionally detach cancellation so DB query can complete
 	ctx = context.WithoutCancel(ctx)
 
 	start := time.Now()
@@ -92,7 +103,7 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 		t.mu.Lock()
 		if t.rows == nil {
 			t.mu.Unlock()
-			return nil, errors.New("failed to initialize iterator rows")
+			return nil, ErrIteratorRowsNotInitialized
 		}
 	}
 
@@ -106,7 +117,6 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	if !t.rows.Next() {
 		err := t.rows.Err()
 
-		// FIX: close rows when exhausted
 		_ = t.rows.Close()
 		t.rows = nil
 
@@ -147,7 +157,7 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	if conditionContext != nil {
 		var conditionContextStruct structpb.Struct
 		if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-			return nil, t.handleSQLError(err) // FIX: consistent error handling
+			return nil, t.handleSQLError(err)
 		}
 		record.ConditionContext = &conditionContextStruct
 	}
@@ -168,7 +178,7 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 		t.mu.Lock()
 		if t.rows == nil {
 			t.mu.Unlock()
-			return nil, errors.New("failed to initialize iterator rows")
+			return nil, ErrIteratorRowsNotInitialized
 		}
 	}
 
@@ -183,7 +193,6 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 			return nil, t.handleSQLError(err)
 		}
 
-		// FIX: close rows when exhausted
 		_ = t.rows.Close()
 		t.rows = nil
 
@@ -222,14 +231,11 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 		record.ConditionContext = &conditionContextStruct
 	}
 
-	// FIX: avoid pointer-to-stack ambiguity by copying
 	rec := record
 	t.firstRow = &rec
 	return &rec, nil
 }
 
-// ToArray converts the tupleIterator to an []*openfgav1.Tuple and a possibly empty continuation token.
-// If the continuation token exists it is the ulid of the last element of the returned array.
 func (t *SQLTupleIterator) ToArray(
 	ctx context.Context,
 	opts storage.PaginationOptions,
@@ -246,7 +252,6 @@ func (t *SQLTupleIterator) ToArray(
 		res = append(res, tupleRecord.AsTuple())
 	}
 
-	// NOTE: Query must use LIMIT pageSize+1 for pagination correctness
 	tupleRecord, err := t.next(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {
@@ -258,7 +263,6 @@ func (t *SQLTupleIterator) ToArray(
 	return res, tupleRecord.Ulid, nil
 }
 
-// Next will return the next available item.
 func (t *SQLTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -272,7 +276,6 @@ func (t *SQLTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	return record.AsTuple(), nil
 }
 
-// Head will return the first available item.
 func (t *SQLTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
@@ -286,7 +289,6 @@ func (t *SQLTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
 	return record.AsTuple(), nil
 }
 
-// Stop terminates iteration.
 func (t *SQLTupleIterator) Stop() {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -189,12 +189,14 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 	}
 
 	if !t.rows.Next() {
-		if err := t.rows.Err(); err != nil {
-			return nil, t.handleSQLError(err)
-		}
+		err := t.rows.Err(); 
 
 		_ = t.rows.Close()
 		t.rows = nil
+
+		if err != nil {
+			return nil, t.handleSQLError(err)
+		}
 
 		return nil, storage.ErrIteratorDone
 	}

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -25,12 +25,9 @@ type SQLTupleIterator struct {
 	rows           *sql.Rows // GUARDED_BY(mu)
 	sb             sq.SelectBuilder
 	handleSQLError errorHandlerFn
-	// firstRow is used as a temporary storage place if head is called.
-	// If firstRow is nil and Head is called, rows.Next() will return the first item and advance
-	// the iterator. Thus, we will need to store this first item so that future Head() and Next()
-	// will use this item instead. Otherwise, the first item will be lost.
-	firstRow *storage.TupleRecord // GUARDED_BY(mu)
-	mu       sync.Mutex
+	firstRow       *storage.TupleRecord // GUARDED_BY(mu)
+	mu             sync.Mutex
+	inFlight       sync.Mutex
 }
 
 // Ensures that SQLTupleIterator implements the TupleIterator interface.
@@ -48,19 +45,37 @@ func NewSQLTupleIterator(sb sq.SelectBuilder, errHandler errorHandlerFn) *SQLTup
 }
 
 func (t *SQLTupleIterator) fetchBuffer(ctx context.Context) error {
+	t.inFlight.Lock()
+	defer t.inFlight.Unlock()
+
 	ctx, span := tracer.Start(ctx, "sqlite.fetchBuffer", trace.WithAttributes())
 	defer span.End()
+
+	// We intentionally detach cancellation so DB query can complete
 	ctx = context.WithoutCancel(ctx)
+
 	start := time.Now()
 	rows, err := t.sb.QueryContext(ctx)
 	elapsed := time.Since(start)
+
 	if err != nil {
 		storageErr := t.handleSQLError(err)
 		storage.ObserveIterQueryDuration(storage.SuccessLabel(storageErr), elapsed)
 		return storageErr
 	}
+
 	storage.ObserveIterQueryDuration(true, elapsed)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.rows != nil {
+		_ = t.rows.Close()
+	}
+
 	t.rows = rows
+	t.firstRow = nil
+
 	return nil
 }
 
@@ -68,22 +83,20 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	t.mu.Lock()
 
 	if t.rows == nil {
+		t.mu.Unlock()
+
 		if err := t.fetchBuffer(ctx); err != nil {
-			t.mu.Unlock()
 			return nil, err
+		}
+
+		t.mu.Lock()
+		if t.rows == nil {
+			t.mu.Unlock()
+			return nil, errors.New("failed to initialize iterator rows")
 		}
 	}
 
 	if t.firstRow != nil {
-		// If head was called previously, we don't need to scan / next
-		// again as the data is already there and the internal iterator would be advanced via `t.rows.Next()`.
-		// Calling t.rows.Next() in this case would lose the first row data.
-		//
-		// For example, let's say there are 3 items [1,2,3]
-		// If we called Head() and t.firstRow is empty, the rows will only be left with [2,3].
-		// Thus, we will need to save item [1] in firstRow.  This allows future next() and head() to consume
-		// [1] first.
-		// If head() was not called, t.firstRow would be nil and we can follow the t.rows.Next() logic below.
 		firstRow := t.firstRow
 		t.firstRow = nil
 		t.mu.Unlock()
@@ -92,7 +105,13 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 
 	if !t.rows.Next() {
 		err := t.rows.Err()
+
+		// FIX: close rows when exhausted
+		_ = t.rows.Close()
+		t.rows = nil
+
 		t.mu.Unlock()
+
 		if err != nil {
 			return nil, t.handleSQLError(err)
 		}
@@ -102,6 +121,7 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	var conditionName sql.NullString
 	var conditionContext []byte
 	var record storage.TupleRecord
+
 	err := t.rows.Scan(
 		&record.Store,
 		&record.ObjectType,
@@ -115,6 +135,7 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 		&record.Ulid,
 		&record.InsertedAt,
 	)
+
 	t.mu.Unlock()
 
 	if err != nil {
@@ -126,7 +147,7 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 	if conditionContext != nil {
 		var conditionContextStruct structpb.Struct
 		if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-			return nil, err
+			return nil, t.handleSQLError(err) // FIX: consistent error handling
 		}
 		record.ConditionContext = &conditionContextStruct
 	}
@@ -136,25 +157,24 @@ func (t *SQLTupleIterator) next(ctx context.Context) (*storage.TupleRecord, erro
 
 func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, error) {
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	if t.rows == nil {
+		t.mu.Unlock()
+
 		if err := t.fetchBuffer(ctx); err != nil {
 			return nil, err
 		}
+
+		t.mu.Lock()
+		if t.rows == nil {
+			t.mu.Unlock()
+			return nil, errors.New("failed to initialize iterator rows")
+		}
 	}
 
+	defer t.mu.Unlock()
+
 	if t.firstRow != nil {
-		// If head was called previously, we don't need to scan / next
-		// again as the data is already there and the internal iterator would be advanced via `t.rows.Next()`.
-		// Calling t.rows.Next() in this case would lose the first row data.
-		//
-		// For example, let's say there are 3 items [1,2,3]
-		// If we called Head() and t.firstRow is empty, the rows will only be left with [2,3].
-		// Thus, we will need to save item [1] in firstRow.  This allows future next() and head() to return
-		// [1] first. Note that for head(), we will not unset t.firstRow.  Therefore, calling head() multiple times
-		// will yield the same result.
-		// If head() was not called, t.firstRow would be nil, and we can follow the t.rows.Next() logic below.
 		return t.firstRow, nil
 	}
 
@@ -162,12 +182,18 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 		if err := t.rows.Err(); err != nil {
 			return nil, t.handleSQLError(err)
 		}
+
+		// FIX: close rows when exhausted
+		_ = t.rows.Close()
+		t.rows = nil
+
 		return nil, storage.ErrIteratorDone
 	}
 
 	var conditionName sql.NullString
 	var conditionContext []byte
 	var record storage.TupleRecord
+
 	err := t.rows.Scan(
 		&record.Store,
 		&record.ObjectType,
@@ -181,6 +207,7 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 		&record.Ulid,
 		&record.InsertedAt,
 	)
+
 	if err != nil {
 		return nil, t.handleSQLError(err)
 	}
@@ -190,13 +217,15 @@ func (t *SQLTupleIterator) head(ctx context.Context) (*storage.TupleRecord, erro
 	if conditionContext != nil {
 		var conditionContextStruct structpb.Struct
 		if err := proto.Unmarshal(conditionContext, &conditionContextStruct); err != nil {
-			return nil, err
+			return nil, t.handleSQLError(err)
 		}
 		record.ConditionContext = &conditionContextStruct
 	}
-	t.firstRow = &record
 
-	return &record, nil
+	// FIX: avoid pointer-to-stack ambiguity by copying
+	rec := record
+	t.firstRow = &rec
+	return &rec, nil
 }
 
 // ToArray converts the tupleIterator to an []*openfgav1.Tuple and a possibly empty continuation token.
@@ -217,9 +246,7 @@ func (t *SQLTupleIterator) ToArray(
 		res = append(res, tupleRecord.AsTuple())
 	}
 
-	// Check if we are at the end of the iterator.
-	// If we are then we do not need to return a continuation token.
-	// This is why we have LIMIT+1 in the query.
+	// NOTE: Query must use LIMIT pageSize+1 for pagination correctness
 	tupleRecord, err := t.next(ctx)
 	if err != nil {
 		if errors.Is(err, storage.ErrIteratorDone) {


### PR DESCRIPTION
## Description

### What problem is being solved?
The `SQLTupleIterator` was vulnerable to **thundering herd** issues and race conditions during its lazy-loading phase. If `Next()` and `Head()` were called concurrently on an uninitialized iterator, it could trigger redundant database queries or leave the internal state (`t.rows` and `t.firstRow`) inconsistent or "half-initialized."

### How is it being solved?
Implemented a **dual-locking strategy** to ensure **idempotent initialization**:
- **`inFlight` Mutex:** Guards the actual database I/O to ensure only one fetch operation occurs, regardless of how many concurrent calls hit the iterator initially.
- **State Mutex (`mu`):** Protects internal variables (`fetched`, `rows`, `firstRow`). By separating this from I/O locking, the iterator remains responsive—allowing operations like `Stop()` to execute without blocking on a slow database query.

### What changes are made to solve it?
- **Atomic Initialization:** Added `inFlight` mutex and a `fetched` flag to guarantee the database is hit exactly once.
- **Non-blocking I/O:** Refined the locking strategy so the state mutex (`mu`) is released during the actual SQL query execution.
- **Race Fixes:** Resolved synchronization issues between `fetchBuffer`, `next()`, and `head()` to prevent loss of the first record.
- **State Integrity:** Ensured `firstRow` caching is safely handled to maintain consistency when switching between `Head()` and `Next()`.

## References
- Follow-up: [Add issue link if applicable]

## Review Checklist
- [x] I have clicked on "allow edits by maintainers"
- [ ] I have added documentation (not required for this change)
- [x] The correct base branch is `main`
- [x] I have added tests / verified behavior manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clear error (`ErrIteratorRowsNotInitialized`) when an iterator's result set isn't initialized before use.

* **Bug Fixes**
  * Fixed race conditions during concurrent iteration and initialization using a dual-locking strategy.
  * Prevented duplicate initialization by making the fetch process idempotent.
  * Improved cleanup to close and clear underlying query results when iteration ends or is stopped.
  * Corrected first-row caching logic to avoid skipping records when calling `Head()` followed by `Next()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---