### PR TITLE
fix: cancel context before waiting on worker pool in ResolveUnionEdges

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -173,12 +173,12 @@ func buildEdgeCacheKey(modelID string, req *Request, edge *authzGraph.WeightedAu
 
 func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []*authzGraph.WeightedAuthorizationModelEdge, visited *sync.Map) (*Response, error) {
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	out := make(chan ResponseMsg, len(edges))
 	var pool errgroup.Group
 	pool.SetLimit(r.concurrencyLimit)
 	defer func() {
+		cancel()
 		_ = pool.Wait()
 		close(out)
 	}()


### PR DESCRIPTION
## Change

Moves the `cancel()` call for the derived context from a standalone `defer cancel()` into the existing deferred cleanup function, placing it **before** `pool.Wait()`.

## Why

Previously, `cancel()` was deferred independently, meaning Go's LIFO defer ordering would call it **after** `pool.Wait()` completed. This meant in-flight goroutines in the worker pool would not receive a cancellation signal until the pool had already finished — defeating the purpose of early cancellation when the parent function returns (e.g., due to a short-circuit on a successful union result).

By calling `cancel()` inside the cleanup defer and before `pool.Wait()`, any still-running workers receive the cancellation signal immediately, allowing the pool to drain faster and reducing unnecessary work.

## Impact

- **File changed:** `internal/check/check.go`
- **Risk:** Low — the change is a reordering of existing cleanup logic.
- **Effect:** Reduced latency and resource usage for union edge resolution when an early result is found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of concurrent operations by adjusting cleanup timing during union edge resolution to ensure proper cancellation sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->