### PR TITLE
fix: v2Check falls back to v1 on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Fixed cache key collisions in experimental `weighted_graph_check` union resolution by moving result caching from the union node level to the individual edge level, preventing collisions across requests that share edges but differ in object or relation. [#3117](https://github.com/openfga/openfga/pull/3117)
 - Fixed a bug in experimental `weighted_graph_check` where in-flight goroutines cancelled by a union short-circuit or recursive resolution could cache a false result, causing subsequent requests to incorrectly return false without querying the datastore. [#3125](https://github.com/openfga/openfga/pull/3125)
+- Fixed experimental `weighted_graph_check` returning an error for models that cannot be represented as a weighted graph; Check now falls back to the standard algorithm instead. [3126](https://github.com/openfga/openfga/pull/3126)
 
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Fixed cache key collisions in experimental `weighted_graph_check` union resolution by moving result caching from the union node level to the individual edge level, preventing collisions across requests that share edges but differ in object or relation. [#3117](https://github.com/openfga/openfga/pull/3117)
 - Fixed a bug in experimental `weighted_graph_check` where in-flight goroutines cancelled by a union short-circuit or recursive resolution could cache a false result, causing subsequent requests to incorrectly return false without querying the datastore. [#3125](https://github.com/openfga/openfga/pull/3125)
-- Fixed experimental `weighted_graph_check` returning an error for models that cannot be represented as a weighted graph; Check now falls back to the standard algorithm instead. [3126](https://github.com/openfga/openfga/pull/3126)
+- Fixed experimental `weighted_graph_check` returning an error when v2Check fails; Check now falls back to the standard algorithm instead.
 
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Fixed
 - Fixed cache key collisions in experimental `weighted_graph_check` union resolution by moving result caching from the union node level to the individual edge level, preventing collisions across requests that share edges but differ in object or relation. [#3117](https://github.com/openfga/openfga/pull/3117)
 - Fixed a bug in experimental `weighted_graph_check` where in-flight goroutines cancelled by a union short-circuit or recursive resolution could cache a false result, causing subsequent requests to incorrectly return false without querying the datastore. [#3125](https://github.com/openfga/openfga/pull/3125)
-- Fixed experimental `weighted_graph_check` returning an error when v2Check fails; Check now falls back to the standard algorithm instead.
+- Fixed experimental `weighted_graph_check` returning an error when v2Check fails; Check now falls back to the standard algorithm instead. [#3126](https://github.com/openfga/openfga/pull/3126)
 
 ### Security
 - Update toolchain Go version to 1.26.3 to address the Go standard library vulnerabilities documented in the [Go 1.26.3 release notes](https://go.dev/doc/devel/release#go1.26.3). [#3115](https://github.com/openfga/openfga/pull/3115)

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -79,7 +79,13 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		if err == nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return res, err
 		}
-		s.logger.WarnWithContext(ctx, "Weighted graph check failed, falling back to main Check", zap.Error(err))
+		requestID, _ := grpc_ctxtags.Extract(ctx).Values()["request_id"].(string)
+		s.logger.WarnWithContext(ctx, "Weighted graph check failed, falling back to main Check",
+			zap.Error(err),
+			zap.String("store_id", storeID),
+			zap.String("model_id", req.GetAuthorizationModelId()),
+			zap.String("request_id", requestID),
+		)
 	}
 
 	typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId())

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -75,7 +75,10 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	if s.featureFlagClient.Boolean(serverconfig.ExperimentalWeightedGraphCheck, storeID) {
 		// TODO: This path is missing some of the metrics/tracing information reported below
 		res, _, err := s.v2Check(ctx, req, s.sharedDatastoreResources.CheckCache, s.sharedDatastoreResources.CacheController, s.authzModelGraphResolver)
-		return res, err
+
+		if !errors.Is(err, modelgraph.ErrInvalidModel) {
+			return res, err
+		}
 	}
 
 	typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId())

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -76,9 +76,10 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		// TODO: This path is missing some of the metrics/tracing information reported below
 		res, _, err := s.v2Check(ctx, req, s.sharedDatastoreResources.CheckCache, s.sharedDatastoreResources.CacheController, s.authzModelGraphResolver)
 
-		if !errors.Is(err, modelgraph.ErrInvalidModel) {
+		if err == nil || errors.Is(err, context.DeadlineExceeded) {
 			return res, err
 		}
+		s.logger.WarnWithContext(ctx, "Weighted graph check failed, falling back to main Check", zap.Error(err))
 	}
 
 	typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId())

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -76,7 +76,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 		// TODO: This path is missing some of the metrics/tracing information reported below
 		res, _, err := s.v2Check(ctx, req, s.sharedDatastoreResources.CheckCache, s.sharedDatastoreResources.CacheController, s.authzModelGraphResolver)
 
-		if err == nil || errors.Is(err, context.DeadlineExceeded) {
+		if err == nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			return res, err
 		}
 		s.logger.WarnWithContext(ctx, "Weighted graph check failed, falling back to main Check", zap.Error(err))

--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -740,3 +740,37 @@ func TestV2CheckQueryCacheEnabled(t *testing.T) {
 		require.Empty(t, checkCache.setKeysWithPrefix("c."), "cache should have no subproblem entries when query cache is disabled")
 	})
 }
+
+func TestCheck_FallsBackToV1WhenWeightedGraphInvalid(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	// An intersection whose branches resolve to different terminal types (user vs bot).
+	// WriteAuthorizationModel accepts this because v1 validation doesn't enforce that all
+	// intersection branches reach the same terminal type, but the weighted graph builder
+	// returns ErrInvalidModel for it. Check must fall back to v1 instead of surfacing the error.
+	modelDSL := `
+		model
+			schema 1.1
+		type user
+		type bot
+		type document
+			relations
+				define user_access: [user]
+				define bot_access: [bot]
+				define viewer: user_access and bot_access
+	`
+
+	s, req := setupCheckServer(t, modelDSL,
+		[]*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "user_access", "user:alice"),
+		},
+		WithFeatureFlagClient(featureflags.NewDefaultClient([]string{serverconfig.ExperimentalWeightedGraphCheck})),
+	)
+
+	resp, err := s.Check(context.Background(), req)
+	require.NoError(t, err)
+	// v1 fallback: alice has user_access but not bot_access, so viewer (AND) is false.
+	require.False(t, resp.GetAllowed())
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

When ExperimentalWeightedGraphCheck is enabled, any error from v2Check — including models that pass write-time validation but can't be built into a weighted graph — is surfaced to the caller instead of degrading gracefully.

#### How is it being solved?

If v2Check returns any non-timeout error, execution falls through to the standard v1 Check algorithm rather than returning the error. The flag can be disabled per-store for customers with incompatible models in the interim.

#### What changes are made to solve it?

- pkg/server/check.go: changed the ExperimentalWeightedGraphCheck branch to only return early on success; any error falls through to v1.
- pkg/server/check_test.go: added TestCheck_FallsBackToV1WhenV2CheckErrors to verify the fallback using a model with a mixed-terminal-type intersection (which v2Check rejects but v1 handles).

## Testing

I tested that the new unit test fails without this code change and passes with it. I also manually tested by running openfga in docker with/without this change with experimental `weighted_graph_check` enabled and behaviour is as expected.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Experimental weighted-graph check no longer fails outright when the new check encounters recoverable errors; it now logs a warning and falls back to the standard resolution algorithm.

* **Tests**
  * Added a test verifying fallback to the standard check when a model is unsuitable for the weighted-graph check.

* **Changelog**
  * Recorded the fix under "Fixed" for the experimental weighted-graph check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3126)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->