### PR TITLE
fix: use the same `request_id` for shadow traces in v2Check

### DIFF
--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -208,15 +208,22 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	return res, nil
 }
 
+// linkedSpanContextKey is a context key used to carry the original span context
+// into a detached context so that v2Check can create a trace link back to the
+// original Check span without parenting under it.
+type linkedSpanContextKey struct{}
+
 func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest, mainRes *openfgav1.CheckResponse, mainTook int64, mainDatastoreQueryCount uint32, mainDatastoreItemCount uint64) {
 	start := time.Now()
 	var res *openfgav1.CheckResponse
 	var shadowMetadata storagewrappers.Metadata
 	var err error
+	originalSpanCtx := trace.SpanContextFromContext(ctx)
 	recoveredErr := panics.Try(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
+		newCtx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
 		defer cancel()
-		res, shadowMetadata, err = s.v2Check(ctx, req, s.sharedDatastoreResources.ShadowCheckCache, s.sharedDatastoreResources.ShadowCacheController, s.shadowAuthzModelGraphResolver)
+		newCtx = context.WithValue(newCtx, linkedSpanContextKey{}, originalSpanCtx)
+		res, shadowMetadata, err = s.v2Check(newCtx, req, s.sharedDatastoreResources.ShadowCheckCache, s.sharedDatastoreResources.ShadowCacheController, s.shadowAuthzModelGraphResolver)
 	})
 	if recoveredErr != nil {
 		err = recoveredErr.AsError()
@@ -253,13 +260,20 @@ func (s *Server) v2Check(
 	storeID := req.GetStoreId()
 	tk := req.GetTupleKey()
 
-	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, trace.WithAttributes(
-		attribute.String("store_id", storeID),
-		attribute.String("object", tk.GetObject()),
-		attribute.String("relation", tk.GetRelation()),
-		attribute.String("user", tk.GetUser()),
-		attribute.String("consistency", req.GetConsistency().String()),
-	))
+	spanOpts := []trace.SpanStartOption{
+		trace.WithAttributes(
+			attribute.String("store_id", storeID),
+			attribute.String("object", tk.GetObject()),
+			attribute.String("relation", tk.GetRelation()),
+			attribute.String("user", tk.GetUser()),
+			attribute.String("consistency", req.GetConsistency().String()),
+		),
+	}
+	if linkedSC, ok := ctx.Value(linkedSpanContextKey{}).(trace.SpanContext); ok && linkedSC.IsValid() {
+		spanOpts = append(spanOpts, trace.WithLinks(trace.Link{SpanContext: linkedSC}))
+		spanOpts = append(spanOpts, trace.WithAttributes(attribute.String("request_id", linkedSC.TraceID().String())))
+	}
+	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, spanOpts...)
 	defer span.End()
 
 	cacheInvalidationTime := time.Time{}

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -208,10 +208,9 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	return res, nil
 }
 
-// linkedSpanContextKey is a context key used to carry the original span context
-// into a detached context so that v2Check can create a trace link back to the
-// original Check span without parenting under it.
-type linkedSpanContextKey struct{}
+// requestIDKey is a context key used to propagate the original request_id
+// into the detached shadow context so v2Check spans carry it as an attribute.
+type requestIDKey struct{}
 
 func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest, mainRes *openfgav1.CheckResponse, mainTook int64, mainDatastoreQueryCount uint32, mainDatastoreItemCount uint64) {
 	start := time.Now()
@@ -219,10 +218,19 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 	var shadowMetadata storagewrappers.Metadata
 	var err error
 	originalSpanCtx := trace.SpanContextFromContext(ctx)
+	var shadowTraceID string
 	recoveredErr := panics.Try(func() {
 		newCtx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
 		defer cancel()
-		newCtx = context.WithValue(newCtx, linkedSpanContextKey{}, originalSpanCtx)
+		// Propagate the original request_id so v2Check spans can carry it as an attribute.
+		newCtx = context.WithValue(newCtx, requestIDKey{}, originalSpanCtx.TraceID().String())
+		// Start a root span to establish the shadow trace_id before entering v2Check.
+		newCtx, rootSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
+			attribute.String("request_id", originalSpanCtx.TraceID().String()),
+			attribute.String("store_id", req.GetStoreId()),
+		))
+		defer rootSpan.End()
+		shadowTraceID = rootSpan.SpanContext().TraceID().String()
 		res, shadowMetadata, err = s.v2Check(newCtx, req, s.sharedDatastoreResources.ShadowCheckCache, s.sharedDatastoreResources.ShadowCacheController, s.shadowAuthzModelGraphResolver)
 	})
 	if recoveredErr != nil {
@@ -237,6 +245,7 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 		return
 	}
 	s.logger.InfoWithContext(ctx, "shadow check",
+		zap.String("shadow_trace_id", shadowTraceID),
 		zap.Bool("matches", mainRes.GetAllowed() == res.GetAllowed()),
 		zap.Int64("main_took", mainTook),
 		zap.Int64("shadow_took", time.Since(start).Milliseconds()),
@@ -269,9 +278,8 @@ func (s *Server) v2Check(
 			attribute.String("consistency", req.GetConsistency().String()),
 		),
 	}
-	if linkedSC, ok := ctx.Value(linkedSpanContextKey{}).(trace.SpanContext); ok && linkedSC.IsValid() {
-		spanOpts = append(spanOpts, trace.WithLinks(trace.Link{SpanContext: linkedSC}))
-		spanOpts = append(spanOpts, trace.WithAttributes(attribute.String("request_id", linkedSC.TraceID().String())))
+	if reqID, ok := ctx.Value(requestIDKey{}).(string); ok && reqID != "" {
+		spanOpts = append(spanOpts, trace.WithAttributes(attribute.String("request_id", reqID)))
 	}
 	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, spanOpts...)
 	defer span.End()


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Add `request_id` to shadow traces in v2Check and `shadow_trace_id` to shadow check logs so that the logs and traces can be correlated.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced observability for check operations with improved request tracing capabilities.
  * Added detailed logging for shadow operations to improve debugging and monitoring visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->