### PR TITLE
fix: ensure acquired limiter token is released on throttle context cancelation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Fixed a potential panic within command error handling. [#3091](https://github.com/openfga/openfga/pull/3091)
 - Fixed a bug that propagated expected errors from list objects when a path short-circuits. [#3096](https://github.com/openfga/openfga/pull/3096)
 - Fixed cache key collisions in experimental `weighted_graph_check` for edges in unions with multiple branches (direct types, wildcards, TTU paths, or intersections). [#3097](https://github.com/openfga/openfga/pull/3097)
+- Fixed a bug in the bounded tuple reader that would cause semaphore token leaks under context cancelation. [#3106](https://github.com/openfga/openfga/pull/3106)
 
 ## [1.15.0] - 2026-04-27
 ### Changed

--- a/pkg/storage/storagewrappers/bounded_datastore.go
+++ b/pkg/storage/storagewrappers/bounded_datastore.go
@@ -210,6 +210,7 @@ func (b *BoundedTupleReader) bound(ctx context.Context, op string) error {
 		b.throttled.Store(true)
 		select {
 		case <-ctx.Done():
+			b.done()
 			return ctx.Err()
 		case <-time.After(b.throttleTime):
 			break


### PR DESCRIPTION
## Change

Adds a `b.done()` call in the `BoundedTupleReader.bound()` method when the context is cancelled during the throttle wait period, before returning `ctx.Err()`.

## Why

When a read operation is throttled and waiting in the `select` block, if the context is cancelled (e.g., parent request timeout or cancellation), the function would return the context error without releasing the previously acquired semaphore token. This caused a token leak in the bounded concurrency limiter, gradually exhausting the available permits and potentially starving subsequent read operations.

Calling `b.done()` before returning ensures the token is properly released back to the limiter.

## Impact

- **File changed:** `pkg/storage/storagewrappers/bounded_datastore.go`
- **Risk:** Low — adds a missing cleanup call on an existing error path.
- **Effect:** Prevents semaphore token leaks under context cancellation during throttled reads, improving reliability under load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a resource leak where concurrency limiter slots could remain held when operations are cancelled, ensuring slots are released promptly on context cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->