### PR TITLE
chore(docker): drop grpc_health_probe from released image

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,14 +2,6 @@
 language: "en-US"
 reviews:
   path_instructions:
-    - path: "Dockerfile"
-      instructions: |
-        When reviewing changes to `Dockerfile`, check if the `ghcr.io/grpc-ecosystem/grpc-health-probe` image reference (version tag and/or digest) was modified.
-
-        If it was changed, verify that `Dockerfile.goreleaser` was also updated in the same PR to use the identical image reference (same version tag and digest). The `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:...` line in `Dockerfile.goreleaser` must match the `FROM ghcr.io/grpc-ecosystem/grpc-health-probe:...` line in `Dockerfile`.
-
-        If `Dockerfile.goreleaser` was not updated to match, flag this as a required change: "The grpc-health-probe image in `Dockerfile.goreleaser` must be updated to match the version in `Dockerfile`."
-
     - path: "CHANGELOG.md"
       instructions: |
         This project uses Keep a Changelog format and Semantic Versioning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Removed
+- Removed the bundled `grpc_health_probe` binary and the `HEALTHCHECK` directive from the released images, so they no longer carry the probe's Go standard library CVE exposure. Kubernetes has supported native gRPC health checking via `livenessProbe.grpc` since v1.23 (GA in v1.24), which covers the primary use case. If you invoke `grpc_health_probe` directly, either switch to `livenessProbe.grpc` or layer the binary on top of the OpenFGA image in your own Dockerfile. [#3103](https://github.com/openfga/openfga/pull/3103)
 
 ## [1.18.3] - 2026-08-05
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.53@sha256:a732f1b3a737926c2902393809b344c9f293b62f7069dbd0614caebd298b2e8d AS grpc_health_probe
-# Please manually update the Dockerfile.goreleaser whenever the grpc health probe is updated
 FROM cgr.dev/chainguard/go:1.26.5@sha256:fd4cfadccffc600948b4d9b3dedb2f447748c5743b58aa66701076a47892c289 AS builder
 
 WORKDIR /app
@@ -22,11 +20,6 @@ EXPOSE 8081
 EXPOSE 8080
 EXPOSE 3000
 
-COPY --from=grpc_health_probe /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 COPY --from=builder /bin/openfga /openfga
-
-# Healthcheck configuration for the container using grpc_health_probe
-# The container will be considered healthy if the gRPC health probe returns a successful response.
-HEALTHCHECK --interval=5s --timeout=30s --retries=3 CMD ["/usr/local/bin/grpc_health_probe", "-addr=:8081"]
 
 ENTRYPOINT ["/openfga"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -2,10 +2,4 @@ FROM cgr.dev/chainguard/static@sha256:60582b2ae6074f641094af0f370d4ab241aab27185
 COPY assets /assets
 COPY openfga /
 
-# Goreleaser does not support multi-stage builds. See:
-# https://github.com/goreleaser/goreleaser/issues/609
-#
-# Dependabot is also not capable of updating inline image copies at this time, so
-# this needs to be updated manually until one of these issues is resolved.
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.53@sha256:a732f1b3a737926c2902393809b344c9f293b62f7069dbd0614caebd298b2e8d /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]

--- a/cmd/openfga/main_test.go
+++ b/cmd/openfga/main_test.go
@@ -161,24 +161,22 @@ func runOpenFGAContainerWithArgs(t *testing.T, commandArgs []string) OpenFGATest
 	grpcHostPort := m[0].HostPort
 
 	if len(commandArgs) > 0 && commandArgs[0] == "run" {
-		// wait for healthy service
+		// The image no longer bundles grpc_health_probe, so it declares no
+		// HEALTHCHECK and the container has no health state to poll. Wait for it
+		// to be running; readiness is asserted from the test process by
+		// EnsureServiceHealthy, which calls the real gRPC and HTTP health
+		// endpoints and is a stronger check than the probe was.
 		policy := backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(30 * time.Second))
 
 		err = backoff.Retry(func() error {
 			inspectResult, err := dockerClient.ContainerInspect(ctx, cont.ID, client.ContainerInspectOptions{})
 			require.NoError(t, err)
-			require.NotNil(t, inspectResult.Container.State.Health)
 
-			if inspectResult.Container.State.Health.Status == container.Healthy {
+			state := inspectResult.Container.State
+			if state.Running {
 				return nil
 			}
-			if inspectResult.Container.State.Health.Status == container.Unhealthy {
-				for _, healthLog := range inspectResult.Container.State.Health.Log {
-					t.Log(healthLog.Output)
-				}
-				return fmt.Errorf("container unhealthy")
-			}
-			return fmt.Errorf("container starting")
+			return fmt.Errorf("container not running (status %q)", state.Status)
 		}, policy)
 		require.NoError(t, err)
 	} else {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,8 +48,3 @@ services:
       - "8081:8081" #grpc
       - "3000:3000" #playground
       - "2112:2112" #prometheus metrics
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
-      interval: 5s
-      timeout: 30s
-      retries: 3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,12 +49,7 @@ services:
       - "3000:3000" #playground
       - "2112:2112" #prometheus metrics
     healthcheck:
-      test:
-        [
-          "CMD",
-          "/usr/local/bin/grpc_health_probe",
-          "-addr=openfga:8081"
-        ]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
       interval: 5s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Fixes #2373

**Why:** `grpc_health_probe` introduces CVE exposure on the openfga image. Kubernetes has had native gRPC health checking (via `livenessProbe.grpc`) since v1.23 (GA since 1.24), so the binary is no longer necessary for the primary use case.

**Changes:**
- Removed the `grpc_health_probe` multi-stage copy from `Dockerfile`
- Removed the `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe` line from `Dockerfile.goreleaser`
- Removed the `HEALTHCHECK` directive from `Dockerfile` that depended on the binary

**Migration:** Users on Kubernetes ≥ 1.24 should switch to the native `livenessProbe.grpc` field. Users who need the probe binary can layer it on top of the openfga image in their own Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Released container images no longer include the bundled gRPC health-probe binary.
  * Removed container healthcheck configurations that relied on the probe.
  * Docker Compose deployments no longer define an automatic healthcheck for the service.
  * Kubernetes-native gRPC probes or separately provided probe tooling can be used instead.
* **Tests**
  * Container readiness validation now checks that the service is running and separately verifies endpoint availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->