### PR TITLE
fix(typesystem): improve error message when tupleset relation has userset type restrictions

### DIFF
--- a/pkg/server/commands/write_authzmodel_test.go
+++ b/pkg/server/commands/write_authzmodel_test.go
@@ -1109,7 +1109,28 @@ func TestWriteAuthorizationModel(t *testing.T) {
 						define viewer: [user] or viewer from parent`).GetTypeDefinitions(),
 			},
 			errCode:    codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
-			errMessage: "the relation type 'folder#parent' on 'parent' in object type 'folder' is not valid",
+			errMessage: "the 'folder#parent' relation is referenced in at least one tupleset and cannot have userset type restrictions; the type restriction 'folder#parent' is not valid for a tupleset relation",
+		},
+		`fail_invalid_type_restriction_on_tupleset_implied_relation`: {
+			setMock: func(datastore *mockstorage.MockOpenFGADatastore) {},
+			request: &openfgav1.WriteAuthorizationModelRequest{
+				StoreId: storeID,
+				TypeDefinitions: parser.MustTransformDSLToProto(`
+				model
+					schema 1.1
+				type user
+					relations
+						define manager: [user]
+				type company
+					relations
+						define employee: [user]
+				type group
+					relations
+						define member: [user, company#employee]
+						define manager: manager from member`).GetTypeDefinitions(),
+			},
+			errCode:    codes.Code(openfgav1.ErrorCode_invalid_authorization_model),
+			errMessage: "the 'group#member' relation is referenced in at least one tupleset and cannot have userset type restrictions; the type restriction 'company#employee' is not valid for a tupleset relation",
 		},
 		`fail_undefined_relation_2`: {
 			setMock: func(datastore *mockstorage.MockOpenFGADatastore) {},

--- a/pkg/typesystem/error.go
+++ b/pkg/typesystem/error.go
@@ -158,3 +158,14 @@ func InvalidRelationTypeError(objectType, relation, relatedObjectType, relatedRe
 
 	return fmt.Errorf("the relation type '%s' on '%s' in object type '%s' is not valid", relationType, relation, objectType)
 }
+
+// InvalidTuplesetRelationTypeRestrictionError returns an error when a tupleset relation
+// includes a userset type restriction (e.g. "company#employee"), which is not allowed.
+// Tupleset relations must only reference direct object types without a relation component.
+func InvalidTuplesetRelationTypeRestrictionError(objectType, relation, relatedObjectType, relatedRelation string) error {
+	relationType := tuple.ToObjectRelationString(relatedObjectType, relatedRelation)
+	return fmt.Errorf(
+		"the '%s#%s' relation is referenced in at least one tupleset and cannot have userset type restrictions; the type restriction '%s' is not valid for a tupleset relation",
+		objectType, relation, relationType,
+	)
+}

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -1385,6 +1385,9 @@ func (t *TypeSystem) validateTypeRestrictions(objectType string, relationName st
 		if related.GetRelationOrWildcard() != nil {
 			// The type of the relation cannot contain a userset or wildcard if the relation is a tupleset relation.
 			if ok, _ := t.IsTuplesetRelation(objectType, relationName); ok {
+				if relatedRelation != "" {
+					return InvalidTuplesetRelationTypeRestrictionError(objectType, relationName, relatedObjectType, relatedRelation)
+				}
 				return InvalidRelationTypeError(objectType, relationName, relatedObjectType, relatedRelation)
 			}
 

--- a/pkg/typesystem/typesystem_test.go
+++ b/pkg/typesystem/typesystem_test.go
@@ -2545,7 +2545,7 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 					},
 				},
 			},
-			err: InvalidRelationTypeError("document", "parent", "folder", "member"),
+			err: InvalidTuplesetRelationTypeRestrictionError("document", "parent", "folder", "member"),
 		},
 		{
 			name: "userset_specified_as_allowed_type_but_the_relation_is_used_in_a_TTU_rewrite_included_in_a_union",
@@ -2604,7 +2604,7 @@ func TestInvalidRelationTypeRestrictionsValidations(t *testing.T) {
 					},
 				},
 			},
-			err: InvalidRelationTypeError("document", "parent", "folder", "parent"),
+			err: InvalidTuplesetRelationTypeRestrictionError("document", "parent", "folder", "parent"),
 		},
 		{
 			name: "WildcardNotAllowedInTheTuplesetPartOfTTU",


### PR DESCRIPTION
## Summary

Fixes #2137

When a tupleset relation (e.g. `member` in `manager from member`) includes a userset type restriction such as `company#employee`, the previous error was:

```
the relation type 'company#employee' on 'member' in object type 'group' is not valid
```

This message doesn't explain *why* the type restriction is invalid. The real constraint — that tupleset relations cannot reference userset types — was hidden.

**New message:**
```
the 'group#member' relation is referenced in at least one tupleset and cannot have userset type restrictions; the type restriction 'company#employee' is not valid for a tupleset relation
```

## Changes

- `pkg/typesystem/error.go`: Add `InvalidTuplesetRelationTypeRestrictionError` for userset-type-restriction-on-tupleset cases.
- `pkg/typesystem/typesystem.go`: Use the new error in `validateTypeRestrictions` when `relatedRelation != ""`.
- `pkg/server/commands/write_authzmodel_test.go`: Update existing test + add regression test for the exact model from issue #2137.

## Test plan

- [x] `go test ./pkg/typesystem/...` passes
- [x] `go test ./pkg/server/commands/...` passes
- [x] Wildcard-only tupleset restriction still uses the generic error (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and clearer error messages when type restrictions on tupleset relations are invalid, making authorization model errors more specific and actionable.
  * Strengthened checks to correctly identify and report cases where referenced relations cannot have userset type restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->