### PR TITLE
fix: unintentional zeroing of slice values by setting slice to nil

### DIFF
--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -246,7 +246,7 @@ func (r *Resolver) ResolveUnionEdges(ctx context.Context, req *Request, edges []
 
 			if res.GetAllowed() {
 				expectedMessages -= len(evaluations)
-				clear(evaluations)
+				evaluations = nil
 				break
 			}
 


### PR DESCRIPTION
## Problem

In `internal/check/check.go`, the `ResolveUnionEdges` method uses a slice called `evaluations` to collect edges that need to be resolved (i.e., those not already cached). When iterating over edges, if a cached result is found that allows access, the remaining evaluations are skipped since the union is already satisfied.

Previously, `clear(evaluations)` was used to discard the pending evaluations. However, Go's `clear()` on a slice **zeroes all elements but retains the length**. This means the subsequent `for _, evaluation := range evaluations` loop would still iterate over the now-zeroed entries, potentially dispatching resolution calls with nil/empty edge values.

## Fix

Replace `clear(evaluations)` with `evaluations = nil`. Setting the slice to `nil` ensures:

1. The subsequent `range` loop has nothing to iterate over (length is 0).
2. No spurious resolution calls are made with zero-valued `pair` structs.
3. The previously allocated memory becomes eligible for garbage collection.

## Affected Code

```go
// internal/check/check.go:248-249
if res.GetAllowed() {
    expectedMessages -= len(evaluations)
    evaluations = nil  // was: clear(evaluations)
    break
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal edge resolution handling in union evaluation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->