### PR TITLE
fix: move subproblem cache lookup from ResolveUnionEdges into ResolveUnion

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -167,10 +167,6 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	if res, ok := r.isCached(req.GetConsistency(), req.GetCacheKey()); ok {
-		return res, nil
-	}
-
 	out := make(chan ResponseMsg, len(edges))
 	var pool errgroup.Group
 	pool.SetLimit(r.concurrencyLimit)
@@ -237,6 +233,10 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 
 // reduce as a logical union operation (exit the moment we have a single true).
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
+	if res, ok := r.isCached(req.GetConsistency(), req.GetCacheKey()); ok {
+		return res, nil
+	}
+
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {
 		// initialize visited map for first time,

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -215,8 +215,6 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 
 			if msg.Res.GetAllowed() {
 				// Short-circuit: In a union, if any branch returns true, we can immediately return.
-				entry := &ResponseCacheEntry{Res: msg.Res, LastModified: time.Now()}
-				r.cache.Set(req.GetCacheKey(), entry, r.cacheTTL)
 				return msg.Res, nil
 			}
 		}
@@ -226,16 +224,22 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 		return nil, err
 	}
 	res := &Response{Allowed: false}
-	entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
-	r.cache.Set(req.GetCacheKey(), entry, r.cacheTTL)
 	return res, nil
 }
 
 // reduce as a logical union operation (exit the moment we have a single true).
-func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
+func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (resp *Response, err error) {
 	if res, ok := r.isCached(req.GetConsistency(), req.GetCacheKey()); ok {
 		return res, nil
 	}
+
+	defer func() {
+		if err != nil {
+			return
+		}
+		entry := &ResponseCacheEntry{Res: resp, LastModified: time.Now()}
+		r.cache.Set(req.GetCacheKey(), entry, r.cacheTTL)
+	}()
 
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -185,7 +185,7 @@ func TestResolveUnionEdges(t *testing.T) {
 					return nil, storage.ErrNotFound
 				}
 				return &openfgav1.Tuple{Key: tuple.NewTupleKey("group:1", "member", "user:maria")}, nil
-			}).MaxTimes(2)
+			}).MinTimes(1)
 
 		resolver := New(Config{
 			Model:            mg,

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -22,6 +22,141 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 )
 
+func TestResolveUnion(t *testing.T) {
+	t.Run("cache_hit_on_union", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+            model
+              schema 1.1
+            type user
+            type group
+              relations
+                define member: [user] or admin
+                define admin: [user]
+        `)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		cachedEntry := &ResponseCacheEntry{
+			Res:          &Response{Allowed: true},
+			LastModified: time.Now(),
+		}
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			ConcurrencyLimit:          10,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+		})
+
+		req, err := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+		})
+		require.NoError(t, err)
+
+		mockCache.EXPECT().Get(req.GetCacheKey()).Return(cachedEntry).Times(1)
+
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+
+		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
+		require.NoError(t, err)
+		require.True(t, res.Allowed)
+	})
+
+	t.Run("partial_cache_hits", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+            model
+              schema 1.1
+            type user
+            type group
+              relations
+                define member: [user] or admin or owner
+                define admin: [user]
+                define owner: [user]
+        `)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		cachedFalse := &ResponseCacheEntry{
+			Res:          &Response{Allowed: false},
+			LastModified: time.Now(),
+		}
+
+		req, err := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+		})
+		require.NoError(t, err)
+
+		// the first cache call should be to check for a subproblem cache entry
+		mockCache.EXPECT().Get(req.GetCacheKey()).Return(nil).Times(1)
+
+		// simulate an edge with a cached false result
+		mockCache.EXPECT().Get(gomock.Any()).Return(cachedFalse).Times(1)
+
+		// other two edges call cache, but get nothing
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).Times(2)
+
+		// only two edges will call to datastore because one was cached
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			DoAndReturn(
+				func(
+					_ context.Context,
+					_ string,
+					filter storage.ReadUserTupleFilter,
+					_ storage.ReadUserTupleOptions,
+				) (*openfgav1.Tuple, error) {
+					return &openfgav1.Tuple{Key: tuple.NewTupleKey(filter.Object, filter.Relation, filter.User)}, nil
+				}).Times(2)
+
+		// each edge sets the results of its resolution
+		edgeCacheSets := mockCache.EXPECT().
+			Set(gomock.Not(gomock.Eq(req.GetCacheKey())), gomock.Any(), gomock.Any()).
+			Times(2)
+
+		// the last cache call should be to set the subproblem cache entry
+		mockCache.EXPECT().
+			Set(req.GetCacheKey(), gomock.Any(), gomock.Any()).
+			After(edgeCacheSets).
+			Times(1)
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			ConcurrencyLimit:          10,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+		})
+
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+
+		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
+		require.NoError(t, err)
+		require.True(t, res.Allowed)
+	})
+}
+
 func TestResolveUnionEdges(t *testing.T) {
 	t.Run("short_circuit_on_first_true", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -126,127 +261,6 @@ func TestResolveUnionEdges(t *testing.T) {
 		res, err := resolver.ResolveUnionEdges(context.Background(), req, edges, nil)
 		require.NoError(t, err)
 		require.False(t, res.GetAllowed())
-	})
-
-	t.Run("cache_hit_on_union", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		storeID := ulid.Make().String()
-		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
-		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
-
-		model := testutils.MustTransformDSLToProtoWithID(`
-            model
-              schema 1.1
-            type user
-            type group
-              relations
-                define member: [user] or admin
-                define admin: [user]
-        `)
-
-		mg, err := modelgraph.New(model)
-		require.NoError(t, err)
-
-		cachedEntry := &ResponseCacheEntry{
-			Res:          &Response{Allowed: true},
-			LastModified: time.Now(),
-		}
-
-		resolver := New(Config{
-			Model:                     mg,
-			Datastore:                 mockDatastore,
-			Cache:                     mockCache,
-			ConcurrencyLimit:          10,
-			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
-		})
-
-		req, err := NewRequest(RequestParams{
-			StoreID:  storeID,
-			Model:    mg,
-			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
-		})
-		require.NoError(t, err)
-
-		mockCache.EXPECT().Get(req.GetCacheKey()).Return(cachedEntry).Times(1)
-
-		node, ok := mg.GetNodeByID("group#member")
-		require.True(t, ok)
-
-		edges, err := mg.FlattenNode(node, "user", false, false)
-		require.NoError(t, err)
-		require.True(t, ok)
-
-		res, err := resolver.ResolveUnionEdges(context.Background(), req, edges, nil)
-		require.NoError(t, err)
-		require.True(t, res.Allowed)
-	})
-
-	t.Run("partial_cache_hits", func(t *testing.T) {
-		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
-
-		storeID := ulid.Make().String()
-		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
-		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
-
-		model := testutils.MustTransformDSLToProtoWithID(`
-            model
-              schema 1.1
-            type user
-            type group
-              relations
-                define member: [user] or admin or owner
-                define admin: [user]
-                define owner: [user]
-        `)
-
-		mg, err := modelgraph.New(model)
-		require.NoError(t, err)
-
-		cachedFalse := &ResponseCacheEntry{
-			Res:          &Response{Allowed: false},
-			LastModified: time.Now(),
-		}
-
-		// First call checks union cache (miss), then checks edge caches
-		mockCache.EXPECT().Get(gomock.Any()).Return(nil).Times(1)
-		mockCache.EXPECT().Get(gomock.Any()).Return(cachedFalse).Times(1)
-		mockCache.EXPECT().Get(gomock.Any()).Return(nil).Times(1)
-		mockCache.EXPECT().Get(gomock.Any()).Return(nil).Times(1)
-
-		// Only two edges need to be evaluated (one was cached)
-		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Return(&openfgav1.Tuple{Key: tuple.NewTupleKey("group:1", "owner", "user:maria")}, nil).Times(2)
-
-		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-
-		resolver := New(Config{
-			Model:                     mg,
-			Datastore:                 mockDatastore,
-			Cache:                     mockCache,
-			ConcurrencyLimit:          10,
-			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
-		})
-
-		req, err := NewRequest(RequestParams{
-			StoreID:  storeID,
-			Model:    mg,
-			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
-		})
-		require.NoError(t, err)
-
-		node, ok := mg.GetNodeByID("group#member")
-		require.True(t, ok)
-
-		edges, err := mg.FlattenNode(node, "user", false, false)
-		require.NoError(t, err)
-		require.True(t, ok)
-
-		res, err := resolver.ResolveUnionEdges(context.Background(), req, edges, nil)
-		require.NoError(t, err)
-		require.True(t, res.Allowed)
 	})
 
 	t.Run("error_on_one_edge_returns_error_when_all_fail", func(t *testing.T) {
@@ -379,9 +393,6 @@ func TestResolveUnionEdges(t *testing.T) {
 
 		mg, err := modelgraph.New(model)
 		require.NoError(t, err)
-
-		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
-		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
When a cache entry exists, this change eliminates unnecessary goroutines and queries within `ResolveRecursive`. Currently `ResolveRecursive` is only called by `ResolveUnion` and `ResolveUnionEdges` is called by `ResolveUnion` and `ResolveRecursive`.

#### What problem is being solved?
Currently, when `ResolveUnion` calls `ResolveRecursive`, two goroutines are spawned and begin to execute queries for their respective subproblems. The first goroutine calls `ResolveUnionEdges` which checks the subproblem cache for the current request. If a request cache entry exists, it returns immediately. If the returned response has `Allowed == true`, the second goroutine is short-circuited via context cancelation.

`ResolveUnion` begins the resolution of the request subproblem for a given node; the cached request subproblem entry represents the resolution of all branches on that node, thus checking for the existence of a cache entry at the top of `ResolveUnion` is logical.

The spawning of the two goroutines in `ResolveRecursive` can be avoided entirely by moving the request subproblem cache check into `ResolveUnion`.

Additionally, `ResolveUnionEdges` is currently setting the subproblem cache entry when it fails to establish reachability. Moving the checking of the subproblem cache entry into `ResolveUnion` requires that we also move setting the cache entry into `ResolveUnion`. This is especially important when `ResolveRecursive` is called by `ResolveUnion`; when `ResolveUnionEdges` sets the cache to `false`, there is still an opportunity for the recursive edges to return a `true` value. If `ResolveUnionEdges` cached a `false` value for the subproblem in this scenario, subsequent calls to `ResolveUnion` will observe a `false` cache entry and return immediately.

#### How is it being solved?
Move the request subproblem cache lookup out of `ResolveUnionEdges` into `ResolveUnion`. This ensures that the cache is checked before `ResolveRecursive` is called and before `ResolveUnionEdges` is called, either by `ResolveUnion` or `ResolveRecursive`.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and reorganized union-resolution caching so request-level results are checked early and actual caching is deferred until a successful computation; no user-visible behavior changes.
* **Tests**
  * Updated and refactored union-resolution tests to validate the new caching interactions and ensure correct outcomes across cached, partial-hit, and empty scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->