### PR TITLE
Fix flaky matrix test

### DIFF
--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -283,8 +283,9 @@ func MustDefaultConfigForParallelTests() *serverconfig.Config {
 	config.Datastore.ConnMaxIdleTime = 5 * time.Second
 	config.Datastore.ConnMaxLifetime = 10 * time.Second
 
-	// extend the timeout for the tests, coverage makes them slower
-	config.RequestTimeout = 10 * time.Second
+	// 30s gives recursive resolution (e.g. userset_recursive_combined_w3)
+	// enough headroom on resource-constrained CI runners.
+	config.RequestTimeout = 30 * time.Second
 
 	return config
 }

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -274,17 +274,18 @@ func MustDefaultConfig() *serverconfig.Config {
 }
 
 // MustDefaultConfigForParallelTests returns default server config suitable for parallel tests.
-// It limits the connection idle time and lifetime to prevent bad connections
+// It relaxes connection lifecycle settings to prevent pool churn under heavy parallel load
 // and extends the request timeout to accommodate slower test environments.
 func MustDefaultConfigForParallelTests() *serverconfig.Config {
 	config := MustDefaultConfig()
 
-	// limit IdleTime and Lifetime to prevent bad connections
-	config.Datastore.ConnMaxIdleTime = 5 * time.Second
-	config.Datastore.ConnMaxLifetime = 10 * time.Second
+	// Relaxed lifecycle prevents connection pool churn: ~268 parallel subtests
+	// cause aggressive recycling with short lifetimes, leading to TCP i/o timeouts
+	// when pgxpool tries to create many replacement connections simultaneously.
+	config.Datastore.ConnMaxIdleTime = 30 * time.Second
+	config.Datastore.ConnMaxLifetime = 60 * time.Second
+	config.Datastore.MaxIdleConns = config.Datastore.MaxOpenConns
 
-	// 30s gives recursive resolution (e.g. userset_recursive_combined_w3)
-	// enough headroom on resource-constrained CI runners.
 	config.RequestTimeout = 30 * time.Second
 
 	return config

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -105,9 +105,9 @@ func BuildClientInterface(t *testing.T, engine string, experimentals []string) C
 	cfg.ListObjectsIteratorCache.Enabled = true
 	cfg.ContextPropagationToDatastore = true
 
-	cfg.MaxConcurrentReadsForListObjects = 25
-	cfg.MaxConcurrentReadsForCheck = 25
-	cfg.MaxConcurrentReadsForListUsers = 25
+	cfg.MaxConcurrentReadsForListObjects = 10
+	cfg.MaxConcurrentReadsForCheck = 10
+	cfg.MaxConcurrentReadsForListUsers = 10
 
 	StartServer(t, cfg)
 

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -105,6 +105,10 @@ func BuildClientInterface(t *testing.T, engine string, experimentals []string) C
 	cfg.ListObjectsIteratorCache.Enabled = true
 	cfg.ContextPropagationToDatastore = true
 
+	cfg.MaxConcurrentReadsForListObjects = 25
+	cfg.MaxConcurrentReadsForCheck = 25
+	cfg.MaxConcurrentReadsForListUsers = 25
+
 	StartServer(t, cfg)
 
 	conn := testutils.CreateGrpcConnection(t, cfg.GRPC.Addr)


### PR DESCRIPTION
## Description

  #### What problem is being solved?

  `TestMatrixPostgres` / `test_userset_recursive_combined_w3` assertions 6 and 7 fail intermittently in CI with `iterator: sql error: timeout: read tcp 127.0.0.1:…->127.0.0.1:…: i/o
  timeout`. The `employee:public` query triggers deep recursive resolution (wildcard expansion + 4 levels of userset recursion + CEL condition evaluation) that fans out ~20-50 concurrent
  storage reads. On resource-constrained CI runners, these reads saturate the connection pool (30 conns) while `MaxConcurrentReads` is effectively unlimited (`math.MaxUint32`). With
  `ContextPropagationToDatastore=true`, the 10s `RequestTimeout` cancels the context, which cascades into in-flight Postgres queries, producing the i/o timeout error.

  #### How is it being solved?

  Two complementary changes reduce pool contention and give recursive resolution enough time headroom:

  1. **Cap `MaxConcurrentReads` to 25** for Check, ListObjects, and ListUsers in matrix tests — this prevents recursive fan-out from attempting more concurrent reads than the pool can
  serve, forcing the resolver to queue internally rather than saturating the pool.

  2. **Increase `RequestTimeout` from 10s to 30s** in `MustDefaultConfigForParallelTests()` — even with capped concurrency, resource-constrained CI runners need more headroom for deep
  recursive resolution to complete.

  #### What changes are made to solve it?

  - `pkg/testutils/testutils.go`: Bump `RequestTimeout` from 10s to 30s in `MustDefaultConfigForParallelTests()`
  - `tests/tests.go`: Add `MaxConcurrentReadsForListObjects`, `MaxConcurrentReadsForCheck`, and `MaxConcurrentReadsForListUsers` (all set to 25) in `BuildClientInterface()`

  ## References

  N/A — this is a CI flakiness fix with no associated issue.

  ## Review Checklist
  - [x] I have clicked on ["allow edits by
  maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
  - [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
  - [x] The correct base branch is being used, if not `main`
  - [ ] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased test request timeout to 30 seconds to improve reliability of parallel test runs.
  * Adjusted datastore connection pooling and concurrency settings to improve performance and stability under heavy parallel load (higher idle/lifetime limits and raised read concurrency for list/check operations).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3129)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->