### PR TITLE
fix: validate datastore uri requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Report `allowed` result and `tuple_key` on Check and experimental `weighted_graph_check` resolution trace spans. [#3116](https://github.com/openfga/openfga/pull/3116)
 
+### Fixed
+- Fixed datastore configuration validation so `run` and `migrate` fail fast when SQL datastore engines are configured without a `datastore.uri`. [#3119](https://github.com/openfga/openfga/pull/3119)
+
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -486,6 +486,10 @@ func (cfg *Config) VerifyServerSettings() error {
 		return err
 	}
 
+	if err := cfg.verifyDatastoreConfig(); err != nil {
+		return err
+	}
+
 	if cfg.GRPC.MaxRecvMsgBytes <= 0 {
 		return fmt.Errorf("config 'grpc.maxRecvMsgBytes' must be greater than 0")
 	}
@@ -542,6 +546,23 @@ func (cfg *Config) VerifyServerSettings() error {
 
 	if cfg.Datastore.MinOpenConns < cfg.Datastore.MinIdleConns {
 		return errors.New("datastore MinOpenConns must not be less than datastore MinIdleConns")
+	}
+
+	return nil
+}
+
+func (cfg *Config) verifyDatastoreConfig() error {
+	switch cfg.Datastore.Engine {
+	case "":
+		return errors.New("config 'datastore.engine' must be set")
+	case "memory":
+		if cfg.Datastore.URI != "" {
+			return errors.New("config 'datastore.uri' must be empty when 'datastore.engine' is 'memory'")
+		}
+	case "postgres", "mysql":
+		if cfg.Datastore.URI == "" {
+			return fmt.Errorf("config 'datastore.uri' must be set when 'datastore.engine' is '%s'", cfg.Datastore.Engine)
+		}
 	}
 
 	return nil

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -48,6 +48,38 @@ func TestVerifyConfig(t *testing.T) {
 		require.EqualError(t, err, "config 'grpc.maxRecvMsgBytes' must be greater than 0")
 	})
 
+	t.Run("datastore_engine_must_be_set", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Datastore.Engine = ""
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "config 'datastore.engine' must be set")
+	})
+
+	t.Run("datastore_uri_must_be_empty_for_memory", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Datastore.URI = "postgres://postgres:password@localhost:5432/postgres"
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "config 'datastore.uri' must be empty when 'datastore.engine' is 'memory'")
+	})
+
+	t.Run("datastore_uri_required_for_postgres", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Datastore.Engine = "postgres"
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "config 'datastore.uri' must be set when 'datastore.engine' is 'postgres'")
+	})
+
+	t.Run("datastore_uri_required_for_mysql", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Datastore.Engine = "mysql"
+
+		err := cfg.Verify()
+		require.EqualError(t, err, "config 'datastore.uri' must be set when 'datastore.engine' is 'mysql'")
+	})
+
 	t.Run("failing_to_set_http_cert_path_will_not_allow_server_to_start", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.HTTP.TLS = &TLSConfig{

--- a/pkg/storage/migrate/migrate.go
+++ b/pkg/storage/migrate/migrate.go
@@ -54,6 +54,10 @@ func RunMigrations(cfg MigrationConfig) error {
 		log.Info("no migrations to run for `memory` datastore")
 		return nil
 	case "mysql":
+		if cfg.URI == "" {
+			return fmt.Errorf("missing datastore uri for mysql datastore engine")
+		}
+
 		driver = "mysql"
 		migrationsPath = assets.MySQLMigrationDir
 
@@ -71,6 +75,10 @@ func RunMigrations(cfg MigrationConfig) error {
 		uri = dsn.FormatDSN()
 
 	case "postgres":
+		if cfg.URI == "" {
+			return fmt.Errorf("missing datastore uri for postgres datastore engine")
+		}
+
 		driver = "pgx"
 		migrationsPath = assets.PostgresMigrationDir
 		var username, password string

--- a/pkg/storage/migrate/migrate_test.go
+++ b/pkg/storage/migrate/migrate_test.go
@@ -10,6 +10,35 @@ import (
 	"github.com/openfga/openfga/pkg/storage/migrate"
 )
 
+func TestRunMigrationsRequiresDatastoreURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		engine      string
+		expectedErr string
+	}{
+		{
+			name:        "postgres",
+			engine:      "postgres",
+			expectedErr: "missing datastore uri for postgres datastore engine",
+		},
+		{
+			name:        "mysql",
+			engine:      "mysql",
+			expectedErr: "missing datastore uri for mysql datastore engine",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := migrate.RunMigrations(migrate.MigrationConfig{
+				Engine:  test.engine,
+				Timeout: 5 * time.Second,
+			})
+			require.EqualError(t, err, test.expectedErr)
+		})
+	}
+}
+
 func TestMigrateCommandRollbacks(t *testing.T) {
 	type EngineConfig struct {
 		Engine     string


### PR DESCRIPTION
## Description

#### What problem is being solved?

`run` and `migrate` could be configured with SQL datastore engines without a `datastore.uri`, letting the process fail later while parsing or opening a connection. `run` could also be started with the default in-memory engine while a URI was set, silently ignoring the URI.

#### How is it being solved?

Add early config validation for datastore engine/URI combinations and fail migrations before opening a DB connection when postgres/mysql URI is missing.

#### What changes are made to solve it?

- Validate datastore engine/URI combinations in server config verification.
- Reject missing postgres/mysql migration URIs before DSN parsing/open.
- Add focused tests for server config and migration validation.
- Add an Unreleased changelog entry.

## References

Closes https://github.com/openfga/openfga/issues/681

## Review Checklist

- [x] I have clicked on the "allow edits by maintainers" option in the PR settings so that maintainers can make minor fixes to my PR.
- [x] I have added documentation for new/changed functionality in this PR or in openfga.dev.
- [x] The correct base branch is being used, if not `main`.
- [x] I have added tests to validate that the change in functionality is working as expected.

Validation:

- `go test ./pkg/server/config ./pkg/storage/migrate -run 'TestVerifyConfig|TestRunMigrationsRequiresDatastoreURI'`
- `npm_config_cache=/tmp/openfga-npm-cache-681 npx keep-a-changelog@2.5.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Datastore validation now enforces engine-specific URI rules: PostgreSQL/MySQL require a configured URI; memory must not have one. `run` and `migrate` now fail fast with clear errors when misconfigured.
* **Tests**
  * Added tests covering datastore URI validation and migration behavior for SQL engines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3119)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->