### PR TITLE
fix(server): validate library-mode config in NewServerWithOpts

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -974,6 +974,18 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		return nil, fmt.Errorf("ListUsers default dispatch throttling threshold must be equal or smaller than max dispatch threshold for ListUsers")
 	}
 
+	if s.maxConcurrentReadsForListUsers == 0 {
+		return nil, fmt.Errorf("config 'maxConcurrentReadsForListUsers' cannot be 0")
+	}
+
+	if s.listObjectsDeadline < 0 {
+		return nil, fmt.Errorf("listObjectsDeadline must be non-negative time duration")
+	}
+
+	if s.listUsersDeadline < 0 {
+		return nil, fmt.Errorf("listUsersDeadline must be non-negative time duration")
+	}
+
 	if s.featureFlagClient == nil {
 		s.featureFlagClient = featureflags.NewDefaultClient(s.experimentals)
 	}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -192,6 +192,42 @@ func TestServerPanicIfValidationsFail(t *testing.T) {
 		})
 	})
 
+	t.Run("zero_max_concurrent_reads_for_list_users", func(t *testing.T) {
+		require.PanicsWithError(t, "failed to construct the OpenFGA server: config 'maxConcurrentReadsForListUsers' cannot be 0", func() {
+			mockController := gomock.NewController(t)
+			defer mockController.Finish()
+			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+			_ = MustNewServerWithOpts(
+				WithDatastore(mockDatastore),
+				WithMaxConcurrentReadsForListUsers(0),
+			)
+		})
+	})
+
+	t.Run("negative_list_objects_deadline", func(t *testing.T) {
+		require.PanicsWithError(t, "failed to construct the OpenFGA server: listObjectsDeadline must be non-negative time duration", func() {
+			mockController := gomock.NewController(t)
+			defer mockController.Finish()
+			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+			_ = MustNewServerWithOpts(
+				WithDatastore(mockDatastore),
+				WithListObjectsDeadline(-1*time.Second),
+			)
+		})
+	})
+
+	t.Run("negative_list_users_deadline", func(t *testing.T) {
+		require.PanicsWithError(t, "failed to construct the OpenFGA server: listUsersDeadline must be non-negative time duration", func() {
+			mockController := gomock.NewController(t)
+			defer mockController.Finish()
+			mockDatastore := mockstorage.NewMockOpenFGADatastore(mockController)
+			_ = MustNewServerWithOpts(
+				WithDatastore(mockDatastore),
+				WithListUsersDeadline(-1*time.Second),
+			)
+		})
+	})
+
 	t.Run("invalid_access_control_setup", func(t *testing.T) {
 		require.PanicsWithError(t, "failed to construct the OpenFGA server: access control parameters are not enabled. They can be enabled for experimental use by passing the `--experimentals enable-access-control` configuration option when running OpenFGA server. Additionally, the `--access-control-store-id` and `--access-control-model-id` parameters must not be empty", func() {
 			mockController := gomock.NewController(t)


### PR DESCRIPTION
## Summary

Closes #1874

When OpenFGA is used as a library via `NewServerWithOpts()`, critical configuration constraints were silently bypassed because `Verify()` is only called on the binary path (`cmd/run/run.go`). This means invalid configurations like zero concurrent reads or negative deadlines were accepted without error.

This PR adds the three missing server-side validations directly in `NewServerWithOpts()`:

- `maxConcurrentReadsForListUsers` cannot be `0`
- `listObjectsDeadline` must be non-negative
- `listUsersDeadline` must be non-negative

These match the existing checks in `VerifyServerSettings()` and ensure library consumers get the same safety guarantees as binary users.

## Changes

- **`pkg/server/server.go`**: Added 3 validation checks in `NewServerWithOpts()` before the "don't throw errors" boundary
- **`pkg/server/server_test.go`**: Added 3 corresponding test cases to `TestServerPanicIfValidationsFail`

## Test plan

- [x] `TestServerPanicIfValidationsFail/zero_max_concurrent_reads_for_list_users`
- [x] `TestServerPanicIfValidationsFail/negative_list_objects_deadline`
- [x] `TestServerPanicIfValidationsFail/negative_list_users_deadline`
- [x] All existing `TestServerPanicIfValidationsFail` subtests still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now rejects invalid server configurations (zero concurrency or negative timeouts), preventing misconfigured instances from initializing.
* **Tests**
  * Added coverage that ensures these configuration validations fail fast if invalid values are provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3127)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->