### PR TITLE
fix: reset visitedUsersetsMap and queryDedupeMap in shallowClone

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand.go
@@ -250,13 +250,20 @@ func WithLogger(logger logger.Logger) ReverseExpandQueryOption {
 
 // shallowClone creates an identical copy of reverseExpandQuery except
 // candidateObjectsMap as list object candidates need to be validated
-// via check.
+// via check. visitedUsersetsMap and queryDedupeMap are also reset so that
+// concurrent intersection/exclusion traversals do not race on shared state
+// and skip branches they haven't explored yet. queryDedupeMap is
+// intentionally per-branch: sharing it across branches would cause one
+// branch to skip in-flight queries that only delivered results to the
+// other branch's channel, producing incomplete results.
 func (c *ReverseExpandQuery) shallowClone() *ReverseExpandQuery {
 	if c == nil {
 		return nil
 	}
 	copy := *c
 	copy.candidateObjectsMap = new(sync.Map)
+	copy.visitedUsersetsMap = new(sync.Map)
+	copy.queryDedupeMap = new(sync.Map)
 	return &copy
 }
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go
@@ -3,7 +3,9 @@ package reverseexpand
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -2939,4 +2941,92 @@ func TestExclusionHandler(t *testing.T) {
 		err = pool.Wait()
 		require.ErrorIs(t, err, errorRet)
 	})
+}
+
+// TestShallowCloneIsolatesSharedMaps guards against a regression where
+// shallowClone shared visitedUsersetsMap and queryDedupeMap with the
+// original query. When intersection/exclusion handlers run the clone and the
+// original concurrently, the goroutine that lost the LoadOrStore race would
+// see the userset as already visited and skip branches it hadn't explored,
+// producing non-deterministic (often empty) results.
+func TestShallowCloneIsolatesSharedMaps(t *testing.T) {
+	ds := memory.New()
+	t.Cleanup(ds.Close)
+
+	// Model with intersection: can_read requires both a direct [user] tuple
+	// and ctx_member on the parent workspace. shallowClone is exercised for
+	// each intersection branch.
+	model := `
+		model
+		  schema 1.1
+		type user
+		type workspace
+		  relations
+		    define ctx_member: [user]
+		type field
+		  relations
+		    define parent_workspace: [workspace]
+		    define can_read: [user] and ctx_member from parent_workspace
+	`
+
+	// Build enough objects that the scheduler will interleave goroutines and
+	// expose a race on visitedUsersetsMap when the clone shares state.
+	const numFields = 20
+	tuples := make([]string, 0, numFields*2+1)
+	expected := make([]string, 0, numFields)
+	for i := 0; i < numFields; i++ {
+		field := fmt.Sprintf("field:%d", i)
+		tuples = append(tuples,
+			fmt.Sprintf("%s#parent_workspace@workspace:w1", field),
+			fmt.Sprintf("%s#can_read@user:alice", field),
+		)
+		expected = append(expected, field)
+	}
+	tuples = append(tuples, "workspace:w1#ctx_member@user:alice")
+
+	storeID, resolvedModel := storagetest.BootstrapFGAStore(t, ds, model, tuples)
+	typesys, err := typesystem.NewAndValidate(context.Background(), resolvedModel)
+	require.NoError(t, err)
+
+	ctx := storage.ContextWithRelationshipTupleReader(context.Background(), ds)
+	ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+
+	// Run many iterations: without the fix, incorrect results appear within
+	// the first handful of runs due to goroutine-scheduling non-determinism.
+	const iterations = 100
+	for iter := 0; iter < iterations; iter++ {
+		resultsChan := make(chan *ReverseExpandResult)
+		errChan := make(chan error, 1)
+
+		go func() {
+			q := NewReverseExpandQuery(ds, typesys, WithListObjectOptimizationsEnabled(true))
+			if execErr := q.Execute(ctx, &ReverseExpandRequest{
+				StoreID:    storeID,
+				ObjectType: "field",
+				Relation:   "can_read",
+				User:       &UserRefObject{Object: &openfgav1.Object{Type: "user", Id: "alice"}},
+			}, resultsChan, NewResolutionMetadata()); execErr != nil {
+				errChan <- execErr
+			}
+		}()
+
+		timeout := time.After(30 * time.Second)
+		var got []string
+	loop:
+		for {
+			select {
+			case res, open := <-resultsChan:
+				if !open {
+					break loop
+				}
+				got = append(got, res.Object)
+			case execErr := <-errChan:
+				require.FailNow(t, "unexpected error", execErr)
+			case <-timeout:
+				require.FailNow(t, "timed out waiting for resultsChan to close")
+			}
+		}
+
+		require.ElementsMatch(t, expected, got, "iteration %d produced wrong results — shallowClone state leak suspected", iter)
+	}
 }


### PR DESCRIPTION
## Summary

`shallowClone` in `ReverseExpandQuery` was allocating a fresh `candidateObjectsMap` but leaving `visitedUsersetsMap` and `queryDedupeMap` pointing to the same maps as the original. When intersection/exclusion handlers fan out the clone and the original as concurrent goroutines, both goroutines race on those shared maps via `sync.Map.LoadOrStore`. The goroutine that loses the race sees the userset as already visited and skips branches it hasn't explored yet — producing non-deterministic, often empty, `ListObjects` results for any model using `and` or `but not`.

The fix mirrors what was already done for `candidateObjectsMap`: allocate a fresh `sync.Map` for each of the two affected fields in `shallowClone`.

**Affected versions**: present since `shallowClone` was introduced; confirmed unfixed through v1.17.1.

## Changes

- `pkg/server/commands/reverseexpand/reverse_expand.go`: allocate fresh `visitedUsersetsMap` and `queryDedupeMap` in `shallowClone`
- `pkg/server/commands/reverseexpand/reverse_expand_weighted_test.go`: add `TestShallowCloneIsolatesSharedMaps` regression test — 20 field objects × 100 iterations with `-race`, reliably reproducing the issue before the fix

## How to reproduce (before fix)

Authorization model with intersection:

```
model
  schema 1.1
type user
type workspace
  relations
    define ctx_member: [user]
type field
  relations
    define parent_workspace: [workspace]
    define can_read: [user] and ctx_member from parent_workspace
```

Repeated `ListObjects` calls for `user:alice` on `field#can_read` return the full list ~1 in 10 times and an empty list the rest of the time, with all caches disabled and a single-instance PostgreSQL backend. The `Openfga-Authorization-Model-Id` response header is identical across all calls, ruling out model-selection as the cause.

Example curl output before fix:
```
# Most calls (~9/10):
{"objects":[]}

# Occasional correct result (~1/10):
{"objects":["field:0","field:1","field:2",...,"field:19"]}
```

## Test plan

- [x] `go test -run TestShallowCloneIsolatesSharedMaps -race ./pkg/server/commands/reverseexpand/...` passes
- [x] `go vet ./pkg/server/commands/reverseexpand/...` clean
- [ ] `make test` full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in reverse-expand traversal so cloned queries no longer share mutable state between parallel branches, preventing nondeterministic or empty results.

* **Tests**
  * Added a regression test that repeatedly runs concurrent reverse-expand executions under weighted scenarios to verify deterministic, isolated behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->