### PR TITLE
increase the check v2 trace information fidelity

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -108,7 +108,11 @@ func (r *Resolver) ResolveCheck(ctx context.Context, req *Request) (*Response, e
 	))
 	defer span.End()
 
-	defer span.RecordError(ctx.Err())
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			span.RecordError(err)
+		}
+	}()
 
 	node, ok := r.model.GetNodeByID(tuple.ToObjectRelationString(req.GetObjectType(), req.GetTupleKey().GetRelation()))
 	if !ok {
@@ -201,7 +205,11 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	))
 	defer span.End()
 
-	defer span.RecordError(ctx.Err())
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			span.RecordError(err)
+		}
+	}()
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -311,7 +319,11 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 	))
 	defer span.End()
 
-	defer span.RecordError(ctx.Err())
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			span.RecordError(err)
+		}
+	}()
 
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {
@@ -492,7 +504,11 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 	))
 	defer span.End()
 
-	defer span.RecordError(ctx.Err())
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			span.RecordError(err)
+		}
+	}()
 
 	nonRecursiveEdges, err := r.model.FlattenNode(edge.GetTo(), req.GetUserType(), req.IsTypedWildcard(), true)
 	if err != nil {
@@ -746,7 +762,11 @@ func (r *Resolver) ResolveEdge(ctx context.Context, req *Request, edge *authzGra
 	))
 	defer span.End()
 
-	defer span.RecordError(ctx.Err())
+	defer func() {
+		if err := ctx.Err(); err != nil {
+			span.RecordError(err)
+		}
+	}()
 
 	var visitedObjects *sync.Map
 	if edge.IsPartOfTupleCycle() || edge.GetRecursiveRelation() != "" {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -12,6 +12,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
@@ -96,15 +97,26 @@ func New(cfg Config) *Resolver {
 
 func (r *Resolver) ResolveCheck(ctx context.Context, req *Request) (*Response, error) {
 	ctx, span := tracer.Start(ctx, "ResolveCheck", trace.WithAttributes(
+		attribute.String("consistency", req.GetConsistency().String()),
 		attribute.String("store_id", req.GetStoreID()),
+		attribute.String("model_id", req.GetAuthorizationModelID()),
+		attribute.String("object", req.GetTupleKey().GetObject()),
+		attribute.String("relation", req.GetTupleKey().GetRelation()),
+		attribute.String("user", req.GetTupleKey().GetUser()),
 		attribute.String("tuple_key", req.GetTupleString()),
 		attribute.Bool("allowed", false),
 	))
 	defer span.End()
 
+	defer span.RecordError(ctx.Err())
+
 	node, ok := r.model.GetNodeByID(tuple.ToObjectRelationString(req.GetObjectType(), req.GetTupleKey().GetRelation()))
 	if !ok {
 		// this should never happen as the request is already validated before
+		span.AddEvent("invalid_node", trace.WithAttributes(
+			attribute.String("node", tuple.ToObjectRelationString(req.GetObjectType(), req.GetTupleKey().GetRelation())),
+		))
+		span.SetStatus(codes.Error, "invalid node")
 		return nil, ErrPanicRequest
 	}
 
@@ -112,19 +124,29 @@ func (r *Resolver) ResolveCheck(ctx context.Context, req *Request) (*Response, e
 	_, ok = r.model.GetNodeWeight(node, req.GetUserType())
 	if !ok {
 		// If the user type is not reachable from the object type and relation, we can immediately return false.
+		span.AddEvent("user_type_not_reachable", trace.WithAttributes(
+			attribute.String("node", node.GetUniqueLabel()),
+			attribute.String("user_type", req.GetUserType()),
+		))
 		return &Response{Allowed: false}, nil
 	}
 
 	// Check if the user is a wildcard and if the node does not have a path to the user type wildcard then return false
 	if req.IsTypedWildcard() && !slices.Contains(node.GetWildcards(), req.GetUserType()) {
+		span.AddEvent("user_wildcard_not_reachable", trace.WithAttributes(
+			attribute.String("node", node.GetUniqueLabel()),
+			attribute.String("user_type", req.GetUserType()),
+		))
 		return &Response{Allowed: false}, nil
 	}
 
 	res, err := r.ResolveUnion(ctx, req, node, nil)
 	if err != nil {
-		telemetry.TraceError(span, err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
+
 	if res.GetAllowed() {
 		span.SetAttributes(attribute.Bool("allowed", true))
 	}
@@ -175,48 +197,83 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	ctx, span := tracer.Start(ctx, "ResolveUnionEdges", trace.WithAttributes(
 		attribute.String("tuple_key", req.GetTupleString()),
 		attribute.Bool("allowed", false),
+		attribute.Int("edge_count", len(edges)),
 	))
 	defer span.End()
+
+	defer span.RecordError(ctx.Err())
 
 	ctx, cancel := context.WithCancel(ctx)
 
 	out := make(chan ResponseMsg, len(edges))
+
 	var pool errgroup.Group
 	pool.SetLimit(r.concurrencyLimit)
+
 	defer func() {
 		cancel()
 		_ = pool.Wait()
 		close(out)
 	}()
 
-	ids := make([]string, 0, len(edges))
+	type pair struct {
+		id   string
+		edge *authzGraph.WeightedAuthorizationModelEdge
+	}
+
+	var expectedMessages int
+	evaluations := make([]pair, 0, len(edges))
+
 	for _, edge := range edges {
 		id := buildEdgeCacheKey(r.model.GetModelID(), req, edge)
-		ids = append(ids, id)
+		expectedMessages++
+
 		if res, ok := r.isCached(req.GetConsistency(), id); ok {
 			span.AddEvent("cache_hit", trace.WithAttributes(
 				attribute.String("cache_key", id),
 				attribute.Bool("allowed", res.GetAllowed()),
 			))
+
 			concurrency.TrySendThroughChannel(ctx, ResponseMsg{ID: id, Res: res}, out)
+
 			if res.GetAllowed() {
+				expectedMessages -= len(evaluations)
+				clear(evaluations)
 				break
 			}
+
 			continue
 		}
+
+		evaluations = append(evaluations, pair{id, edge})
+	}
+
+	for _, evaluation := range evaluations {
 		pool.Go(func() error {
-			res, err := r.ResolveEdge(ctx, req, edge, visited)
+			res, err := r.ResolveEdge(ctx, req, evaluation.edge, visited)
 			if err == nil && ctx.Err() == nil {
 				entry := &ResponseCacheEntry{Res: res, LastModified: time.Now()}
-				r.cache.Set(id, entry, r.cacheTTL)
+				r.cache.Set(evaluation.id, entry, r.cacheTTL)
 			}
-			concurrency.TrySendThroughChannel(ctx, ResponseMsg{ID: id, Res: res, Err: err}, out)
+
+			span.AddEvent("edge_resolved", trace.WithAttributes(
+				attribute.String("cache_key", evaluation.id),
+				attribute.Bool("allowed", res.GetAllowed()),
+			))
+
+			if err != nil {
+				span.RecordError(err, trace.WithAttributes(
+					attribute.String("edge.to", evaluation.edge.GetTo().GetUniqueLabel()),
+				))
+			}
+
+			concurrency.TrySendThroughChannel(ctx, ResponseMsg{ID: evaluation.id, Res: res, Err: err}, out)
 			return nil
 		})
 	}
 
 	var err error
-	for range ids {
+	for range expectedMessages {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -233,21 +290,28 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 			}
 		}
 	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	if err != nil {
 		// we only return error in a union when all edges are exhausted and there is at least one edge with error
 		return nil, err
 	}
-	res := &Response{Allowed: false}
-	return res, nil
+
+	return &Response{Allowed: false}, nil
 }
 
 // reduce as a logical union operation (exit the moment we have a single true).
 func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGraph.WeightedAuthorizationModelNode, visited *sync.Map) (*Response, error) {
 	ctx, span := tracer.Start(ctx, "ResolveUnion", trace.WithAttributes(
 		attribute.String("tuple_key", req.GetTupleString()),
-		attribute.Bool("cached", false),
+		attribute.String("node", node.GetUniqueLabel()),
 	))
 	defer span.End()
+
+	defer span.RecordError(ctx.Err())
 
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {
@@ -419,13 +483,27 @@ func (r *Resolver) resolveRecursiveTTU(ctx context.Context, req *Request, edge *
 }
 
 func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *authzGraph.WeightedAuthorizationModelEdge, visited *sync.Map, canApplyOptimization bool) (*Response, error) {
+	ctx, span := tracer.Start(ctx, "ResolveRecursive", trace.WithAttributes(
+		attribute.String("edge.to", edge.GetTo().GetUniqueLabel()),
+		attribute.String("edge.from", edge.GetFrom().GetUniqueLabel()),
+		attribute.String("tuple_key", req.GetTupleString()),
+		attribute.Bool("allowed", false),
+		attribute.Bool("canApplyOptimization", canApplyOptimization),
+	))
+	defer span.End()
+
+	defer span.RecordError(ctx.Err())
+
 	nonRecursiveEdges, err := r.model.FlattenNode(edge.GetTo(), req.GetUserType(), req.IsTypedWildcard(), true)
 	if err != nil {
 		return nil, errors.Join(ErrPanicRequest, err)
 	}
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
 	out := make(chan ResponseMsg, 2)
+
 	go func() {
 		res, err := r.ResolveUnionEdges(ctx, req, nonRecursiveEdges, visited)
 		concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res, Err: err}, out)
@@ -435,9 +513,6 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 		cacheKey := buildEdgeCacheKey(r.model.GetModelID(), req, edge)
 
 		if res, ok := r.isCached(req.GetConsistency(), cacheKey); ok {
-			span := trace.SpanFromContext(ctx)
-			span.SetAttributes(attribute.Bool("cached", true))
-
 			concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res}, out)
 			return
 		}
@@ -461,7 +536,7 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 		concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res, Err: err}, out)
 	}()
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -472,10 +547,16 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 			}
 
 			if msg.Res.GetAllowed() {
+				span.SetAttributes(attribute.Bool("allowed", true))
 				return msg.Res, nil
 			}
 		}
 	}
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	return &Response{Allowed: false}, err
 }
 
@@ -658,6 +739,15 @@ func (r *Resolver) ResolveExclusion(ctx context.Context, req *Request, node *aut
 }
 
 func (r *Resolver) ResolveEdge(ctx context.Context, req *Request, edge *authzGraph.WeightedAuthorizationModelEdge, visited *sync.Map) (*Response, error) {
+	ctx, span := tracer.Start(ctx, "ResolveEdge", trace.WithAttributes(
+		attribute.String("tuple_key", req.GetTupleString()),
+		attribute.String("edge.to", edge.GetTo().GetUniqueLabel()),
+		attribute.String("edge.from", edge.GetFrom().GetUniqueLabel()),
+	))
+	defer span.End()
+
+	defer span.RecordError(ctx.Err())
+
 	var visitedObjects *sync.Map
 	if edge.IsPartOfTupleCycle() || edge.GetRecursiveRelation() != "" {
 		visitedObjects = visited

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -108,11 +108,11 @@ func (r *Resolver) ResolveCheck(ctx context.Context, req *Request) (*Response, e
 	))
 	defer span.End()
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			span.RecordError(err)
 		}
-	}()
+	}(ctx)
 
 	node, ok := r.model.GetNodeByID(tuple.ToObjectRelationString(req.GetObjectType(), req.GetTupleKey().GetRelation()))
 	if !ok {
@@ -205,11 +205,11 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 	))
 	defer span.End()
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			span.RecordError(err)
 		}
-	}()
+	}(ctx)
 
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -320,11 +320,11 @@ func (r *Resolver) ResolveUnion(ctx context.Context, req *Request, node *authzGr
 	))
 	defer span.End()
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			span.RecordError(err)
 		}
-	}()
+	}(ctx)
 
 	emptyCycle := visited == nil
 	if emptyCycle && node.GetNodeType() == authzGraph.SpecificTypeAndRelation && (node.GetRecursiveRelation() == node.GetUniqueLabel() || node.IsPartOfTupleCycle()) {
@@ -505,11 +505,11 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 	))
 	defer span.End()
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			span.RecordError(err)
 		}
-	}()
+	}(ctx)
 
 	nonRecursiveEdges, err := r.model.FlattenNode(edge.GetTo(), req.GetUserType(), req.IsTypedWildcard(), true)
 	if err != nil {
@@ -763,11 +763,11 @@ func (r *Resolver) ResolveEdge(ctx context.Context, req *Request, edge *authzGra
 	))
 	defer span.End()
 
-	defer func() {
+	defer func(ctx context.Context) {
 		if err := ctx.Err(); err != nil {
 			span.RecordError(err)
 		}
-	}()
+	}(ctx)
 
 	var visitedObjects *sync.Map
 	if edge.IsPartOfTupleCycle() || edge.GetRecursiveRelation() != "" {

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -305,6 +305,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 
 	if err != nil {
 		// we only return error in a union when all edges are exhausted and there is at least one edge with error
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -501,7 +501,7 @@ func (r *Resolver) ResolveRecursive(ctx context.Context, req *Request, edge *aut
 		attribute.String("edge.from", edge.GetFrom().GetUniqueLabel()),
 		attribute.String("tuple_key", req.GetTupleString()),
 		attribute.Bool("allowed", false),
-		attribute.Bool("canApplyOptimization", canApplyOptimization),
+		attribute.Bool("can_apply_optimization", canApplyOptimization),
 	))
 	defer span.End()
 


### PR DESCRIPTION
## Overview

This change enhances the OpenTelemetry tracing instrumentation in the Check v2 resolver (`internal/check/check.go`) to provide significantly more detailed and actionable trace data for debugging and observability.

## Key Changes

### Richer Span Attributes

- `ResolveCheck` now records `consistency`, `model_id`, `object`, `relation`, and `user` as individual span attributes (previously only `tuple_key` and `store_id`).
- `ResolveUnionEdges` now includes `edge_count`.
- `ResolveUnion` replaces the `cached` attribute with a `node` label for clearer identification.
- New spans added for `ResolveRecursive` and `ResolveEdge` — these methods previously had no dedicated spans.

### Improved Error Recording

- Switched from a custom `telemetry.TraceError` helper to direct `span.RecordError()` + `span.SetStatus(codes.Error, ...)` calls, aligning with the OpenTelemetry SDK conventions.
- Added `defer span.RecordError(ctx.Err())` to key methods so context cancellations are always captured on the span.

### Structured Events for Early Returns

- Added `span.AddEvent` calls for short-circuit paths: `invalid_node`, `user_type_not_reachable`, `user_wildcard_not_reachable`, `cache_hit`, and `edge_resolved`. Each event carries relevant attributes.

### Minor Refactors in `ResolveUnionEdges`

- Replaced the flat `ids` slice with a `pair` struct (`id` + `edge`) to avoid closure-over-loop-variable issues when goroutines reference edge data.
- Introduced an `expectedMessages` counter so the result loop only waits for messages that will actually be sent (avoids unnecessary blocking when a cache hit resolves early).
- Added an explicit `ctx.Err()` check after the receive loop to surface cancellations that arrive between iterations.

### Modernization

- Uses Go range-over-integer (`for range 2`) instead of C-style loops.

## Impact

Traces from the Check v2 path will now contain enough detail to diagnose slow or incorrect resolutions without needing to reproduce the issue locally — especially useful for production debugging and performance analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved resolution performance and concurrency for faster, more responsive permission checks.
  * Added more detailed trace attributes and events for better observability of evaluation paths and conditions.
  * Implemented smarter short-circuiting for cached/fast-false results to reduce unnecessary work.
  * Refined error and cancellation handling to avoid spurious error statuses and surface real failures more accurately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->