### PR TITLE
chore: drop grpc_health_probe binary from released Docker image

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,11 +1,4 @@
 FROM cgr.dev/chainguard/static@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b
 COPY assets /assets
 COPY openfga /
-
-# Goreleaser does not support multi-stage builds. See:
-# https://github.com/goreleaser/goreleaser/issues/609
-#
-# Dependabot is also not capable of updating inline image copies at this time, so
-# this needs to be updated manually until one of these issues is resolved.
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.50@sha256:72c25a244d947eb2b31db49cdb503c4c807d6895c67253eefac5ffde15c44fbd /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
## Summary

Closes #2373

Kubernetes v1.23+ (released Dec 2021) has native gRPC liveness/readiness probe support via `livenessProbe.grpc`, making the bundled `grpc_health_probe` binary unnecessary. The binary is copied from an external image layer and regularly surfaces CVEs unrelated to OpenFGA itself.

**Changes:**
- Removes the `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe` line from `Dockerfile.goreleaser`
- No application code or behaviour changes

Consumers on Kubernetes < v1.23 can layer the binary on top of the released image in their own Dockerfile.

## Test plan
- [ ] Docker image builds without the binary
- [ ] Verify `grpc_health_probe` is absent from the released image layers
- [ ] helm-charts liveness probe updated to native `livenessProbe.grpc` (separate PR in openfga/helm-charts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the container image by removing an obsolete multi-stage workaround.
  * Resulting image and build configuration are leaner and cleaner, reducing maintenance and build complexity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->