### PR TITLE
release: update changelog for release `v1.15.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.15.1] - 2026-05-06
 ### Changed
 - Reuse a single MySQL container across tests by replacing the test fixture implementation, improving test performance and reducing resource usage. [#3042](https://github.com/openfga/openfga/pull/3042)
 
@@ -1627,7 +1629,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.15.0...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.15.1...HEAD
+[1.15.1]: https://github.com/openfga/openfga/compare/v1.15.0...v1.15.1
 [1.15.0]: https://github.com/openfga/openfga/compare/v1.14.2...v1.15.0
 [1.14.2]: https://github.com/openfga/openfga/compare/v1.14.1...v1.14.2
 [1.14.1]: https://github.com/openfga/openfga/compare/v1.14.0...v1.14.1


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.15.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog documentation to include new Unreleased section and configured version reference links to prepare for 1.15.1 pre-release support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->