### PR TITLE
fix: close all channels opened thus far, before return on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Fixed a bug that propagated expected errors from list objects when a path short-circuits. [#3096](https://github.com/openfga/openfga/pull/3096)
 - Fixed cache key collisions in experimental `weighted_graph_check` for edges in unions with multiple branches (direct types, wildcards, TTU paths, or intersections). [#3097](https://github.com/openfga/openfga/pull/3097)
 - Fixed a bug in the bounded tuple reader that would cause semaphore token leaks under context cancelation. [#3106](https://github.com/openfga/openfga/pull/3106)
+- Fixed a bug that could cause deadlocks in check by holding message streams open indefinitely upon error. [#3111](https://github.com/openfga/openfga/pull/3111)
 
 ## [1.15.0] - 2026-04-27
 ### Changed

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -587,6 +587,9 @@ func fastPathOperationSetup(ctx context.Context, req *ResolveCheckRequest, resol
 	for idx, child := range children {
 		producerChan, err := fastPathRewrite(ctx, req, child)
 		if err != nil {
+			for _, stream := range iterStreams {
+				stream.Stop()
+			}
 			return nil, err
 		}
 		iterStreams = append(iterStreams, iterator.NewStream(idx, producerChan))


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
### Problem

In `internal/graph/weight_two_resolver.go`, the function `fastPathOperationSetup` iterates over children and creates an `iterator.Stream` for each one. If `fastPathRewrite` returns an error partway through the loop, the function returned immediately without stopping the streams that had already been created. This leaked goroutines/channels associated with those streams.

### Fix

Before returning the error, the function now iterates over all previously-created `iterStreams` and calls `stream.Stop()` on each, ensuring resources are properly released on the error path.

### Changed Files

| File | Change |
|------|--------|
| `internal/graph/weight_two_resolver.go` | Added cleanup loop (+3 lines) in the error branch of `fastPathOperationSetup` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure in-progress producer/check streams are properly cleaned up on failure, preventing resource leaks and potential deadlocks.
* **Documentation**
  * Updated changelog with a note about the fix for streams left open after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->