### PR TITLE
fix: move v2Check union cache to edge-level in `ResolveUnionEdges` and `ResolveRecursive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Report `allowed` result and `tuple_key` on Check and experimental `weighted_graph_check` resolution trace spans. [#3116](https://github.com/openfga/openfga/pull/3116)
 
+### Fixed
+- Fixed cache key collisions in experimental `weighted_graph_check` union resolution by moving result caching from the union node level to the individual edge level, preventing collisions across requests that share edges but differ in object or relation. [#3117](https://github.com/openfga/openfga/pull/3117)
+
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -246,6 +246,35 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	return res, nil
 }
 
+func (r *Resolver) buildNodeCacheKey(req *Request, node *authzGraph.WeightedAuthorizationModelNode) string {
+	model := r.model.GetModelID()
+	object := req.GetTupleKey().GetObject()
+	relation := req.GetTupleKey().GetRelation()
+	user := req.GetTupleKey().GetUser()
+	label := node.GetUniqueLabel()
+	invariant := req.GetInvariantCacheKey()
+
+	size := len(cacheKeyPrefix) + len(model) + len(object) + len(relation) + len(user) + len(label) + len(invariant)
+	size += 5 // delimiters are one byte each
+
+	var b strings.Builder
+	b.Grow(size)
+
+	b.WriteString(cacheKeyPrefix)
+	b.WriteString(model)
+	b.WriteByte(cacheKeyDelimiter)
+	b.WriteString(object)
+	b.WriteByte(cacheKeyDelimiter)
+	b.WriteString(relation)
+	b.WriteByte(cacheKeyDelimiter)
+	b.WriteString(user)
+	b.WriteByte(cacheKeyDelimiter)
+	b.WriteString(label)
+	b.WriteByte(cacheKeyDelimiter)
+	b.WriteString(invariant)
+	return b.String()
+}
+
 // reduce as a logical union operation (exit the moment we have a single true).
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (resp *Response, err error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
@@ -254,7 +283,7 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 	))
 	defer span.End()
 
-	if res, ok := r.isCached(req.GetConsistency(), req.GetCacheKey()); ok {
+	if res, ok := r.isCached(req.GetConsistency(), r.buildNodeCacheKey(req, node)); ok {
 		span.SetAttributes(attribute.Bool("cached", true))
 		return res, nil
 	}
@@ -264,7 +293,7 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 			return
 		}
 		entry := &ResponseCacheEntry{Res: resp, LastModified: time.Now()}
-		r.cache.Set(req.GetCacheKey(), entry, r.cacheTTL)
+		r.cache.Set(r.buildNodeCacheKey(req, node), entry, r.cacheTTL)
 	}()
 
 	emptyCycle := visited == nil

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -246,34 +246,6 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	return res, nil
 }
 
-func buildNodeCacheKey(modelID string, req *Request, node *authzGraph.WeightedAuthorizationModelNode) string {
-	object := req.GetTupleKey().GetObject()
-	relation := req.GetTupleKey().GetRelation()
-	user := req.GetTupleKey().GetUser()
-	label := node.GetUniqueLabel()
-	invariant := req.GetInvariantCacheKey()
-
-	size := len(cacheKeyPrefix) + len(modelID) + len(object) + len(relation) + len(user) + len(label) + len(invariant)
-	size += 5 // delimiters are one byte each
-
-	var b strings.Builder
-	b.Grow(size)
-
-	b.WriteString(cacheKeyPrefix)
-	b.WriteString(modelID)
-	b.WriteByte(cacheKeyDelimiter)
-	b.WriteString(object)
-	b.WriteByte(cacheKeyDelimiter)
-	b.WriteString(relation)
-	b.WriteByte(cacheKeyDelimiter)
-	b.WriteString(user)
-	b.WriteByte(cacheKeyDelimiter)
-	b.WriteString(label)
-	b.WriteByte(cacheKeyDelimiter)
-	b.WriteString(invariant)
-	return b.String()
-}
-
 // reduce as a logical union operation (exit the moment we have a single true).
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (resp *Response, err error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
@@ -281,21 +253,6 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 		attribute.Bool("cached", false),
 	))
 	defer span.End()
-
-	cacheKey := buildNodeCacheKey(r.model.GetModelID(), req, node)
-
-	if res, ok := r.isCached(req.GetConsistency(), cacheKey); ok {
-		span.SetAttributes(attribute.Bool("cached", true))
-		return res, nil
-	}
-
-	defer func() {
-		if err != nil {
-			return
-		}
-		entry := &ResponseCacheEntry{Res: resp, LastModified: time.Now()}
-		r.cache.Set(cacheKey, entry, r.cacheTTL)
-	}()
 
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {
@@ -480,8 +437,19 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 	}()
 
 	go func() {
+		cacheKey := buildEdgeCacheKey(r.model.GetModelID(), req, edge)
+
+		if res, ok := r.isCached(req.GetConsistency(), cacheKey); ok {
+			span := trace.SpanFromContext(ctx)
+			span.SetAttributes(attribute.Bool("cached", true))
+
+			concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res}, out)
+			return
+		}
+
 		var err error
 		var res *Response
+
 		switch edge.GetEdgeType() {
 		case authzGraph.DirectEdge:
 			res, err = r.resolveRecursiveUserset(ctx, req, edge, visited, canApplyOptimization)
@@ -491,6 +459,10 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 			res, err = nil, ErrPanicRequest
 		}
 
+		if err == nil {
+			entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
+			r.cache.Set(cacheKey, entry, r.cacheTTL)
+		}
 		concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res, Err: err}, out)
 	}()
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -245,6 +245,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
 		attribute.String("tuple_key", req.GetTupleString()),
+		attribute.Bool("cached", false),
 	))
 	defer span.End()
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -246,22 +246,21 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	return res, nil
 }
 
-func (r *Resolver) buildNodeCacheKey(req *Request, node *authzGraph.WeightedAuthorizationModelNode) string {
-	model := r.model.GetModelID()
+func buildNodeCacheKey(modelID string, req *Request, node *authzGraph.WeightedAuthorizationModelNode) string {
 	object := req.GetTupleKey().GetObject()
 	relation := req.GetTupleKey().GetRelation()
 	user := req.GetTupleKey().GetUser()
 	label := node.GetUniqueLabel()
 	invariant := req.GetInvariantCacheKey()
 
-	size := len(cacheKeyPrefix) + len(model) + len(object) + len(relation) + len(user) + len(label) + len(invariant)
+	size := len(cacheKeyPrefix) + len(modelID) + len(object) + len(relation) + len(user) + len(label) + len(invariant)
 	size += 5 // delimiters are one byte each
 
 	var b strings.Builder
 	b.Grow(size)
 
 	b.WriteString(cacheKeyPrefix)
-	b.WriteString(model)
+	b.WriteString(modelID)
 	b.WriteByte(cacheKeyDelimiter)
 	b.WriteString(object)
 	b.WriteByte(cacheKeyDelimiter)
@@ -283,7 +282,7 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 	))
 	defer span.End()
 
-	cacheKey := r.buildNodeCacheKey(req, node)
+	cacheKey := buildNodeCacheKey(r.model.GetModelID(), req, node)
 
 	if res, ok := r.isCached(req.GetConsistency(), cacheKey); ok {
 		span.SetAttributes(attribute.Bool("cached", true))

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -245,7 +245,6 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
 		attribute.String("tuple_key", req.GetTupleString()),
-		attribute.Bool("cached", false),
 	))
 	defer span.End()
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -283,7 +283,9 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 	))
 	defer span.End()
 
-	if res, ok := r.isCached(req.GetConsistency(), r.buildNodeCacheKey(req, node)); ok {
+	cacheKey := r.buildNodeCacheKey(req, node)
+
+	if res, ok := r.isCached(req.GetConsistency(), cacheKey); ok {
 		span.SetAttributes(attribute.Bool("cached", true))
 		return res, nil
 	}
@@ -293,7 +295,7 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 			return
 		}
 		entry := &ResponseCacheEntry{Res: resp, LastModified: time.Now()}
-		r.cache.Set(r.buildNodeCacheKey(req, node), entry, r.cacheTTL)
+		r.cache.Set(cacheKey, entry, r.cacheTTL)
 	}()
 
 	emptyCycle := visited == nil

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -189,9 +189,6 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 		close(out)
 	}()
 
-	relation := req.GetTupleKey().GetRelation()
-	objectType := tuple.GetType(req.GetTupleKey().GetObject())
-	objectRelation := tuple.ToObjectRelationString(objectType, relation)
 	ids := make([]string, 0, len(edges))
 	for _, edge := range edges {
 		id := buildEdgeCacheKey(r.model.GetModelID(), req, edge)
@@ -209,9 +206,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 		}
 		pool.Go(func() error {
 			res, err := r.ResolveEdge(ctx, req, edge, visited)
-			// we only need to cache the response for the edge if the edge does not belong to the request relation
-			// otherwise the subproblem should be sufficient
-			if err == nil && edge.GetRelationDefinition() != objectRelation {
+			if err == nil {
 				entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
 				r.cache.Set(id, entry, r.cacheTTL)
 			}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -242,7 +242,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 }
 
 // reduce as a logical union operation (exit the moment we have a single true).
-func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (resp *Response, err error) {
+func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
 		attribute.String("tuple_key", req.GetTupleString()),
 		attribute.Bool("cached", false),

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -64,7 +64,9 @@ func TestResolveUnion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		mockCache.EXPECT().Get(req.GetCacheKey()).Return(cachedEntry).Times(1)
+		cacheKey := buildNodeCacheKey(model.GetId(), req, mg.GetOrAddNode("group#member", "group#member", authzGraph.SpecificTypeAndRelation))
+
+		mockCache.EXPECT().Get(cacheKey).Return(cachedEntry).Times(1)
 
 		node, ok := mg.GetNodeByID("group#member")
 		require.True(t, ok)
@@ -108,8 +110,10 @@ func TestResolveUnion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		cacheKey := buildNodeCacheKey(model.GetId(), req, mg.GetOrAddNode("group#member", "group#member", authzGraph.SpecificTypeAndRelation))
+
 		// the first cache call should be to check for a subproblem cache entry
-		mockCache.EXPECT().Get(req.GetCacheKey()).Return(nil).Times(1)
+		mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 		// simulate an edge with a cached false result
 		mockCache.EXPECT().Get(gomock.Any()).Return(cachedFalse).Times(1)
@@ -131,12 +135,12 @@ func TestResolveUnion(t *testing.T) {
 
 		// each edge sets the results of its resolution
 		edgeCacheSets := mockCache.EXPECT().
-			Set(gomock.Not(gomock.Eq(req.GetCacheKey())), gomock.Any(), gomock.Any()).
+			Set(gomock.Not(gomock.Eq(cacheKey)), gomock.Any(), gomock.Any()).
 			Times(2)
 
 		// the last cache call should be to set the subproblem cache entry
 		mockCache.EXPECT().
-			Set(req.GetCacheKey(), gomock.Any(), gomock.Any()).
+			Set(cacheKey, gomock.Any(), gomock.Any()).
 			After(edgeCacheSets).
 			Times(1)
 

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -163,6 +163,57 @@ func TestResolveUnion(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, res.Allowed)
 	})
+
+	t.Run("caches_all_edges", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+            model
+              schema 1.1
+            type user
+            type group
+              relations
+                define member: [user] or admin
+                define admin: [user]
+        `)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(nil, storage.ErrNotFound).Times(2)
+
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
+		// Both edges (including the one whose relationDefinition matches objectRelation) must be cached.
+		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			ConcurrencyLimit:          10,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+		})
+
+		req, err := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+		})
+		require.NoError(t, err)
+
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+
+		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
+		require.NoError(t, err)
+		require.False(t, res.GetAllowed())
+	})
 }
 
 func TestResolveUnionEdges(t *testing.T) {
@@ -5492,6 +5543,142 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			TupleKey: tuple.NewTupleKey("document:4", "viewer", "user:*"),
 		})
 		require.NoError(t, err)
+
+		resolver.strategies[DefaultStrategyName] = NewDefault(mg, resolver, 10)
+
+		res, err := resolver.ResolveCheck(context.Background(), req)
+		require.NoError(t, err)
+		require.True(t, res.GetAllowed())
+	})
+
+	t.Run("caches_recursive_edge_on_miss", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+		mockPlanner := mocks.NewMockManager(ctrl)
+		mockSelector := mocks.NewMockSelector(ctrl)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+		   model
+			schema 1.1
+		   type user
+		   type document
+			relations
+			   define viewer: [user] or viewer from parent
+			   define parent: [document]
+	  	`)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		mockPlanner.EXPECT().GetPlanSelector(gomock.Any()).Return(mockSelector).AnyTimes()
+		mockSelector.EXPECT().Select(gomock.Any()).Return(DefaultPlan).AnyTimes()
+		mockSelector.EXPECT().UpdateStats(gomock.Any(), gomock.Any()).AnyTimes()
+
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(nil, storage.ErrNotFound).AnyTimes()
+
+		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			AnyTimes().
+			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
+				if filter.Object == "document:1" {
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:2")}}), nil
+				}
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+			})
+
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
+		// ResolveRecursive must write its result to the cache after resolution.
+		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1)
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			Planner:                   mockPlanner,
+			ConcurrencyLimit:          10,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+		})
+
+		req, err := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
+		})
+		require.NoError(t, err)
+
+		resolver.strategies[DefaultStrategyName] = NewDefault(mg, resolver, 10)
+
+		res, err := resolver.ResolveCheck(context.Background(), req)
+		require.NoError(t, err)
+		require.False(t, res.GetAllowed())
+	})
+
+	t.Run("cache_hit_on_recursive_edge", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+		mockPlanner := mocks.NewMockManager(ctrl)
+		mockSelector := mocks.NewMockSelector(ctrl)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+		   model
+			schema 1.1
+		   type user
+		   type document
+			relations
+			   define viewer: [user] or viewer from parent
+			   define parent: [document]
+	  	`)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		mockPlanner.EXPECT().GetPlanSelector(gomock.Any()).Return(mockSelector).AnyTimes()
+		mockSelector.EXPECT().Select(gomock.Any()).Return(DefaultPlan).AnyTimes()
+		mockSelector.EXPECT().UpdateStats(gomock.Any(), gomock.Any()).AnyTimes()
+
+		// Only the non-recursive direct [user] edge calls the datastore.
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(nil, storage.ErrNotFound).AnyTimes()
+
+		req, err := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
+		})
+		require.NoError(t, err)
+
+		// Pre-populate the cache for the recursive edge.
+		node, ok := mg.GetNodeByID("document#viewer")
+		require.True(t, ok)
+		recursiveEdge, ok := mg.CanApplyRecursion(node, "", true)
+		require.True(t, ok)
+		recursiveKey := buildEdgeCacheKey(model.GetId(), req, recursiveEdge)
+
+		cachedTrue := &ResponseCacheEntry{
+			Res:          &Response{Allowed: true},
+			LastModified: time.Now(),
+		}
+		mockCache.EXPECT().Get(recursiveKey).Return(cachedTrue).Times(1)
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
+		// Non-recursive edges may still write to the cache.
+		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			Planner:                   mockPlanner,
+			ConcurrencyLimit:          10,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+		})
 
 		resolver.strategies[DefaultStrategyName] = NewDefault(mg, resolver, 10)
 

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -3,7 +3,6 @@ package check
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -347,15 +346,12 @@ func TestResolveUnionEdges(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			DoAndReturn(func(context.Context, string, storage.ReadUserTupleFilter, storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
+			DoAndReturn(func(ctx context.Context, _ string, _ storage.ReadUserTupleFilter, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
 				cancel()
-				time.Sleep(10 * time.Millisecond)
-				return nil, storage.ErrNotFound
+				return nil, ctx.Err()
 			}).MaxTimes(2)
 
-		key := fmt.Sprintf(`^c\.%s\|group:1\|user:maria\|group#admin\|`, mg.GetModelID())
 		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
-		mockCache.EXPECT().Set(gomock.Regex(key), gomock.Any(), gomock.Any()).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -44,11 +44,6 @@ func TestResolveUnion(t *testing.T) {
 		mg, err := modelgraph.New(model)
 		require.NoError(t, err)
 
-		cachedEntry := &ResponseCacheEntry{
-			Res:          &Response{Allowed: true},
-			LastModified: time.Now(),
-		}
-
 		resolver := New(Config{
 			Model:                     mg,
 			Datastore:                 mockDatastore,
@@ -67,9 +62,30 @@ func TestResolveUnion(t *testing.T) {
 		node, ok := mg.GetNodeByID("group#member")
 		require.True(t, ok)
 
-		cacheKey := buildNodeCacheKey(model.GetId(), req, node)
+		edges, ok := mg.GetEdgesFromNode(node)
+		require.True(t, ok)
 
-		mockCache.EXPECT().Get(cacheKey).Return(cachedEntry).Times(1)
+		union := edges[0].GetTo()
+		edges, ok = mg.GetEdgesFromNode(union)
+		require.True(t, ok)
+
+		cachedTrue := &ResponseCacheEntry{
+			Res:          &Response{Allowed: true},
+			LastModified: time.Now(),
+		}
+		firstCacheKey := buildEdgeCacheKey(model.GetId(), req, edges[0])
+		mockCache.EXPECT().Get(firstCacheKey).Return(cachedTrue).Times(1)
+
+		admin := edges[1].GetTo()
+		edges, ok = mg.GetEdgesFromNode(admin)
+		require.True(t, ok)
+
+		cachedFalse := &ResponseCacheEntry{
+			Res:          &Response{Allowed: false},
+			LastModified: time.Now(),
+		}
+		secondCacheKey := buildEdgeCacheKey(model.GetId(), req, edges[0])
+		mockCache.EXPECT().Get(secondCacheKey).Return(cachedFalse).MaxTimes(1)
 
 		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
 		require.NoError(t, err)
@@ -113,11 +129,6 @@ func TestResolveUnion(t *testing.T) {
 		node, ok := mg.GetNodeByID("group#member")
 		require.True(t, ok)
 
-		cacheKey := buildNodeCacheKey(model.GetId(), req, node)
-
-		// the first cache call should be to check for a subproblem cache entry
-		mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
-
 		// simulate an edge with a cached false result
 		mockCache.EXPECT().Get(gomock.Any()).Return(cachedFalse).Times(1)
 
@@ -137,15 +148,9 @@ func TestResolveUnion(t *testing.T) {
 				}).Times(2)
 
 		// each edge sets the results of its resolution
-		edgeCacheSets := mockCache.EXPECT().
-			Set(gomock.Not(gomock.Eq(cacheKey)), gomock.Any(), gomock.Any()).
-			Times(2)
-
-		// the last cache call should be to set the subproblem cache entry
 		mockCache.EXPECT().
-			Set(cacheKey, gomock.Any(), gomock.Any()).
-			After(edgeCacheSets).
-			Times(1)
+			Set(gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(2)
 
 		resolver := New(Config{
 			Model:                     mg,

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -64,12 +64,12 @@ func TestResolveUnion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		cacheKey := buildNodeCacheKey(model.GetId(), req, mg.GetOrAddNode("group#member", "group#member", authzGraph.SpecificTypeAndRelation))
-
-		mockCache.EXPECT().Get(cacheKey).Return(cachedEntry).Times(1)
-
 		node, ok := mg.GetNodeByID("group#member")
 		require.True(t, ok)
+
+		cacheKey := buildNodeCacheKey(model.GetId(), req, node)
+
+		mockCache.EXPECT().Get(cacheKey).Return(cachedEntry).Times(1)
 
 		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
 		require.NoError(t, err)
@@ -110,7 +110,10 @@ func TestResolveUnion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		cacheKey := buildNodeCacheKey(model.GetId(), req, mg.GetOrAddNode("group#member", "group#member", authzGraph.SpecificTypeAndRelation))
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+
+		cacheKey := buildNodeCacheKey(model.GetId(), req, node)
 
 		// the first cache call should be to check for a subproblem cache entry
 		mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
@@ -151,9 +154,6 @@ func TestResolveUnion(t *testing.T) {
 			ConcurrencyLimit:          10,
 			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
 		})
-
-		node, ok := mg.GetNodeByID("group#member")
-		require.True(t, ok)
 
 		res, err := resolver.ResolveUnion(context.Background(), req, node, nil)
 		require.NoError(t, err)


### PR DESCRIPTION
## Problem

`ResolveUnion` used only the request's cache key to store and fetch its subproblem cache entry. However, each call to ResolveUnion is unique to the node argument value. Without incorporating the node identity into the cache key, entries could overlap at various levels during check request resolution, leading to incorrect cached results being returned.

However, caching in `ResolveUnion` can create too many cache entries, causing contention within the cache as entries competed for space. Caching at the node level is also architecturally misplaced — caching should be done at the edges (individual resolution paths), not the nodes (aggregation points).

## Solution

Removed all cache get/set logic from `ResolveUnion`. Moved caching into `ResolveRecursive`, where each edge's resolution result is individually cached using `buildEdgeCacheKey`. This means:

- Cache lookups happen at the start of each recursive edge resolution goroutine
- Cache stores happen after a successful edge resolution
- No cache entry is created for the union node itself

This reduces the total number of cache entries and places caching closer to the actual computation, preventing cache contention.

## Files Changed

- `internal/check/check.go` — Removed union-level caching; added edge-level cache get/set in `ResolveRecursive`.
- `internal/check/check_test.go` — Updated tests to expect edge-level caching instead of node-level caching; removed node cache key assertions and added edge traversal to set up per-edge cache expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched cached reads and deferred writes to use node- and edge-specific cache keys, improving caching precision to reduce redundant work and deliver more consistent, faster responses.
* **Tests**
  * Updated unit tests to validate the new node/edge-specific cache key behavior and relaxed prior single-request cache assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->