### PR TITLE
fix(authn/oidc): refresh JWKS on unknown kid to handle key rotation

### DIFF
--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -38,7 +38,8 @@ type RemoteOidcAuthenticator struct {
 }
 
 var (
-	jwkRefreshInterval = 48 * time.Hour
+	jwkRefreshInterval  = 48 * time.Hour
+	jwkRefreshRateLimit = 1 * time.Minute
 
 	errInvalidClaims = status.Error(codes.Code(openfgav1.AuthErrorCode_invalid_claims), "invalid claims")
 	fetchJWKs        = fetchJWK
@@ -185,8 +186,10 @@ func fetchJWK(oidc *RemoteOidcAuthenticator) error {
 
 func (oidc *RemoteOidcAuthenticator) GetKeys() (*keyfunc.JWKS, error) {
 	jwks, err := keyfunc.Get(oidc.JwksURI, keyfunc.Options{
-		Client:          oidc.httpClient,
-		RefreshInterval: jwkRefreshInterval,
+		Client:            oidc.httpClient,
+		RefreshInterval:   jwkRefreshInterval,
+		RefreshUnknownKID: true,
+		RefreshRateLimit:  jwkRefreshRateLimit,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching keys from %v: %w", oidc.JwksURI, err)


### PR DESCRIPTION
## Summary

- Set `RefreshUnknownKID: true` on the `keyfunc.Options` used to build the JWKS, so the cache is refetched when a token arrives with a `kid` that is not currently cached. This is the standard mitigation for issuer key rotation (e.g. AWS EKS rotates every 7 days, which is longer than the 48h periodic refresh).
- Set `RefreshRateLimit: 1 * time.Minute` to protect the issuer from a refresh storm if tokens with unknown `kid`s arrive in bursts. This pairing is recommended by the [keyfunc docs](https://github.com/MicahParks/keyfunc/blob/v2.1.0/options.go) whenever `RefreshUnknownKID` is enabled.

Without `RefreshUnknownKID`, when an issuer evicts an old key from the JWKS between OpenFGA's 48h refreshes, valid tokens signed with the new key are rejected with `invalid claims` until the next periodic refresh or a process restart. See #3099 for the full failure mode and an EKS-specific reproduction.

Closes #3099

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/authn/oidc/...` — existing OIDC tests still pass
- [ ] In a deployment with a rotating issuer (e.g. EKS), confirm that after the issuer evicts the old signing key, OpenFGA accepts tokens signed with the new key without a restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented rate limiting for JSON Web Key (JWK) refreshes to improve system performance and reduce unnecessary refresh operations
  * Enhanced authentication to automatically refresh keys when encountering unknown key identifiers, improving reliability and security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->