### PR TITLE
docs: align source build output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Report `allowed` result and `tuple_key` on Check and experimental `weighted_graph_check` resolution trace spans. [#3116](https://github.com/openfga/openfga/pull/3116)
 
+### Fixed
+- Fixed source build documentation to point at `./dist/openfga`, matching the `make build` output path. [#3120](https://github.com/openfga/openfga/pull/3120)
+
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ generate-mocks: $(GO_BIN)/mockgen ## Generate mock stubs
 #-----------------------------------------------------------------------------------------------------------------------
 .PHONY: build install
 
-build: ## Build the OpenFGA service binary. Build directory can be overridden using BUILD_DIR="desired/path", default is ".dist/". Usage `BUILD_DIR="." make build`
+build: ## Build the OpenFGA service binary. Build directory can be overridden using BUILD_DIR="desired/path", default is "./dist". Usage `BUILD_DIR="." make build`
 	${call print, "Building the OpenFGA binary within ${BUILD_DIR}/${BINARY_NAME}"}
 	@go build -v -o "${BUILD_DIR}/${BINARY_NAME}" "$(CURDIR)/cmd/openfga"
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,15 @@ openfga run
 
 ```shell
 git clone https://github.com/openfga/openfga.git && cd openfga
-go build -o ./openfga ./cmd/openfga
-./openfga run
+make build
+./dist/openfga run
+```
+
+To build directly with `go build`, use the same output path:
+
+```shell
+go build -o ./dist/openfga ./cmd/openfga
+./dist/openfga run
 ```
 
 ### Verify Installation


### PR DESCRIPTION
## Description

#### What problem is being solved?

README source-build instructions generated and ran `./openfga`, while `make build` writes `./dist/openfga`. The Makefile help text also described the default build directory as `.dist/`.

#### How is it being solved?

Use `make build` in the README source-build flow and document `./dist/openfga`. Keep a direct `go build` alternative with the same output path.

#### What changes are made to solve it?

- Update README source-build commands to use `./dist/openfga`.
- Fix Makefile build help text to say `./dist`.
- Add an Unreleased changelog entry.

## References

Closes https://github.com/openfga/openfga/issues/2123

## Review Checklist

- [x] I have clicked on the "allow edits by maintainers" option in the PR settings so that maintainers can make minor fixes to my PR.
- [x] I have added documentation for new/changed functionality in this PR or in openfga.dev.
- [x] The correct base branch is being used, if not `main`.
- [ ] I have added tests to validate that the change in functionality is working as expected. Not applicable; this is a documentation/help text update.

Validation:

- `make build`
- `npm_config_cache=/tmp/openfga-npm-cache-2123 npx keep-a-changelog@2.5.3`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected help text to document the default build output directory as ./dist (was .dist/)
  * Updated build-from-source instructions to show building and running the binary from ./dist/openfga
  * Added a changelog entry noting the corrected source build path under "Unreleased"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3120)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->