### PR TITLE
feat: Allow multiple audiences

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -890,8 +890,8 @@
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_ISSUER"
                 },
                 "audience": {
-                    "description": "one or more OIDC audiences that will be accepted as valid when verifying the `aud` field of the JWTs. A token is accepted if its `aud` matches any of the configured audiences.",
-                    "type": "array",
+                    "description": "one or more OIDC audiences that will be accepted as valid when verifying the `aud` field of the JWTs. A token is accepted if its `aud` matches any of the configured audiences. Accepts either a single string or a list of strings.",
+                    "type": ["string", "array"],
                     "items": {
                         "type": "string"
                     },

--- a/.config-schema.json
+++ b/.config-schema.json
@@ -890,8 +890,11 @@
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_ISSUER"
                 },
                 "audience": {
-                    "description": "The OIDC audience of the tokens being signed by the authorization server.",
-                    "type": "string",
+                    "description": "one or more OIDC audiences that will be accepted as valid when verifying the `aud` field of the JWTs. A token is accepted if its `aud` matches any of the configured audiences.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
                     "x-env-variable": "OPENFGA_AUTHN_OIDC_AUDIENCE"
                 },
                 "issuerAliases": {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -182,7 +182,7 @@ func NewRunCommand() *cobra.Command {
 
 	flags.StringSlice("authn-preshared-keys", defaultConfig.Authn.Keys, "one or more preshared keys to use for authentication")
 
-	flags.String("authn-oidc-audience", defaultConfig.Authn.Audience, "the OIDC audience of the tokens being signed by the authorization server")
+	flags.StringSlice("authn-oidc-audience", defaultConfig.Authn.Audiences, "one or more OIDC audiences that will be accepted as valid when verifying the `aud` field of the JWTs. A token is accepted if its `aud` matches any of the configured audiences")
 
 	flags.String("authn-oidc-issuer", defaultConfig.Authn.Issuer, "the OIDC issuer (authorization server) signing the tokens, and where the keys will be fetched from")
 
@@ -551,7 +551,7 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 		authenticator, err = presharedkey.NewPresharedKeyAuthenticator(config.Authn.Keys)
 	case "oidc":
 		s.Logger.Info("using 'oidc' authentication")
-		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audience, config.Authn.Subjects, config.Authn.ClientIDClaims)
+		authenticator, err = oidc.NewRemoteOidcAuthenticator(config.Authn.Issuer, config.Authn.IssuerAliases, config.Authn.Audiences, config.Authn.Subjects, config.Authn.ClientIDClaims)
 	default:
 		return nil, fmt.Errorf("unsupported authentication method '%v'", config.Authn.Method)
 	}

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -557,8 +557,8 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 	cfg.Authn.Method = "oidc"
 	cfg.Authn.AuthnOIDCConfig = &serverconfig.AuthnOIDCConfig{
-		Audience: "openfga.dev",
-		Issuer:   localOIDCServerURL,
+		Audiences: []string{"openfga.dev"},
+		Issuer:    localOIDCServerURL,
 	}
 
 	oidcServerPortReleaser()
@@ -633,7 +633,7 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 	cfg.Authn.Method = "oidc"
 	cfg.Authn.AuthnOIDCConfig = &serverconfig.AuthnOIDCConfig{
-		Audience:      "openfga.dev",
+		Audiences:     []string{"openfga.dev"},
 		Issuer:        oidcServerURL1,
 		IssuerAliases: []string{oidcServerURL2},
 	}
@@ -1573,6 +1573,26 @@ requestDurationDispatchCountBuckets: [32,42]
 	require.Equal(t, 5*time.Second, cfg.CheckQueryCache.TTL)
 	require.Equal(t, []string{"33", "44"}, cfg.RequestDurationDatastoreQueryCountBuckets)
 	require.Equal(t, []string{"32", "42"}, cfg.RequestDurationDispatchCountBuckets)
+}
+
+// TestParseConfigOIDCAudienceScalarIsBackwardCompatible verifies that the OIDC
+// audience config, which changed from a single string to a list of strings,
+// still accepts the old scalar form and coerces it into a one-element slice.
+func TestParseConfigOIDCAudienceScalarIsBackwardCompatible(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	util.PrepareTempConfigFile(t, "authn:\n    oidc:\n        audience: openfga.dev\n")
+
+	runCmd := NewRunCommand()
+	runCmd.RunE = func(cmd *cobra.Command, _ []string) error { return nil }
+	rootCmd := cmd.NewRootCommand()
+	rootCmd.AddCommand(runCmd)
+	rootCmd.SetArgs([]string{"run"})
+	require.NoError(t, rootCmd.Execute())
+
+	cfg, err := ReadConfig()
+	require.NoError(t, err)
+	require.Equal(t, []string{"openfga.dev"}, cfg.Authn.Audiences)
 }
 
 func TestParseConfigCacheTTLJitterPercentageFromFlag(t *testing.T) {

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -51,10 +51,18 @@ var _ authn.OIDCAuthenticator = (*RemoteOidcAuthenticator)(nil)
 func NewRemoteOidcAuthenticator(mainIssuer string, issuerAliases []string, audiences []string, subjects []string, clientIDClaims []string) (*RemoteOidcAuthenticator, error) {
 	client := retryablehttp.NewClient()
 	client.Logger = nil
+
+	normalizedAudiences := make([]string, 0, len(audiences))
+	for _, aud := range audiences {
+		if trimmed := strings.TrimSpace(aud); trimmed != "" {
+			normalizedAudiences = append(normalizedAudiences, trimmed)
+		}
+	}
+
 	oidc := &RemoteOidcAuthenticator{
 		MainIssuer:     mainIssuer,
 		IssuerAliases:  issuerAliases,
-		Audiences:      audiences,
+		Audiences:      normalizedAudiences,
 		Subjects:       subjects,
 		httpClient:     client.StandardClient(),
 		ClientIDClaims: clientIDClaims,
@@ -88,16 +96,8 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 		jwt.WithExpirationRequired(),
 	}
 
-	audiences := make([]string, 0, len(oidc.Audiences))
-	for _, aud := range oidc.Audiences {
-		if trimmed := strings.TrimSpace(aud); trimmed != "" {
-			audiences = append(audiences, trimmed)
-		}
-	}
-	if len(audiences) > 0 {
-		// WithAudience matches if the token's `aud` claim contains ANY of the
-		// configured audiences (not all of them).
-		options = append(options, jwt.WithAudience(audiences...))
+	if len(oidc.Audiences) > 0 {
+		options = append(options, jwt.WithAudience(oidc.Audiences...))
 	}
 
 	jwtParser := jwt.NewParser(options...)

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -27,7 +27,7 @@ import (
 type RemoteOidcAuthenticator struct {
 	MainIssuer     string
 	IssuerAliases  []string
-	Audience       string
+	Audiences      []string
 	Subjects       []string
 	ClientIDClaims []string
 
@@ -48,13 +48,13 @@ var (
 var _ authn.Authenticator = (*RemoteOidcAuthenticator)(nil)
 var _ authn.OIDCAuthenticator = (*RemoteOidcAuthenticator)(nil)
 
-func NewRemoteOidcAuthenticator(mainIssuer string, issuerAliases []string, audience string, subjects []string, clientIDClaims []string) (*RemoteOidcAuthenticator, error) {
+func NewRemoteOidcAuthenticator(mainIssuer string, issuerAliases []string, audiences []string, subjects []string, clientIDClaims []string) (*RemoteOidcAuthenticator, error) {
 	client := retryablehttp.NewClient()
 	client.Logger = nil
 	oidc := &RemoteOidcAuthenticator{
 		MainIssuer:     mainIssuer,
 		IssuerAliases:  issuerAliases,
-		Audience:       audience,
+		Audiences:      audiences,
 		Subjects:       subjects,
 		httpClient:     client.StandardClient(),
 		ClientIDClaims: clientIDClaims,
@@ -88,8 +88,16 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 		jwt.WithExpirationRequired(),
 	}
 
-	if strings.TrimSpace(oidc.Audience) != "" {
-		options = append(options, jwt.WithAudience(oidc.Audience))
+	audiences := make([]string, 0, len(oidc.Audiences))
+	for _, aud := range oidc.Audiences {
+		if trimmed := strings.TrimSpace(aud); trimmed != "" {
+			audiences = append(audiences, trimmed)
+		}
+	}
+	if len(audiences) > 0 {
+		// WithAudience matches if the token's `aud` claim contains ANY of the
+		// configured audiences (not all of them).
+		options = append(options, jwt.WithAudience(audiences...))
 	}
 
 	jwtParser := jwt.NewParser(options...)

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -43,7 +43,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -65,7 +65,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -86,7 +86,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -109,7 +109,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_2",
 					issuerURL:      "",
-					audience:       "",
+					audiences:      nil,
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -129,7 +129,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "",
-					audience:       "",
+					audiences:      nil,
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -148,7 +148,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "",
+					audiences:      nil,
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -168,7 +168,28 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
+					issuerAliases:  nil,
+					subjects:       []string{"openfga client"},
+					clientIDClaims: []string{"azp"},
+					jwtClaims: jwt.MapClaims{
+						"iss": "right_issuer",
+						"aud": "wrong_audience",
+						"exp": time.Now().Add(10 * time.Minute).Unix(),
+					},
+					privateKeyOverride: nil,
+				})
+			},
+			expectedError: "invalid claims",
+		},
+		{
+			testDescription: "when_token's_audience_matches_none_of_the_multiple_audiences_configured,_MUST_return_'invalid_audience'_error",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
+				return quickConfigSetup(Config{
+					jwkKid:         "kid_1",
+					jwtKid:         "kid_1",
+					issuerURL:      "right_issuer",
+					audiences:      []string{"right_audience", "other_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -189,7 +210,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: []string{"azp"},
@@ -211,7 +232,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_1",
 					jwtKid:         "kid_1",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"valid-sub-1", "valid-sub-2"},
 					clientIDClaims: []string{"azp"},
@@ -257,7 +278,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "",
+					audiences:      nil,
 					issuerAliases:  nil,
 					subjects:       nil,
 					clientIDClaims: []string{"custom_claim", "custom_claim_2"},
@@ -280,7 +301,53 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
+					issuerAliases:  nil,
+					subjects:       []string{"openfga client"},
+					clientIDClaims: azpClientIDClaims,
+					jwtClaims: jwt.MapClaims{
+						"iss":   "right_issuer",
+						"aud":   "right_audience",
+						"sub":   "openfga client",
+						"azp":   clientID,
+						"scope": scopes,
+						"exp":   time.Now().Add(10 * time.Minute).Unix(),
+					},
+					privateKeyOverride: nil,
+				})
+			},
+		},
+		{
+			testDescription: "when_a_configured_audience_has_surrounding_whitespace,_it_is_trimmed_and_a_matching_token_MUST_be_accepted",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
+				return quickConfigSetup(Config{
+					jwkKid:         "kid_2",
+					jwtKid:         "kid_2",
+					issuerURL:      "right_issuer",
+					audiences:      []string{"  right_audience  ", ""},
+					issuerAliases:  nil,
+					subjects:       []string{"openfga client"},
+					clientIDClaims: azpClientIDClaims,
+					jwtClaims: jwt.MapClaims{
+						"iss":   "right_issuer",
+						"aud":   "right_audience",
+						"sub":   "openfga client",
+						"azp":   clientID,
+						"scope": scopes,
+						"exp":   time.Now().Add(10 * time.Minute).Unix(),
+					},
+					privateKeyOverride: nil,
+				})
+			},
+		},
+		{
+			testDescription: "when_multiple_audiences_are_configured,_a_token_matching_any_one_of_them_MUST_be_accepted",
+			testSetup: func() (*RemoteOidcAuthenticator, context.Context, Config, error) {
+				return quickConfigSetup(Config{
+					jwkKid:         "kid_2",
+					jwtKid:         "kid_2",
+					issuerURL:      "right_issuer",
+					audiences:      []string{"other_audience", "right_audience"},
 					issuerAliases:  nil,
 					subjects:       []string{"openfga client"},
 					clientIDClaims: azpClientIDClaims,
@@ -303,7 +370,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  []string{"issuer_alias"},
 					subjects:       []string{"openfga client"},
 					clientIDClaims: customClientIDClaims,
@@ -326,7 +393,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  []string{"issuer_alias"},
 					subjects:       []string{"openfga client"},
 					clientIDClaims: azpClientIDClaims,
@@ -349,7 +416,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       nil,
 					clientIDClaims: azpClientIDClaims,
@@ -372,7 +439,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       nil,
 					clientIDClaims: nil,
@@ -395,7 +462,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       nil,
 					clientIDClaims: nil,
@@ -418,7 +485,7 @@ func TestRemoteOidcAuthenticator_Authenticate(t *testing.T) {
 					jwkKid:         "kid_2",
 					jwtKid:         "kid_2",
 					issuerURL:      "right_issuer",
-					audience:       "right_audience",
+					audiences:      []string{"right_audience"},
 					issuerAliases:  nil,
 					subjects:       nil,
 					clientIDClaims: []string{"custom_claim", "custom_claim_2"},
@@ -473,7 +540,7 @@ type Config struct {
 	jwkKid             string
 	jwtKid             string
 	issuerURL          string
-	audience           string
+	audiences          []string
 	issuerAliases      []string
 	subjects           []string
 	clientIDClaims     []string
@@ -492,7 +559,7 @@ func quickConfigSetup(c Config) (*RemoteOidcAuthenticator, context.Context, Conf
 	fetchJWKs = fetchKeysMock(publicKey, c.jwkKid)
 
 	// Initialize RemoteOidcAuthenticator
-	oidc, err := NewRemoteOidcAuthenticator(c.issuerURL, c.issuerAliases, c.audience, c.subjects, c.clientIDClaims)
+	oidc, err := NewRemoteOidcAuthenticator(c.issuerURL, c.issuerAliases, c.audiences, c.subjects, c.clientIDClaims)
 	if err != nil {
 		return nil, nil, c, err
 	}
@@ -560,7 +627,7 @@ func TestRemoteOidcAuthenticator_RefreshUnknownKID(t *testing.T) {
 	server := newJWKSTestServer(map[string]*rsa.PublicKey{"kid_1": pubKey1})
 	defer server.close()
 
-	oidc, err := NewRemoteOidcAuthenticator(server.server.URL, nil, "aud", nil, nil)
+	oidc, err := NewRemoteOidcAuthenticator(server.server.URL, nil, []string{"aud"}, nil, nil)
 	require.NoError(t, err)
 	defer oidc.Close()
 
@@ -613,7 +680,7 @@ func TestRemoteOidcAuthenticator_RefreshRateLimit(t *testing.T) {
 	server := newJWKSTestServer(map[string]*rsa.PublicKey{"kid_1": pubKey1})
 	defer server.close()
 
-	oidc, err := NewRemoteOidcAuthenticator(server.server.URL, nil, "aud", nil, nil)
+	oidc, err := NewRemoteOidcAuthenticator(server.server.URL, nil, []string{"aud"}, nil, nil)
 	require.NoError(t, err)
 	defer oidc.Close()
 

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -224,7 +224,7 @@ type AuthnOIDCConfig struct {
 	Issuer         string
 	IssuerAliases  []string
 	Subjects       []string
-	Audience       string
+	Audiences      []string `mapstructure:"audience"`
 	ClientIDClaims []string
 }
 


### PR DESCRIPTION
## Description
Allow multiple audiences to be configured for authentication.

#### What problem is being solved?
It is a common use case to provide a list of audiences the service accepts (see  [RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3))

#### How is it being solved?
Transform Authn.AuthnOIDCConfig to a string array. Each item in the incoming is parsed and sanitized then verified against this array. This change is backwards compatible.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC authentication accepts multiple audience values; tokens matching any configured audience are valid.
* **Behavior / CLI**
  * Server startup flag now supports a comma-separated list of OIDC audiences for configuration.
* **Compatibility**
  * Single audience strings remain accepted and are coerced to a one-element list.
* **Tests**
  * Added tests verifying scalar-to-list compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->