### PR TITLE
fix: expose context errors when they can be the potential cause of an underlying datastore error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Fixed
 - Fixed a potential panic within command error handling. [#3091](https://github.com/openfga/openfga/pull/3091)
+- Fixed a bug that propagated expected errors from list objects when a path short-circuits. [#3096](https://github.com/openfga/openfga/pull/3096)
 
 ## [1.15.0] - 2026-04-27
 ### Changed

--- a/internal/listobjects/pipeline/store.go
+++ b/internal/listobjects/pipeline/store.go
@@ -140,13 +140,12 @@ type TupleKeyItemReceiver struct {
 }
 
 // Recv returns the next object identifier from the underlying iterator.
-// It returns false when the iterator is exhausted, closed, or the context
-// is cancelled.
+// It returns false when the iterator is exhausted or closed.
 func (r *TupleKeyItemReceiver) Recv(ctx context.Context) (Item, bool) {
 	var item Item
 
 	for {
-		if r.closed.Load() || ctx.Err() != nil {
+		if r.closed.Load() {
 			return item, false
 		}
 		t, err := r.itr.Next(ctx)

--- a/internal/listobjects/pipeline/store.go
+++ b/internal/listobjects/pipeline/store.go
@@ -112,6 +112,9 @@ func (r *ValidatingStore) createIterator(
 	)
 
 	if err != nil {
+		// The context error is a potential cause of the
+		// datastore error; expose the context error.
+		err = errors.Join(ctx.Err(), err)
 		return iterator.Error[*openfgav1.Tuple](fmt.Errorf("datastore: %w", err))
 	}
 	return it
@@ -153,6 +156,10 @@ func (r *TupleKeyItemReceiver) Recv(ctx context.Context) (Item, bool) {
 			if errors.Is(err, storage.ErrIteratorDone) {
 				return item, false
 			}
+
+			// The context error is a potential cause of the
+			// datastore error; expose the context error.
+			err = errors.Join(ctx.Err(), err)
 			item.Err = fmt.Errorf("iterator: %w", err)
 			return item, true
 		}

--- a/internal/listobjects/pipeline/store_test.go
+++ b/internal/listobjects/pipeline/store_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
@@ -14,6 +15,88 @@ import (
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/storage"
 )
+
+var ErrTestDatastore = errors.New("test datastore")
+var ErrTestIterator = errors.New("test iterator")
+
+type TestTupleIterator struct {
+	storage.TupleIterator
+}
+
+func (i *TestTupleIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
+	if ctx.Err() != nil {
+		return nil, ErrTestIterator
+	}
+	return nil, storage.ErrIteratorDone
+}
+
+func (i *TestTupleIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
+	if ctx.Err() != nil {
+		return nil, ErrTestIterator
+	}
+	return nil, storage.ErrIteratorDone
+}
+
+func (i *TestTupleIterator) Stop() {}
+
+type TestTupleReader struct {
+	storage.RelationshipTupleReader
+}
+
+func (s *TestTupleReader) ReadStartingWithUser(
+	ctx context.Context,
+	store string,
+	filter storage.ReadStartingWithUserFilter,
+	options storage.ReadStartingWithUserOptions,
+) (storage.TupleIterator, error) {
+	if ctx.Err() != nil {
+		return nil, ErrTestDatastore
+	}
+	return &TestTupleIterator{}, nil
+}
+
+func TestStore_ContextCancelation(t *testing.T) {
+	t.Run("cancel before query", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var reader TestTupleReader
+		store := pipeline.NewValidatingStore(&reader, Store)
+
+		receiver := store.Read(ctx, pipeline.ObjectQuery{
+			ObjectType: "test",
+			Relation:   "test",
+			Users:      []string{"test"},
+			Conditions: []string{},
+		})
+
+		item, ok := receiver.Recv(context.Background())
+		require.True(t, ok)
+		require.ErrorIs(t, item.Err, context.Canceled)
+		require.ErrorIs(t, item.Err, ErrTestDatastore)
+	})
+
+	t.Run("cancel after query", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var reader TestTupleReader
+		store := pipeline.NewValidatingStore(&reader, Store)
+
+		receiver := store.Read(ctx, pipeline.ObjectQuery{
+			ObjectType: "test",
+			Relation:   "test",
+			Users:      []string{"test"},
+			Conditions: []string{},
+		})
+
+		cancel()
+
+		item, ok := receiver.Recv(ctx)
+		require.True(t, ok)
+		require.ErrorIs(t, item.Err, context.Canceled)
+		require.ErrorIs(t, item.Err, ErrTestIterator)
+	})
+}
 
 func TestReaderRead(t *testing.T) {
 	t.Run("yields objects from matching tuples", func(t *testing.T) {
@@ -168,7 +251,7 @@ func TestReaderRead(t *testing.T) {
 		}
 	})
 
-	t.Run("context cancellation stops iteration", func(t *testing.T) {
+	t.Run("context cancelation stops iteration", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		store := mocks.NewMockRelationshipTupleReader(ctrl)
 
@@ -194,17 +277,21 @@ func TestReaderRead(t *testing.T) {
 		})
 		defer receiver.Close()
 
+		var err error
+
 		for {
-			_, ok := receiver.Recv(ctx)
+			item, ok := receiver.Recv(ctx)
 			if !ok {
 				break
 			}
+			err = item.Err
 			count++
 		}
 
-		if count > 0 {
-			t.Fatalf("expected no items from cancelled context, got %d", count)
+		if count != 1 {
+			t.Fatalf("expected one item from cancelled context, got %d", count)
 		}
+		require.ErrorIs(t, err, context.Canceled)
 	})
 
 	t.Run("user filter parses userset notation", func(t *testing.T) {


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
When a list objects intersection or difference worker short-circuits during normal operation, it may be possible for the resulting context cancelation to surface a database error.

#### How is it being solved?
When a context cancelation -- or exceeded deadline -- is the cause of an underlying database error, wrap the context error with the database error. This will cause the list objects worker to handle the error properly without causing a cancelation of the entire algorithm.

#### What changes are made to solve it?
Use `errors.Join` to wrap the context error, when present, with the database error. This is done within the list objects data store interface layer.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Read/iteration error reporting now preserves context cancellation so cancellations before or during reads surface complete error information.

* **Tests**
  * Added deterministic tests for cancellation scenarios and tightened expectations for items produced when context is canceled.

* **Documentation**
  * Changelog updated with an Unreleased → Fixed entry describing the list-objects error propagation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->