### PR TITLE
fix: error handler panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Fixed a potential panic within command error handling. [#3091](https://github.com/openfga/openfga/pull/3091)
 
 ## [1.15.0] - 2026-04-27
 ### Changed

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -294,6 +294,10 @@ func TestCheckCommandErrorToServerError(t *testing.T) {
 				},
 			),
 		},
+		`9`: {
+			inputError:    nil,
+			expectedError: serverErrors.ErrNil,
+		},
 	}
 
 	for name, testCase := range testcases {

--- a/pkg/server/commands/check_command_test.go
+++ b/pkg/server/commands/check_command_test.go
@@ -284,6 +284,16 @@ func TestCheckCommandErrorToServerError(t *testing.T) {
 			inputError:    ofga_errors.ErrUnknown,
 			expectedError: ofga_errors.ErrUnknown,
 		},
+		`8`: {
+			inputError: &tuple.InvalidTupleError{
+				Cause: &InvalidTupleError{Cause: errors.New("oh no")},
+			},
+			expectedError: serverErrors.HandleTupleValidateError(
+				&tuple.InvalidTupleError{
+					Cause: &InvalidTupleError{Cause: errors.New("oh no")},
+				},
+			),
+		},
 	}
 
 	for name, testCase := range testcases {

--- a/pkg/server/commands/errors.go
+++ b/pkg/server/commands/errors.go
@@ -11,8 +11,6 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
-var errInvalidTuple *tuple.InvalidTupleError
-
 type InvalidTupleError struct {
 	Cause error
 }
@@ -105,8 +103,9 @@ func CheckCommandErrorToServerError(err error) error {
 		return serverErrors.HandleTupleValidateError(&tupleError)
 	}
 
-	if errors.Is(err, errInvalidTuple) {
-		return serverErrors.HandleTupleValidateError(err)
+	var errInvalidTuple *tuple.InvalidTupleError
+	if errors.As(err, &errInvalidTuple) {
+		return serverErrors.HandleTupleValidateError(errInvalidTuple)
 	}
 
 	if errors.Is(err, graph.ErrResolutionDepthExceeded) {

--- a/pkg/server/errors/errors.go
+++ b/pkg/server/errors/errors.go
@@ -33,6 +33,8 @@ var (
 
 	// ErrTransactionThrottled can apply when a limit is hit at the database level.
 	ErrTransactionThrottled = status.Error(codes.ResourceExhausted, "transaction was throttled by the datastore")
+
+	ErrNil = errors.New("nil")
 )
 
 type InternalError struct {
@@ -63,6 +65,10 @@ func (e InternalError) GRPCStatus() *status.Status {
 func NewInternalError(public string, internal error) InternalError {
 	if public == "" {
 		public = InternalServerErrorMsg
+	}
+
+	if internal == nil {
+		internal = ErrNil
 	}
 
 	return InternalError{


### PR DESCRIPTION


<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Currently there is a potential for a line of code to be reached that will always pass a `nil` value to `errors.Is` as the target value, resulting in a panic when ultimately an attempt is made to call `Error()` on the `nil` value. The call to `(*tuple.InvalidTupleError).Error()` attempts to access a struct field on the `nil` receiver value, resulting in a `nil` pointer dereference.

#### What problem is being solved?
Fix the code that can result in a panic.

#### How is it being solved?
Use the proper method `errors.As`, to inspect the error of type `tuple.InvalidTupleError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tuple validation error detection and ensured nil internal errors are handled to prevent a potential panic during command error handling.
* **Tests**
  * Added a unit test verifying correct conversion and handling of tuple validation errors (including nil input).
* **Chores**
  * Added an Unreleased “Fixed” entry to the changelog documenting this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->