### PR TITLE
ci: make pr benchmark comparisons less fragile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -174,6 +174,7 @@ jobs:
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./cache/benchmark-data.json
-          # Save with commit hash to avoid "cache already exists"
-          # Save with OS & CPU info to prevent comparing against results from different CPUs
-          key: ${{ github.sha }}-${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-go-benchmark
+          # Save with OS & CPU info first so PRs can fall back to the most recent
+          # same-hardware baseline via restore-keys; commit hash last keeps each
+          # entry unique and avoids "cache already exists".
+          key: ${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-${{ github.sha }}-go-benchmark

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -299,7 +299,7 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./cache/benchmark-data.json
-          # Key ordering (OS-CPU-SHA) mirrors main.yaml's save key. restore-keys
+          # Key ordering (OS-CPU-SHA) identical to main.yaml's saved key. restore-keys
           # falls back to the most recent same-hardware baseline from any prior
           # main commit when the exact main-SHA baseline is missing (timing race,
           # failed main run, eviction) — never comparing across different CPUs.

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -314,7 +314,7 @@ jobs:
       - name: Note fallback baseline used
         if: steps.cache.outputs.cache-hit != 'true' && steps.cache.outputs.cache-matched-key != '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
         run: |
-          echo "::notice title=Benchmark baseline is not exact::No baseline for the exact main commit; comparing against the most recent same-hardware baseline (${{ steps.cache.outputs.cache-matched-key }})."
+          echo "::notice title=Benchmark baseline is not exact::No baseline for the exact main commit; comparing against the most recent same-hardware baseline ('${{ steps.cache.outputs.cache-matched-key }}')."
 
       - name: Compare benchmarks with Main
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -354,7 +354,7 @@ jobs:
       - name: Warn that regression check was skipped
         if: steps.cache.outputs.cache-matched-key == '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
         run: |
-          echo "::warning title=Benchmark regression check skipped::No same-hardware baseline found for OS=${{ runner.os }} CPU=${{ steps.system-info.outputs.cpu-model }}. Benchmarks ran but were NOT compared against main."
+          echo "::warning title=Benchmark regression check skipped::No same-hardware baseline found for OS='${{ runner.os }}' CPU='${{ steps.system-info.outputs.cpu-model }}'. Benchmarks ran but were NOT compared against main."
           {
             echo "### ⚠️ Benchmark regression check skipped"
             echo "No same-hardware baseline was available to compare against. Benchmarks ran but no regression check was performed."

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -299,11 +299,26 @@ jobs:
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./cache/benchmark-data.json
-          key: ${{ steps.get-main-branch-sha.outputs.sha }}-${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-go-benchmark
+          # Key ordering (OS-CPU-SHA) mirrors main.yaml's save key. restore-keys
+          # falls back to the most recent same-hardware baseline from any prior
+          # main commit when the exact main-SHA baseline is missing (timing race,
+          # failed main run, eviction) — never comparing across different CPUs.
+          key: ${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-${{ steps.get-main-branch-sha.outputs.sha }}-go-benchmark
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.system-info.outputs.cpu-model }}-
+
+      # A fallback (restore-keys) hit sets cache-hit=false but populates
+      # cache-matched-key, so branch on cache-matched-key to cover exact AND
+      # fallback baselines. Empty cache-matched-key means no same-hardware
+      # baseline exists at all.
+      - name: Note fallback baseline used
+        if: steps.cache.outputs.cache-hit != 'true' && steps.cache.outputs.cache-matched-key != '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
+        run: |
+          echo "::notice title=Benchmark baseline is not exact::No baseline for the exact main commit; comparing against the most recent same-hardware baseline (${{ steps.cache.outputs.cache-matched-key }})."
 
       - name: Compare benchmarks with Main
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
-        if: steps.cache.outputs.cache-hit == 'true' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
+        if: steps.cache.outputs.cache-matched-key != '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
@@ -321,7 +336,7 @@ jobs:
 
       - name: Run benchmarks but don't compare to Main branch
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
-        if: steps.cache.outputs.cache-hit != 'true' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
+        if: steps.cache.outputs.cache-matched-key == '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
         with:
           # What benchmark tool the output.txt came from
           tool: 'go'
@@ -332,3 +347,15 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           # Enable Job Summary for PRs
           summary-always: true
+
+      # When no same-hardware baseline exists at all, benchmarks ran but nothing
+      # was compared. Surface this loudly (annotation + job summary) so a green
+      # check is never mistaken for "no regression". Job intentionally stays green.
+      - name: Warn that regression check was skipped
+        if: steps.cache.outputs.cache-matched-key == '' && (steps.changes.outputs.perf == 'true' || github.event_name == 'merge_group')
+        run: |
+          echo "::warning title=Benchmark regression check skipped::No same-hardware baseline found for OS=${{ runner.os }} CPU=${{ steps.system-info.outputs.cpu-model }}. Benchmarks ran but were NOT compared against main."
+          {
+            echo "### ⚠️ Benchmark regression check skipped"
+            echo "No same-hardware baseline was available to compare against. Benchmarks ran but no regression check was performed."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Update PR workflow benchmark comparison to be less flakey. [#3153](https://github.com/openfga/openfga/pull/3153)
 
 ## [1.17.0] - 2026-06-02
 ### Added


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
Our PR benchmark action currently searches the action cache for `steps.get-main-branch-sha.outputs.sha`; aka the current main branch SHA's benchmark run. So, if a PR is opened shortly after `main` was updated and `main` hasn't completed running benchmarks, or if the most recent `main` branch benchmark run failed for any reason, the PR workflow will not find a benchmark run to compare against, and it will silently skip the comparison.

#### How is it being solved?
This PR changes the key used and implements github actions' `restore-keys` directive. The key is now structured as: `{OS}-{CPU}-{SHA}`. In the event a record is not available for that specific SHA, `restore-keys` will fall back and look for benchmark records which match on `{OS}-{CPU}`.

Because a `restore-keys` fallback hit sets `cache-hit` to `false`, the comparison steps now gate on `cache-matched-key` (which is populated on both exact and fallback hits) rather than `cache-hit` — otherwise the fallback baseline would be restored but the comparison would still be skipped.

When a fallback baseline is used, the job emits a `::notice::` indicating the comparison wasn't against the exact `main` commit. When *no* same-hardware baseline exists at all, the job now emits a `::warning::` and a job-summary note rather than passing silently — so a green check is never mistaken for "no regression". The job intentionally stays green in that case to avoid blocking merges on transient cache misses or brand-new runner hardware.

Note: a fallback comparison may be against an older `main` commit than the PR's actual parent. This is the intended trade to eliminate the silent skip, and the `::notice::` makes it transparent in the run logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved benchmark caching to prefer same-hardware baselines and reordered keys so restore fallbacks favor matching OS/CPU before commit; CI now only compares against a baseline when a same-hardware entry exists and emits a warning/summary when comparisons are skipped.

* **Documentation**
  * Updated release notes to describe the hardware-aware benchmark caching and comparison behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->