### PR TITLE
chore: bump grpc-health-probe to v0.4.52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Security
 - Update toolchain Go version to 1.26.4 to address the Go standard library vulnerabilities documented in the [Go 1.26.4 release notes](https://go.dev/doc/devel/release#go1.26.4). [#3159](https://github.com/openfga/openfga/pull/3159)
-- Update grpc-health-probe to `v0.4.52`, rebuilt with Go 1.26.4, so released images no longer ship the Go standard library vulnerabilities fixed in the [Go 1.26.4 release notes](https://go.dev/doc/devel/release#go1.26.4).
+- Update grpc-health-probe to `v0.4.52`, rebuilt with Go 1.26.4, so released images no longer ship the Go standard library vulnerabilities fixed in the [Go 1.26.4 release notes](https://go.dev/doc/devel/release#go1.26.4). [#3164](https://github.com/openfga/openfga/pull/3164)
 
 ## [1.17.0] - 2026-06-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Security
 - Update toolchain Go version to 1.26.4 to address the Go standard library vulnerabilities documented in the [Go 1.26.4 release notes](https://go.dev/doc/devel/release#go1.26.4). [#3159](https://github.com/openfga/openfga/pull/3159)
+- Update grpc-health-probe to `v0.4.52`, rebuilt with Go 1.26.4, so released images no longer ship the Go standard library vulnerabilities fixed in the [Go 1.26.4 release notes](https://go.dev/doc/devel/release#go1.26.4).
 
 ## [1.17.0] - 2026-06-02
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.51@sha256:cc4ff9327e602119103bedef448eec26f8ba02bce5c81107cb3685c360c4a6c0 AS grpc_health_probe
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52@sha256:0303b506a288d544ed99fef17a55c8c5ce872f498f643c396b532b3595089ac9 AS grpc_health_probe
 # Please manually update the Dockerfile.goreleaser whenever the grpc health probe is updated
 FROM cgr.dev/chainguard/go:1.26.4@sha256:e100be9286b2fb0d161e375426aded92c39ffeb716fdddce4d4ca7e7f00a045c AS builder
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,5 +7,5 @@ COPY openfga /
 #
 # Dependabot is also not capable of updating inline image copies at this time, so
 # this needs to be updated manually until one of these issues is resolved.
-COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.51@sha256:cc4ff9327e602119103bedef448eec26f8ba02bce5c81107cb3685c360c4a6c0 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52@sha256:0303b506a288d544ed99fef17a55c8c5ce872f498f643c396b532b3595089ac9 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
 ENTRYPOINT ["/openfga"]


### PR DESCRIPTION
## Description

grpc-health-probe v0.4.51 is built with Go 1.26.3, so images built from main are still flagged by scanners for the Go standard library vulnerabilities fixed in Go 1.26.4 (CVE-2026-42504 among others), even after the toolchain bump in #3159.

[v0.4.52](https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.52) is built with Go 1.26.4 and x/net v0.55.0. Verified by extracting the binary from `ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52` and checking `go version -m`:

```
/ko-app/grpc-health-probe: go1.26.4
	dep	golang.org/x/net	v0.55.0
```

With this bump, a grype scan of the image built from this branch reports no vulnerabilities.

Updated both `Dockerfile` and `Dockerfile.goreleaser` as the comment in the latter asks, plus a CHANGELOG entry following the format of #3146 and #3159.

## References

- https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.52
- https://go.dev/doc/devel/release#go1.26.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated grpc-health-probe to v0.4.52 (built with Go 1.26.4) in container images, addressing Go standard library vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->