### PR TITLE
fix: shadow v2check and check use the same trace

### DIFF
--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -219,7 +219,7 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 		newCtx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
 		defer cancel()
 		// Inject the original span context so shadow spans share the same trace ID.
-		newCtx = trace.ContextWithRemoteSpanContext(newCtx, originalSpanCtx)
+		newCtx = trace.ContextWithSpanContext(newCtx, originalSpanCtx)
 		newCtx, shadowSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
 			attribute.String("store_id", req.GetStoreId()),
 		))

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -214,9 +214,12 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 	var res *openfgav1.CheckResponse
 	var shadowMetadata storagewrappers.Metadata
 	var err error
+	originalSpanCtx := trace.SpanContextFromContext(ctx)
 	recoveredErr := panics.Try(func() {
-		newCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.shadowCheckResolverTimeout)
+		newCtx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
 		defer cancel()
+		// Inject the original span context so shadow spans share the same trace ID.
+		newCtx = trace.ContextWithRemoteSpanContext(newCtx, originalSpanCtx)
 		newCtx, shadowSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
 			attribute.String("store_id", req.GetStoreId()),
 		))

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -52,12 +52,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		attribute.KeyValue{Key: "consistency", Value: attribute.StringValue(req.GetConsistency().String())},
 	))
 	isShadowRunning := s.featureFlagClient.Boolean(serverconfig.ExperimentalShadowWeightedGraphCheck, req.GetStoreId())
-	shadowClosesSpan := false
-	defer func() {
-		if !shadowClosesSpan {
-			span.End()
-		}
-	}()
+	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
 		if err := req.Validate(); err != nil {
@@ -206,46 +201,29 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	}
 
 	if isShadowRunning {
-		shadowClosesSpan = true
-		go func() {
-			defer span.End()
-			s.shadowV2Check(ctx, req, res, endTime,
-				resp.GetResolutionMetadata().DatastoreQueryCount,
-				resp.GetResolutionMetadata().DatastoreItemCount)
-		}()
+		go s.shadowV2Check(ctx, req, res, endTime,
+			resp.GetResolutionMetadata().DatastoreQueryCount,
+			resp.GetResolutionMetadata().DatastoreItemCount)
 	}
 
 	return res, nil
 }
-
-// requestIDKey is a context key used to propagate the original request_id
-// into the detached shadow context so v2Check spans carry it as an attribute.
-type requestIDKey struct{}
 
 func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest, mainRes *openfgav1.CheckResponse, mainTook int64, mainDatastoreQueryCount uint32, mainDatastoreItemCount uint64) {
 	start := time.Now()
 	var res *openfgav1.CheckResponse
 	var shadowMetadata storagewrappers.Metadata
 	var err error
-	originalSpanCtx := trace.SpanContextFromContext(ctx)
-	var shadowTraceID string
 	recoveredErr := panics.Try(func() {
-		newCtx, cancel := context.WithTimeout(context.Background(), s.shadowCheckResolverTimeout)
+		newCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), s.shadowCheckResolverTimeout)
 		defer cancel()
-		// Propagate the original request_id so v2Check spans can carry it as an attribute.
-		newCtx = context.WithValue(newCtx, requestIDKey{}, originalSpanCtx.TraceID().String())
-		// Start a root span to establish the shadow trace_id before entering v2Check.
-		newCtx, rootSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
-			attribute.String("request_id", originalSpanCtx.TraceID().String()),
+		newCtx, shadowSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
 			attribute.String("store_id", req.GetStoreId()),
 		))
-		defer rootSpan.End()
-		shadowTraceID = rootSpan.SpanContext().TraceID().String()
+		defer shadowSpan.End()
 		res, shadowMetadata, err = s.v2Check(newCtx, req, s.sharedDatastoreResources.ShadowCheckCache, s.sharedDatastoreResources.ShadowCacheController, s.shadowAuthzModelGraphResolver)
 		if err == nil {
-			matches := mainRes.GetAllowed() == res.GetAllowed()
-			rootSpan.SetAttributes(attribute.Bool("matches", matches))
-			trace.SpanFromContext(ctx).SetAttributes(attribute.Bool("matches", matches))
+			shadowSpan.SetAttributes(attribute.Bool("matches", mainRes.GetAllowed() == res.GetAllowed()))
 		}
 	})
 	if recoveredErr != nil {
@@ -260,7 +238,6 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 		return
 	}
 	s.logger.InfoWithContext(ctx, "shadow check",
-		zap.String("shadow_trace_id", shadowTraceID),
 		zap.Bool("matches", mainRes.GetAllowed() == res.GetAllowed()),
 		zap.Int64("main_took", mainTook),
 		zap.Int64("shadow_took", time.Since(start).Milliseconds()),
@@ -287,19 +264,13 @@ func (s *Server) v2Check(
 	storeID := req.GetStoreId()
 	tk := req.GetTupleKey()
 
-	spanOpts := []trace.SpanStartOption{
-		trace.WithAttributes(
-			attribute.String("store_id", storeID),
-			attribute.String("object", tk.GetObject()),
-			attribute.String("relation", tk.GetRelation()),
-			attribute.String("user", tk.GetUser()),
-			attribute.String("consistency", req.GetConsistency().String()),
-		),
-	}
-	if reqID, ok := ctx.Value(requestIDKey{}).(string); ok && reqID != "" {
-		spanOpts = append(spanOpts, trace.WithAttributes(attribute.String("request_id", reqID)))
-	}
-	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, spanOpts...)
+	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, trace.WithAttributes(
+		attribute.String("store_id", storeID),
+		attribute.String("object", tk.GetObject()),
+		attribute.String("relation", tk.GetRelation()),
+		attribute.String("user", tk.GetUser()),
+		attribute.String("consistency", req.GetConsistency().String()),
+	))
 	defer span.End()
 
 	cacheInvalidationTime := time.Time{}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Shadow v2 check and check should share the same trace.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ensured tracing spans are always closed for more reliable trace completion.
  * Shadow-mode checks now run as simpler background tasks, improving execution consistency.
  * Reduced tracing/logging noise by standardizing span attributes and removing shadow-specific trace identifiers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3118)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->