### PR TITLE
fix: don't cache false results from cancelled-context goroutines in v2Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 - Fixed cache key collisions in experimental `weighted_graph_check` union resolution by moving result caching from the union node level to the individual edge level, preventing collisions across requests that share edges but differ in object or relation. [#3117](https://github.com/openfga/openfga/pull/3117)
+- Fixed a bug in experimental `weighted_graph_check` where in-flight goroutines cancelled by a union short-circuit or recursive resolution could cache a false result, causing subsequent requests to incorrectly return false without querying the datastore. [#3125](https://github.com/openfga/openfga/pull/3125)
 
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -206,7 +206,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 		}
 		pool.Go(func() error {
 			res, err := r.ResolveEdge(ctx, req, edge, visited)
-			if err == nil {
+			if err == nil && ctx.Err() == nil {
 				entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
 				r.cache.Set(id, entry, r.cacheTTL)
 			}
@@ -454,7 +454,7 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 			res, err = nil, ErrPanicRequest
 		}
 
-		if err == nil {
+		if err == nil && ctx.Err() == nil {
 			entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
 			r.cache.Set(cacheKey, entry, r.cacheTTL)
 		}

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -3,6 +3,7 @@ package check
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/internal/modelgraph"
+	"github.com/openfga/openfga/internal/planner"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -146,10 +148,11 @@ func TestResolveUnion(t *testing.T) {
 					return &openfgav1.Tuple{Key: tuple.NewTupleKey(filter.Object, filter.Relation, filter.User)}, nil
 				}).Times(2)
 
-		// each edge sets the results of its resolution
+		// edges that complete before the union short-circuits will cache their results;
+		// edges cancelled by the short-circuit will not (ctx.Err() != nil guard).
 		mockCache.EXPECT().
 			Set(gomock.Any(), gomock.Any(), gomock.Any()).
-			Times(2)
+			MinTimes(1).MaxTimes(2)
 
 		resolver := New(Config{
 			Model:                     mg,
@@ -568,6 +571,180 @@ func TestResolveUnionEdges(t *testing.T) {
 		res, err := resolver.ResolveUnionEdges(context.Background(), req, edges, nil)
 		require.NoError(t, err)
 		require.False(t, res.GetAllowed())
+	})
+
+	t.Run("cancelled_context_does_not_write_to_cache", func(t *testing.T) {
+		// Regression: goroutines must not write to cache when the context is cancelled,
+		// even when ResolveEdge returns ({false}, nil).
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
+		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		// MinTimes(1) confirms goroutines reached the datastore, so Times(0) on Set is not vacuous.
+		// The mocks ignore ctx, so the cancelled context doesn't prevent these calls.
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(nil, storage.ErrNotFound).MinTimes(1)
+		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(storage.NewStaticTupleIterator(nil), nil).MinTimes(1)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+            model
+              schema 1.1
+            type user
+            type group
+              relations
+                define member: [user, group#member]
+        `)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			CacheTTL:                  10 * time.Second,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+			ConcurrencyLimit:          10,
+			Planner:                   planner.New(&planner.Config{}),
+			// Inject a strategy that always returns ({false}, nil) unconditionally,
+			// directly simulating what DefaultStrategy.execute produces under the select race —
+			// ctx.Err() == nil is the only thing blocking the cache write.
+			Strategies: map[string]Strategy{
+				DefaultStrategyName:   &alwaysFalseNilErrStrategy{},
+				WeightTwoStrategyName: &alwaysFalseNilErrStrategy{},
+				RecursiveStrategyName: &alwaysFalseNilErrStrategy{},
+			},
+		})
+
+		req, reqErr := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+		})
+		require.NoError(t, reqErr)
+
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+		edges, flatErr := mg.FlattenNode(node, "user", false, false)
+		require.NoError(t, flatErr)
+		require.NotEmpty(t, edges) // ensures goroutines are actually dispatched
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _ = resolver.ResolveUnionEdges(ctx, req, edges, nil)
+	})
+}
+
+// alwaysFalseNilErrStrategy simulates DefaultStrategy.execute returning ({false}, nil)
+// under the select race on context cancellation — the exact value that would be cached.
+// done, if non-nil, is called via defer just before the strategy returns, providing the
+// closest available synchronisation point to the cache-write decision in check.go.
+type alwaysFalseNilErrStrategy struct {
+	done func()
+}
+
+func (s *alwaysFalseNilErrStrategy) Userset(_ context.Context, _ *Request, _ *authzGraph.WeightedAuthorizationModelEdge, _ storage.TupleKeyIterator, _ *sync.Map) (*Response, error) {
+	if s.done != nil {
+		defer s.done()
+	}
+	return &Response{Allowed: false}, nil
+}
+
+func (s *alwaysFalseNilErrStrategy) TTU(_ context.Context, _ *Request, _ *authzGraph.WeightedAuthorizationModelEdge, _ storage.TupleKeyIterator, _ *sync.Map) (*Response, error) {
+	if s.done != nil {
+		defer s.done()
+	}
+	return &Response{Allowed: false}, nil
+}
+
+func TestResolveRecursive(t *testing.T) {
+	t.Run("cancelled_context_does_not_write_to_cache", func(t *testing.T) {
+		// Same invariant as ResolveUnionEdges: the goroutine must not write to cache when
+		// context is cancelled, even when the strategy returns ({false}, nil).
+		// Unlike ResolveUnionEdges (which has pool.Wait()), ResolveRecursive spawns detached
+		// goroutines, so ctrl.Finish() must be called explicitly after goroutineDone.Wait().
+		//
+		// Limitation: goroutineDone fires when the strategy returns, but the cache-write
+		// decision (`if ctx.Err() == nil`) executes a few instructions later in check.go.
+		// This is not a true happens-before guarantee. The test is correct in practice because
+		// the context is pre-cancelled, making ctx.Err() != nil a deterministic constant that
+		// the guard always evaluates to false — cache.Set is never reached regardless of
+		// scheduling. A regression (guard removed) could go undetected if ctrl.Finish()
+		// races ahead of the now-unconditional cache.Set in the goroutine.
+		ctrl := gomock.NewController(t)
+
+		storeID := ulid.Make().String()
+		mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
+		mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+		model := testutils.MustTransformDSLToProtoWithID(`
+            model
+              schema 1.1
+            type user
+            type group
+              relations
+                define member: [user] or member from parent
+                define parent: [group]
+        `)
+
+		mg, err := modelgraph.New(model)
+		require.NoError(t, err)
+
+		// MinTimes(1) confirms the recursive goroutine reached the datastore, making
+		// the Times(0) assertion on Set meaningful rather than vacuous.
+		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(storage.NewStaticTupleIterator(nil), nil).MinTimes(1)
+		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+			Return(nil, storage.ErrNotFound).AnyTimes()
+
+		var goroutineDone sync.WaitGroup
+		goroutineDone.Add(1)
+		strategy := &alwaysFalseNilErrStrategy{done: goroutineDone.Done}
+
+		resolver := New(Config{
+			Model:                     mg,
+			Datastore:                 mockDatastore,
+			Cache:                     mockCache,
+			CacheTTL:                  10 * time.Second,
+			LastCacheInvalidationTime: time.Now().Add(-time.Hour),
+			ConcurrencyLimit:          10,
+			Planner:                   planner.New(&planner.Config{}),
+			Strategies: map[string]Strategy{
+				DefaultStrategyName:   strategy,
+				WeightTwoStrategyName: strategy,
+				RecursiveStrategyName: strategy,
+			},
+		})
+
+		req, reqErr := NewRequest(RequestParams{
+			StoreID:  storeID,
+			Model:    mg,
+			TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+		})
+		require.NoError(t, reqErr)
+
+		node, ok := mg.GetNodeByID("group#member")
+		require.True(t, ok)
+		recursiveEdge, canApply := mg.CanApplyRecursion(node, "user", true)
+		require.True(t, canApply)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, _ = resolver.ResolveRecursive(ctx, req, recursiveEdge, &sync.Map{}, false)
+		goroutineDone.Wait() // wait for the recursive goroutine to run past the cache-write point
+		ctrl.Finish()        // now validate Times(0)
 	})
 }
 

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -645,8 +645,8 @@ func TestResolveUnionEdges(t *testing.T) {
 
 // alwaysFalseNilErrStrategy simulates DefaultStrategy.execute returning ({false}, nil)
 // under the select race on context cancellation — the exact value that would be cached.
-// done, if non-nil, is called via defer just before the strategy returns, providing the
-// closest available synchronisation point to the cache-write decision in check.go.
+// If non-nil, done is called via defer just before the strategy returns, providing the
+// closest available synchronization point to the cache-write decision in check.go.
 type alwaysFalseNilErrStrategy struct {
 	done func()
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

When a union short-circuits on a true result, in-flight goroutines for other edges have their context cancelled. Due to a race in `DefaultStrategy.execute` (and other strategies), these goroutines can return `({Allowed: false}, nil)` — a nil error with a false result. The nil error passes the `if err == nil` cache guard, poisoning the cache with a false entry. Future requests hit this entry and return false without any datastore queries.

#### How is it being solved?

Adding a `ctx.Err() == nil` check alongside the existing `err == nil` guard before any cache write. A cancelled context means the result is incomplete, not authoritative — so it should never be persisted.

#### What changes are made to solve it?

- `internal/check/check.go`: add `ctx.Err() == nil` guard before `cache.Set` in both `ResolveUnionEdges` and `ResolveRecursive` goroutines                                                                                                                 
- `internal/check/check_test.go`: regression tests for both sites — inject a strategy that unconditionally returns `({false}, nil)` (directly simulating the race output) with a pre-cancelled context, and assert `cache.Set` is never called 

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

n/a

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
n/a
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
n/a
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented canceled or in-flight operations from being written to the in-memory cache, avoiding propagation of incorrect false results.
  * Ensured cache entries are only stored when operations complete successfully and the request context remains valid, improving cache reliability so subsequent requests no longer observe stale false responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3125)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->