### PR TITLE
chore: update grpc-health-probe to latest to addres std lib CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Fixed experimental `weighted_graph_check` incorrectly falling back to the standard algorithm on deadline/cancellation/throttle-timeout errors; these are now returned directly. Also fixed `weighted_graph_check` emitting metrics under the wrong method label when used as the primary algorithm. [#3141](https://github.com/openfga/openfga/pull/3141)
 - Fixed a bug in experimental `weighted_graph_check` where the `weight2` strategy could return false denies when contextual tuples were present, because their concatenation with datastore results violated the sort assumption of the pruning optimization. [#3145](https://github.com/openfga/openfga/pull/3145)
 
+### Security
+- Update grpc-health-probe to `v0.4.50` to address multiple CVEs in the go std lib. [#3146](https://github.com/openfga/openfga/pull/3146)
+
 ## [1.16.0] - 2026-05-20
 ### Added
 - Added datastore ping timeout (PingTimeout) and datastore ping retry timeout (PingRetryMaxElapsedTime) configurations. [#3113](https://github.com/openfga/openfga/pull/3113)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48@sha256:b615f8b80a6796490b91bfe0f7f4d59cf73767d4921968495cb8b4024090e151 AS grpc_health_probe
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.50@sha256:72c25a244d947eb2b31db49cdb503c4c807d6895c67253eefac5ffde15c44fbd AS grpc_health_probe
 # Please manually update the Dockerfile.goreleaser whenever the grpc health probe is updated
 FROM cgr.dev/chainguard/go:1.26.3@sha256:e476979fab066f2ac354111fac6002542d6411b4ae7120b13cc229cac0fa0820 AS builder
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,5 +7,5 @@ COPY openfga /
 #
 # Dependabot is also not capable of updating inline image copies at this time, so
 # this needs to be updated manually until one of these issues is resolved.
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.48@sha256:b615f8b80a6796490b91bfe0f7f4d59cf73767d4921968495cb8b4024090e151 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.50@sha256:72c25a244d947eb2b31db49cdb503c4c807d6895c67253eefac5ffde15c44fbd /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Update grpc-health-prob to `v0.4.50` to address a number of stdlib CVEs affecting its go version:
<img width="1336" height="335" alt="image" src="https://github.com/user-attachments/assets/c2d53426-e2f4-4423-9f1b-2105704f4e47" />

[v0.4.50 is on go 1.26.3](https://github.com/grpc-ecosystem/grpc-health-probe/blob/v0.4.50/go.mod)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated grpc-health-probe to v0.4.50 to address a CVE-related issue.

* **Chores**
  * Bumped grpc-health-probe dependency version from v0.4.48 to v0.4.50 across container images and build configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openfga/openfga/pull/3146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->