### PR TITLE
fix: use deterministic proto marshaling for stored authorization models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)
+- Use `proto.MarshalOptions{Deterministic: true}` when serializing authorization models to the `serialized_protobuf` column, ensuring consistent stored bytes within a given OpenFGA version for models with map-keyed type definitions. [#3171](https://github.com/openfga/openfga/pull/3171)
 
 ## [1.18.0] - 2026-06-16
 ### Fixed
 - Use `crypto/subtle.ConstantTimeCompare` for preshared key authentication to close a timing side-channel where the prior map lookup could reveal information about valid key bytes. [#3168](https://github.com/openfga/openfga/pull/3168) Thanks to [@geo-chen](https://github.com/geo-chen) for reporting this.
-- Use `proto.MarshalOptions{Deterministic: true}` when serializing authorization models to the `serialized_protobuf` column, ensuring consistent stored bytes within a given OpenFGA version for models with map-keyed type definitions. [#3171](https://github.com/openfga/openfga/pull/3171)
 
 ### Security
 - Fixed identifier comparison on the MySQL backend to be case-sensitive, matching Postgres and SQLite. Ships schema migrations 008, which require a maintenance window — see the [operator runbook](assets/migrations/mysql/collation_migrations.md) before upgrading. Resolves [CVE-2026-55170](https://github.com/openfga/openfga/security/advisories/GHSA-cf98-j28v-49v6). Thank you [@sahajamoth](https://github.com/sahajamoth) for bringing this to our attention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.18.0] - 2026-06-16
 ### Fixed
 - Use `crypto/subtle.ConstantTimeCompare` for preshared key authentication to close a timing side-channel where the prior map lookup could reveal information about valid key bytes. [#3168](https://github.com/openfga/openfga/pull/3168) Thanks to [@geo-chen](https://github.com/geo-chen) for reporting this.
+- Use `proto.MarshalOptions{Deterministic: true}` when serializing authorization models to the `serialized_protobuf` column, ensuring consistent stored bytes within a given OpenFGA version for models with map-keyed type definitions. [#3171](https://github.com/openfga/openfga/pull/3171)
 
 ### Security
 - Fixed identifier comparison on the MySQL backend to be case-sensitive, matching Postgres and SQLite. Ships schema migrations 008, which require a maintenance window — see the [operator runbook](assets/migrations/mysql/collation_migrations.md) before upgrading. Resolves [CVE-2026-55170](https://github.com/openfga/openfga/security/advisories/GHSA-cf98-j28v-49v6). Thank you [@sahajamoth](https://github.com/sahajamoth) for bringing this to our attention.

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -974,7 +974,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal authorization model: %w", err)
 	}
 
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -972,7 +972,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		return nil
 	}
 
-	pbdata, err := proto.Marshal(model)
+	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -974,7 +974,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return fmt.Errorf("marshal authorization model: %w", err)
+		return err
 	}
 
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -972,7 +972,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		return nil
 	}
 
-	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
+	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -1010,7 +1010,7 @@ func WriteAuthorizationModel(
 		return nil
 	}
 
-	pbdata, err := proto.Marshal(model)
+	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -31,6 +31,10 @@ import (
 
 var tracer = otel.Tracer("pkg/storage/sqlcommon")
 
+// DeterministicMarshalOpts marshals proto messages with stable map-key ordering.
+// Use this instead of proto.Marshal for any value written to persistent storage.
+var DeterministicMarshalOpts = proto.MarshalOptions{Deterministic: true}
+
 // Config defines the configuration parameters
 // for setting up and managing a sql connection.
 type Config struct {
@@ -1010,7 +1014,7 @@ func WriteAuthorizationModel(
 		return nil
 	}
 
-	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
+	pbdata, err := DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -1016,7 +1017,7 @@ func WriteAuthorizationModel(
 
 	pbdata, err := DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal authorization model: %w", err)
 	}
 
 	_, err = dbInfo.stbl.

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -1017,7 +1016,7 @@ func WriteAuthorizationModel(
 
 	pbdata, err := DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return fmt.Errorf("marshal authorization model: %w", err)
+		return err
 	}
 
 	_, err = dbInfo.stbl.

--- a/pkg/storage/sqlcommon/sqlcommon_test.go
+++ b/pkg/storage/sqlcommon/sqlcommon_test.go
@@ -283,6 +283,10 @@ func TestFetchBufferMetric(t *testing.T) {
 	})
 }
 
+// TestDeterministicMarshalOpts verifies that DeterministicMarshalOpts produces
+// identical bytes across repeated marshals of the same authorization model,
+// including models with map-keyed relations where plain proto.Marshal is
+// non-deterministic.
 func TestDeterministicMarshalOpts(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/storage/sqlcommon/sqlcommon_test.go
+++ b/pkg/storage/sqlcommon/sqlcommon_test.go
@@ -282,3 +282,33 @@ func TestFetchBufferMetric(t *testing.T) {
 		require.GreaterOrEqual(t, sqlIterQuerySampleCount(t, "true"), before+1)
 	})
 }
+
+func TestDeterministicMarshalOpts(t *testing.T) {
+	t.Parallel()
+
+	// Build a model with multiple map-keyed relations to expose the non-deterministic
+	// serialization that plain proto.Marshal can produce.
+	model := &openfgav1.AuthorizationModel{
+		Id:            "01HVMMBCMGZNT3SED4Z17ECXCA",
+		SchemaVersion: "1.1",
+		TypeDefinitions: []*openfgav1.TypeDefinition{
+			{
+				Type: "document",
+				Relations: map[string]*openfgav1.Userset{
+					"owner":  {Userset: &openfgav1.Userset_This{This: &openfgav1.DirectUserset{}}},
+					"editor": {Userset: &openfgav1.Userset_This{This: &openfgav1.DirectUserset{}}},
+					"viewer": {Userset: &openfgav1.Userset_This{This: &openfgav1.DirectUserset{}}},
+				},
+			},
+		},
+	}
+
+	b1, err := DeterministicMarshalOpts.Marshal(model)
+	require.NoError(t, err)
+
+	b2, err := DeterministicMarshalOpts.Marshal(model)
+	require.NoError(t, err)
+
+	require.Equal(t, b1, b2, "DeterministicMarshalOpts must produce identical bytes across calls")
+	require.True(t, DeterministicMarshalOpts.Deterministic)
+}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -999,7 +999,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return fmt.Errorf("marshal authorization model: %w", err)
+		return err
 	}
 
 	err = busyRetry(func() error {

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -997,7 +997,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		return nil
 	}
 
-	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
+	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -997,7 +997,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 		return nil
 	}
 
-	pbdata, err := proto.Marshal(model)
+	pbdata, err := proto.MarshalOptions{Deterministic: true}.Marshal(model)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -999,7 +999,7 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 	pbdata, err := sqlcommon.DeterministicMarshalOpts.Marshal(model)
 	if err != nil {
-		return err
+		return fmt.Errorf("marshal authorization model: %w", err)
 	}
 
 	err = busyRetry(func() error {


### PR DESCRIPTION
## Summary

`proto.Marshal` in Go does not guarantee stable byte output for messages containing map fields. `AuthorizationModel` uses `map<string, Userset>` for the `relations` field on each `TypeDefinition`, so serialized bytes differ across runs for the same logical model.

This PR switches the storage write path to `proto.MarshalOptions{Deterministic: true}`, which sorts map keys before encoding and produces identical bytes for identical models.

## Why this matters

Any consumer doing byte-level comparison of exported DB rows — checksums, idempotency checks on generated fixtures, diff-based drift detection — gets spurious diffs. We hit this while building a pipeline that commits a `pg_dump` of the seeded authorization model as a reproducible artifact: every run produced a different hex blob for unchanged input.

## Change

- Storage write path only: `proto.Marshal(model)` → `proto.MarshalOptions{Deterministic: true}.Marshal(model)`
- Affected backends: `sqlcommon`, `postgres`, `sqlite` (the `WriteAuthorizationModel` path in each)
- Read paths are unaffected
- Existing rows in deployed databases are unaffected (only newly written rows change)

## Notes

`Deterministic: true` is safe for all proto v2 API usage; it does not affect deserialization compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of authorization model storage across database backends by switching to deterministic protobuf serialization for the persisted authorization model payload, ensuring identical serialized bytes across repeated writes.

* **Tests**
  * Added a test to confirm deterministic marshaling produces identical bytes across repeated calls and that deterministic mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->