### PR TITLE
fix: prevent v2Check strategies returning spurious false on context cancellation

### DIFF
--- a/internal/check/default.go
+++ b/internal/check/default.go
@@ -123,6 +123,11 @@ func (s *DefaultStrategy) execute(ctx context.Context, req *Request, edge *authz
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case outcome, ok := <-responsesChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				return &Response{Allowed: false}, err
 			}

--- a/internal/check/default_test.go
+++ b/internal/check/default_test.go
@@ -438,3 +438,68 @@ func TestDefaultTTU(t *testing.T) {
 		})
 	}
 }
+
+// TestDefaultExecuteCancelledContextRace is a probabilistic regression test for the race where
+// Go's select non-deterministically picks a closed responsesChan over ctx.Done() when both are
+// ready simultaneously. Without the ctx.Err() guard this would occasionally return
+// {Allowed:false, nil} instead of propagating the cancellation error.
+func TestDefaultExecuteCancelledContextRace(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		  model
+		   schema 1.1
+
+		  type user
+		  type document
+		   relations
+			define member: [user]
+			define viewer: member from owner
+			define owner: [document]
+	`)
+
+	mg, err := modelgraph.New(model)
+	require.NoError(t, err)
+
+	edges, ok := mg.GetEdgesFromNodeId("document#viewer")
+	require.True(t, ok)
+
+	var ttuEdge *authzGraph.WeightedAuthorizationModelEdge
+	for _, edge := range edges {
+		if edge.GetEdgeType() == authzGraph.TTUEdge {
+			ttuEdge = edge
+			break
+		}
+	}
+	require.NotNil(t, ttuEdge)
+
+	storeID := ulid.Make().String()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockResolver := NewMockCheckResolver(ctrl)
+	// Return not-allowed so the strategy keeps consuming; this keeps responsesChan active
+	// and widens the window where ctx.Done() and the channel close race.
+	mockResolver.EXPECT().ResolveUnion(gomock.Any(), gomock.Any(), gomock.Any(), nil).
+		MaxTimes(1).Return(&Response{Allowed: false}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so both cases are ready immediately
+
+	iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+		tuple.NewTupleKey("document:1", "owner", "document:2"),
+	})
+	strategy := NewDefault(mg, mockResolver, 2)
+
+	req, err := NewRequest(RequestParams{
+		StoreID:  storeID,
+		Model:    mg,
+		TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
+	})
+	require.NoError(t, err)
+
+	res, err := strategy.TTU(ctx, req, ttuEdge, iter, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, res)
+}

--- a/internal/check/recursive.go
+++ b/internal/check/recursive.go
@@ -215,6 +215,11 @@ func (s *Recursive) recursiveMatch(ctx context.Context, req *Request, recursiveE
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case msg, ok := <-responsesChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				return &Response{Allowed: false}, err
 			}

--- a/internal/check/recursive.go
+++ b/internal/check/recursive.go
@@ -106,6 +106,11 @@ func (s *Recursive) execute(ctx context.Context, req *Request, edge *authzGraph.
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case msg, ok := <-leftChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				leftChan = nil
 				// if no ids from the left side were returned then return false without error
@@ -139,6 +144,11 @@ func (s *Recursive) execute(ctx context.Context, req *Request, edge *authzGraph.
 			}
 
 		case msg, ok := <-rightChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				rightChan = nil
 				if len(idsFromObject) == 0 {

--- a/internal/check/recursive_test.go
+++ b/internal/check/recursive_test.go
@@ -1467,6 +1467,62 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 	})
 }
 
+// TestRecursiveExecuteCancelledContextRace is a probabilistic regression test for the race where
+// Go's select non-deterministically picks a closed leftChan/rightChan over ctx.Done() when both
+// are ready simultaneously. Without the ctx.Err() guard this would occasionally return
+// {Allowed:false, nil} instead of propagating the cancellation error.
+func TestRecursiveExecuteCancelledContextRace(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+		type user
+		type group
+			relations
+				define member: [user] or member from parent
+				define parent: [group]
+	`)
+
+	mg, err := modelgraph.New(model)
+	require.NoError(t, err)
+
+	node, ok := mg.GetNodeByID("group#member")
+	require.True(t, ok)
+	recursiveEdge, ok := mg.CanApplyRecursion(node, "user", true)
+	require.True(t, ok)
+
+	storeID := ulid.Make().String()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+	// Non-empty iterator so leftChan carries a value before closing,
+	// widening the window where ctx.Done() and the channel close are both ready.
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+		MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		{Key: tuple.NewTupleKey("group:2", "member", "user:maria")},
+	}), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
+
+	req, err := NewRequest(RequestParams{
+		StoreID:  storeID,
+		Model:    mg,
+		TupleKey: tuple.NewTupleKey("group:1", "member", "user:maria"),
+	})
+	require.NoError(t, err)
+
+	strategy := NewRecursive(mg, mockDatastore, 5)
+	res, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+		tuple.NewTupleKey("group:1", "parent", "group:2"),
+	}), nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, res)
+}
+
 func TestRecursiveTTUWithContextualTuples(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)

--- a/internal/check/weight2.go
+++ b/internal/check/weight2.go
@@ -92,6 +92,11 @@ func (s *Weight2) execute(ctx context.Context, leftChan chan *iterator.Msg, righ
 
 		// Process an item from the left channel
 		case leftMsg, ok := <-leftChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				leftChan = nil
 				if len(leftSeen) == 0 {
@@ -139,6 +144,11 @@ func (s *Weight2) execute(ctx context.Context, leftChan chan *iterator.Msg, righ
 
 		// Process an item from the right channel
 		case rightMsg, ok := <-rightChan:
+			// select may choose a closed channel over ctx.Done(); re-check cancellation.
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+
 			if !ok {
 				rightChan = nil
 				if len(rightSeen) == 0 {

--- a/internal/check/weight2_test.go
+++ b/internal/check/weight2_test.go
@@ -928,3 +928,68 @@ func TestWeight2TTU(t *testing.T) {
 		require.True(t, res.GetAllowed())
 	})
 }
+
+// TestWeight2ExecuteCancelledContextRace is a probabilistic regression test for the race where
+// Go's select non-deterministically picks a closed leftChan/rightChan over ctx.Done() when both
+// are ready simultaneously. Without the ctx.Err() guard this would occasionally return
+// {Allowed:false, nil} instead of propagating the cancellation error.
+func TestWeight2ExecuteCancelledContextRace(t *testing.T) {
+	t.Cleanup(func() { goleak.VerifyNone(t) })
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	storeID := ulid.Make().String()
+
+	mockDatastore := mocks.NewMockOpenFGADatastore(ctrl)
+	// Non-empty iterator so leftChan carries a value before closing,
+	// widening the window where ctx.Done() and the channel close are both ready.
+	// group#all is a union of "members" and "public" so bottomUp calls ReadStartingWithUser
+	// for each operand (members, public-direct, public-wildcard); allow up to 3 calls.
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
+		MaxTimes(3).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
+	}), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+		type user
+		type group
+			relations
+				define members: [user]
+				define public: [user, user:*]
+				define all: members or public
+		type document
+			relations
+				define viewer: [group#all]
+	`)
+
+	mg, err := modelgraph.New(model)
+	require.NoError(t, err)
+
+	edges, ok := mg.GetEdgesFromNodeId("group#all")
+	require.True(t, ok)
+
+	iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		User:     "group:1#all",
+		Relation: "viewer",
+		Object:   "document:1",
+	}})
+
+	strategy := NewWeight2(mg, mockDatastore)
+	req, err := NewRequest(RequestParams{
+		StoreID:  storeID,
+		Model:    mg,
+		TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:1"),
+	})
+	require.NoError(t, err)
+
+	res, err := strategy.Userset(ctx, req, edges[0], iter, nil)
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, res)
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

When a context is cancelled, iterator.ToChannel closes its output channel (because iter.Next(ctx) returns context.Canceled, satisfying IterIsDoneOrCancelled). This means ctx.Done() and the channel close become ready simultaneously in the select loop. Go's select picks non-deterministically between ready cases, so the channel branch can be chosen instead of ctx.Done(). When the channel is closed (ok == false) and the accumulated result set is empty, the strategies were returning &Response{Allowed: false}, nil — a definitive authorization result — instead of propagating the cancellation error. This is a silent false-negative that could be cached (see commit c3068126).

#### How is it being solved?

After the select picks a channel case, immediately re-check ctx.Err(). If it's non-nil, the channel closed due to cancellation rather than exhaustion, so propagate the error instead of acting on the closed channel.

#### What changes are made to solve it?

- default.go — guard added after case outcome, ok := <-responsesChan                                                                                                                                                                                        
- weight2.go — guard added after both case leftMsg, ok := <-leftChan and case rightMsg, ok := <-rightChan         
- recursive.go — same guard added to execute (both leftChan and rightChan cases); additionally, the visited map in recursiveMatch is pre-populated before the goroutine pool starts, closing a separate race where a node could be dispatched twice if it was picked off the range loop before being marked visited                                                                                                                                                                                                   
- Three test files — one probabilistic regression test per strategy, each pre-cancelling the context so both ctx.Done() and the channel close are simultaneously ready

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed race conditions in multiple authorization evaluation paths so canceled operations now consistently return the context error instead of continuing with stale results.

* **Tests**
  * Added regression tests to verify cancellation behavior and prevention of stale outcomes across different evaluation strategies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3128)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->