### PR TITLE
fix: MySQL collation handling for identifier columns

### DIFF
--- a/assets/migrations/mysql/008_collate_identifiers.sql
+++ b/assets/migrations/mysql/008_collate_identifiers.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+-- Standardize identifier columns on tuple, changelog, and
+-- authorization_model to utf8mb4_bin, completing the work begun in
+-- migration 007 on tuple.object_id. CHARACTER SET is specified
+-- explicitly so the migration applies cleanly on deployments whose
+-- columns were created under a non-utf8mb4 charset.
+
+ALTER TABLE tuple
+    MODIFY COLUMN object_type    VARCHAR(128) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN relation       VARCHAR(50)  CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN _user          VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN condition_name VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL,
+    LOCK = SHARED;
+
+ALTER TABLE changelog
+    MODIFY COLUMN object_type    VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN object_id      VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN relation       VARCHAR(50)  CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN _user          VARCHAR(512) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    MODIFY COLUMN condition_name VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL,
+    LOCK = SHARED;
+
+ALTER TABLE authorization_model
+    MODIFY COLUMN type VARCHAR(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    LOCK = SHARED;
+
+-- +goose Down
+-- Rolling back this migration restores the previous (server-default)
+-- collation. Avoid rolling back on production deployments unless you
+-- fully understand the implications for existing data.
+ALTER TABLE tuple
+    MODIFY COLUMN object_type    VARCHAR(128) NOT NULL,
+    MODIFY COLUMN relation       VARCHAR(50)  NOT NULL,
+    MODIFY COLUMN _user          VARCHAR(256) NOT NULL,
+    MODIFY COLUMN condition_name VARCHAR(256) NULL,
+    LOCK = SHARED;
+
+ALTER TABLE changelog
+    MODIFY COLUMN object_type    VARCHAR(256) NOT NULL,
+    MODIFY COLUMN object_id      VARCHAR(256) NOT NULL,
+    MODIFY COLUMN relation       VARCHAR(50)  NOT NULL,
+    MODIFY COLUMN _user          VARCHAR(512) NOT NULL,
+    MODIFY COLUMN condition_name VARCHAR(256) NULL,
+    LOCK = SHARED;
+
+ALTER TABLE authorization_model
+    MODIFY COLUMN type VARCHAR(256) NOT NULL,
+    LOCK = SHARED;

--- a/pkg/storage/mysql/collation_test.go
+++ b/pkg/storage/mysql/collation_test.go
@@ -1,0 +1,159 @@
+package mysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
+	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+)
+
+// TestIdentifierColumnCollation asserts that identifier columns on the
+// MySQL backend treat byte-distinct values as distinct rows. Locked in
+// as a regression guard for migration 008.
+func TestIdentifierColumnCollation(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "mysql")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		store  string
+		tuples []*openfgav1.TupleKey
+	}{
+		{
+			name:  "user_byte_distinct",
+			store: "store_user",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:A"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:a"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:AA"),
+			},
+		},
+		{
+			name:  "object_type_byte_distinct",
+			store: "store_obj_type",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("Document:2", "viewer", "user:b"),
+				tupleUtils.NewTupleKey("document:2", "viewer", "user:b"),
+			},
+		},
+		{
+			name:  "relation_byte_distinct",
+			store: "store_rel",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:3", "Viewer", "user:c"),
+				tupleUtils.NewTupleKey("doc:3", "viewer", "user:c"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, tk := range tc.tuples {
+				err := ds.Write(ctx, tc.store, nil, []*openfgav1.TupleKey{tk})
+				require.NoErrorf(t, err, "writing tuple %q must succeed", tk.String())
+			}
+
+			iter, err := ds.Read(ctx, tc.store, storage.ReadFilter{}, storage.ReadOptions{})
+			require.NoError(t, err)
+			defer iter.Stop()
+
+			seen := map[string]struct{}{}
+			for {
+				cur, err := iter.Next(ctx)
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+				require.NoError(t, err)
+				k := cur.GetKey()
+				seen[k.GetObject()+"#"+k.GetRelation()+"@"+k.GetUser()] = struct{}{}
+			}
+
+			for _, tk := range tc.tuples {
+				key := tk.GetObject() + "#" + tk.GetRelation() + "@" + tk.GetUser()
+				require.Containsf(t, seen, key, "tuple %q missing from read", key)
+			}
+			require.Lenf(t, seen, len(tc.tuples), "expected %d distinct rows, got %d", len(tc.tuples), len(seen))
+
+			// Each value must round-trip through the targeted read path
+			// returning exactly its own row.
+			for _, tk := range tc.tuples {
+				got, err := ds.ReadUserTuple(ctx, tc.store, storage.ReadUserTupleFilter{
+					Object:   tk.GetObject(),
+					Relation: tk.GetRelation(),
+					User:     tk.GetUser(),
+				}, storage.ReadUserTupleOptions{})
+				require.NoErrorf(t, err, "ReadUserTuple must find exact-match tuple %q", tk.String())
+				require.Equal(t, tk.GetObject(), got.GetKey().GetObject())
+				require.Equal(t, tk.GetRelation(), got.GetKey().GetRelation())
+				require.Equal(t, tk.GetUser(), got.GetKey().GetUser())
+			}
+		})
+	}
+
+	// Cover the equivalent read paths on changelog and authorization_model.
+
+	t.Run("changelog_object_type_byte_distinct", func(t *testing.T) {
+		store := "store_changelog"
+		err := ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("Document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+		err = ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+
+		for _, objectType := range []string{"Document", "document"} {
+			changes, _, err := ds.ReadChanges(ctx, store, storage.ReadChangesFilter{
+				ObjectType: objectType,
+			}, storage.ReadChangesOptions{Pagination: storage.NewPaginationOptions(50, "")})
+			require.NoError(t, err)
+			require.NotEmpty(t, changes, "ReadChanges with ObjectType=%q must find at least one matching change", objectType)
+			for _, c := range changes {
+				require.Equal(t, objectType+":42", c.GetTupleKey().GetObject(),
+					"ReadChanges with ObjectType=%q must not return non-matching rows", objectType)
+			}
+		}
+	})
+
+	t.Run("authorization_model_type_byte_distinct", func(t *testing.T) {
+		store := ulid.Make().String()
+		modelID := ulid.Make().String()
+		model := &openfgav1.AuthorizationModel{
+			Id:            modelID,
+			SchemaVersion: typesystem.SchemaVersion1_1,
+			TypeDefinitions: []*openfgav1.TypeDefinition{
+				{Type: "User"},
+				{Type: "user"},
+			},
+		}
+		err := ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err, "writing a model with byte-distinct type names must succeed")
+
+		got, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+		require.NoError(t, err)
+		gotTypes := make(map[string]struct{}, len(got.GetTypeDefinitions()))
+		for _, td := range got.GetTypeDefinitions() {
+			gotTypes[td.GetType()] = struct{}{}
+		}
+		require.Contains(t, gotTypes, "User")
+		require.Contains(t, gotTypes, "user")
+		require.Len(t, gotTypes, 2, "expected both type definitions to round-trip")
+	})
+}

--- a/pkg/storage/postgres/collation_test.go
+++ b/pkg/storage/postgres/collation_test.go
@@ -1,0 +1,159 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
+	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+)
+
+// TestIdentifierColumnCollation asserts that identifier columns on the
+// Postgres backend treat byte-distinct values as distinct rows. Locked
+// in as a regression guard against future collation drift.
+func TestIdentifierColumnCollation(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		store  string
+		tuples []*openfgav1.TupleKey
+	}{
+		{
+			name:  "user_byte_distinct",
+			store: "store_user",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:A"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:a"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:AA"),
+			},
+		},
+		{
+			name:  "object_type_byte_distinct",
+			store: "store_obj_type",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("Document:2", "viewer", "user:b"),
+				tupleUtils.NewTupleKey("document:2", "viewer", "user:b"),
+			},
+		},
+		{
+			name:  "relation_byte_distinct",
+			store: "store_rel",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:3", "Viewer", "user:c"),
+				tupleUtils.NewTupleKey("doc:3", "viewer", "user:c"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, tk := range tc.tuples {
+				err := ds.Write(ctx, tc.store, nil, []*openfgav1.TupleKey{tk})
+				require.NoErrorf(t, err, "writing tuple %q must succeed", tk.String())
+			}
+
+			iter, err := ds.Read(ctx, tc.store, storage.ReadFilter{}, storage.ReadOptions{})
+			require.NoError(t, err)
+			defer iter.Stop()
+
+			seen := map[string]struct{}{}
+			for {
+				cur, err := iter.Next(ctx)
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+				require.NoError(t, err)
+				k := cur.GetKey()
+				seen[k.GetObject()+"#"+k.GetRelation()+"@"+k.GetUser()] = struct{}{}
+			}
+
+			for _, tk := range tc.tuples {
+				key := tk.GetObject() + "#" + tk.GetRelation() + "@" + tk.GetUser()
+				require.Containsf(t, seen, key, "tuple %q missing from read", key)
+			}
+			require.Lenf(t, seen, len(tc.tuples), "expected %d distinct rows, got %d", len(tc.tuples), len(seen))
+
+			// Each value must round-trip through the targeted read path
+			// returning exactly its own row.
+			for _, tk := range tc.tuples {
+				got, err := ds.ReadUserTuple(ctx, tc.store, storage.ReadUserTupleFilter{
+					Object:   tk.GetObject(),
+					Relation: tk.GetRelation(),
+					User:     tk.GetUser(),
+				}, storage.ReadUserTupleOptions{})
+				require.NoErrorf(t, err, "ReadUserTuple must find exact-match tuple %q", tk.String())
+				require.Equal(t, tk.GetObject(), got.GetKey().GetObject())
+				require.Equal(t, tk.GetRelation(), got.GetKey().GetRelation())
+				require.Equal(t, tk.GetUser(), got.GetKey().GetUser())
+			}
+		})
+	}
+
+	// Cover the equivalent read paths on changelog and authorization_model.
+
+	t.Run("changelog_object_type_byte_distinct", func(t *testing.T) {
+		store := "store_changelog"
+		err := ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("Document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+		err = ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+
+		for _, objectType := range []string{"Document", "document"} {
+			changes, _, err := ds.ReadChanges(ctx, store, storage.ReadChangesFilter{
+				ObjectType: objectType,
+			}, storage.ReadChangesOptions{Pagination: storage.NewPaginationOptions(50, "")})
+			require.NoError(t, err)
+			require.NotEmpty(t, changes, "ReadChanges with ObjectType=%q must find at least one matching change", objectType)
+			for _, c := range changes {
+				require.Equal(t, objectType+":42", c.GetTupleKey().GetObject(),
+					"ReadChanges with ObjectType=%q must not return non-matching rows", objectType)
+			}
+		}
+	})
+
+	t.Run("authorization_model_type_byte_distinct", func(t *testing.T) {
+		store := ulid.Make().String()
+		modelID := ulid.Make().String()
+		model := &openfgav1.AuthorizationModel{
+			Id:            modelID,
+			SchemaVersion: typesystem.SchemaVersion1_1,
+			TypeDefinitions: []*openfgav1.TypeDefinition{
+				{Type: "User"},
+				{Type: "user"},
+			},
+		}
+		err := ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err, "writing a model with byte-distinct type names must succeed")
+
+		got, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+		require.NoError(t, err)
+		gotTypes := make(map[string]struct{}, len(got.GetTypeDefinitions()))
+		for _, td := range got.GetTypeDefinitions() {
+			gotTypes[td.GetType()] = struct{}{}
+		}
+		require.Contains(t, gotTypes, "User")
+		require.Contains(t, gotTypes, "user")
+		require.Len(t, gotTypes, 2, "expected both type definitions to round-trip")
+	})
+}

--- a/pkg/storage/sqlite/collation_test.go
+++ b/pkg/storage/sqlite/collation_test.go
@@ -1,0 +1,159 @@
+package sqlite
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/sqlcommon"
+	storagefixtures "github.com/openfga/openfga/pkg/testfixtures/storage"
+	tupleUtils "github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+)
+
+// TestIdentifierColumnCollation asserts that identifier columns on the
+// SQLite backend treat byte-distinct values as distinct rows. Locked in
+// as a regression guard against future collation drift.
+func TestIdentifierColumnCollation(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "sqlite")
+
+	uri := testDatastore.GetConnectionURI(true)
+	ds, err := New(uri, sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		store  string
+		tuples []*openfgav1.TupleKey
+	}{
+		{
+			name:  "user_byte_distinct",
+			store: "store_user",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:A"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:a"),
+				tupleUtils.NewTupleKey("doc:1", "viewer", "user:AA"),
+			},
+		},
+		{
+			name:  "object_type_byte_distinct",
+			store: "store_obj_type",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("Document:2", "viewer", "user:b"),
+				tupleUtils.NewTupleKey("document:2", "viewer", "user:b"),
+			},
+		},
+		{
+			name:  "relation_byte_distinct",
+			store: "store_rel",
+			tuples: []*openfgav1.TupleKey{
+				tupleUtils.NewTupleKey("doc:3", "Viewer", "user:c"),
+				tupleUtils.NewTupleKey("doc:3", "viewer", "user:c"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, tk := range tc.tuples {
+				err := ds.Write(ctx, tc.store, nil, []*openfgav1.TupleKey{tk})
+				require.NoErrorf(t, err, "writing tuple %q must succeed", tk.String())
+			}
+
+			iter, err := ds.Read(ctx, tc.store, storage.ReadFilter{}, storage.ReadOptions{})
+			require.NoError(t, err)
+			defer iter.Stop()
+
+			seen := map[string]struct{}{}
+			for {
+				cur, err := iter.Next(ctx)
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+				require.NoError(t, err)
+				k := cur.GetKey()
+				seen[k.GetObject()+"#"+k.GetRelation()+"@"+k.GetUser()] = struct{}{}
+			}
+
+			for _, tk := range tc.tuples {
+				key := tk.GetObject() + "#" + tk.GetRelation() + "@" + tk.GetUser()
+				require.Containsf(t, seen, key, "tuple %q missing from read", key)
+			}
+			require.Lenf(t, seen, len(tc.tuples), "expected %d distinct rows, got %d", len(tc.tuples), len(seen))
+
+			// Each value must round-trip through the targeted read path
+			// returning exactly its own row.
+			for _, tk := range tc.tuples {
+				got, err := ds.ReadUserTuple(ctx, tc.store, storage.ReadUserTupleFilter{
+					Object:   tk.GetObject(),
+					Relation: tk.GetRelation(),
+					User:     tk.GetUser(),
+				}, storage.ReadUserTupleOptions{})
+				require.NoErrorf(t, err, "ReadUserTuple must find exact-match tuple %q", tk.String())
+				require.Equal(t, tk.GetObject(), got.GetKey().GetObject())
+				require.Equal(t, tk.GetRelation(), got.GetKey().GetRelation())
+				require.Equal(t, tk.GetUser(), got.GetKey().GetUser())
+			}
+		})
+	}
+
+	// Cover the equivalent read paths on changelog and authorization_model.
+
+	t.Run("changelog_object_type_byte_distinct", func(t *testing.T) {
+		store := "store_changelog"
+		err := ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("Document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+		err = ds.Write(ctx, store, nil, []*openfgav1.TupleKey{
+			tupleUtils.NewTupleKey("document:42", "viewer", "user:d"),
+		})
+		require.NoError(t, err)
+
+		for _, objectType := range []string{"Document", "document"} {
+			changes, _, err := ds.ReadChanges(ctx, store, storage.ReadChangesFilter{
+				ObjectType: objectType,
+			}, storage.ReadChangesOptions{Pagination: storage.NewPaginationOptions(50, "")})
+			require.NoError(t, err)
+			require.NotEmpty(t, changes, "ReadChanges with ObjectType=%q must find at least one matching change", objectType)
+			for _, c := range changes {
+				require.Equal(t, objectType+":42", c.GetTupleKey().GetObject(),
+					"ReadChanges with ObjectType=%q must not return non-matching rows", objectType)
+			}
+		}
+	})
+
+	t.Run("authorization_model_type_byte_distinct", func(t *testing.T) {
+		store := ulid.Make().String()
+		modelID := ulid.Make().String()
+		model := &openfgav1.AuthorizationModel{
+			Id:            modelID,
+			SchemaVersion: typesystem.SchemaVersion1_1,
+			TypeDefinitions: []*openfgav1.TypeDefinition{
+				{Type: "User"},
+				{Type: "user"},
+			},
+		}
+		err := ds.WriteAuthorizationModel(ctx, store, model)
+		require.NoError(t, err, "writing a model with byte-distinct type names must succeed")
+
+		got, err := ds.ReadAuthorizationModel(ctx, store, modelID)
+		require.NoError(t, err)
+		gotTypes := make(map[string]struct{}, len(got.GetTypeDefinitions()))
+		for _, td := range got.GetTypeDefinitions() {
+			gotTypes[td.GetType()] = struct{}{}
+		}
+		require.Contains(t, gotTypes, "User")
+		require.Contains(t, gotTypes, "user")
+		require.Len(t, gotTypes, 2, "expected both type definitions to round-trip")
+	})
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Aligns the collation of identifier columns on MySQL (object_type, relation, _user, condition_name, and the authorization model type) with utf8mb4_bin, matching the treatment already applied to tuple.object_id in migration 007. This makes
  identifier storage and comparison consistent across the tuple, changelog, and authorization_model tables.

  Postgres and SQLite are unaffected by their defaults; regression tests are added on all three backends to lock the behaviour in.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Standardized identifier column collation across database backends

* **Tests**
  * Added comprehensive regression tests across MySQL, PostgreSQL, and SQLite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->