### PR TITLE
fix: pre-mark all object IDs as visited before spawning goroutines in v2Check recursiveMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Fixed
 - Fixed experimental `weighted_graph_check` incorrectly falling back to the standard algorithm on deadline/cancellation/throttle-timeout errors; these are now returned directly. Also fixed `weighted_graph_check` emitting metrics under the wrong method label when used as the primary algorithm. [#3141](https://github.com/openfga/openfga/pull/3141)
+- Fixed redundant datastore reads in experimental `weighted_graph_check` recursive resolution when multiple objects are evaluated concurrently, caused by a race between goroutine startup and visited-map population. [#3143](https://github.com/openfga/openfga/pull/3143)
 
 ## [1.16.0] - 2026-05-20
 ### Added

--- a/internal/check/recursive.go
+++ b/internal/check/recursive.go
@@ -187,8 +187,11 @@ func (s *Recursive) recursiveMatch(ctx context.Context, req *Request, recursiveE
 	var pool errgroup.Group
 	pool.SetLimit(s.concurrencyLimit)
 
+	// Mark all IDs visited before starting goroutines to avoid redundant reads.
 	for id := range idsFromObject {
-		visited.Store(id, true)
+		visited.Store(id, struct{}{})
+	}
+	for id := range idsFromObject {
 		pool.Go(func() error {
 			s.recursiveMatchResolver(ctx, req, edge, recursiveType, &pool, idsFromUser, visited, id, responsesChan)
 			return nil


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

In v2Check's `recursiveMatch` function, goroutines could start before all initial object IDs were marked visited, causing a goroutine for one ID to treat another initial ID as unvisited and issue a redundant datastore read for it.

#### How is it being solved?

All initial IDs are now marked visited before any goroutines are spawned, so no goroutine can discover a peer ID as new.

#### What changes are made to solve it?

The single loop in `recursiveMatch` that interleaved `visited.Store` and `pool.Go` is split into two: one that marks all IDs visited, then one that spawns the goroutines.

The stored value is also normalized from `true` to `struct{}{}` for consistency - following how the visited map is used, values in it are only checked [here](https://github.com/openfga/openfga/blob/c0f5c138883acc9633ba75f55ad5574e7f547d66/internal/check/filters.go#L34), which does a `visited.LoadOrStore(keyFunc(tk), struct{}{})`.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a race condition in the experimental weighted graph check that caused redundant datastore reads during concurrent object evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->