### PR TITLE
fix: use query start time as iterator cache entry LastModified to prevent stale-read survival

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Changed
 - Update PR workflow benchmark comparison to be less flakey. [#3153](https://github.com/openfga/openfga/pull/3153)
 
+### Fixed
+- Fixed a race where an iterator cache entry flushed concurrently with a write could survive cache controller invalidation checks, causing stale tuples to be returned to subsequent requests. [#3155](https://github.com/openfga/openfga/pull/3155) Thanks to [@0xmrma](https://github.com/0xmrma) for reporting this bug.
+
 ## [1.17.0] - 2026-06-02
 ### Added
 - Added a configurable trace sampler via `trace.sampler` (`OPENFGA_TRACE_SAMPLER` / `OTEL_TRACES_SAMPLER`), supporting the standard OpenTelemetry strategies `always_on`, `always_off`, `traceidratio`, `parentbased_always_on`, `parentbased_always_off`, and `parentbased_traceidratio`. This lets OpenFGA honor upstream parent sampling decisions when running as a downstream service. Defaults to `traceidratio` to preserve existing behavior. [#3072](https://github.com/openfga/openfga/pull/3072) Thanks [@armujahid](https://github.com/armujahid)!

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -660,8 +660,5 @@ func (c *cachedIterator) flush() {
 	c.records = nil
 
 	c.cache.Set(c.cacheKey, &storage.TupleIteratorCacheEntry{Tuples: records, LastModified: c.initializedAt}, storage.JitteredTTL(c.ttl, c.jitterPercentage))
-	for _, k := range c.invalidEntityKeys {
-		c.cache.Delete(k)
-	}
 	tuplesCacheSizeHistogram.WithLabelValues(c.operation, c.method).Observe(float64(len(records)))
 }

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -425,7 +425,11 @@ type cachedIterator struct {
 	cache             storage.InMemoryCache[any]
 	ttl               time.Duration
 	jitterPercentage  uint32
-	initializedAt     time.Time
+	// initializedAt records when the DB query was initiated. It is used as a
+	// pre-write guard against stale results and as LastModified when flushing
+	// to cache, so that invalidation entries written after the query start are
+	// correctly detected as newer by future findInCache callers.
+	initializedAt time.Time
 
 	objectID   string
 	objectType string
@@ -655,7 +659,7 @@ func (c *cachedIterator) flush() {
 	c.tuples = nil
 	c.records = nil
 
-	c.cache.Set(c.cacheKey, &storage.TupleIteratorCacheEntry{Tuples: records, LastModified: time.Now()}, storage.JitteredTTL(c.ttl, c.jitterPercentage))
+	c.cache.Set(c.cacheKey, &storage.TupleIteratorCacheEntry{Tuples: records, LastModified: c.initializedAt}, storage.JitteredTTL(c.ttl, c.jitterPercentage))
 	for _, k := range c.invalidEntityKeys {
 		c.cache.Delete(k)
 	}

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -1354,6 +1354,74 @@ func TestCachedIterator(t *testing.T) {
 		require.Nil(t, iter.records)
 	})
 
+	t.Run("cache_entry_last_modified_uses_query_start_time", func(t *testing.T) {
+		// The race this tests: iterator starts at t0, the pre-write invalidation check
+		// passes (no invalidation entry exists yet), then a write is recorded at t1
+		// between the guard and flush, then flush writes the entry. With old code
+		// LastModified = time.Now() ≈ t2 > t1, so findInCache considers the entry
+		// fresh and returns stale data. With the fix, LastModified = initializedAt = t0
+		// < t1, so findInCache correctly rejects it.
+		maxCacheSize := 10
+		cacheKey := testCacheKey("cache-key")
+		ttl := 5 * time.Hour
+		store := ulid.Make().String()
+		invalidEntityKey := storage.InvalidIteratorByObjectRelationCacheKey(store, "document:1", "viewer")
+
+		cache, err := storage.NewInMemoryLRUCache([]storage.InMemoryLRUCacheOpt[any]{
+			storage.WithMaxCacheSize[any](int64(100)),
+		}...)
+		require.NoError(t, err)
+		defer cache.Stop()
+
+		t0 := time.Now().Add(-2 * time.Second)
+
+		iter := &cachedIterator{
+			ctx:               ctx,
+			iter:              storage.NewStaticTupleIterator(tuples),
+			store:             store,
+			operation:         "operation",
+			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
+			cacheKey:          cacheKey,
+			invalidStoreKey:   storage.InvalidIteratorCacheKey(store),
+			invalidEntityKeys: []keys.Key{invalidEntityKey},
+			cache:             cache,
+			maxResultSize:     maxCacheSize,
+			ttl:               ttl,
+			initializedAt:     t0,
+			sf:                &singleflight.Group{},
+			wg:                &sync.WaitGroup{},
+			logger:            logger.NewNoopLogger(),
+		}
+
+		// Fully drain so flush() will be called (iterator already consumed).
+		for {
+			_, err := iter.Next(ctx)
+			if errors.Is(err, storage.ErrIteratorDone) {
+				break
+			}
+			require.NoError(t, err)
+		}
+
+		// No invalidation entry in cache when Stop runs, so the pre-write guard passes.
+		iter.Stop()
+		iter.wg.Wait()
+
+		// Confirm the entry was flushed with LastModified = t0 (initializedAt), not time.Now().
+		raw := cache.Get(cacheKey)
+		require.NotNil(t, raw, "expected cache entry to be written")
+		entry := raw.(*storage.TupleIteratorCacheEntry)
+		require.Equal(t, t0, entry.LastModified)
+
+		// Simulate a write that raced between the pre-write guard and the flush.
+		// t1 is after t0 (query start) but before the flush completed.
+		t1 := time.Now().Add(-1 * time.Second)
+		cache.Set(invalidEntityKey, &storage.InvalidEntityCacheEntry{LastModified: t1}, ttl)
+
+		// findInCache must reject the entry: entry.LastModified (t0) < write (t1).
+		_, ok := findInCache(cache, cacheKey, storage.InvalidIteratorCacheKey(store), []keys.Key{invalidEntityKey})
+		require.False(t, ok, "stale cache entry should be invalidated because write occurred after query start")
+	})
+
 	t.Run("prevent_draining_if_queried_before_invalidation_time", func(t *testing.T) {
 		maxCacheSize := 10
 		cacheKey := testCacheKey("cache-key")

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -229,8 +229,6 @@ func TestReadStartingWithUser(t *testing.T) {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKeys[0]),
-			mockCache.EXPECT().Delete(invalidEntityKeys[1]),
 		)
 
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
@@ -352,8 +350,6 @@ func TestReadStartingWithUser(t *testing.T) {
 			mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), ttl).DoAndReturn(func(_ keys.Key, entry *storage.TupleIteratorCacheEntry, _ time.Duration) {
 				require.Empty(t, entry.Tuples)
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKeys[0]),
-			mockCache.EXPECT().Delete(invalidEntityKeys[1]),
 		)
 
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
@@ -493,7 +489,6 @@ func TestReadUsersetTuples(t *testing.T) {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKey),
 		)
 
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
@@ -567,7 +562,6 @@ func TestReadUsersetTuples(t *testing.T) {
 			mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), ttl).DoAndReturn(func(_ keys.Key, entry *storage.TupleIteratorCacheEntry, _ time.Duration) {
 				require.Empty(t, entry.Tuples)
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKey),
 		)
 
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
@@ -701,7 +695,6 @@ func TestRead(t *testing.T) {
 					t.Fatalf("mismatch (-want +got):\n%s", diff)
 				}
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKey),
 		)
 
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
@@ -775,7 +768,6 @@ func TestRead(t *testing.T) {
 			mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), ttl).DoAndReturn(func(_ keys.Key, entry *storage.TupleIteratorCacheEntry, _ time.Duration) {
 				require.Empty(t, entry.Tuples)
 			}),
-			mockCache.EXPECT().Delete(invalidEntityKey),
 		)
 
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -1347,25 +1347,36 @@ func TestCachedIterator(t *testing.T) {
 	})
 
 	t.Run("cache_entry_last_modified_uses_query_start_time", func(t *testing.T) {
-		// The race this tests: iterator starts at t0, the pre-write invalidation check
-		// passes (no invalidation entry exists yet), then a write is recorded at t1
-		// between the guard and flush, then flush writes the entry. With old code
-		// LastModified = time.Now() ≈ t2 > t1, so findInCache considers the entry
-		// fresh and returns stale data. With the fix, LastModified = initializedAt = t0
-		// < t1, so findInCache correctly rejects it.
+		// The race: iterator starts at t0, the pre-write guard passes (no invalidation
+		// entry yet), then a write is recorded at t1 between the guard and flush().
+		// With the fix, LastModified = initializedAt = t0 < t1, so findInCache rejects
+		// the stale entry. We exercise the real race by injecting the invalidation entry
+		// inside the cache's Set call, before it returns to flush().
 		maxCacheSize := 10
 		cacheKey := testCacheKey("cache-key")
 		ttl := 5 * time.Hour
 		store := ulid.Make().String()
 		invalidEntityKey := storage.InvalidIteratorByObjectRelationCacheKey(store, "document:1", "viewer")
 
-		cache, err := storage.NewInMemoryLRUCache([]storage.InMemoryLRUCacheOpt[any]{
+		inner, err := storage.NewInMemoryLRUCache([]storage.InMemoryLRUCacheOpt[any]{
 			storage.WithMaxCacheSize[any](int64(100)),
 		}...)
 		require.NoError(t, err)
-		defer cache.Stop()
+		defer inner.Stop()
 
 		t0 := time.Now().Add(-2 * time.Second)
+		t1 := time.Now().Add(-1 * time.Second) // write between guard and flush
+
+		// interceptingCache injects the invalidation entry when flush() calls Set for
+		// the tuple cache key, simulating a concurrent write that races the flush.
+		intercepting := &interceptingCache{
+			InMemoryCache: inner,
+			onSet: func(k keys.Key) {
+				if k == cacheKey {
+					inner.Set(invalidEntityKey, &storage.InvalidEntityCacheEntry{LastModified: t1}, ttl)
+				}
+			},
+		}
 
 		iter := &cachedIterator{
 			ctx:               ctx,
@@ -1376,7 +1387,7 @@ func TestCachedIterator(t *testing.T) {
 			cacheKey:          cacheKey,
 			invalidStoreKey:   storage.InvalidIteratorCacheKey(store),
 			invalidEntityKeys: []keys.Key{invalidEntityKey},
-			cache:             cache,
+			cache:             intercepting,
 			maxResultSize:     maxCacheSize,
 			ttl:               ttl,
 			initializedAt:     t0,
@@ -1385,7 +1396,7 @@ func TestCachedIterator(t *testing.T) {
 			logger:            logger.NewNoopLogger(),
 		}
 
-		// Fully drain so flush() will be called (iterator already consumed).
+		// Fully drain so flush() is called in the foreground (iterator already consumed).
 		for {
 			_, err := iter.Next(ctx)
 			if errors.Is(err, storage.ErrIteratorDone) {
@@ -1394,23 +1405,18 @@ func TestCachedIterator(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		// No invalidation entry in cache when Stop runs, so the pre-write guard passes.
+		// No invalidation entry in cache yet, so the pre-write guard passes.
 		iter.Stop()
 		iter.wg.Wait()
 
-		// Confirm the entry was flushed with LastModified = t0 (initializedAt), not time.Now().
-		raw := cache.Get(cacheKey)
+		// The cache entry must have been written with LastModified = t0 (initializedAt).
+		raw := inner.Get(cacheKey)
 		require.NotNil(t, raw, "expected cache entry to be written")
 		entry := raw.(*storage.TupleIteratorCacheEntry)
 		require.Equal(t, t0, entry.LastModified)
 
-		// Simulate a write that raced between the pre-write guard and the flush.
-		// t1 is after t0 (query start) but before the flush completed.
-		t1 := time.Now().Add(-1 * time.Second)
-		cache.Set(invalidEntityKey, &storage.InvalidEntityCacheEntry{LastModified: t1}, ttl)
-
-		// findInCache must reject the entry: entry.LastModified (t0) < write (t1).
-		_, ok := findInCache(cache, cacheKey, storage.InvalidIteratorCacheKey(store), []keys.Key{invalidEntityKey})
+		// findInCache must reject it: entry.LastModified (t0) < invalidation (t1).
+		_, ok := findInCache(intercepting, cacheKey, storage.InvalidIteratorCacheKey(store), []keys.Key{invalidEntityKey})
 		require.False(t, ok, "stale cache entry should be invalidated because write occurred after query start")
 	})
 
@@ -1591,6 +1597,18 @@ func (s *mockCalledTupleIterator) Stop() {
 }
 
 func (s *mockCalledTupleIterator) IsOrdered() bool { return s.iter.IsOrdered() }
+
+// interceptingCache wraps an InMemoryCache and calls onSet before each Set,
+// allowing tests to inject side effects that race with a cache write.
+type interceptingCache struct {
+	storage.InMemoryCache[any]
+	onSet func(keys.Key)
+}
+
+func (c *interceptingCache) Set(k keys.Key, v any, ttl time.Duration) {
+	c.onSet(k)
+	c.InMemoryCache.Set(k, v, ttl)
+}
 
 // invalidIteratorByUserObjectTypeKeys is a test helper that returns one
 // invalidation cache key per user, mirroring the production fan-out previously


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

In the v1 iterator cache, a tuple iterator buffered its results starting at t0, but wrote them to cache at t2 (flush time) with LastModified = t2. If a write occurred at t1 where t0 < t1 < t2, the cache controller's invalidation entry had LastModified = t1. `findInCache` checks `entry.LastModified.Before(invalidation.LastModified)`, so `t2.Before(t1) = false` — the stale read survived invalidation and would be served to future requests.

The `flush()` deletion of `invalidEntityKeys` created a second race window: if a write recorded an invalidation entry between the pre-write guard and the flush, `flush()` would delete it — leaving the stale cache entry with no marker to reject it on future reads.

Thanks to @0xmrma for reporting this bug.

#### How is it being solved?

The `cachedIterator` now records `initializedAt = time.Now()` at creation (when the DB query is initiated) and uses that as `LastModified` when flushing to cache. This ensures any write timestamped after the query started is detected as newer than the cache entry by `findInCache`. Note that this solution is already [employed by the v2 iterator cache](https://github.com/openfga/openfga/blob/14404b693084a816450afd952495416afe3e470d/pkg/storage/storagewrappers/iterator_cache.go#L130).

#### What changes are made to solve it?

- cached_datastore.go: Removed the duplicate createdAt field (it was set to time.Now() alongside initializedAt and served the same purpose). flush() now uses c.initializedAt for LastModified. The initializedAt field comment documents both its roles: pre-write guard and cache entry timestamp. Also, removed the invalidEntityKeys deletion loop from flush(). Invalidation entries now expire by TTL rather than being proactively deleted, which is safe — findInCache already ignores invalidation entries whose LastModified is older than the cache entry's LastModified.
- cached_datastore_test.go: Added cache_entry_last_modified_uses_query_start_time test — sets initializedAt to a past time, drains and flushes the iterator, confirms the cache entry carries the past timestamp, then inserts an invalidation entry between initializedAt and now and confirms findInCache rejects the entry.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race where cached iterator entries could remain valid after concurrent invalidations by aligning cache entry timestamps with query start time, preventing stale results.

* **Tests**
  * Added a race-focused test validating cache writes use the query start time and updated existing cache tests to reflect corrected invalidation behavior.

* **Documentation**
  * Updated changelog with the fix and related entry reorganizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->