### PR TITLE
fix: replace golang.org/x/exp/maps with stdlib maps to resolve govet inline errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.1
-	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f
 	golang.org/x/sync v0.20.0
 	gonum.org/v1/gonum v0.17.0
 	google.golang.org/grpc v1.80.0
@@ -129,6 +128,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -3,6 +3,7 @@ package condition
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"sync"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/google/cel-go/common"
 	celtypes "github.com/google/cel-go/common/types"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"

--- a/internal/graph/resolve_check_request.go
+++ b/internal/graph/resolve_check_request.go
@@ -2,11 +2,11 @@ package graph
 
 import (
 	"errors"
+	"maps"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Recently [ran into](https://github.com/openfga/openfga/actions/runs/25243562099/job/74023708782?pr=3102) these linting errors:

```
  Error: internal/condition/condition.go:218:35: inline: cannot inline: type parameter inference is not yet supported (govet)
  	clonedContextFields := maps.Clone(contextFields)
  	                                 ^
  Error: internal/condition/condition.go:221:12: inline: cannot inline: type parameter inference is not yet supported (govet)
  		maps.Copy(clonedContextFields, fields)
  		         ^
  Error: internal/graph/resolve_check_request.go:155:40: inline: cannot inline: type parameter inference is not yet supported (govet)
  		VisitedPaths:              maps.Clone(r.GetVisitedPaths()),
  		                                     ^
```

This started happening because we always use the [latest golangci-lint version](https://github.com/openfga/openfga/blob/f282b6a5e0c021e958aacc48d420ff7507c94a72/.github/workflows/pull_request.yaml#L24) and in the recently released [2.12.0](https://github.com/golangci/golangci-lint/releases/tag/v2.12.0) version, they added [govet: add `inline` analyzer](https://github.com/golangci/golangci-lint/pull/6385).

#### How is it being solved?

Replace `golang.org/x/exp/maps` with the stdlib `maps`, available since Go 1.21. The `golang.org/x/exp/maps` functions mostly just [call the stdlib `maps` functions](https://github.com/golang/exp/blob/746e56fc9e2fafde18176275ce0b96b06ac53955/maps/maps.go#L68) now.

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use Go standard library components instead of external packages, improving long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->