### PR TITLE
feat: add opt-in sorted results to Read, ReadUsersetTuples, and ReadStartingWithUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Added opt-in `WithResultsSortedAscending` to `ReadOptions` and `ReadUsersetTuplesOptions`, and made `ReadStartingWithUser` honour its existing flag (previously it sorted unconditionally). All iterator types now accurately report `IsOrdered()`. The experimental `weighted_graph_check` `weight2` pruning optimization can now fire when results are sorted. [#3173](https://github.com/openfga/openfga/pull/3173)
+
 ### Fixed
 - Use `crypto/subtle.ConstantTimeCompare` for preshared key authentication to close a timing side-channel where the prior map lookup could reveal information about valid key bytes. [#3168](https://github.com/openfga/openfga/pull/3168) Thanks to [@geo-chen](https://github.com/geo-chen) for reporting this.
 

--- a/internal/check/bottom_up.go
+++ b/internal/check/bottom_up.go
@@ -176,6 +176,7 @@ func (s *bottomUp) specificType(ctx context.Context, req *Request, edge *authzGr
 	defer span.End()
 
 	opts := storage.ReadStartingWithUserOptions{
+		WithResultsSortedAscending: true,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -213,6 +214,7 @@ func (s *bottomUp) specificTypeWildcard(ctx context.Context, req *Request, edge 
 	defer span.End()
 
 	opts := storage.ReadStartingWithUserOptions{
+		WithResultsSortedAscending: true,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -253,7 +255,7 @@ func (s *bottomUp) buildIterator(ctx context.Context, req *Request, edge *authzG
 	// deduplication is only happening on the merged iterator and contextual tuples will always overwrite the base iterator
 	iter := storage.NewTupleKeyIteratorFromTupleIterator(i)
 	if ctxTuples, ok := req.GetContextualTuplesByUserID(userID, relation, objectType); ok {
-		iter = iterator.Merge(iter, storage.NewStaticTupleKeyIterator(ctxTuples), func(a, b *openfgav1.TupleKey) int {
+		iter = iterator.Merge(iter, storage.NewStaticTupleKeyIterator(ctxTuples, true), func(a, b *openfgav1.TupleKey) int {
 			if a.GetObject() < b.GetObject() {
 				return -1
 			}
@@ -293,7 +295,7 @@ func (b *batcher) add(val string) {
 
 func (b *batcher) flush(stopped bool) {
 	if len(b.items) > 0 {
-		concurrency.TrySendThroughChannel(b.ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](b.items)}, b.out)
+		concurrency.TrySendThroughChannel(b.ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](b.items, true)}, b.out)
 		// Get a new buffer from the pool for the next batch.
 		// We cannot reuse the current one because ownership of the slice has been passed to the iterator.
 		if stopped {

--- a/internal/check/bottom_up.go
+++ b/internal/check/bottom_up.go
@@ -176,7 +176,7 @@ func (s *bottomUp) specificType(ctx context.Context, req *Request, edge *authzGr
 	defer span.End()
 
 	opts := storage.ReadStartingWithUserOptions{
-		WithResultsSortedAscending: true,
+		SortAsc: true,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -214,7 +214,7 @@ func (s *bottomUp) specificTypeWildcard(ctx context.Context, req *Request, edge 
 	defer span.End()
 
 	opts := storage.ReadStartingWithUserOptions{
-		WithResultsSortedAscending: true,
+		SortAsc: true,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -255,7 +255,7 @@ func (s *bottomUp) buildIterator(ctx context.Context, req *Request, edge *authzG
 	// deduplication is only happening on the merged iterator and contextual tuples will always overwrite the base iterator
 	iter := storage.NewTupleKeyIteratorFromTupleIterator(i)
 	if ctxTuples, ok := req.GetContextualTuplesByUserID(userID, relation, objectType); ok {
-		iter = iterator.Merge(iter, storage.NewStaticTupleKeyIterator(ctxTuples, true), func(a, b *openfgav1.TupleKey) int {
+		iter = iterator.Merge(iter, storage.NewOrderedStaticTupleKeyIterator(ctxTuples), func(a, b *openfgav1.TupleKey) int {
 			if a.GetObject() < b.GetObject() {
 				return -1
 			}
@@ -295,7 +295,7 @@ func (b *batcher) add(val string) {
 
 func (b *batcher) flush(stopped bool) {
 	if len(b.items) > 0 {
-		concurrency.TrySendThroughChannel(b.ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](b.items, true)}, b.out)
+		concurrency.TrySendThroughChannel(b.ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](b.items)}, b.out)
 		// Get a new buffer from the pool for the next batch.
 		// We cannot reuse the current one because ownership of the slice has been passed to the iterator.
 		if stopped {

--- a/internal/check/bottom_up_test.go
+++ b/internal/check/bottom_up_test.go
@@ -41,10 +41,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -95,10 +96,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -150,10 +152,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -207,10 +210,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{"xcond", ""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -266,6 +270,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
@@ -319,10 +324,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -373,10 +379,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -427,10 +434,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -483,10 +491,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{"xcond"},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -542,6 +551,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
@@ -652,28 +662,28 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
 		producer3 := make(chan *iterator.Msg, 4)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer3)
 		producers = append(producers, iterator.FromChannel(producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"})}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
 		close(producer4)
 		producers = append(producers, iterator.FromChannel(producer4))
 
@@ -755,7 +765,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -801,7 +811,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -846,7 +856,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -882,7 +892,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -973,31 +983,31 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 2)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
 		producer3 := make(chan *iterator.Msg, 6)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer3)
 		producers = append(producers, iterator.FromChannel(producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
 		close(producer4)
 		producers = append(producers, iterator.FromChannel(producer4))
 
@@ -1080,7 +1090,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -1126,7 +1136,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -1171,7 +1181,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1204,7 +1214,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1242,7 +1252,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1279,7 +1289,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1377,20 +1387,20 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 6)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 6)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1491,7 +1501,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -1534,7 +1544,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1567,7 +1577,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 
 		for _, objs := range objects {
 			producer := make(chan *iterator.Msg, 1)
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -1615,7 +1625,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1648,7 +1658,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1675,7 +1685,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		res := make(chan *iterator.Msg)
 		producers := make([]storage.Iterator[string], 0)
 		producer1 := make(chan *iterator.Msg, 1)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		iter1 := mocks.NewMockIterator[string](ctrl)
@@ -1735,11 +1745,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1852,11 +1862,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1963,11 +1973,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
 				case "banned":
-					return storage.NewStaticTupleIterator(readStartingWithUserBanned), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserBanned, false), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2080,13 +2090,13 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
 				case "analyzer":
-					return storage.NewStaticTupleIterator(readStartingWithUserAnalyzer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserAnalyzer, false), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2173,10 +2183,11 @@ func TestBottomUpResolveRewriteForWildcardRequests(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(readStartingWithUserViewer), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil)
 
 		// Create a model with a union operator
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -2309,9 +2320,9 @@ func TestBottomUpResolveRewriteForWildcardRequests(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2541,7 +2552,7 @@ func TestBottomUp_SetOperationSetup_StopsIteratorsOnError(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				switch filter.Relation {
 				case "member":
-					return storage.NewStaticTupleIterator(tuples), nil
+					return storage.NewStaticTupleIterator(tuples, false), nil
 				case "editor":
 					return nil, errors.New("datastore error")
 				default:
@@ -2600,7 +2611,7 @@ func TestBottomUp_SetOperationSetup_StopsIteratorsOnError(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				switch filter.Relation {
 				case "member":
-					return storage.NewStaticTupleIterator(tuples), nil
+					return storage.NewStaticTupleIterator(tuples, false), nil
 				case "editor":
 					return nil, errors.New("datastore error")
 				default:

--- a/internal/check/bottom_up_test.go
+++ b/internal/check/bottom_up_test.go
@@ -45,7 +45,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -100,7 +100,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -156,7 +156,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -214,7 +214,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -328,7 +328,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -383,7 +383,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -438,7 +438,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -495,7 +495,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model

--- a/internal/check/bottom_up_test.go
+++ b/internal/check/bottom_up_test.go
@@ -41,11 +41,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -96,11 +96,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -152,11 +152,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -210,11 +210,11 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{"xcond", ""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -270,7 +270,7 @@ func TestBottomUpSpecificType(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
@@ -324,11 +324,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -379,11 +379,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -434,11 +434,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -491,11 +491,11 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{"xcond"},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -551,7 +551,7 @@ func TestBottomUpSpecificTypeWildcard(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
@@ -662,28 +662,28 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
 		producer3 := make(chan *iterator.Msg, 4)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer3)
 		producers = append(producers, iterator.FromChannel(producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:4"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
 		close(producer4)
 		producers = append(producers, iterator.FromChannel(producer4))
 
@@ -765,7 +765,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -811,7 +811,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](keys)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -856,7 +856,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -892,7 +892,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -983,31 +983,31 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 2)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
 		producer3 := make(chan *iterator.Msg, 6)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer3)
 		producers = append(producers, iterator.FromChannel(producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:4"})}
 		close(producer4)
 		producers = append(producers, iterator.FromChannel(producer4))
 
@@ -1090,7 +1090,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -1136,7 +1136,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](keys)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -1181,7 +1181,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1214,7 +1214,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1252,7 +1252,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1289,7 +1289,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1387,20 +1387,20 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 6)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 6)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 
@@ -1501,7 +1501,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.FromChannel(producer))
 				}
@@ -1544,7 +1544,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		producers = append(producers, iterator.FromChannel(producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1577,7 +1577,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 
 		for _, objs := range objects {
 			producer := make(chan *iterator.Msg, 1)
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 			close(producer)
 			producers = append(producers, iterator.FromChannel(producer))
 		}
@@ -1625,7 +1625,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1658,7 +1658,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.FromChannel(producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1685,7 +1685,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		res := make(chan *iterator.Msg)
 		producers := make([]storage.Iterator[string], 0)
 		producer1 := make(chan *iterator.Msg, 1)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer1)
 		producers = append(producers, iterator.FromChannel(producer1))
 		iter1 := mocks.NewMockIterator[string](ctrl)
@@ -1745,11 +1745,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserEditor), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserCommenter), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1862,11 +1862,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserEditor), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserCommenter), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1973,11 +1973,11 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil
 				case "banned":
-					return storage.NewStaticTupleIterator(readStartingWithUserBanned, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserBanned), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserEditor), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2090,13 +2090,13 @@ func TestBottomUpResolveRewrite(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil
 				case "analyzer":
-					return storage.NewStaticTupleIterator(readStartingWithUserAnalyzer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserAnalyzer), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserEditor), nil
 				case "commenter":
-					return storage.NewStaticTupleIterator(readStartingWithUserCommenter, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserCommenter), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2183,11 +2183,11 @@ func TestBottomUpResolveRewriteForWildcardRequests(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:*"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil)
 
 		// Create a model with a union operator
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -2320,9 +2320,9 @@ func TestBottomUpResolveRewriteForWildcardRequests(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserViewer, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserViewer), nil
 				case "editor":
-					return storage.NewStaticTupleIterator(readStartingWithUserEditor, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserEditor), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -2552,7 +2552,7 @@ func TestBottomUp_SetOperationSetup_StopsIteratorsOnError(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				switch filter.Relation {
 				case "member":
-					return storage.NewStaticTupleIterator(tuples, false), nil
+					return storage.NewUnorderedStaticTupleIterator(tuples), nil
 				case "editor":
 					return nil, errors.New("datastore error")
 				default:
@@ -2611,7 +2611,7 @@ func TestBottomUp_SetOperationSetup_StopsIteratorsOnError(t *testing.T) {
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				switch filter.Relation {
 				case "member":
-					return storage.NewStaticTupleIterator(tuples, false), nil
+					return storage.NewUnorderedStaticTupleIterator(tuples), nil
 				case "editor":
 					return nil, errors.New("datastore error")
 				default:

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -899,7 +899,7 @@ func (r *Resolver) specificTypeWildcard(ctx context.Context, req *Request, edge 
 	if ctxTuples, ok := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), relation, req.GetUserType()); ok {
 		for _, ct := range ctxTuples {
 			if tuple.IsTypedWildcard(ct.GetUser()) {
-				iter = storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{ct}, false)
+				iter = storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{ct})
 				break
 			}
 		}
@@ -986,7 +986,7 @@ func (r *Resolver) specificTypeAndRelation(ctx context.Context, req *Request, ed
 		AllowedUserTypeRestrictions: allowedTypes,
 		Conditions:                  edge.GetConditions(),
 	}, storage.ReadUsersetTuplesOptions{
-		WithResultsSortedAscending: sortResults,
+		SortAsc: sortResults,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -1071,8 +1071,8 @@ func (r *Resolver) ttu(ctx context.Context, req *Request, edge *authzGraph.Weigh
 			Conditions: tuplesetEdge.GetConditions(),
 		},
 		storage.ReadOptions{
-			WithResultsSortedAscending: sortResults,
-			Consistency:                storage.ConsistencyOptions{Preference: req.GetConsistency()},
+			SortAsc:     sortResults,
+			Consistency: storage.ConsistencyOptions{Preference: req.GetConsistency()},
 		},
 	)
 	if err != nil {
@@ -1131,7 +1131,7 @@ func (r *Resolver) buildIterator(ctx context.Context, req *Request, iter storage
 
 	// STEP 2: Merge contextual tuples (these are request-specific and not cached)
 	if ctxTuples, ok := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), relation, userType); ok {
-		tupleKeyIter = iterator.Concat(storage.NewStaticTupleKeyIterator(ctxTuples, true), tupleKeyIter)
+		tupleKeyIter = iterator.Concat(storage.NewOrderedStaticTupleKeyIterator(ctxTuples), tupleKeyIter)
 	}
 
 	// STEP 3: Build filter chain

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -899,7 +899,7 @@ func (r *Resolver) specificTypeWildcard(ctx context.Context, req *Request, edge 
 	if ctxTuples, ok := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), relation, req.GetUserType()); ok {
 		for _, ct := range ctxTuples {
 			if tuple.IsTypedWildcard(ct.GetUser()) {
-				iter = storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{ct})
+				iter = storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{ct}, false)
 				break
 			}
 		}
@@ -975,12 +975,18 @@ func (r *Resolver) specificTypeAndRelation(ctx context.Context, req *Request, ed
 		Type:               userObjectType,
 		RelationOrWildcard: &openfgav1.RelationReference_Relation{Relation: userRelation},
 	}}
+	w, _ := edge.GetWeight(req.GetUserType())
+	_, hasCtxTuples := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), relation, edge.GetTo().GetUniqueLabel())
+	// Sort when weight=2 (weight2 strategy requires sorted results for pruning optimization),
+	// no ctx tuples (Concat breaks IsOrdered), and user is a concrete ID (not a userset).
+	sortResults := !tuple.IsObjectRelation(req.GetTupleKey().GetUser()) && w == 2 && !hasCtxTuples
 	tIter, err := r.datastore.ReadUsersetTuples(ctx, req.GetStoreID(), storage.ReadUsersetTuplesFilter{
 		Object:                      req.GetTupleKey().GetObject(),
 		Relation:                    relation,
 		AllowedUserTypeRestrictions: allowedTypes,
 		Conditions:                  edge.GetConditions(),
 	}, storage.ReadUsersetTuplesOptions{
+		WithResultsSortedAscending: sortResults,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},
@@ -1009,7 +1015,7 @@ func (r *Resolver) specificTypeAndRelation(ctx context.Context, req *Request, ed
 		DefaultStrategyName: DefaultPlan,
 	}
 
-	if w, _ := edge.GetWeight(req.GetUserType()); w == 2 {
+	if w == 2 {
 		possibleStrategies[WeightTwoStrategyName] = weight2Plan
 	}
 
@@ -1050,6 +1056,11 @@ func (r *Resolver) ttu(ctx context.Context, req *Request, edge *authzGraph.Weigh
 	}
 
 	userFilter := subjectType + ":"
+	w, _ := edge.GetWeight(req.GetUserType())
+	_, hasCtxTuples := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), tuplesetRelation, subjectType)
+	// Sort when weight=2 (weight2 strategy requires sorted results for pruning optimization),
+	// no ctx tuples (Concat breaks IsOrdered), and user is a concrete ID (not a userset).
+	sortResults := !tuple.IsObjectRelation(req.GetTupleKey().GetUser()) && w == 2 && !hasCtxTuples
 	tIter, err := r.datastore.Read(
 		ctx,
 		req.GetStoreID(),
@@ -1059,7 +1070,10 @@ func (r *Resolver) ttu(ctx context.Context, req *Request, edge *authzGraph.Weigh
 			User:       userFilter,
 			Conditions: tuplesetEdge.GetConditions(),
 		},
-		storage.ReadOptions{Consistency: storage.ConsistencyOptions{Preference: req.GetConsistency()}},
+		storage.ReadOptions{
+			WithResultsSortedAscending: sortResults,
+			Consistency:                storage.ConsistencyOptions{Preference: req.GetConsistency()},
+		},
 	)
 	if err != nil {
 		return nil, err
@@ -1085,7 +1099,7 @@ func (r *Resolver) ttu(ctx context.Context, req *Request, edge *authzGraph.Weigh
 		DefaultStrategyName: DefaultPlan,
 	}
 
-	if w, _ := edge.GetWeight(req.GetUserType()); w == 2 {
+	if w == 2 {
 		possibleStrategies[WeightTwoStrategyName] = weight2Plan
 	}
 
@@ -1117,7 +1131,7 @@ func (r *Resolver) buildIterator(ctx context.Context, req *Request, iter storage
 
 	// STEP 2: Merge contextual tuples (these are request-specific and not cached)
 	if ctxTuples, ok := req.GetContextualTuplesByObjectID(req.GetTupleKey().GetObject(), relation, userType); ok {
-		tupleKeyIter = iterator.Concat(storage.NewStaticTupleKeyIterator(ctxTuples), tupleKeyIter)
+		tupleKeyIter = iterator.Concat(storage.NewStaticTupleKeyIterator(ctxTuples, true), tupleKeyIter)
 	}
 
 	// STEP 3: Build filter chain

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -3998,7 +3998,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				WithResultsSortedAscending: true,
 				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, true), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4315,7 +4315,7 @@ func TestTTU(t *testing.T) {
 			},
 		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}, false), nil).Times(1)
+		}}, true), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4620,7 +4620,7 @@ func TestTTU(t *testing.T) {
 			},
 		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}, false), nil).Times(1)
+		}}, true), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -506,7 +506,7 @@ func TestResolveUnionEdges(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Relation == "member" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}, false), nil
 				}
 				return nil, storage.ErrNotFound
 			}).MaxTimes(1)
@@ -601,7 +601,7 @@ func TestResolveUnionEdges(t *testing.T) {
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, storage.ErrNotFound).MinTimes(1)
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil), nil).MinTimes(1)
+			Return(storage.NewStaticTupleIterator(nil, false), nil).MinTimes(1)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
             model
@@ -714,7 +714,7 @@ func TestResolveRecursive(t *testing.T) {
 		// MinTimes(1) confirms the recursive goroutine reached the datastore, making
 		// the Times(0) assertion on Set meaningful rather than vacuous.
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil), nil).MinTimes(1)
+			Return(storage.NewStaticTupleIterator(nil, false), nil).MinTimes(1)
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, storage.ErrNotFound).AnyTimes()
 
@@ -1015,10 +1015,10 @@ func TestResolveIntersection(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Relation == "member" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}, false), nil
 				}
 				if filter.Relation == "admin" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "admin", "user:*")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "admin", "user:*")}}, false), nil
 				}
 				return nil, storage.ErrNotFound
 			}).MaxTimes(2)
@@ -2064,7 +2064,7 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}, false), nil).Times(1)
 
 		mockDatastore.EXPECT().ReadUserTuple(
 			gomock.Any(),
@@ -2131,11 +2131,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:4#principal")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:4#principal")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -2206,11 +2206,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -2272,11 +2272,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:1#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:1#viewer")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -2338,11 +2338,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#member")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#member")}}, false), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "member", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "member", "document:3#viewer")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -3173,7 +3173,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3226,7 +3226,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3332,7 +3332,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 					Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 				},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3451,7 +3451,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{"non_expired"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: expectedTuple}}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: expectedTuple}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3526,7 +3526,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{"non_expired"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3693,7 +3693,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3758,7 +3758,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3820,7 +3820,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3995,9 +3995,10 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			storage.ReadUsersetTuplesOptions{
-				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
+				WithResultsSortedAscending: true,
+				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4078,7 +4079,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				"document:2#owner",
 				"validTime",
 				testutils.MustNewStruct(t, map[string]interface{}{"expiration": expiredTime.Format(time.RFC3339)})),
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4159,7 +4160,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				"document:2#owner",
 				"validTime",
 				testutils.MustNewStruct(t, map[string]interface{}{"expiration": futureTime.Format(time.RFC3339)})),
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4232,7 +4233,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil).MaxTimes(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).MaxTimes(1)
 
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
@@ -4308,10 +4309,13 @@ func TestTTU(t *testing.T) {
 				User:       "document:",
 				Conditions: []string{authzGraph.NoCond},
 			},
-			storage.ReadOptions{Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED}},
+			storage.ReadOptions{
+				WithResultsSortedAscending: true,
+				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+			},
 		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4379,7 +4383,7 @@ func TestTTU(t *testing.T) {
 			gomock.Any(),
 		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4441,7 +4445,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4610,10 +4614,13 @@ func TestTTU(t *testing.T) {
 			gomock.Any(),
 			storeID,
 			gomock.Any(),
-			storage.ReadOptions{Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}},
+			storage.ReadOptions{
+				WithResultsSortedAscending: true,
+				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
+			},
 		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4692,7 +4699,7 @@ func TestTTU(t *testing.T) {
 					}),
 				},
 			},
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4771,7 +4778,7 @@ func TestTTU(t *testing.T) {
 					}),
 				},
 			},
-		}}), nil).Times(1)
+		}}, false), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4837,7 +4844,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil).AnyTimes()
+		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).AnyTimes()
 
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
@@ -4917,15 +4924,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:x")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:x")}}, false), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5003,7 +5010,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "reader":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				default:
 					return nil, storage.ErrNotFound
 				}
@@ -5012,7 +5019,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5021,15 +5028,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}, false), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5104,13 +5111,13 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				// Manually check the relation and return the right data
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5119,15 +5126,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}, false), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5189,15 +5196,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes().DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 			switch filter.Object {
 			case "document:1":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:x#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:x#viewer")}}, false), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			}
 		})
 
@@ -5274,9 +5281,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "reader":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5285,22 +5292,22 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "group" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}, false), nil
 				}
 			case "document:2":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
 				}
 			case "document:3":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 				}
 			case "document:4":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
 				}
 			}
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 		})
 
 		resolver := New(Config{
@@ -5374,7 +5381,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				// Manually check the relation and return the right data
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5382,22 +5389,22 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "group" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}, false), nil
 				}
 			case "document:2":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
 				}
 			case "document:3":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 				}
 			case "document:4":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
 				}
 			}
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 		})
 
 		resolver := New(Config{
@@ -5460,9 +5467,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5470,9 +5477,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Object == "group:g1" && filter.Relation == "viewer" {
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5481,9 +5488,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:g2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5544,17 +5551,17 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if len(filter.AllowedUserTypeRestrictions) > 0 {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}, false), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			}
 		})
 
@@ -5617,9 +5624,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5627,9 +5634,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Object == "group:g1" && filter.Relation == "viewer" {
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5638,9 +5645,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:g2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}, false), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 				}
 			})
 
@@ -5702,17 +5709,17 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if len(filter.AllowedUserTypeRestrictions) > 0 {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}, false), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			}
 		})
 
@@ -5772,9 +5779,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes().
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
 				if filter.Object == "document:1" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:2")}}), nil
+					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:2")}}, false), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			})
 
 		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
@@ -5953,7 +5960,7 @@ func TestResolveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.ObjectType {
 				case "group":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
 				default:
 					return nil, storage.ErrNotFound
 				}
@@ -5962,7 +5969,7 @@ func TestResolveCheck(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(readTuples), nil
+				return storage.NewStaticTupleIterator(readTuples, false), nil
 			})
 
 		resolver := New(Config{

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -506,7 +506,7 @@ func TestResolveUnionEdges(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Relation == "member" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}), nil
 				}
 				return nil, storage.ErrNotFound
 			}).MaxTimes(1)
@@ -601,7 +601,7 @@ func TestResolveUnionEdges(t *testing.T) {
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, storage.ErrNotFound).MinTimes(1)
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil, false), nil).MinTimes(1)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil).MinTimes(1)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
             model
@@ -714,7 +714,7 @@ func TestResolveRecursive(t *testing.T) {
 		// MinTimes(1) confirms the recursive goroutine reached the datastore, making
 		// the Times(0) assertion on Set meaningful rather than vacuous.
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil, false), nil).MinTimes(1)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil).MinTimes(1)
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			Return(nil, storage.ErrNotFound).AnyTimes()
 
@@ -1015,10 +1015,10 @@ func TestResolveIntersection(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Relation == "member" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "member", "user:*")}}), nil
 				}
 				if filter.Relation == "admin" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "admin", "user:*")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:1", "admin", "user:*")}}), nil
 				}
 				return nil, storage.ErrNotFound
 			}).MaxTimes(2)
@@ -2064,7 +2064,7 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}), nil).Times(1)
 
 		mockDatastore.EXPECT().ReadUserTuple(
 			gomock.Any(),
@@ -2131,11 +2131,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "member", "document:3#viewer")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:4#principal")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:4#principal")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -2206,11 +2206,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -2272,11 +2272,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:3#viewer")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:1#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:1#viewer")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -2338,11 +2338,11 @@ func TestResolveCheckUsersetRequest(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#member")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#member")}}), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "member", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "member", "document:3#viewer")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -3173,7 +3173,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3226,7 +3226,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3332,7 +3332,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 					Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 				},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3451,7 +3451,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{"non_expired"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: expectedTuple}}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: expectedTuple}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3526,7 +3526,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				Conditions:                  []string{"non_expired"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{expectedTuple}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3693,7 +3693,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3758,7 +3758,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3820,7 +3820,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -3995,10 +3995,10 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			storage.ReadUsersetTuplesOptions{
-				WithResultsSortedAscending: true,
-				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
+				SortAsc:     true,
+				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}, true), nil).Times(1)
+		).Return(storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:2#owner")}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4072,14 +4072,14 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{"validTime"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKeyWithCondition(
 				"document:1",
 				"viewer",
 				"document:2#owner",
 				"validTime",
 				testutils.MustNewStruct(t, map[string]interface{}{"expiration": expiredTime.Format(time.RFC3339)})),
-		}}, false), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4153,14 +4153,14 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{"validTime"},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKeyWithCondition(
 				"document:1",
 				"viewer",
 				"document:2#owner",
 				"validTime",
 				testutils.MustNewStruct(t, map[string]interface{}{"expiration": futureTime.Format(time.RFC3339)})),
-		}}, false), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4233,7 +4233,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).MaxTimes(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil).MaxTimes(1)
 
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
@@ -4310,12 +4310,12 @@ func TestTTU(t *testing.T) {
 				Conditions: []string{authzGraph.NoCond},
 			},
 			storage.ReadOptions{
-				WithResultsSortedAscending: true,
-				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+				SortAsc:     true,
+				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}, true), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4381,9 +4381,9 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}, false), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4445,7 +4445,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).Times(1)
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4615,12 +4615,12 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			storage.ReadOptions{
-				WithResultsSortedAscending: true,
-				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
+				SortAsc:     true,
+				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 			},
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
-		}}, true), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4687,7 +4687,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: &openfgav1.TupleKey{
 				Object:   "document:1",
 				Relation: "parent",
@@ -4699,7 +4699,7 @@ func TestTTU(t *testing.T) {
 					}),
 				},
 			},
-		}}, false), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4766,7 +4766,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: &openfgav1.TupleKey{
 				Object:   "document:1",
 				Relation: "parent",
@@ -4778,7 +4778,7 @@ func TestTTU(t *testing.T) {
 					}),
 				},
 			},
-		}}, false), nil).Times(1)
+		}}), nil).Times(1)
 
 		resolver := New(Config{
 			Model:            mg,
@@ -4844,7 +4844,7 @@ func TestTTU(t *testing.T) {
 			storeID,
 			gomock.Any(),
 			gomock.Any(),
-		).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil).AnyTimes()
+		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil).AnyTimes()
 
 		mockDatastore.EXPECT().ReadUserTuple(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
@@ -4924,15 +4924,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:x")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:x")}}), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5010,7 +5010,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "reader":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				default:
 					return nil, storage.ErrNotFound
 				}
@@ -5019,7 +5019,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5028,15 +5028,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5111,13 +5111,13 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				// Manually check the relation and return the right data
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5126,15 +5126,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "document:1":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "group:g1")}}), nil
 				case "document:2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "parent", "document:1")}}), nil
 				case "document:3":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "parent", "document:2")}}), nil
 				case "document:4":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "parent", "document:3")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5196,15 +5196,15 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes().DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 			switch filter.Object {
 			case "document:1":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:x#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "document:x#viewer")}}), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}
 		})
 
@@ -5281,9 +5281,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "reader":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5292,22 +5292,22 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "group" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}), nil
 				}
 			case "document:2":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
 				}
 			case "document:3":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 				}
 			case "document:4":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
 				}
 			}
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+			return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 		})
 
 		resolver := New(Config{
@@ -5381,7 +5381,7 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadStartingWithUserFilter, opts storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				// Manually check the relation and return the right data
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5389,22 +5389,22 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "group" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "group:g1#viewer")}}), nil
 				}
 			case "document:2":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
 				}
 			case "document:3":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 				}
 			case "document:4":
 				if filter.AllowedUserTypeRestrictions[0].GetType() == "document" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
 				}
 			}
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+			return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 		})
 
 		resolver := New(Config{
@@ -5467,9 +5467,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5477,9 +5477,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Object == "group:g1" && filter.Relation == "viewer" {
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5488,9 +5488,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:g2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5551,17 +5551,17 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if len(filter.AllowedUserTypeRestrictions) > 0 {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}
 		})
 
@@ -5624,9 +5624,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "viewer":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5634,9 +5634,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				if filter.Object == "group:g1" && filter.Relation == "viewer" {
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
@@ -5645,9 +5645,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:g2":
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("group:g2", "parent", "group:g1")}}), nil
 				default:
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 				}
 			})
 
@@ -5709,17 +5709,17 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			switch filter.Object {
 			case "document:1":
 				if len(filter.AllowedUserTypeRestrictions) > 0 {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "viewer", "user:*")}}), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			case "document:2":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:2", "viewer", "document:1#viewer")}}), nil
 			case "document:3":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:3", "viewer", "document:2#viewer")}}), nil
 			case "document:4":
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:4", "viewer", "document:3#viewer")}}), nil
 			default:
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}
 		})
 
@@ -5779,9 +5779,9 @@ func TestResolveRecursiveCheck(t *testing.T) {
 			AnyTimes().
 			DoAndReturn(func(_ context.Context, _ string, filter storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
 				if filter.Object == "document:1" {
-					return storage.NewStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:2")}}, false), nil
+					return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{Key: tuple.NewTupleKey("document:1", "parent", "document:2")}}), nil
 				}
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			})
 
 		mockCache.EXPECT().Get(gomock.Any()).Return(nil).AnyTimes()
@@ -5960,7 +5960,7 @@ func TestResolveCheck(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.ObjectType {
 				case "group":
-					return storage.NewStaticTupleIterator(readStartingWithUserReader, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserReader), nil
 				default:
 					return nil, storage.ErrNotFound
 				}
@@ -5969,7 +5969,7 @@ func TestResolveCheck(t *testing.T) {
 		mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 			AnyTimes(). // Allow any number of calls
 			DoAndReturn(func(ctx context.Context, sID string, filter storage.ReadUsersetTuplesFilter, opts storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(readTuples, false), nil
+				return storage.NewUnorderedStaticTupleIterator(readTuples), nil
 			})
 
 		resolver := New(Config{

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -4313,7 +4313,7 @@ func TestTTU(t *testing.T) {
 				SortAsc:     true,
 				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 			},
-		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
 		}}), nil).Times(1)
 
@@ -4618,7 +4618,7 @@ func TestTTU(t *testing.T) {
 				SortAsc:     true,
 				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY},
 			},
-		).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{{
+		).Return(storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{{
 			Key: tuple.NewTupleKey("document:1", "parent", "document:2"),
 		}}), nil).Times(1)
 

--- a/internal/check/default_test.go
+++ b/internal/check/default_test.go
@@ -207,7 +207,7 @@ func TestDefaultUserset(t *testing.T) {
 			mockResolver := NewMockCheckResolver(ctrl)
 			tt.setupMock(mockResolver)
 
-			iter := storage.NewStaticTupleKeyIterator(tt.tuples, false)
+			iter := storage.NewUnorderedStaticTupleKeyIterator(tt.tuples)
 			strategy := NewDefault(mg, mockResolver, 2)
 
 			req, err := NewRequest(RequestParams{
@@ -416,7 +416,7 @@ func TestDefaultTTU(t *testing.T) {
 			mockResolver := NewMockCheckResolver(ctrl)
 			tt.setupMock(mockResolver)
 
-			iter := storage.NewStaticTupleKeyIterator(tt.tuples, false)
+			iter := storage.NewUnorderedStaticTupleKeyIterator(tt.tuples)
 			strategy := NewDefault(mg, mockResolver, 2)
 
 			req, err := NewRequest(RequestParams{
@@ -486,9 +486,9 @@ func TestDefaultExecuteCancelledContextRace(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so both cases are ready immediately
 
-	iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+	iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:1", "owner", "document:2"),
-	}, false)
+	})
 	strategy := NewDefault(mg, mockResolver, 2)
 
 	req, err := NewRequest(RequestParams{

--- a/internal/check/default_test.go
+++ b/internal/check/default_test.go
@@ -207,7 +207,7 @@ func TestDefaultUserset(t *testing.T) {
 			mockResolver := NewMockCheckResolver(ctrl)
 			tt.setupMock(mockResolver)
 
-			iter := storage.NewStaticTupleKeyIterator(tt.tuples)
+			iter := storage.NewStaticTupleKeyIterator(tt.tuples, false)
 			strategy := NewDefault(mg, mockResolver, 2)
 
 			req, err := NewRequest(RequestParams{
@@ -416,7 +416,7 @@ func TestDefaultTTU(t *testing.T) {
 			mockResolver := NewMockCheckResolver(ctrl)
 			tt.setupMock(mockResolver)
 
-			iter := storage.NewStaticTupleKeyIterator(tt.tuples)
+			iter := storage.NewStaticTupleKeyIterator(tt.tuples, false)
 			strategy := NewDefault(mg, mockResolver, 2)
 
 			req, err := NewRequest(RequestParams{
@@ -488,7 +488,7 @@ func TestDefaultExecuteCancelledContextRace(t *testing.T) {
 
 	iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
 		tuple.NewTupleKey("document:1", "owner", "document:2"),
-	})
+	}, false)
 	strategy := NewDefault(mg, mockResolver, 2)
 
 	req, err := NewRequest(RequestParams{

--- a/internal/check/recursive.go
+++ b/internal/check/recursive.go
@@ -307,7 +307,7 @@ func (s *Recursive) buildTupleMapperForID(ctx context.Context, req *Request, edg
 		}
 
 		if ctxTuples, ok := req.GetContextualTuplesByObjectID(id, relation, subjectType); ok {
-			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples, true)
+			ctxIter = storage.NewOrderedStaticTupleKeyIterator(ctxTuples)
 		}
 
 		kind = storage.TTUKind
@@ -332,7 +332,7 @@ func (s *Recursive) buildTupleMapperForID(ctx context.Context, req *Request, edg
 		}
 
 		if ctxTuples, ok := req.GetContextualTuplesByObjectID(id, userRelation, edge.GetTo().GetUniqueLabel()); ok {
-			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples, true)
+			ctxIter = storage.NewOrderedStaticTupleKeyIterator(ctxTuples)
 		}
 
 		kind = storage.UsersetKind

--- a/internal/check/recursive.go
+++ b/internal/check/recursive.go
@@ -307,7 +307,7 @@ func (s *Recursive) buildTupleMapperForID(ctx context.Context, req *Request, edg
 		}
 
 		if ctxTuples, ok := req.GetContextualTuplesByObjectID(id, relation, subjectType); ok {
-			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples)
+			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples, true)
 		}
 
 		kind = storage.TTUKind
@@ -332,7 +332,7 @@ func (s *Recursive) buildTupleMapperForID(ctx context.Context, req *Request, edg
 		}
 
 		if ctxTuples, ok := req.GetContextualTuplesByObjectID(id, userRelation, edge.GetTo().GetUniqueLabel()); ok {
-			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples)
+			ctxIter = storage.NewStaticTupleKeyIterator(ctxTuples, true)
 		}
 
 		kind = storage.UsersetKind

--- a/internal/check/recursive_test.go
+++ b/internal/check/recursive_test.go
@@ -172,13 +172,13 @@ func TestRecursiveTTU(t *testing.T) {
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				Conditions: []string{""},
 			}, storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
-				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+				SortAsc:     true,
+				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 			},
-			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, true), tt.readStartingWithUserTuplesError)
+			).MaxTimes(1).Return(storage.NewOrderedStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples[1:] {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readTuplesError)
 			}
 
 			ctx := context.Background()
@@ -201,7 +201,7 @@ func TestRecursiveTTU(t *testing.T) {
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
 
-			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 			require.Equal(t, tt.expectedError, err)
 			if tt.expected != nil {
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
@@ -392,45 +392,45 @@ type group
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readTuples[1:] {
-					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
+					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readTuplesError)
 				}
 
 				ctx := context.Background()
@@ -452,7 +452,7 @@ type group
 				}
 
 				strategy := NewRecursive(mg, mockDatastore, 5)
-				result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+				result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			})
@@ -587,10 +587,10 @@ func TestRecursiveUserset(t *testing.T) {
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				Conditions: []string{""},
-			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
+			}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
-				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
+				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readUsersetTuplesError)
 			}
 			model := testutils.MustTransformDSLToProtoWithID(`
 						model
@@ -631,7 +631,7 @@ func TestRecursiveUserset(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 			require.Equal(t, tt.expectedError, err)
 			if tt.expected != nil {
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
@@ -793,24 +793,24 @@ func TestRecursiveUserset(t *testing.T) {
 						// Manually check the relation and return the right data
 						switch filter.Relation {
 						case "rel4":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError
 						case "rel7":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError
 						case "rel8":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError
 						case "rel5":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError
 						case "rel6":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError
 						case "member":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError
+							return storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError
 						default:
 							return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 						}
 					})
 
 				for _, tuples := range tt.readUsersetTuples[1:] {
-					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
+					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readUsersetTuplesError)
 				}
 				model := testutils.MustTransformDSLToProtoWithID(`
 		model
@@ -859,7 +859,7 @@ func TestRecursiveUserset(t *testing.T) {
 				}
 
 				strategy := NewRecursive(mg, mockDatastore, 5)
-				result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+				result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			})
@@ -1042,7 +1042,7 @@ func TestRecursiveMatch(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			for _, mock := range tt.readMocks {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock, false), nil)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(mock), nil)
 			}
 
 			model := testutils.MustTransformDSLToProtoWithID(`
@@ -1092,9 +1092,9 @@ func TestRecursiveMatch(t *testing.T) {
 		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).DoAndReturn(
 			func(ctx context.Context, store string, filter storage.ReadFilter, options storage.ReadOptions) (storage.TupleIterator, error) {
 				cancel()
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 					{Key: tuple.NewTupleKey("group:1", "parent", "group:2")},
-				}, false), nil
+				}), nil
 			},
 		)
 
@@ -1246,13 +1246,13 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "activator":
-					return storage.NewStaticTupleIterator(readStartingWithUserActivator, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserActivator), nil
 				case "admin":
-					return storage.NewStaticTupleIterator(readStartingWithUserAdmin, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserAdmin), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserPublic), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserRestricted), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1264,15 +1264,15 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:1":
-					return storage.NewStaticTupleIterator(readGroup1Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup1Parent), nil
 				case "group:3":
-					return storage.NewStaticTupleIterator(readGroup3Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup3Parent), nil
 				case "group:5":
-					return storage.NewStaticTupleIterator(readGroup5Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup5Parent), nil
 				case "group:4":
-					return storage.NewStaticTupleIterator(readGroup4Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup4Parent), nil
 				default:
-					return storage.NewStaticTupleIterator(readEmpty, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readEmpty), nil
 				}
 			})
 		ctx := context.Background()
@@ -1296,7 +1296,7 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 		require.NoError(t, err)
 
 		strategy := NewRecursive(mg, mockDatastore, 5)
-		result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks, false), nil)
+		result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(initialTks), nil)
 		require.NoError(t, err)
 		require.True(t, result.GetAllowed())
 	})
@@ -1412,13 +1412,13 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "activator":
-					return storage.NewStaticTupleIterator(readStartingWithUserActivator, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserActivator), nil
 				case "admin":
-					return storage.NewStaticTupleIterator(readStartingWithUserAdmin, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserAdmin), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserPublic), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserRestricted), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1430,15 +1430,15 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:1":
-					return storage.NewStaticTupleIterator(readGroup1Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup1Parent), nil
 				case "group:3":
-					return storage.NewStaticTupleIterator(readGroup3Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup3Parent), nil
 				case "group:5":
-					return storage.NewStaticTupleIterator(readGroup5Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup5Parent), nil
 				case "group:4":
-					return storage.NewStaticTupleIterator(readGroup4Parent, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readGroup4Parent), nil
 				default:
-					return storage.NewStaticTupleIterator(readEmpty, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readEmpty), nil
 				}
 			})
 		ctx := context.Background()
@@ -1462,7 +1462,7 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 		require.NoError(t, err)
 
 		strategy := NewRecursive(mg, mockDatastore, 5)
-		result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks, false), nil)
+		result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(initialTks), nil)
 		require.NoError(t, err)
 		require.True(t, result.GetAllowed())
 	})
@@ -1501,9 +1501,9 @@ func TestRecursiveExecuteCancelledContextRace(t *testing.T) {
 	// Non-empty iterator so leftChan carries a value before closing,
 	// widening the window where ctx.Done() and the channel close are both ready.
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-		MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 		{Key: tuple.NewTupleKey("group:2", "member", "user:maria")},
-	}, false), nil)
+	}), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
@@ -1516,9 +1516,9 @@ func TestRecursiveExecuteCancelledContextRace(t *testing.T) {
 	require.NoError(t, err)
 
 	strategy := NewRecursive(mg, mockDatastore, 5)
-	res, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+	res, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{
 		tuple.NewTupleKey("group:1", "parent", "group:2"),
-	}, false), nil)
+	}), nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, res)
@@ -1619,11 +1619,11 @@ func TestRecursiveTTUWithContextualTuples(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), nil)
+				MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuples), nil)
 
 			for _, tuples := range tt.readTuples[1:] {
 				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), nil)
+					MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 			}
 
 			ctx := context.Background()
@@ -1646,7 +1646,7 @@ func TestRecursiveTTUWithContextualTuples(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 		})
@@ -1729,11 +1729,11 @@ func TestRecursiveUsersetWithContextualTuples(t *testing.T) {
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 
 			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), nil)
+				MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuples), nil)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
 				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), nil)
+					MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 			}
 
 			model := testutils.MustTransformDSLToProtoWithID(`
@@ -1775,7 +1775,7 @@ func TestRecursiveUsersetWithContextualTuples(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
+			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 		})

--- a/internal/check/recursive_test.go
+++ b/internal/check/recursive_test.go
@@ -175,7 +175,7 @@ func TestRecursiveTTU(t *testing.T) {
 				WithResultsSortedAscending: true,
 				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 			},
-			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
+			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, true), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples[1:] {
 				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)

--- a/internal/check/recursive_test.go
+++ b/internal/check/recursive_test.go
@@ -172,12 +172,13 @@ func TestRecursiveTTU(t *testing.T) {
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				Conditions: []string{""},
 			}, storage.ReadStartingWithUserOptions{
-				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+				WithResultsSortedAscending: true,
+				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 			},
-			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
+			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples[1:] {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
 			}
 
 			ctx := context.Background()
@@ -200,7 +201,7 @@ func TestRecursiveTTU(t *testing.T) {
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
 
-			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 			require.Equal(t, tt.expectedError, err)
 			if tt.expected != nil {
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
@@ -391,45 +392,45 @@ type group
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					Conditions: []string{""},
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readTuples[1:] {
-					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
+					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
 				}
 
 				ctx := context.Background()
@@ -451,7 +452,7 @@ type group
 				}
 
 				strategy := NewRecursive(mg, mockDatastore, 5)
-				result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+				result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			})
@@ -586,10 +587,10 @@ func TestRecursiveUserset(t *testing.T) {
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				Conditions: []string{""},
-			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
+			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
-				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
+				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
 			}
 			model := testutils.MustTransformDSLToProtoWithID(`
 						model
@@ -630,7 +631,7 @@ func TestRecursiveUserset(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 			require.Equal(t, tt.expectedError, err)
 			if tt.expected != nil {
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
@@ -792,24 +793,24 @@ func TestRecursiveUserset(t *testing.T) {
 						// Manually check the relation and return the right data
 						switch filter.Relation {
 						case "rel4":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError
 						case "rel7":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError
 						case "rel8":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError
 						case "rel5":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError
 						case "rel6":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError
 						case "member":
-							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError
+							return storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError
 						default:
 							return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 						}
 					})
 
 				for _, tuples := range tt.readUsersetTuples[1:] {
-					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
+					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
 				}
 				model := testutils.MustTransformDSLToProtoWithID(`
 		model
@@ -858,7 +859,7 @@ func TestRecursiveUserset(t *testing.T) {
 				}
 
 				strategy := NewRecursive(mg, mockDatastore, 5)
-				result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+				result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			})
@@ -1041,7 +1042,7 @@ func TestRecursiveMatch(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			for _, mock := range tt.readMocks {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock), nil)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock, false), nil)
 			}
 
 			model := testutils.MustTransformDSLToProtoWithID(`
@@ -1093,7 +1094,7 @@ func TestRecursiveMatch(t *testing.T) {
 				cancel()
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					{Key: tuple.NewTupleKey("group:1", "parent", "group:2")},
-				}), nil
+				}, false), nil
 			},
 		)
 
@@ -1245,13 +1246,13 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "activator":
-					return storage.NewStaticTupleIterator(readStartingWithUserActivator), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserActivator, false), nil
 				case "admin":
-					return storage.NewStaticTupleIterator(readStartingWithUserAdmin), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserAdmin, false), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1263,15 +1264,15 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:1":
-					return storage.NewStaticTupleIterator(readGroup1Parent), nil
+					return storage.NewStaticTupleIterator(readGroup1Parent, false), nil
 				case "group:3":
-					return storage.NewStaticTupleIterator(readGroup3Parent), nil
+					return storage.NewStaticTupleIterator(readGroup3Parent, false), nil
 				case "group:5":
-					return storage.NewStaticTupleIterator(readGroup5Parent), nil
+					return storage.NewStaticTupleIterator(readGroup5Parent, false), nil
 				case "group:4":
-					return storage.NewStaticTupleIterator(readGroup4Parent), nil
+					return storage.NewStaticTupleIterator(readGroup4Parent, false), nil
 				default:
-					return storage.NewStaticTupleIterator(readEmpty), nil
+					return storage.NewStaticTupleIterator(readEmpty, false), nil
 				}
 			})
 		ctx := context.Background()
@@ -1295,7 +1296,7 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 		require.NoError(t, err)
 
 		strategy := NewRecursive(mg, mockDatastore, 5)
-		result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks), nil)
+		result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks, false), nil)
 		require.NoError(t, err)
 		require.True(t, result.GetAllowed())
 	})
@@ -1411,13 +1412,13 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "activator":
-					return storage.NewStaticTupleIterator(readStartingWithUserActivator), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserActivator, false), nil
 				case "admin":
-					return storage.NewStaticTupleIterator(readStartingWithUserAdmin), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserAdmin, false), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -1429,15 +1430,15 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Object {
 				case "group:1":
-					return storage.NewStaticTupleIterator(readGroup1Parent), nil
+					return storage.NewStaticTupleIterator(readGroup1Parent, false), nil
 				case "group:3":
-					return storage.NewStaticTupleIterator(readGroup3Parent), nil
+					return storage.NewStaticTupleIterator(readGroup3Parent, false), nil
 				case "group:5":
-					return storage.NewStaticTupleIterator(readGroup5Parent), nil
+					return storage.NewStaticTupleIterator(readGroup5Parent, false), nil
 				case "group:4":
-					return storage.NewStaticTupleIterator(readGroup4Parent), nil
+					return storage.NewStaticTupleIterator(readGroup4Parent, false), nil
 				default:
-					return storage.NewStaticTupleIterator(readEmpty), nil
+					return storage.NewStaticTupleIterator(readEmpty, false), nil
 				}
 			})
 		ctx := context.Background()
@@ -1461,7 +1462,7 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 		require.NoError(t, err)
 
 		strategy := NewRecursive(mg, mockDatastore, 5)
-		result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks), nil)
+		result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(initialTks, false), nil)
 		require.NoError(t, err)
 		require.True(t, result.GetAllowed())
 	})
@@ -1502,7 +1503,7 @@ func TestRecursiveExecuteCancelledContextRace(t *testing.T) {
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 		{Key: tuple.NewTupleKey("group:2", "member", "user:maria")},
-	}), nil)
+	}, false), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
@@ -1517,7 +1518,7 @@ func TestRecursiveExecuteCancelledContextRace(t *testing.T) {
 	strategy := NewRecursive(mg, mockDatastore, 5)
 	res, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
 		tuple.NewTupleKey("group:1", "parent", "group:2"),
-	}), nil)
+	}, false), nil)
 
 	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, res)
@@ -1618,11 +1619,11 @@ func TestRecursiveTTUWithContextualTuples(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), nil)
+				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), nil)
 
 			for _, tuples := range tt.readTuples[1:] {
 				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), nil)
+					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), nil)
 			}
 
 			ctx := context.Background()
@@ -1645,7 +1646,7 @@ func TestRecursiveTTUWithContextualTuples(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+			result, err := strategy.TTU(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 		})
@@ -1728,11 +1729,11 @@ func TestRecursiveUsersetWithContextualTuples(t *testing.T) {
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 
 			mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), nil)
+				MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), nil)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
 				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), nil)
+					MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), nil)
 			}
 
 			model := testutils.MustTransformDSLToProtoWithID(`
@@ -1774,7 +1775,7 @@ func TestRecursiveUsersetWithContextualTuples(t *testing.T) {
 			}
 
 			strategy := NewRecursive(mg, mockDatastore, 5)
-			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys), nil)
+			result, err := strategy.Userset(ctx, req, recursiveEdge, storage.NewStaticTupleKeyIterator(tupleKeys, false), nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 		})

--- a/internal/check/weight2_test.go
+++ b/internal/check/weight2_test.go
@@ -38,35 +38,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		ctx := context.Background()
 
@@ -94,7 +97,7 @@ func TestWeight2Userset(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -123,35 +126,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		ctx := context.Background()
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -178,7 +184,7 @@ func TestWeight2Userset(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -206,35 +212,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		ctx := context.Background()
 
@@ -262,7 +271,7 @@ func TestWeight2Userset(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -289,35 +298,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		ctx := context.Background()
 
@@ -345,7 +357,7 @@ func TestWeight2Userset(t *testing.T) {
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -416,11 +428,11 @@ func TestWeight2Userset(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "members":
-					return storage.NewStaticTupleIterator(readStartingWithUserMembers), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserMembers, false), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -456,7 +468,7 @@ func TestWeight2Userset(t *testing.T) {
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -491,35 +503,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		ctx := context.Background()
 
@@ -548,7 +563,7 @@ func TestWeight2TTU(t *testing.T) {
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -576,35 +591,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		ctx := context.Background()
 
@@ -633,7 +651,7 @@ func TestWeight2TTU(t *testing.T) {
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -661,35 +679,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		ctx := context.Background()
 
@@ -718,7 +739,7 @@ func TestWeight2TTU(t *testing.T) {
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -746,35 +767,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
+			WithResultsSortedAscending: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		ctx := context.Background()
 
@@ -803,7 +827,7 @@ func TestWeight2TTU(t *testing.T) {
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -873,11 +897,11 @@ func TestWeight2TTU(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "members":
-					return storage.NewStaticTupleIterator(readStartingWithUserMembers), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserMembers, false), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted), nil
+					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -914,7 +938,7 @@ func TestWeight2TTU(t *testing.T) {
 			User:     "group:2",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -951,7 +975,7 @@ func TestWeight2ExecuteCancelledContextRace(t *testing.T) {
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 		MaxTimes(3).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 		{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-	}), nil)
+	}, false), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
@@ -980,7 +1004,7 @@ func TestWeight2ExecuteCancelledContextRace(t *testing.T) {
 		User:     "group:1#all",
 		Relation: "viewer",
 		Object:   "document:1",
-	}})
+	}}, false)
 
 	strategy := NewWeight2(mg, mockDatastore)
 	req, err := NewRequest(RequestParams{
@@ -1058,12 +1082,12 @@ func TestWeight2ExecuteConcatOrderingBug(t *testing.T) {
 	datastoreGated, gate, blocked := newGatedIterator[*openfgav1.TupleKey](
 		storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
 			{Object: "document:1", Relation: "viewer", User: "group:2#members"},
-		}),
+		}, false),
 	)
 	rightIter := storage.WrapIterator(storage.UsersetKind, iterator.Concat[*openfgav1.TupleKey](
 		storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
 			{Object: "document:1", Relation: "viewer", User: "group:9#members"},
-		}),
+		}, false),
 		datastoreGated,
 	))
 
@@ -1073,7 +1097,7 @@ func TestWeight2ExecuteConcatOrderingBug(t *testing.T) {
 		// meaning "group:9" is already in the right channel buffer. Only then send
 		// left so that execute processes right's contextual tuple first.
 		<-blocked
-		leftChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"group:1", "group:2"})}
+		leftChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"group:1", "group:2"}, false)}
 		close(leftChan)
 		// Ungate the datastore source; execute will process left entirely before
 		// returning to the outer select, so timing here doesn't affect correctness.

--- a/internal/check/weight2_test.go
+++ b/internal/check/weight2_test.go
@@ -38,38 +38,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		ctx := context.Background()
 
@@ -93,11 +93,11 @@ func TestWeight2Userset(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("group#all")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -126,38 +126,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		ctx := context.Background()
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -180,11 +180,11 @@ func TestWeight2Userset(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("group#all")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -212,38 +212,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		ctx := context.Background()
 
@@ -267,11 +267,11 @@ func TestWeight2Userset(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("group#all")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -298,38 +298,38 @@ func TestWeight2Userset(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		ctx := context.Background()
 
@@ -353,11 +353,11 @@ func TestWeight2Userset(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("group#all")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -428,11 +428,11 @@ func TestWeight2Userset(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "members":
-					return storage.NewStaticTupleIterator(readStartingWithUserMembers, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserMembers), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserPublic), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserRestricted), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -464,11 +464,11 @@ func TestWeight2Userset(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -503,38 +503,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		ctx := context.Background()
 
@@ -559,11 +559,11 @@ func TestWeight2TTU(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -591,38 +591,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		ctx := context.Background()
 
@@ -647,11 +647,11 @@ func TestWeight2TTU(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -679,38 +679,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		ctx := context.Background()
 
@@ -735,11 +735,11 @@ func TestWeight2TTU(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -767,38 +767,38 @@ func TestWeight2TTU(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: tuple.TypedPublicWildcard("user")}},
 			Conditions: []string{""},
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		ctx := context.Background()
 
@@ -823,11 +823,11 @@ func TestWeight2TTU(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
 			StoreID:  storeID,
@@ -897,11 +897,11 @@ func TestWeight2TTU(t *testing.T) {
 				// Manually check the relation and return the right data
 				switch filter.Relation {
 				case "members":
-					return storage.NewStaticTupleIterator(readStartingWithUserMembers, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserMembers), nil
 				case "public_restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserPublic, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserPublic), nil
 				case "restricted":
-					return storage.NewStaticTupleIterator(readStartingWithUserRestricted, false), nil
+					return storage.NewUnorderedStaticTupleIterator(readStartingWithUserRestricted), nil
 				default:
 					return nil, fmt.Errorf("unexpected relation %s", filter.Relation)
 				}
@@ -934,11 +934,11 @@ func TestWeight2TTU(t *testing.T) {
 		edges, ok := mg.GetEdgesFromNodeId("document#viewer")
 		require.True(t, ok)
 
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 
 		strategy := NewWeight2(mg, mockDatastore)
 		req, err := NewRequest(RequestParams{
@@ -973,9 +973,9 @@ func TestWeight2ExecuteCancelledContextRace(t *testing.T) {
 	// group#all is a union of "members" and "public" so bottomUp calls ReadStartingWithUser
 	// for each operand (members, public-direct, public-wildcard); allow up to 3 calls.
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-		MaxTimes(3).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		MaxTimes(3).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 		{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-	}, false), nil)
+	}), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so ctx.Done() and the ToChannel close race immediately
@@ -1000,11 +1000,11 @@ func TestWeight2ExecuteCancelledContextRace(t *testing.T) {
 	edges, ok := mg.GetEdgesFromNodeId("group#all")
 	require.True(t, ok)
 
-	iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+	iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 		User:     "group:1#all",
 		Relation: "viewer",
 		Object:   "document:1",
-	}}, false)
+	}})
 
 	strategy := NewWeight2(mg, mockDatastore)
 	req, err := NewRequest(RequestParams{
@@ -1080,14 +1080,14 @@ func TestWeight2ExecuteConcatOrderingBug(t *testing.T) {
 	// UsersetKind mapper extracts the object portion from the User field:
 	//   "group:9#members" → "group:9",  "group:2#members" → "group:2"
 	datastoreGated, gate, blocked := newGatedIterator[*openfgav1.TupleKey](
-		storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+		storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{
 			{Object: "document:1", Relation: "viewer", User: "group:2#members"},
-		}, false),
+		}),
 	)
 	rightIter := storage.WrapIterator(storage.UsersetKind, iterator.Concat[*openfgav1.TupleKey](
-		storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+		storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{
 			{Object: "document:1", Relation: "viewer", User: "group:9#members"},
-		}, false),
+		}),
 		datastoreGated,
 	))
 
@@ -1097,7 +1097,7 @@ func TestWeight2ExecuteConcatOrderingBug(t *testing.T) {
 		// meaning "group:9" is already in the right channel buffer. Only then send
 		// left so that execute processes right's contextual tuple first.
 		<-blocked
-		leftChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"group:1", "group:2"}, false)}
+		leftChan <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"group:1", "group:2"})}
 		close(leftChan)
 		// Ungate the datastore source; execute will process left entirely before
 		// returning to the outer select, so timing here doesn't affect correctness.

--- a/internal/checkutil/checkutil.go
+++ b/internal/checkutil/checkutil.go
@@ -96,7 +96,7 @@ func IteratorReadStartingFromUser(ctx context.Context,
 	reqTupleKey := req.GetTupleKey()
 
 	opts := storage.ReadStartingWithUserOptions{
-		WithResultsSortedAscending: sortResults,
+		SortAsc: sortResults,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},

--- a/internal/checkutil/checkutil.go
+++ b/internal/checkutil/checkutil.go
@@ -91,12 +91,12 @@ func IteratorReadStartingFromUser(ctx context.Context,
 	req resolveCheckRequest,
 	objectRel string,
 	objectIDs storage.SortedSet,
-	sortContextualTuples bool) (storage.TupleKeyIterator, error) {
+	sortResults bool) (storage.TupleKeyIterator, error) {
 	storeID := req.GetStoreID()
 	reqTupleKey := req.GetTupleKey()
 
 	opts := storage.ReadStartingWithUserOptions{
-		WithResultsSortedAscending: sortContextualTuples,
+		WithResultsSortedAscending: sortResults,
 		Consistency: storage.ConsistencyOptions{
 			Preference: req.GetConsistency(),
 		},

--- a/internal/checkutil/checkutil_test.go
+++ b/internal/checkutil/checkutil_test.go
@@ -300,7 +300,7 @@ func TestIteratorReadStartingFromUser(t *testing.T) {
 				ObjectIDs:  objectIDs,
 			}
 			expectedOpts := storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
+				SortAsc: true,
 				Consistency: storage.ConsistencyOptions{
 					Preference: req.GetConsistency(),
 				},

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -2007,7 +2007,7 @@ func TestCheckTTU(t *testing.T) {
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, storage.ReadFilter{Object: "group:1", Relation: "parent", User: ""}, gomock.Any()).
 			Times(1).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		// act
 		res, err := checker.checkTTU(ctx, req, ttuRewrite)(ctx)
@@ -2496,7 +2496,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 
 			storeID := ulid.Make().String()
 			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
+			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples, false), tt.readUsersetTuplesError)
 
 			ts, err := typesystem.New(tt.model)
 			require.NoError(t, err)
@@ -2664,7 +2664,7 @@ func TestStreamedLookupUsersetFromIterator(t *testing.T) {
 					Object:                      "group:1",
 					Relation:                    "member",
 					AllowedUserTypeRestrictions: restrictions,
-				}, gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
+				}, gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples, false), tt.readUsersetTuplesError)
 			}
 
 			req := &ResolveCheckRequest{

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -2007,7 +2007,7 @@ func TestCheckTTU(t *testing.T) {
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, storage.ReadFilter{Object: "group:1", Relation: "parent", User: ""}, gomock.Any()).
 			Times(1).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		// act
 		res, err := checker.checkTTU(ctx, req, ttuRewrite)(ctx)
@@ -2496,7 +2496,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 
 			storeID := ulid.Make().String()
 			ds := mocks.NewMockRelationshipTupleReader(ctrl)
-			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples, false), tt.readUsersetTuplesError)
+			ds.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).Times(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
 
 			ts, err := typesystem.New(tt.model)
 			require.NoError(t, err)
@@ -2664,7 +2664,7 @@ func TestStreamedLookupUsersetFromIterator(t *testing.T) {
 					Object:                      "group:1",
 					Relation:                    "member",
 					AllowedUserTypeRestrictions: restrictions,
-				}, gomock.Any()).Times(1).Return(storage.NewStaticTupleIterator(tt.readUsersetTuples, false), tt.readUsersetTuplesError)
+				}, gomock.Any()).Times(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readUsersetTuples), tt.readUsersetTuplesError)
 			}
 
 			req := &ResolveCheckRequest{

--- a/internal/graph/default_resolver_test.go
+++ b/internal/graph/default_resolver_test.go
@@ -105,7 +105,7 @@ func TestDefaultUserset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewUnorderedStaticTupleKeyIterator(tt.tuples), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 
@@ -218,7 +218,7 @@ func TestDefaultTTU(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewUnorderedStaticTupleKeyIterator(tt.tuples), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)
@@ -359,7 +359,7 @@ func TestProduceUsersetDispatches(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewUnorderedStaticTupleKeyIterator(tt.tuples), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)
@@ -523,7 +523,7 @@ func TestProduceTTUDispatches(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewUnorderedStaticTupleKeyIterator(tt.tuples), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)

--- a/internal/graph/default_resolver_test.go
+++ b/internal/graph/default_resolver_test.go
@@ -105,7 +105,7 @@ func TestDefaultUserset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 
@@ -218,7 +218,7 @@ func TestDefaultTTU(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)
@@ -359,7 +359,7 @@ func TestProduceUsersetDispatches(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)
@@ -523,7 +523,7 @@ func TestProduceTTUDispatches(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
-			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples), filter)
+			iter := storage.NewConditionsFilteredTupleKeyIterator(storage.NewStaticTupleKeyIterator(tt.tuples, false), filter)
 			checker := NewLocalChecker()
 			defer checker.Close()
 			mockResolver := NewMockCheckResolver(ctrl)

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -82,7 +82,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 
 			t.Run("when_empty_iterator", func(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
+					Times(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -107,7 +107,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:2", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
-					}), nil)
+					}, false), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -176,7 +176,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 					MaxTimes(1).
 					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
-					}), nil)
+					}, false), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -237,7 +237,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 
 			t.Run("when_empty_iterator", func(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					Times(1).Return(storage.NewStaticTupleIterator(nil), nil)
+					Times(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 				t.Cleanup(c.End)
@@ -262,7 +262,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:2", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
-					}), nil)
+					}, false), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 				t.Cleanup(c.End)
@@ -331,7 +331,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 					MaxTimes(1).
 					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "parent", "user:XYZ")},
-					}), nil)
+					}, false), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 
@@ -372,16 +372,16 @@ func TestIteratorToUserset(t *testing.T) {
 		chans := make([]<-chan *iterator.Msg, 0, 3)
 		iterChan1 := make(chan *iterator.Msg, 2)
 		iterChan1 <- &iterator.Msg{Iter: mocks.NewErrorIterator[string]([]string{"1"})}
-		iterChan1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"2"})}
+		iterChan1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"2"}, false)}
 		close(iterChan1)
 		chans = append(chans, iterChan1)
 		iterChan2 := make(chan *iterator.Msg, 2)
-		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"3", "4"})}
-		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"5", "6"})}
+		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"3", "4"}, false)}
+		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"5", "6"}, false)}
 		close(iterChan2)
 		chans = append(chans, iterChan2)
 		iterChan3 := make(chan *iterator.Msg, 1)
-		iterChan3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"7"})}
+		iterChan3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"7"}, false)}
 		close(iterChan3)
 		chans = append(chans, iterChan3)
 
@@ -415,7 +415,7 @@ func TestIteratorToUserset(t *testing.T) {
 		chans := make([]<-chan *iterator.Msg, 0, 5)
 		for i := 1; i <= 5; i++ {
 			iterChan := make(chan *iterator.Msg, 1)
-			iterChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{strconv.Itoa(i)})}
+			iterChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{strconv.Itoa(i)}, false)}
 			close(iterChan)
 			chans = append(chans, iterChan)
 		}

--- a/internal/graph/object_providers_test.go
+++ b/internal/graph/object_providers_test.go
@@ -82,7 +82,7 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 
 			t.Run("when_empty_iterator", func(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					Times(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+					Times(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -103,11 +103,11 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().
 					ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:2", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
-					}, false), nil)
+					}), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -174,9 +174,9 @@ func TestRecursiveTTUObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().
 					ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					MaxTimes(1).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
-					}, false), nil)
+					}), nil)
 
 				c := newRecursiveTTUObjectProvider(ts, ttu)
 				t.Cleanup(c.End)
@@ -237,7 +237,7 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 
 			t.Run("when_empty_iterator", func(t *testing.T) {
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
-					Times(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+					Times(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 				t.Cleanup(c.End)
@@ -258,11 +258,11 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().
 					ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					Times(1).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:2", "admin", "user:XYZ")},
 						{Key: tuple.NewTupleKey("document:3", "admin", "user:XYZ")},
-					}, false), nil)
+					}), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 				t.Cleanup(c.End)
@@ -329,9 +329,9 @@ func TestRecursiveUsersetObjectProvider(t *testing.T) {
 				mockDatastore.EXPECT().
 					ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).
 					MaxTimes(1).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:1", "parent", "user:XYZ")},
-					}, false), nil)
+					}), nil)
 
 				c := newRecursiveUsersetObjectProvider(ts)
 
@@ -372,16 +372,16 @@ func TestIteratorToUserset(t *testing.T) {
 		chans := make([]<-chan *iterator.Msg, 0, 3)
 		iterChan1 := make(chan *iterator.Msg, 2)
 		iterChan1 <- &iterator.Msg{Iter: mocks.NewErrorIterator[string]([]string{"1"})}
-		iterChan1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"2"}, false)}
+		iterChan1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"2"})}
 		close(iterChan1)
 		chans = append(chans, iterChan1)
 		iterChan2 := make(chan *iterator.Msg, 2)
-		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"3", "4"}, false)}
-		iterChan2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"5", "6"}, false)}
+		iterChan2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"3", "4"})}
+		iterChan2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"5", "6"})}
 		close(iterChan2)
 		chans = append(chans, iterChan2)
 		iterChan3 := make(chan *iterator.Msg, 1)
-		iterChan3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"7"}, false)}
+		iterChan3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"7"})}
 		close(iterChan3)
 		chans = append(chans, iterChan3)
 
@@ -415,7 +415,7 @@ func TestIteratorToUserset(t *testing.T) {
 		chans := make([]<-chan *iterator.Msg, 0, 5)
 		for i := 1; i <= 5; i++ {
 			iterChan := make(chan *iterator.Msg, 1)
-			iterChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{strconv.Itoa(i)}, false)}
+			iterChan <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{strconv.Itoa(i)})}
 			close(iterChan)
 			chans = append(chans, iterChan)
 		}

--- a/internal/graph/recursive_resolver_test.go
+++ b/internal/graph/recursive_resolver_test.go
@@ -167,10 +167,10 @@ func TestRecursiveTTU(t *testing.T) {
 			}, storage.ReadStartingWithUserOptions{
 				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
 				WithResultsSortedAscending: true},
-			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
+			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples[1:] {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
 			}
 
 			req := &ResolveCheckRequest{
@@ -193,7 +193,7 @@ func TestRecursiveTTU(t *testing.T) {
 				})
 			}
 
-			result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+			result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -373,45 +373,45 @@ type group
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readTuples[1:] {
-					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readTuplesError)
+					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
 				}
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -434,7 +434,7 @@ type group
 					})
 				}
 
-				result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+				result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 				require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -453,7 +453,7 @@ type group
 				{
 					Key: tuple.NewTupleKey("group:30", "member", "user:maria"),
 				},
-			}), nil)
+			}, false), nil)
 
 		for i := 1; i < 26; i++ {
 			mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
@@ -461,7 +461,7 @@ type group
 					{
 						Key: tuple.NewTupleKey("group:"+strconv.Itoa(i), "parent", "group:"+strconv.Itoa(i+1)),
 					},
-				}), nil)
+				}, false), nil)
 		}
 		model := parser.MustTransformDSLToProto(`
 model
@@ -488,7 +488,7 @@ type group
 		checker := NewLocalChecker()
 		tupleKeys := []*openfgav1.TupleKey{{Object: "group:0", Relation: "parent", User: "group:1"}}
 
-		result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+		result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 		require.Nil(t, result)
 		require.Equal(t, ErrResolutionDepthExceeded, err)
 	})
@@ -621,10 +621,10 @@ func TestRecursiveUserset(t *testing.T) {
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				ObjectIDs:  nil,
-			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
+			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
-				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
+				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
 			}
 			model := parser.MustTransformDSLToProto(`
 						model
@@ -658,7 +658,7 @@ func TestRecursiveUserset(t *testing.T) {
 				})
 			}
 
-			result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+			result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -817,45 +817,45 @@ func TestRecursiveUserset(t *testing.T) {
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readUsersetTuples[1:] {
-					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples), tt.readUsersetTuplesError)
+					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
 				}
 				model := parser.MustTransformDSLToProto(`
 		model
@@ -897,7 +897,7 @@ func TestRecursiveUserset(t *testing.T) {
 					})
 				}
 
-				result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+				result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 				require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -916,7 +916,7 @@ func TestRecursiveUserset(t *testing.T) {
 				{
 					Key: tuple.NewTupleKey("group:bad", "member", "user:maria"),
 				},
-			}), nil)
+			}, false), nil)
 
 		for i := 1; i < 26; i++ {
 			mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
@@ -924,7 +924,7 @@ func TestRecursiveUserset(t *testing.T) {
 					{
 						Key: tuple.NewTupleKey("group:"+strconv.Itoa(i+1), "member", "group:"+strconv.Itoa(i)+"#member"),
 					},
-				}), nil)
+				}, false), nil)
 		}
 		model := parser.MustTransformDSLToProto(`
 							model
@@ -951,7 +951,7 @@ func TestRecursiveUserset(t *testing.T) {
 		checker := NewLocalChecker()
 		tupleKeys := []*openfgav1.TupleKey{{Object: "group:1", Relation: "member", User: "group:0#member"}}
 
-		result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
+		result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
 		require.Nil(t, result)
 		require.Equal(t, ErrResolutionDepthExceeded, err)
 	})
@@ -1033,7 +1033,7 @@ func TestBreadthFirstRecursiveMatch(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			for _, mock := range tt.readMocks {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock), nil)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock, false), nil)
 			}
 
 			model := parser.MustTransformDSLToProto(`

--- a/internal/graph/recursive_resolver_test.go
+++ b/internal/graph/recursive_resolver_test.go
@@ -165,12 +165,12 @@ func TestRecursiveTTU(t *testing.T) {
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				ObjectIDs:  nil,
 			}, storage.ReadStartingWithUserOptions{
-				Consistency:                storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
-				WithResultsSortedAscending: true},
-			).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
+				Consistency: storage.ConsistencyOptions{Preference: openfgav1.ConsistencyPreference_UNSPECIFIED},
+				SortAsc:     true},
+			).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readTuples[1:] {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readTuplesError)
 			}
 
 			req := &ResolveCheckRequest{
@@ -193,7 +193,7 @@ func TestRecursiveTTU(t *testing.T) {
 				})
 			}
 
-			result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+			result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -373,45 +373,45 @@ type group
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readTuples[1:] {
-					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readTuplesError)
+					mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readTuplesError)
 				}
 
 				ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
@@ -434,7 +434,7 @@ type group
 					})
 				}
 
-				result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+				result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 				require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -449,19 +449,19 @@ type group
 		storeID := ulid.Make().String()
 		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 				{
 					Key: tuple.NewTupleKey("group:30", "member", "user:maria"),
 				},
-			}, false), nil)
+			}), nil)
 
 		for i := 1; i < 26; i++ {
 			mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
-				storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+				storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 					{
 						Key: tuple.NewTupleKey("group:"+strconv.Itoa(i), "parent", "group:"+strconv.Itoa(i+1)),
 					},
-				}, false), nil)
+				}), nil)
 		}
 		model := parser.MustTransformDSLToProto(`
 model
@@ -488,7 +488,7 @@ type group
 		checker := NewLocalChecker()
 		tupleKeys := []*openfgav1.TupleKey{{Object: "group:0", Relation: "parent", User: "group:1"}}
 
-		result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+		result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 		require.Nil(t, result)
 		require.Equal(t, ErrResolutionDepthExceeded, err)
 	})
@@ -621,10 +621,10 @@ func TestRecursiveUserset(t *testing.T) {
 				Relation:   "member",
 				UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 				ObjectIDs:  nil,
-			}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuples, false), tt.readStartingWithUserTuplesError)
+			}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuples), tt.readStartingWithUserTuplesError)
 
 			for _, tuples := range tt.readUsersetTuples[1:] {
-				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
+				mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readUsersetTuplesError)
 			}
 			model := parser.MustTransformDSLToProto(`
 						model
@@ -658,7 +658,7 @@ func TestRecursiveUserset(t *testing.T) {
 				})
 			}
 
-			result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+			result, err := checker.recursiveUserset(ctx, req, nil, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 			require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -817,45 +817,45 @@ func TestRecursiveUserset(t *testing.T) {
 					Relation:   "member",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesMember, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesMember), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel4",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel4, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel4), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel7",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel7, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel7), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel8",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel8, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel8), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel5",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel5, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel5), tt.readStartingWithUserTuplesError)
 
 				mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 					ObjectType: "group",
 					Relation:   "rel6",
 					UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 					ObjectIDs:  nil,
-				}, gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tt.readStartingWithUserTuplesRel6, false), tt.readStartingWithUserTuplesError)
+				}, gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tt.readStartingWithUserTuplesRel6), tt.readStartingWithUserTuplesError)
 
 				for _, tuples := range tt.readUsersetTuples[1:] {
-					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(tuples, false), tt.readUsersetTuplesError)
+					mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(tuples), tt.readUsersetTuplesError)
 				}
 				model := parser.MustTransformDSLToProto(`
 		model
@@ -897,7 +897,7 @@ func TestRecursiveUserset(t *testing.T) {
 					})
 				}
 
-				result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+				result, err := checker.recursiveUserset(ctx, req, nil, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 				require.Equal(t, tt.expectedError, err)
 				require.Equal(t, tt.expected.GetAllowed(), result.GetAllowed())
 				require.Equal(t, tt.expected.GetResolutionMetadata(), result.GetResolutionMetadata())
@@ -912,19 +912,19 @@ func TestRecursiveUserset(t *testing.T) {
 		storeID := ulid.Make().String()
 		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 				{
 					Key: tuple.NewTupleKey("group:bad", "member", "user:maria"),
 				},
-			}, false), nil)
+			}), nil)
 
 		for i := 1; i < 26; i++ {
 			mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(
-				storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+				storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 					{
 						Key: tuple.NewTupleKey("group:"+strconv.Itoa(i+1), "member", "group:"+strconv.Itoa(i)+"#member"),
 					},
-				}, false), nil)
+				}), nil)
 		}
 		model := parser.MustTransformDSLToProto(`
 							model
@@ -951,7 +951,7 @@ func TestRecursiveUserset(t *testing.T) {
 		checker := NewLocalChecker()
 		tupleKeys := []*openfgav1.TupleKey{{Object: "group:1", Relation: "member", User: "group:0#member"}}
 
-		result, err := checker.recursiveUserset(ctx, req, nil, storage.NewStaticTupleKeyIterator(tupleKeys, false), "recursive")(ctx)
+		result, err := checker.recursiveUserset(ctx, req, nil, storage.NewUnorderedStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 		require.Nil(t, result)
 		require.Equal(t, ErrResolutionDepthExceeded, err)
 	})
@@ -1033,7 +1033,7 @@ func TestBreadthFirstRecursiveMatch(t *testing.T) {
 
 			mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
 			for _, mock := range tt.readMocks {
-				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewStaticTupleIterator(mock, false), nil)
+				mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(mock), nil)
 			}
 
 			model := parser.MustTransformDSLToProto(`

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -298,6 +298,7 @@ func addNextItemInSliceStreamsToBatch(ctx context.Context, streamSlices []*itera
 	return batch, nil
 }
 
+// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
 func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 
@@ -370,6 +371,7 @@ func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<
 	}
 }
 
+// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
 func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 
@@ -460,6 +462,7 @@ func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outCha
 	}
 }
 
+// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
 func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -292,7 +292,7 @@ func addNextItemInSliceStreamsToBatch(ctx context.Context, streamSlices []*itera
 		batch = append(batch, item)
 	}
 	if len(batch) > IteratorMinBatchThreshold {
-		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch)}, outChan)
+		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
 		batch = make([]string, 0)
 	}
 	return batch, nil
@@ -304,7 +304,7 @@ func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -376,7 +376,7 @@ func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outCha
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -466,7 +466,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -567,7 +567,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 			}
 			batch = append(batch, items...)
 			if len(batch) > IteratorMinBatchThreshold {
-				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch)}, outChan)
+				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
 				batch = make([]string, 0)
 			}
 			iterStreams, err = streams.CleanDone(ctx)

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -292,20 +292,20 @@ func addNextItemInSliceStreamsToBatch(ctx context.Context, streamSlices []*itera
 		batch = append(batch, item)
 	}
 	if len(batch) > IteratorMinBatchThreshold {
-		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
+		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](batch)}, outChan)
 		batch = make([]string, 0)
 	}
 	return batch, nil
 }
 
-// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
+// Requires each stream to yield object IDs in ascending order (use SortAsc on reads); the merge produces incorrect results otherwise.
 func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](batch)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -371,14 +371,14 @@ func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<
 	}
 }
 
-// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
+// Requires each stream to yield object IDs in ascending order (use SortAsc on reads); the merge produces incorrect results otherwise.
 func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](batch)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -462,14 +462,14 @@ func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outCha
 	}
 }
 
-// Requires each stream to yield object IDs in ascending order (use WithResultsSortedAscending on reads); the merge produces incorrect results otherwise.
+// Requires each stream to yield object IDs in ascending order (use SortAsc on reads); the merge produces incorrect results otherwise.
 func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan chan<- *iterator.Msg) {
 	batch := make([]string, 0)
 
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](batch)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -570,7 +570,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 			}
 			batch = append(batch, items...)
 			if len(batch) > IteratorMinBatchThreshold {
-				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
+				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewOrderedStaticIterator[string](batch)}, outChan)
 				batch = make([]string, 0)
 			}
 			iterStreams, err = streams.CleanDone(ctx)

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -292,7 +292,7 @@ func addNextItemInSliceStreamsToBatch(ctx context.Context, streamSlices []*itera
 		batch = append(batch, item)
 	}
 	if len(batch) > IteratorMinBatchThreshold {
-		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
+		concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
 		batch = make([]string, 0)
 	}
 	return batch, nil
@@ -305,7 +305,7 @@ func fastPathUnion(ctx context.Context, streams *iterator.Streams, outChan chan<
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -378,7 +378,7 @@ func fastPathIntersection(ctx context.Context, streams *iterator.Streams, outCha
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -469,7 +469,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 	defer func() {
 		// flush
 		if len(batch) > 0 {
-			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
+			concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
 		}
 		close(outChan)
 		streams.Stop()
@@ -570,7 +570,7 @@ func fastPathDifference(ctx context.Context, streams *iterator.Streams, outChan 
 			}
 			batch = append(batch, items...)
 			if len(batch) > IteratorMinBatchThreshold {
-				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, false)}, outChan)
+				concurrency.TrySendThroughChannel(ctx, &iterator.Msg{Iter: storage.NewStaticIterator[string](batch, true)}, outChan)
 				batch = make([]string, 0)
 			}
 			iterStreams, err = streams.CleanDone(ctx)

--- a/internal/graph/weight_two_resolver_test.go
+++ b/internal/graph/weight_two_resolver_test.go
@@ -63,11 +63,11 @@ func TestFastPathDirect(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -110,7 +110,7 @@ func TestFastPathDirect(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:1"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
@@ -243,28 +243,28 @@ func TestFastPathUnion(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
 		producer3 := make(chan *iterator.Msg, 4)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer3)
 		producers = append(producers, iterator.NewStream(0, producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:4"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
 		close(producer4)
 		producers = append(producers, iterator.NewStream(0, producer4))
 
@@ -346,7 +346,7 @@ func TestFastPathUnion(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(0, producer))
 				}
@@ -392,7 +392,7 @@ func TestFastPathUnion(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](keys)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(0, producer))
 		}
@@ -437,7 +437,7 @@ func TestFastPathUnion(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -470,7 +470,7 @@ func TestFastPathUnion(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -560,31 +560,31 @@ func TestFastPathIntersection(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 2)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
 		producer3 := make(chan *iterator.Msg, 6)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer3)
 		producers = append(producers, iterator.NewStream(0, producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:4"})}
 		close(producer4)
 		producers = append(producers, iterator.NewStream(0, producer4))
 
@@ -667,7 +667,7 @@ func TestFastPathIntersection(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(0, producer))
 				}
@@ -713,7 +713,7 @@ func TestFastPathIntersection(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](keys)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(0, producer))
 		}
@@ -758,7 +758,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -791,7 +791,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -826,7 +826,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -865,7 +865,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -963,20 +963,20 @@ func TestFastPathDifference(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 6)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:8"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:9"})}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(BaseIndex, producer1))
 
 		producer2 := make(chan *iterator.Msg, 6)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:5"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:6"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(DifferenceIndex, producer2))
 
@@ -1077,7 +1077,7 @@ func TestFastPathDifference(t *testing.T) {
 
 				for idx, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+					producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(idx, producer))
 				}
@@ -1120,7 +1120,7 @@ func TestFastPathDifference(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1153,7 +1153,7 @@ func TestFastPathDifference(t *testing.T) {
 
 		for idx, objs := range objects {
 			producer := make(chan *iterator.Msg, 1)
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
+			producer <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string](objs)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(idx, producer))
 		}
@@ -1201,7 +1201,7 @@ func TestFastPathDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1233,7 +1233,7 @@ func TestFastPathDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1257,7 +1257,7 @@ func TestFastPathDifference(t *testing.T) {
 		res := make(chan *iterator.Msg)
 		producers := make([]*iterator.Stream, 0)
 		producer1 := make(chan *iterator.Msg, 1)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		iter1 := mocks.NewMockIterator[string](ctrl)
@@ -1326,11 +1326,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1343,9 +1343,9 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1368,11 +1368,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1401,11 +1401,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1418,9 +1418,9 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -1442,11 +1442,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1475,9 +1475,9 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1490,11 +1490,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1517,11 +1517,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1550,9 +1550,9 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1565,11 +1565,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1592,11 +1592,11 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1647,7 +1647,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			tuple.NewTupleKey("folder:target", "target", "group:1#intersect"),
 		}
 
-		usersetIterator := storage.NewStaticTupleKeyIterator(usersetTuples, false)
+		usersetIterator := storage.NewUnorderedStaticTupleKeyIterator(usersetTuples)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -1658,24 +1658,24 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "member2",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples), false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples)), nil)
 
 		ctx := setRequestContext(context.Background(), ts, mockDatastore, contextualTuples)
 
@@ -1712,11 +1712,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1729,9 +1729,9 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1755,11 +1755,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1786,9 +1786,9 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1801,11 +1801,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		checker := NewLocalChecker()
 		ctx := context.Background()
@@ -1830,11 +1830,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1861,11 +1861,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}, false), nil)
+		}), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1878,9 +1878,9 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1904,11 +1904,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1935,9 +1935,9 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1950,11 +1950,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			},
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+		).MaxTimes(1).Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}, false), nil)
+		}), nil)
 
 		checker := NewLocalChecker()
 		ctx := context.Background()
@@ -1979,11 +1979,11 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 
 		ctx = typesystem.ContextWithTypesystem(ctx, ts)
 		ctx = storage.ContextWithRelationshipTupleReader(ctx, mockDatastore)
-		iter := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{{
+		iter := storage.NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{{
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}}, false)
+		}})
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -2030,7 +2030,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		tuplesets := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("folder:target", "parent", "group:1"),
 		}
-		rightHandSideIterator := storage.NewStaticTupleKeyIterator(tuplesets, false)
+		rightHandSideIterator := storage.NewUnorderedStaticTupleKeyIterator(tuplesets)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -2041,24 +2041,24 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "member2",
 			UserFilter: []*openfgav1.ObjectRelation{{Object: "user:maria"}},
 			ObjectIDs:  nil,
 		}, storage.ReadStartingWithUserOptions{
-			WithResultsSortedAscending: true,
+			SortAsc: true,
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples), false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples)), nil)
 
 		ctx := setRequestContext(context.Background(), ts, mockDatastore, contextualTuples)
 

--- a/internal/graph/weight_two_resolver_test.go
+++ b/internal/graph/weight_two_resolver_test.go
@@ -67,7 +67,7 @@ func TestFastPathDirect(t *testing.T) {
 			Consistency: storage.ConsistencyOptions{
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		model := testutils.MustTransformDSLToProtoWithID(`
 			model
@@ -243,28 +243,28 @@ func TestFastPathUnion(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
 		producer3 := make(chan *iterator.Msg, 4)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer3)
 		producers = append(producers, iterator.NewStream(0, producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"})}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
 		close(producer4)
 		producers = append(producers, iterator.NewStream(0, producer4))
 
@@ -346,7 +346,7 @@ func TestFastPathUnion(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(0, producer))
 				}
@@ -392,7 +392,7 @@ func TestFastPathUnion(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(0, producer))
 		}
@@ -437,7 +437,7 @@ func TestFastPathUnion(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -470,7 +470,7 @@ func TestFastPathUnion(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -560,31 +560,31 @@ func TestFastPathIntersection(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 3)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 2)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
 		producer3 := make(chan *iterator.Msg, 6)
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer3 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer3)
 		producers = append(producers, iterator.NewStream(0, producer3))
 
 		producer4 := make(chan *iterator.Msg, 2)
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"})}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer4 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:4"}, false)}
 		close(producer4)
 		producers = append(producers, iterator.NewStream(0, producer4))
 
@@ -667,7 +667,7 @@ func TestFastPathIntersection(t *testing.T) {
 
 				for _, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(0, producer))
 				}
@@ -713,7 +713,7 @@ func TestFastPathIntersection(t *testing.T) {
 			for j := 0; j < numItems; j++ {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys, false)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(0, producer))
 		}
@@ -758,7 +758,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -791,7 +791,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -826,7 +826,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -865,7 +865,7 @@ func TestFastPathIntersection(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -963,20 +963,20 @@ func TestFastPathDifference(t *testing.T) {
 		ctx := context.Background()
 
 		producer1 := make(chan *iterator.Msg, 6)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"})}
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:8"}, false)}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:9"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(BaseIndex, producer1))
 
 		producer2 := make(chan *iterator.Msg, 6)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"})}
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:5"}, false)}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:6"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(DifferenceIndex, producer2))
 
@@ -1077,7 +1077,7 @@ func TestFastPathDifference(t *testing.T) {
 
 				for idx, objs := range tt.objects {
 					producer := make(chan *iterator.Msg, 1)
-					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+					producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 					close(producer)
 					producers = append(producers, iterator.NewStream(idx, producer))
 				}
@@ -1120,7 +1120,7 @@ func TestFastPathDifference(t *testing.T) {
 		producers = append(producers, iterator.NewStream(0, producer1))
 
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 
@@ -1153,7 +1153,7 @@ func TestFastPathDifference(t *testing.T) {
 
 		for idx, objs := range objects {
 			producer := make(chan *iterator.Msg, 1)
-			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs)}
+			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](objs, false)}
 			close(producer)
 			producers = append(producers, iterator.NewStream(idx, producer))
 		}
@@ -1201,7 +1201,7 @@ func TestFastPathDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1233,7 +1233,7 @@ func TestFastPathDifference(t *testing.T) {
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		producer2 := make(chan *iterator.Msg, 1)
-		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer2 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer2)
 		producers = append(producers, iterator.NewStream(0, producer2))
 		pool := concurrency.NewPool(ctx, 1)
@@ -1257,7 +1257,7 @@ func TestFastPathDifference(t *testing.T) {
 		res := make(chan *iterator.Msg)
 		producers := make([]*iterator.Stream, 0)
 		producer1 := make(chan *iterator.Msg, 1)
-		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
+		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"}, false)}
 		close(producer1)
 		producers = append(producers, iterator.NewStream(0, producer1))
 		iter1 := mocks.NewMockIterator[string](ctrl)
@@ -1330,7 +1330,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1345,7 +1345,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1372,7 +1372,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1405,7 +1405,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1420,7 +1420,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 		model := testutils.MustTransformDSLToProtoWithID(`
@@ -1446,7 +1446,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1477,7 +1477,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1494,7 +1494,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1521,7 +1521,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			User:     "group:1#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1552,7 +1552,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1569,7 +1569,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1596,7 +1596,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			User:     "group:2#all",
 			Relation: "viewer",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2Userset(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1647,7 +1647,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 			tuple.NewTupleKey("folder:target", "target", "group:1#intersect"),
 		}
 
-		usersetIterator := storage.NewStaticTupleKeyIterator(usersetTuples)
+		usersetIterator := storage.NewStaticTupleKeyIterator(usersetTuples, false)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -1663,7 +1663,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "member2",
@@ -1675,7 +1675,7 @@ func TestCheckUsersetFastPathV2(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples)), nil)
+			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples), false), nil)
 
 		ctx := setRequestContext(context.Background(), ts, mockDatastore, contextualTuples)
 
@@ -1716,7 +1716,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1731,7 +1731,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1759,7 +1759,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1788,7 +1788,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1805,7 +1805,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		checker := NewLocalChecker()
 		ctx := context.Background()
@@ -1834,7 +1834,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			User:     "group:1",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1865,7 +1865,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "members", "user:1")},
-		}), nil)
+		}, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1880,7 +1880,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		checker := NewLocalChecker()
 		ctx := context.Background()
 
@@ -1908,7 +1908,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -1937,7 +1937,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			},
 			WithResultsSortedAscending: true,
 		},
-		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil), nil)
+		).MaxTimes(1).Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "public",
@@ -1954,7 +1954,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		},
 		).MaxTimes(1).Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("group:1", "public", "user:*")},
-		}), nil)
+		}, false), nil)
 
 		checker := NewLocalChecker()
 		ctx := context.Background()
@@ -1983,7 +1983,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 			User:     "group:2",
 			Relation: "parent",
 			Object:   "document:1",
-		}})
+		}}, false)
 		val, err := checker.weight2TTU(ctx, &ResolveCheckRequest{
 			StoreID:              storeID,
 			AuthorizationModelID: ts.GetAuthorizationModelID(),
@@ -2030,7 +2030,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 		tuplesets := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("folder:target", "parent", "group:1"),
 		}
-		rightHandSideIterator := storage.NewStaticTupleKeyIterator(tuplesets)
+		rightHandSideIterator := storage.NewStaticTupleKeyIterator(tuplesets, false)
 
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -2046,7 +2046,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
 			ObjectType: "group",
 			Relation:   "member2",
@@ -2058,7 +2058,7 @@ func TestCheckTTUFastPathV2(t *testing.T) {
 				Preference: openfgav1.ConsistencyPreference_UNSPECIFIED,
 			}},
 		).Times(1).
-			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples)), nil)
+			Return(storage.NewStaticTupleIterator(testutils.ConvertTuplesKeysToTuples(dbTuples), false), nil)
 
 		ctx := setRequestContext(context.Background(), ts, mockDatastore, contextualTuples)
 

--- a/internal/iterator/concat_test.go
+++ b/internal/iterator/concat_test.go
@@ -185,7 +185,7 @@ func TestConcat(t *testing.T) {
 }
 
 func TestConcatIsOrdered(t *testing.T) {
-	iter := Concat(storage.NewStaticIterator[string]([]string{"a"}, false), storage.NewStaticIterator[string]([]string{"b"}, false))
+	iter := Concat(storage.NewUnorderedStaticIterator[string]([]string{"a"}), storage.NewUnorderedStaticIterator[string]([]string{"b"}))
 	defer iter.Stop()
 	require.False(t, iter.IsOrdered())
 }

--- a/internal/iterator/concat_test.go
+++ b/internal/iterator/concat_test.go
@@ -185,7 +185,7 @@ func TestConcat(t *testing.T) {
 }
 
 func TestConcatIsOrdered(t *testing.T) {
-	iter := Concat(storage.NewStaticIterator[string]([]string{"a"}), storage.NewStaticIterator[string]([]string{"b"}))
+	iter := Concat(storage.NewStaticIterator[string]([]string{"a"}, false), storage.NewStaticIterator[string]([]string{"b"}, false))
 	defer iter.Stop()
 	require.False(t, iter.IsOrdered())
 }

--- a/internal/iterator/filter_test.go
+++ b/internal/iterator/filter_test.go
@@ -34,7 +34,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -63,7 +63,7 @@ func TestFilter_Conditions(t *testing.T) {
 		}
 
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -91,7 +91,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -115,7 +115,7 @@ func TestFilter_Conditions(t *testing.T) {
 	t.Run("empty_list", func(t *testing.T) {
 		var tuples []*openfgav1.TupleKey
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -132,7 +132,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -145,7 +145,7 @@ func TestFilter_Conditions(t *testing.T) {
 	t.Run("ctx_timeout", func(t *testing.T) {
 		var tuples []*openfgav1.TupleKey
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -178,7 +178,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 			tuple.NewTupleKey("document:doc1", "viewer", "user:jon"), // duplicate
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			uniqueFilter,
 		)
 		defer iter.Stop()
@@ -215,7 +215,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 			tuple.NewTupleKey("document:doc3", "viewer", "user:maria"),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			uniqueFilter,
 		)
 		defer iter.Stop()
@@ -237,7 +237,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 }
 
 func TestFilterIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[string]([]string{"a"}, true)
+	inner := storage.NewOrderedStaticIterator[string]([]string{"a"})
 	iter := NewFilteredIterator(inner, func(s string) (bool, error) { return true, nil })
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -263,7 +263,7 @@ func TestFilter_MultipleFilters(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc3", "viewer", "user:maria", "condition1", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples, false),
+			storage.NewUnorderedStaticTupleKeyIterator(tuples),
 			conditionFilter,
 			uniqueFilter,
 		)

--- a/internal/iterator/filter_test.go
+++ b/internal/iterator/filter_test.go
@@ -34,7 +34,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -63,7 +63,7 @@ func TestFilter_Conditions(t *testing.T) {
 		}
 
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -91,7 +91,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -115,7 +115,7 @@ func TestFilter_Conditions(t *testing.T) {
 	t.Run("empty_list", func(t *testing.T) {
 		var tuples []*openfgav1.TupleKey
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -132,7 +132,7 @@ func TestFilter_Conditions(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -145,7 +145,7 @@ func TestFilter_Conditions(t *testing.T) {
 	t.Run("ctx_timeout", func(t *testing.T) {
 		var tuples []*openfgav1.TupleKey
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 		)
 		defer iter.Stop()
@@ -178,7 +178,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 			tuple.NewTupleKey("document:doc1", "viewer", "user:jon"), // duplicate
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			uniqueFilter,
 		)
 		defer iter.Stop()
@@ -215,7 +215,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 			tuple.NewTupleKey("document:doc3", "viewer", "user:maria"),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			uniqueFilter,
 		)
 		defer iter.Stop()
@@ -237,7 +237,7 @@ func TestFilter_Uniqueness(t *testing.T) {
 }
 
 func TestFilterIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[string]([]string{"a"})
+	inner := storage.NewStaticIterator[string]([]string{"a"}, true)
 	iter := NewFilteredIterator(inner, func(s string) (bool, error) { return true, nil })
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -263,7 +263,7 @@ func TestFilter_MultipleFilters(t *testing.T) {
 			tuple.NewTupleKeyWithCondition("document:doc3", "viewer", "user:maria", "condition1", nil),
 		}
 		iter := NewFilteredIterator(
-			storage.NewStaticTupleKeyIterator(tuples),
+			storage.NewStaticTupleKeyIterator(tuples, false),
 			conditionFilter,
 			uniqueFilter,
 		)

--- a/internal/iterator/merge_test.go
+++ b/internal/iterator/merge_test.go
@@ -23,15 +23,15 @@ func TestMergedIteratorIsOrdered(t *testing.T) {
 	}
 
 	t.Run("both_ordered_true", func(t *testing.T) {
-		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}, true), storage.NewStaticIterator[string]([]string{"b"}, true), compareFn)
+		iter := Merge(storage.NewOrderedStaticIterator[string]([]string{"a"}), storage.NewOrderedStaticIterator[string]([]string{"b"}), compareFn)
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("one_unordered_false", func(t *testing.T) {
 		// Concat returns IsOrdered()=false, simulating an unordered right side
-		unordered := Concat(storage.NewStaticIterator[string]([]string{"a"}, false), storage.NewStaticIterator[string]([]string{"b"}, false))
-		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}, false), unordered, compareFn)
+		unordered := Concat(storage.NewUnorderedStaticIterator[string]([]string{"a"}), storage.NewUnorderedStaticIterator[string]([]string{"b"}))
+		iter := Merge(storage.NewUnorderedStaticIterator[string]([]string{"a"}), unordered, compareFn)
 		defer iter.Stop()
 		require.False(t, iter.IsOrdered())
 	})
@@ -48,8 +48,8 @@ func TestMergedIterator(t *testing.T) {
 	}
 
 	t.Run("both_iterators_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -58,8 +58,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("first_iterator_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -76,8 +76,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("second_iterator_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2"})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -94,8 +94,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("merge_sorted_iterators", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:3", "obj:5"}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:4", "obj:6"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:3", "obj:5"})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:2", "obj:4", "obj:6"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -111,8 +111,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("skip_duplicates", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3", "obj:5"}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:3", "obj:4"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3", "obj:5"})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:2", "obj:3", "obj:4"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -128,8 +128,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("all_duplicates", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -151,7 +151,7 @@ func TestMergedIterator(t *testing.T) {
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).Return("", errors.New("init error"))
 
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -164,7 +164,7 @@ func TestMergedIterator(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})
 
 		iter2 := mocks.NewMockIterator[string](ctrl)
 		iter2.EXPECT().Next(gomock.Any()).Return("", errors.New("init error"))
@@ -184,7 +184,7 @@ func TestMergedIterator(t *testing.T) {
 		iter1.EXPECT().Next(gomock.Any()).Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).Return("", errors.New("iteration error"))
 
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -197,7 +197,7 @@ func TestMergedIterator(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})
 
 		iter2 := mocks.NewMockIterator[string](ctrl)
 		iter2.EXPECT().Next(gomock.Any()).Return("obj:1", nil)
@@ -214,8 +214,8 @@ func TestMergedIterator(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
+		iter1 := storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})
+		iter2 := storage.NewUnorderedStaticIterator[string]([]string{"obj:2"})
 
 		merged := Merge(iter1, iter2, compareFn)
 

--- a/internal/iterator/merge_test.go
+++ b/internal/iterator/merge_test.go
@@ -23,15 +23,15 @@ func TestMergedIteratorIsOrdered(t *testing.T) {
 	}
 
 	t.Run("both_ordered_true", func(t *testing.T) {
-		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}), storage.NewStaticIterator[string]([]string{"b"}), compareFn)
+		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}, true), storage.NewStaticIterator[string]([]string{"b"}, true), compareFn)
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("one_unordered_false", func(t *testing.T) {
 		// Concat returns IsOrdered()=false, simulating an unordered right side
-		unordered := Concat(storage.NewStaticIterator[string]([]string{"a"}), storage.NewStaticIterator[string]([]string{"b"}))
-		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}), unordered, compareFn)
+		unordered := Concat(storage.NewStaticIterator[string]([]string{"a"}, false), storage.NewStaticIterator[string]([]string{"b"}, false))
+		iter := Merge(storage.NewStaticIterator[string]([]string{"a"}, false), unordered, compareFn)
 		defer iter.Stop()
 		require.False(t, iter.IsOrdered())
 	})
@@ -48,8 +48,8 @@ func TestMergedIterator(t *testing.T) {
 	}
 
 	t.Run("both_iterators_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{})
-		iter2 := storage.NewStaticIterator[string]([]string{})
+		iter1 := storage.NewStaticIterator[string]([]string{}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -58,8 +58,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("first_iterator_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{})
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"})
+		iter1 := storage.NewStaticIterator[string]([]string{}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -76,8 +76,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("second_iterator_empty", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"})
-		iter2 := storage.NewStaticIterator[string]([]string{})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -94,8 +94,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("merge_sorted_iterators", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:3", "obj:5"})
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:4", "obj:6"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:3", "obj:5"}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:4", "obj:6"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -111,8 +111,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("skip_duplicates", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3", "obj:5"})
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:3", "obj:4"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3", "obj:5"}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:2", "obj:3", "obj:4"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -128,8 +128,8 @@ func TestMergedIterator(t *testing.T) {
 	})
 
 	t.Run("all_duplicates", func(t *testing.T) {
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"})
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:1", "obj:2", "obj:3"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -151,7 +151,7 @@ func TestMergedIterator(t *testing.T) {
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).Return("", errors.New("init error"))
 
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:1"})
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -164,7 +164,7 @@ func TestMergedIterator(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
 
 		iter2 := mocks.NewMockIterator[string](ctrl)
 		iter2.EXPECT().Next(gomock.Any()).Return("", errors.New("init error"))
@@ -184,7 +184,7 @@ func TestMergedIterator(t *testing.T) {
 		iter1.EXPECT().Next(gomock.Any()).Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).Return("", errors.New("iteration error"))
 
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"})
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 
@@ -197,7 +197,7 @@ func TestMergedIterator(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:2"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
 
 		iter2 := mocks.NewMockIterator[string](ctrl)
 		iter2.EXPECT().Next(gomock.Any()).Return("obj:1", nil)
@@ -214,8 +214,8 @@ func TestMergedIterator(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"})
-		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"})
+		iter1 := storage.NewStaticIterator[string]([]string{"obj:1"}, false)
+		iter2 := storage.NewStaticIterator[string]([]string{"obj:2"}, false)
 
 		merged := Merge(iter1, iter2, compareFn)
 

--- a/internal/iterator/skip_test.go
+++ b/internal/iterator/skip_test.go
@@ -79,7 +79,7 @@ func TestSkipTo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			iter := storage.NewStaticIterator(tt.values, false)
+			iter := storage.NewUnorderedStaticIterator(tt.values)
 			defer iter.Stop()
 
 			err := SkipTo(ctx, iter, tt.target)
@@ -150,7 +150,7 @@ func TestSkipToContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		iter := storage.NewStaticIterator([]string{"a", "b", "c"}, false)
+		iter := storage.NewUnorderedStaticIterator([]string{"a", "b", "c"})
 		defer iter.Stop()
 
 		err := SkipTo(ctx, iter, "z")
@@ -210,7 +210,7 @@ func TestSkipToWithLexicographicOrdering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			iter := storage.NewStaticIterator(tt.values, false)
+			iter := storage.NewUnorderedStaticIterator(tt.values)
 			defer iter.Stop()
 
 			err := SkipTo(ctx, iter, tt.target)

--- a/internal/iterator/skip_test.go
+++ b/internal/iterator/skip_test.go
@@ -79,7 +79,7 @@ func TestSkipTo(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			iter := storage.NewStaticIterator(tt.values)
+			iter := storage.NewStaticIterator(tt.values, false)
 			defer iter.Stop()
 
 			err := SkipTo(ctx, iter, tt.target)
@@ -150,7 +150,7 @@ func TestSkipToContextCancellation(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		iter := storage.NewStaticIterator([]string{"a", "b", "c"})
+		iter := storage.NewStaticIterator([]string{"a", "b", "c"}, false)
 		defer iter.Stop()
 
 		err := SkipTo(ctx, iter, "z")
@@ -210,7 +210,7 @@ func TestSkipToWithLexicographicOrdering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			iter := storage.NewStaticIterator(tt.values)
+			iter := storage.NewStaticIterator(tt.values, false)
 			defer iter.Stop()
 
 			err := SkipTo(ctx, iter, tt.target)

--- a/internal/iterator/stream_test.go
+++ b/internal/iterator/stream_test.go
@@ -21,7 +21,7 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("fetchSource", func(t *testing.T) {
 		t.Run("no_nil_buffer_should_not_fetch", func(t *testing.T) {
 			stream := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false)}
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"})}
 			err := stream.fetchSource(context.Background())
 			// notice there is no error even when there is no source
 			require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("fetch_from_source", func(t *testing.T) {
 			c := make(chan *Msg, 1)
 			stream := NewStream(0, c)
-			c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
+			c <- &Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{"obj:1"})}
 			err := stream.fetchSource(context.Background())
 			require.NoError(t, err)
 			require.False(t, stream.sourceIsClosed)
@@ -72,7 +72,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer_not_done", func(t *testing.T) {
 			dut := Stream{
 				sourceIsClosed: false,
-				buffer:         storage.NewStaticIterator[string]([]string{}, false),
+				buffer:         storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			require.False(t, dut.isDone())
 		})
@@ -93,7 +93,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer_but_done", func(t *testing.T) {
 			dut := Stream{
 				sourceIsClosed: true,
-				buffer:         storage.NewStaticIterator[string]([]string{}, false),
+				buffer:         storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			require.False(t, dut.isDone())
 		})
@@ -113,7 +113,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("empty_buffer", func(t *testing.T) {
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			item, err := dut.Head(context.Background())
 			require.ErrorIs(t, err, storage.ErrIteratorDone)
@@ -123,7 +123,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer", func(t *testing.T) {
 			item := "obj:1"
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{item}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{item}),
 			}
 			res, err := dut.Head(context.Background())
 			require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("empty_buffer", func(t *testing.T) {
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			item, err := dut.Next(context.Background())
 			require.ErrorIs(t, err, storage.ErrIteratorDone)
@@ -152,7 +152,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer", func(t *testing.T) {
 			item := "obj:1"
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{item}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{item}),
 			}
 			item, err := dut.Next(context.Background())
 			require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("Drain", func(t *testing.T) {
 		t.Run("empty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			items, err := dut.Drain(context.Background())
 			require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("nonEmpty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:1", "obj:2"}),
 			}
 			items, err := dut.Drain(context.Background())
 			require.NoError(t, err)
@@ -199,14 +199,14 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("SkipToTargetObject", func(t *testing.T) {
 		t.Run("bad_target", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			err := dut.SkipToTargetObject(context.Background(), "bad_target")
 			require.Error(t, err)
 		})
 		t.Run("empty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{}),
 			}
 			err := dut.SkipToTargetObject(context.Background(), "obj:2")
 			require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:4")
 			require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:2")
 			require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3", "obj:4"}, false),
+				buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3", "obj:4"}),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:2")
 			require.NoError(t, err)
@@ -280,13 +280,13 @@ func TestIteratorStream(t *testing.T) {
 		})
 	})
 	t.Run("Stop", func(t *testing.T) {
-		sourceIter := storage.NewStaticIterator[string]([]string{"obj:10", "obj:11"}, false)
+		sourceIter := storage.NewUnorderedStaticIterator[string]([]string{"obj:10", "obj:11"})
 
 		c := make(chan *Msg, 1)
 		c <- &Msg{Iter: sourceIter}
 		close(c)
 
-		buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"}, false)
+		buf := storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"})
 
 		dut := &Stream{
 			buffer: buf,
@@ -309,16 +309,16 @@ func TestNextItemInSliceStreams(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 	t.Run("error_on_empty", func(t *testing.T) {
-		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{}, false)}
-		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
+		stream1 := &Stream{buffer: storage.NewUnorderedStaticIterator[string]([]string{})}
+		stream2 := &Stream{buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0"})}
 		item, err := NextItemInSliceStreams(context.Background(), []*Stream{stream1, stream2}, []int{0, 1})
 		require.ErrorIs(t, err, storage.ErrIteratorDone)
 		require.Empty(t, item)
 	})
 	t.Run("skip_item", func(t *testing.T) {
-		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
-		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1"}, false)}
-		stream3 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:2"}, false)}
+		stream1 := &Stream{buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:3"})}
+		stream2 := &Stream{buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1"})}
+		stream3 := &Stream{buffer: storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:2"})}
 		item, err := NextItemInSliceStreams(context.Background(), []*Stream{stream1, stream2, stream3}, []int{1, 2})
 		require.NoError(t, err)
 		require.Equal(t, "obj:0", item)
@@ -367,7 +367,7 @@ func TestIteratorStreams(t *testing.T) {
 					close(c)
 				} else {
 					expectedLen++
-					c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{}, false)}
+					c <- &Msg{Iter: storage.NewUnorderedStaticIterator[string]([]string{})}
 				}
 				streams = append(streams, producer)
 			}
@@ -393,7 +393,7 @@ func TestIteratorStreams(t *testing.T) {
 	t.Run("Stop", func(t *testing.T) {
 		streams := make([]*Stream, 3)
 		for i := 0; i < 3; i++ {
-			buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"}, false)
+			buf := storage.NewUnorderedStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"})
 			c := make(chan *Msg, 1)
 			close(c)
 			streams[i] = &Stream{

--- a/internal/iterator/stream_test.go
+++ b/internal/iterator/stream_test.go
@@ -21,7 +21,7 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("fetchSource", func(t *testing.T) {
 		t.Run("no_nil_buffer_should_not_fetch", func(t *testing.T) {
 			stream := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"})}
+				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false)}
 			err := stream.fetchSource(context.Background())
 			// notice there is no error even when there is no source
 			require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("fetch_from_source", func(t *testing.T) {
 			c := make(chan *Msg, 1)
 			stream := NewStream(0, c)
-			c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"})}
+			c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:1"}, false)}
 			err := stream.fetchSource(context.Background())
 			require.NoError(t, err)
 			require.False(t, stream.sourceIsClosed)
@@ -72,7 +72,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer_not_done", func(t *testing.T) {
 			dut := Stream{
 				sourceIsClosed: false,
-				buffer:         storage.NewStaticIterator[string]([]string{}),
+				buffer:         storage.NewStaticIterator[string]([]string{}, false),
 			}
 			require.False(t, dut.isDone())
 		})
@@ -93,7 +93,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer_but_done", func(t *testing.T) {
 			dut := Stream{
 				sourceIsClosed: true,
-				buffer:         storage.NewStaticIterator[string]([]string{}),
+				buffer:         storage.NewStaticIterator[string]([]string{}, false),
 			}
 			require.False(t, dut.isDone())
 		})
@@ -113,7 +113,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("empty_buffer", func(t *testing.T) {
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}),
+				buffer: storage.NewStaticIterator[string]([]string{}, false),
 			}
 			item, err := dut.Head(context.Background())
 			require.ErrorIs(t, err, storage.ErrIteratorDone)
@@ -123,7 +123,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer", func(t *testing.T) {
 			item := "obj:1"
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{item}),
+				buffer: storage.NewStaticIterator[string]([]string{item}, false),
 			}
 			res, err := dut.Head(context.Background())
 			require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("empty_buffer", func(t *testing.T) {
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}),
+				buffer: storage.NewStaticIterator[string]([]string{}, false),
 			}
 			item, err := dut.Next(context.Background())
 			require.ErrorIs(t, err, storage.ErrIteratorDone)
@@ -152,7 +152,7 @@ func TestIteratorStream(t *testing.T) {
 		t.Run("non_empty_buffer", func(t *testing.T) {
 			item := "obj:1"
 			dut := &Stream{
-				buffer: storage.NewStaticIterator[string]([]string{item}),
+				buffer: storage.NewStaticIterator[string]([]string{item}, false),
 			}
 			item, err := dut.Next(context.Background())
 			require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("Drain", func(t *testing.T) {
 		t.Run("empty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}),
+				buffer: storage.NewStaticIterator[string]([]string{}, false),
 			}
 			items, err := dut.Drain(context.Background())
 			require.NoError(t, err)
@@ -175,7 +175,7 @@ func TestIteratorStream(t *testing.T) {
 		})
 		t.Run("nonEmpty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}),
+				buffer: storage.NewStaticIterator[string]([]string{"obj:1", "obj:2"}, false),
 			}
 			items, err := dut.Drain(context.Background())
 			require.NoError(t, err)
@@ -199,14 +199,14 @@ func TestIteratorStream(t *testing.T) {
 	t.Run("SkipToTargetObject", func(t *testing.T) {
 		t.Run("bad_target", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}),
+				buffer: storage.NewStaticIterator[string]([]string{}, false),
 			}
 			err := dut.SkipToTargetObject(context.Background(), "bad_target")
 			require.Error(t, err)
 		})
 		t.Run("empty", func(t *testing.T) {
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{}),
+				buffer: storage.NewStaticIterator[string]([]string{}, false),
 			}
 			err := dut.SkipToTargetObject(context.Background(), "obj:2")
 			require.NoError(t, err)
@@ -236,7 +236,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}),
+				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:4")
 			require.NoError(t, err)
@@ -247,7 +247,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}),
+				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:2", "obj:3"}, false),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:2")
 			require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestIteratorStream(t *testing.T) {
 			ctx := context.Background()
 
 			dut := Stream{
-				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3", "obj:4"}),
+				buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3", "obj:4"}, false),
 			}
 			err := dut.SkipToTargetObject(ctx, "obj:2")
 			require.NoError(t, err)
@@ -280,13 +280,13 @@ func TestIteratorStream(t *testing.T) {
 		})
 	})
 	t.Run("Stop", func(t *testing.T) {
-		sourceIter := storage.NewStaticIterator[string]([]string{"obj:10", "obj:11"})
+		sourceIter := storage.NewStaticIterator[string]([]string{"obj:10", "obj:11"}, false)
 
 		c := make(chan *Msg, 1)
 		c <- &Msg{Iter: sourceIter}
 		close(c)
 
-		buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"})
+		buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"}, false)
 
 		dut := &Stream{
 			buffer: buf,
@@ -309,16 +309,16 @@ func TestNextItemInSliceStreams(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 	t.Run("error_on_empty", func(t *testing.T) {
-		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{})}
-		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0"})}
+		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{}, false)}
+		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0"}, false)}
 		item, err := NextItemInSliceStreams(context.Background(), []*Stream{stream1, stream2}, []int{0, 1})
 		require.ErrorIs(t, err, storage.ErrIteratorDone)
 		require.Empty(t, item)
 	})
 	t.Run("skip_item", func(t *testing.T) {
-		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:3"})}
-		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1"})}
-		stream3 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:2"})}
+		stream1 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:3"}, false)}
+		stream2 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:1"}, false)}
+		stream3 := &Stream{buffer: storage.NewStaticIterator[string]([]string{"obj:0", "obj:2"}, false)}
 		item, err := NextItemInSliceStreams(context.Background(), []*Stream{stream1, stream2, stream3}, []int{1, 2})
 		require.NoError(t, err)
 		require.Equal(t, "obj:0", item)
@@ -367,7 +367,7 @@ func TestIteratorStreams(t *testing.T) {
 					close(c)
 				} else {
 					expectedLen++
-					c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{})}
+					c <- &Msg{Iter: storage.NewStaticIterator[string]([]string{}, false)}
 				}
 				streams = append(streams, producer)
 			}
@@ -393,7 +393,7 @@ func TestIteratorStreams(t *testing.T) {
 	t.Run("Stop", func(t *testing.T) {
 		streams := make([]*Stream, 3)
 		for i := 0; i < 3; i++ {
-			buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"})
+			buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"}, false)
 			c := make(chan *Msg, 1)
 			close(c)
 			streams[i] = &Stream{

--- a/internal/iterator/validate_test.go
+++ b/internal/iterator/validate_test.go
@@ -54,7 +54,7 @@ func (t *TestIterator[T]) Stop() {
 func (t *TestIterator[T]) IsOrdered() bool { return true }
 
 func TestValidatingIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[int]([]int{1, 2, 3}, true)
+	inner := storage.NewOrderedStaticIterator[int]([]int{1, 2, 3})
 	iter := Validate(inner, func(v int) (bool, error) { return true, nil })
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())

--- a/internal/iterator/validate_test.go
+++ b/internal/iterator/validate_test.go
@@ -54,7 +54,7 @@ func (t *TestIterator[T]) Stop() {
 func (t *TestIterator[T]) IsOrdered() bool { return true }
 
 func TestValidatingIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[int]([]int{1, 2, 3})
+	inner := storage.NewStaticIterator[int]([]int{1, 2, 3}, true)
 	iter := Validate(inner, func(v int) (bool, error) { return true, nil })
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())

--- a/internal/listobjects/pipeline/store_test.go
+++ b/internal/listobjects/pipeline/store_test.go
@@ -110,7 +110,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -177,7 +177,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -217,7 +217,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		// Only allow odd-numbered documents.
 		validator := func(tk *openfgav1.TupleKey) (bool, error) {
@@ -262,7 +262,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -310,7 +310,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -343,7 +343,7 @@ func TestReaderRead(t *testing.T) {
 					return opts.Consistency.Preference == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 				}),
 			).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1",
 			pipeline.WithStoreConsistency(openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY),
@@ -383,7 +383,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -417,7 +417,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(nil), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -449,7 +449,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 

--- a/internal/listobjects/pipeline/store_test.go
+++ b/internal/listobjects/pipeline/store_test.go
@@ -110,7 +110,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -177,7 +177,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -217,7 +217,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		// Only allow odd-numbered documents.
 		validator := func(tk *openfgav1.TupleKey) (bool, error) {
@@ -262,7 +262,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -310,7 +310,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -343,7 +343,7 @@ func TestReaderRead(t *testing.T) {
 					return opts.Consistency.Preference == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 				}),
 			).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1",
 			pipeline.WithStoreConsistency(openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY),
@@ -383,7 +383,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -417,7 +417,7 @@ func TestReaderRead(t *testing.T) {
 				}),
 				gomock.Any(),
 			).
-			Return(storage.NewStaticTupleIterator(nil), nil)
+			Return(storage.NewStaticTupleIterator(nil, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
@@ -449,7 +449,7 @@ func TestReaderRead(t *testing.T) {
 
 		store.EXPECT().
 			ReadStartingWithUser(gomock.Any(), "store-1", gomock.Any(), gomock.Any()).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -3024,7 +3024,7 @@ func TestListUsersReadFails_NoLeaks(t *testing.T) {
 		}),
 		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 			}),
 	)
 
@@ -3078,7 +3078,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 			Object:   "folder:1",
 			Relation: "viewer",
 		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
+			return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil
 		}),
 	)
 

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -3024,7 +3024,7 @@ func TestListUsersReadFails_NoLeaks(t *testing.T) {
 		}),
 		mockDatastore.EXPECT().Read(gomock.Any(), store, gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 			}),
 	)
 
@@ -3078,7 +3078,7 @@ func TestListUsersReadFails_NoLeaks_TTU(t *testing.T) {
 			Object:   "folder:1",
 			Relation: "viewer",
 		}, gomock.Any()).DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
-			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil
+			return storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil
 		}),
 	)
 

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -50,7 +50,7 @@ func TestReverseExpandResultChannelClosed(t *testing.T) {
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
 		Times(1).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-			iterator := storage.NewStaticTupleIterator(tuples)
+			iterator := storage.NewStaticTupleIterator(tuples, false)
 			return iterator, nil
 		})
 
@@ -122,7 +122,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 		Times(1).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 			// simulate many goroutines trying to write to the results channel
-			iterator := storage.NewStaticTupleIterator(tuples)
+			iterator := storage.NewStaticTupleIterator(tuples, false)
 			return iterator, nil
 		})
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -400,7 +400,7 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					{Key: tuple.NewTupleKey("group:fga", "member", "user:anne")},
-				}), nil
+				}, false), nil
 			}),
 
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
@@ -413,7 +413,7 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 					// NOTE this tuple is invalid
 					{Key: tuple.NewTupleKey("group:eng", "member", "fail:fga#member")},
-				}), nil
+				}, false), nil
 			}),
 	},
 	)
@@ -831,7 +831,7 @@ func TestReverseExpandHonorsConsistency(t *testing.T) {
 	mockDatastore.EXPECT().
 		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), unspecifiedConsistency).
 		Times(1).
-		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 
 	request := &ReverseExpandRequest{
 		StoreID:    store,
@@ -861,7 +861,7 @@ func TestReverseExpandHonorsConsistency(t *testing.T) {
 	mockDatastore.EXPECT().
 		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), highConsistency).
 		Times(1).
-		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 
 	resultChanTwo := make(chan *ReverseExpandResult)
 	err = reverseExpandQuery.Execute(ctx, request, resultChanTwo, NewResolutionMetadata())

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -50,7 +50,7 @@ func TestReverseExpandResultChannelClosed(t *testing.T) {
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), store, gomock.Any(), gomock.Any()).
 		Times(1).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-			iterator := storage.NewStaticTupleIterator(tuples, false)
+			iterator := storage.NewUnorderedStaticTupleIterator(tuples)
 			return iterator, nil
 		})
 
@@ -122,7 +122,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 		Times(1).
 		DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
 			// simulate many goroutines trying to write to the results channel
-			iterator := storage.NewStaticTupleIterator(tuples, false)
+			iterator := storage.NewUnorderedStaticTupleIterator(tuples)
 			return iterator, nil
 		})
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -398,9 +398,9 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 		}, gomock.Any()).
 			Times(1).
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 					{Key: tuple.NewTupleKey("group:fga", "member", "user:anne")},
-				}, false), nil
+				}), nil
 			}),
 
 		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, storage.ReadStartingWithUserFilter{
@@ -410,10 +410,10 @@ func TestReverseExpandIgnoresInvalidTuples(t *testing.T) {
 		}, gomock.Any()).
 			Times(1).
 			DoAndReturn(func(_ context.Context, _ string, _ storage.ReadStartingWithUserFilter, _ storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 					// NOTE this tuple is invalid
 					{Key: tuple.NewTupleKey("group:eng", "member", "fail:fga#member")},
-				}, false), nil
+				}), nil
 			}),
 	},
 	)
@@ -831,7 +831,7 @@ func TestReverseExpandHonorsConsistency(t *testing.T) {
 	mockDatastore.EXPECT().
 		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), unspecifiedConsistency).
 		Times(1).
-		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+		Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 
 	request := &ReverseExpandRequest{
 		StoreID:    store,
@@ -861,7 +861,7 @@ func TestReverseExpandHonorsConsistency(t *testing.T) {
 	mockDatastore.EXPECT().
 		ReadStartingWithUser(gomock.Any(), store, gomock.Any(), highConsistency).
 		Times(1).
-		Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+		Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 
 	resultChanTwo := make(chan *ReverseExpandResult)
 	err = reverseExpandQuery.Execute(ctx, request, resultChanTwo, NewResolutionMetadata())

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1153,7 +1153,7 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 		DoAndReturn(
 			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				time.Sleep(100 * time.Millisecond)
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}, false), nil
+				return storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}), nil
 			})
 
 	s := MustNewServerWithOpts(

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1153,7 +1153,7 @@ func TestShortestPathToSolutionWins(t *testing.T) {
 		DoAndReturn(
 			func(_ context.Context, _ string, _ storage.ReadUsersetTuplesFilter, _ storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
 				time.Sleep(100 * time.Millisecond)
-				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}), nil
+				return storage.NewStaticTupleIterator([]*openfgav1.Tuple{returnedTuple}, false), nil
 			})
 
 	s := MustNewServerWithOpts(

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -28,6 +28,7 @@ type staticIterator struct {
 	records           []*storage.TupleRecord
 	continuationToken string
 	mu                sync.Mutex
+	ordered           bool
 }
 
 // match returns true if all the fields in t [*storage.TupleRecord] are equal to
@@ -82,8 +83,7 @@ func (s *staticIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 // Stop does not do anything for staticIterator.
 func (s *staticIterator) Stop() {}
 
-// IsOrdered conservatively returns false until datastore methods expose ordering guarantees.
-func (s *staticIterator) IsOrdered() bool { return false }
+func (s *staticIterator) IsOrdered() bool { return s.ordered }
 
 // Head see [storage.Iterator].Next.
 func (s *staticIterator) Head(ctx context.Context) (*openfgav1.Tuple, error) {
@@ -200,11 +200,21 @@ func WithMaxTypesPerAuthorizationModel(n int) StorageOption {
 func (s *MemoryBackend) Close() {}
 
 // Read see [storage.RelationshipTupleReader].Read.
-func (s *MemoryBackend) Read(ctx context.Context, store string, filter storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
+func (s *MemoryBackend) Read(ctx context.Context, store string, filter storage.ReadFilter, options storage.ReadOptions) (storage.TupleIterator, error) {
 	ctx, span := tracer.Start(ctx, "memory.Read")
 	defer span.End()
 
-	return s.read(ctx, store, filter, nil)
+	iter, err := s.read(ctx, store, filter, nil)
+	if err != nil {
+		return nil, err
+	}
+	if options.WithResultsSortedAscending {
+		sort.Slice(iter.records, func(i, j int) bool {
+			return iter.records[i].User < iter.records[j].User
+		})
+		iter.ordered = true
+	}
+	return iter, nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -510,7 +520,7 @@ func (s *MemoryBackend) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
-	_ storage.ReadUsersetTuplesOptions,
+	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	_, span := tracer.Start(ctx, "memory.ReadUsersetTuples")
 	defer span.End()
@@ -545,7 +555,12 @@ func (s *MemoryBackend) ReadUsersetTuples(
 		}
 	}
 
-	return &staticIterator{records: matches}, nil
+	if options.WithResultsSortedAscending {
+		sort.Slice(matches, func(i, j int) bool {
+			return matches[i].User < matches[j].User
+		})
+	}
+	return &staticIterator{records: matches, ordered: options.WithResultsSortedAscending}, nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -592,11 +607,13 @@ func (s *MemoryBackend) ReadStartingWithUser(
 			matches = append(matches, t)
 		}
 	}
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i].ObjectID < matches[j].ObjectID
-	})
+	if options.WithResultsSortedAscending {
+		sort.Slice(matches, func(i, j int) bool {
+			return matches[i].ObjectID < matches[j].ObjectID
+		})
+	}
 
-	return &staticIterator{records: matches}, nil
+	return &staticIterator{records: matches, ordered: options.WithResultsSortedAscending}, nil
 }
 
 func findAuthorizationModelByID(

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -208,7 +208,7 @@ func (s *MemoryBackend) Read(ctx context.Context, store string, filter storage.R
 	if err != nil {
 		return nil, err
 	}
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sort.Slice(iter.records, func(i, j int) bool {
 			return iter.records[i].User < iter.records[j].User
 		})
@@ -555,12 +555,12 @@ func (s *MemoryBackend) ReadUsersetTuples(
 		}
 	}
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sort.Slice(matches, func(i, j int) bool {
 			return matches[i].User < matches[j].User
 		})
 	}
-	return &staticIterator{records: matches, ordered: options.WithResultsSortedAscending}, nil
+	return &staticIterator{records: matches, ordered: options.SortAsc}, nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -607,13 +607,13 @@ func (s *MemoryBackend) ReadStartingWithUser(
 			matches = append(matches, t)
 		}
 	}
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sort.Slice(matches, func(i, j int) bool {
 			return matches[i].ObjectID < matches[j].ObjectID
 		})
 	}
 
-	return &staticIterator{records: matches, ordered: options.WithResultsSortedAscending}, nil
+	return &staticIterator{records: matches, ordered: options.SortAsc}, nil
 }
 
 func findAuthorizationModelByID(

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -145,7 +145,7 @@ func (s *Datastore) Read(
 
 	sb := s.buildTupleQuery(store, filter)
 	if options.SortAsc {
-		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
+		sb = sb.OrderBy("_user")
 	}
 	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.SortAsc), nil
 }
@@ -334,7 +334,7 @@ func (s *Datastore) ReadUsersetTuples(
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
 	if options.SortAsc {
-		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
+		sb = sb.OrderBy("_user")
 	}
 
 	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.SortAsc), nil

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -334,7 +334,6 @@ func (s *Datastore) ReadUsersetTuples(
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
 	if options.SortAsc {
-		// See comment in Read for why COLLATE utf8mb4_bin is required here.
 		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
 	}
 

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -145,11 +145,6 @@ func (s *Datastore) Read(
 
 	sb := s.buildTupleQuery(store, filter)
 	if options.SortAsc {
-		// COLLATE utf8mb4_bin forces bytewise ordering to match Go's string comparison (<).
-		// Without it, MySQL's default collation (typically case-insensitive) may produce a
-		// different sort order, breaking the weight2 pruning algorithm.
-		// Note: because _user is not defined as utf8mb4_bin at the column level, MySQL cannot
-		// use an index to satisfy this sort and will sort in memory.
 		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
 	}
 	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.SortAsc), nil

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -138,12 +138,21 @@ func (s *Datastore) Read(
 	ctx context.Context,
 	store string,
 	filter storage.ReadFilter,
-	_ storage.ReadOptions,
+	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
+	_, span := startTrace(ctx, "Read")
 	defer span.End()
 
-	return s.read(ctx, store, filter, nil)
+	sb := s.buildTupleQuery(store, filter)
+	if options.WithResultsSortedAscending {
+		// COLLATE utf8mb4_bin forces bytewise ordering to match Go's string comparison (<).
+		// Without it, MySQL's default collation (typically case-insensitive) may produce a
+		// different sort order, breaking the weight2 pruning algorithm.
+		// Note: because _user is not defined as utf8mb4_bin at the column level, MySQL cannot
+		// use an index to satisfy this sort and will sort in memory.
+		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
+	}
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -151,19 +160,19 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 	ctx, span := startTrace(ctx, "ReadPage")
 	defer span.End()
 
-	iter, err := s.read(ctx, store, filter, &options)
-	if err != nil {
-		return nil, "", err
+	sb := s.buildTupleQuery(store, filter).OrderBy("ulid")
+	if options.Pagination.From != "" {
+		sb = sb.Where(sq.GtOrEq{"ulid": options.Pagination.From})
 	}
+	if options.Pagination.PageSize != 0 {
+		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
+	}
+	iter := sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, false)
 	defer iter.Stop()
-
 	return iter.ToArray(ctx, options.Pagination)
 }
 
-func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*sqlcommon.SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
-
+func (s *Datastore) buildTupleQuery(store string, filter storage.ReadFilter) sq.SelectBuilder {
 	sb := s.stbl.
 		Select(
 			"store", "object_type", "object_id", "relation",
@@ -172,9 +181,6 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 		).
 		From("tuple").
 		Where(sq.Eq{"store": store})
-	if options != nil {
-		sb = sb.OrderBy("ulid")
-	}
 
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
 	if objectType != "" {
@@ -194,23 +200,13 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 			sb = sb.Where(sq.Like{"_user": userType + ":%"})
 		}
 	}
-
 	if len(filter.Conditions) > 0 {
 		// Use COALESCE to treat NULL and '' as the same value (empty string).
 		// This allows filtering for "no condition" (e.g., filter.Conditions = [""])
 		// to correctly match rows where condition_name is either '' OR NULL.
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-
-	if options != nil && options.Pagination.From != "" {
-		token := options.Pagination.From
-		sb = sb.Where(sq.GtOrEq{"ulid": token})
-	}
-	if options != nil && options.Pagination.PageSize != 0 {
-		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
-	}
-
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError), nil
+	return sb
 }
 
 // Write see [storage.RelationshipTupleWriter].Write.
@@ -298,7 +294,7 @@ func (s *Datastore) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
-	_ storage.ReadUsersetTuplesOptions,
+	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	_, span := startTrace(ctx, "ReadUsersetTuples")
 	defer span.End()
@@ -342,8 +338,12 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
+	if options.WithResultsSortedAscending {
+		// See comment in Read for why COLLATE utf8mb4_bin is required here.
+		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
+	}
 
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError), nil
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -351,7 +351,7 @@ func (s *Datastore) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
-	_ storage.ReadStartingWithUserOptions,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	_, span := startTrace(ctx, "ReadStartingWithUser")
 	defer span.End()
@@ -377,7 +377,11 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 			"_user":       targetUsersArg,
-		}).OrderBy("object_id")
+		})
+
+	if options.WithResultsSortedAscending {
+		builder = builder.OrderBy("object_id")
+	}
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})
@@ -385,7 +389,7 @@ func (s *Datastore) ReadStartingWithUser(
 	if len(filter.Conditions) > 0 {
 		builder = builder.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(builder), HandleSQLError), nil
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(builder), HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -144,7 +144,7 @@ func (s *Datastore) Read(
 	defer span.End()
 
 	sb := s.buildTupleQuery(store, filter)
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		// COLLATE utf8mb4_bin forces bytewise ordering to match Go's string comparison (<).
 		// Without it, MySQL's default collation (typically case-insensitive) may produce a
 		// different sort order, breaking the weight2 pruning algorithm.
@@ -152,7 +152,7 @@ func (s *Datastore) Read(
 		// use an index to satisfy this sort and will sort in memory.
 		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
 	}
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.SortAsc), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -338,12 +338,12 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		// See comment in Read for why COLLATE utf8mb4_bin is required here.
 		sb = sb.OrderBy("_user COLLATE utf8mb4_bin")
 	}
 
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(sb), HandleSQLError, options.SortAsc), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -379,7 +379,7 @@ func (s *Datastore) ReadStartingWithUser(
 			"_user":       targetUsersArg,
 		})
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		builder = builder.OrderBy("object_id")
 	}
 
@@ -389,7 +389,7 @@ func (s *Datastore) ReadStartingWithUser(
 	if len(filter.Conditions) > 0 {
 		builder = builder.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(builder), HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(sqlcommon.NewSBIteratorQuery(builder), HandleSQLError, options.SortAsc), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -338,11 +338,19 @@ func (s *Datastore) Read(
 	filter storage.ReadFilter,
 	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
+	_, span := startTrace(ctx, "Read")
 	defer span.End()
 
-	readPool := s.getPgxPool(options.Consistency.Preference)
-	return s.read(ctx, store, filter, nil, readPool)
+	sb := s.buildTupleQuery(store, filter)
+	if options.WithResultsSortedAscending {
+		sb = sb.OrderBy("_user collate \"C\"")
+	}
+	db := s.getPgxPool(options.Consistency.Preference)
+	poolGetRows, err := NewPgxTxnGetRows(db, sb)
+	if err != nil {
+		return nil, HandleSQLError(err)
+	}
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -350,20 +358,24 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 	ctx, span := startTrace(ctx, "ReadPage")
 	defer span.End()
 
-	readPool := s.getPgxPool(options.Consistency.Preference)
-	iter, err := s.read(ctx, store, filter, &options, readPool)
-	if err != nil {
-		return nil, "", err
+	sb := s.buildTupleQuery(store, filter).OrderBy("ulid")
+	if options.Pagination.From != "" {
+		sb = sb.Where(sq.GtOrEq{"ulid": options.Pagination.From})
 	}
+	if options.Pagination.PageSize != 0 {
+		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
+	}
+	db := s.getPgxPool(options.Consistency.Preference)
+	poolGetRows, err := NewPgxTxnGetRows(db, sb)
+	if err != nil {
+		return nil, "", HandleSQLError(err)
+	}
+	iter := sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, false)
 	defer iter.Stop()
-
 	return iter.ToArray(ctx, options.Pagination)
 }
 
-func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions, db *pgxpool.Pool) (*sqlcommon.SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
-
+func (s *Datastore) buildTupleQuery(store string, filter storage.ReadFilter) sq.SelectBuilder {
 	sb := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
 		Select(
 			"store", "object_type", "object_id", "relation",
@@ -372,9 +384,6 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 		).
 		From("tuple").
 		Where(sq.Eq{"store": store})
-	if options != nil {
-		sb = sb.OrderBy("ulid")
-	}
 
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
 	if objectType != "" {
@@ -394,27 +403,13 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 			sb = sb.Where(sq.Like{"_user": userType + ":%"})
 		}
 	}
-
 	if len(filter.Conditions) > 0 {
 		// Use COALESCE to treat NULL and '' as the same value (empty string).
 		// This allows filtering for "no condition" (e.g., filter.Conditions = [""])
 		// to correctly match rows where condition_name is either '' OR NULL.
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-
-	if options != nil && options.Pagination.From != "" {
-		sb = sb.Where(sq.GtOrEq{"ulid": options.Pagination.From})
-	}
-	if options != nil && options.Pagination.PageSize != 0 {
-		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
-	}
-
-	poolGetRows, err := NewPgxTxnGetRows(db, sb)
-	if err != nil {
-		return nil, HandleSQLError(err)
-	}
-
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
+	return sb
 }
 
 // Write see [storage.RelationshipTupleWriter].Write.
@@ -765,13 +760,16 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
+	if options.WithResultsSortedAscending {
+		sb = sb.OrderBy("_user collate \"C\"")
+	}
 
 	poolGetRows, err := NewPgxTxnGetRows(db, sb)
 	if err != nil {
 		return nil, HandleSQLError(err)
 	}
 
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -807,7 +805,11 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 			"_user":       targetUsersArg,
-		}).OrderBy("object_id collate \"C\"")
+		})
+
+	if options.WithResultsSortedAscending {
+		builder = builder.OrderBy("object_id collate \"C\"")
+	}
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})
@@ -819,7 +821,7 @@ func (s *Datastore) ReadStartingWithUser(
 	if err != nil {
 		return nil, HandleSQLError(err)
 	}
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError), nil
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.
@@ -1414,7 +1416,7 @@ func selectExistingRowsForWrite(ctx context.Context, stbl sq.StatementBuilderTyp
 		return HandleSQLError(err)
 	}
 
-	iter := sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError)
+	iter := sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, false)
 	defer iter.Stop()
 
 	items, _, err := iter.ToArray(ctx, storage.PaginationOptions{PageSize: len(keys)})

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -342,7 +342,7 @@ func (s *Datastore) Read(
 	defer span.End()
 
 	sb := s.buildTupleQuery(store, filter)
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sb = sb.OrderBy("_user collate \"C\"")
 	}
 	db := s.getPgxPool(options.Consistency.Preference)
@@ -350,7 +350,7 @@ func (s *Datastore) Read(
 	if err != nil {
 		return nil, HandleSQLError(err)
 	}
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.SortAsc), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -760,7 +760,7 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sb = sb.OrderBy("_user collate \"C\"")
 	}
 
@@ -769,7 +769,7 @@ func (s *Datastore) ReadUsersetTuples(
 		return nil, HandleSQLError(err)
 	}
 
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.SortAsc), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -807,7 +807,7 @@ func (s *Datastore) ReadStartingWithUser(
 			"_user":       targetUsersArg,
 		})
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		builder = builder.OrderBy("object_id collate \"C\"")
 	}
 
@@ -821,7 +821,7 @@ func (s *Datastore) ReadStartingWithUser(
 	if err != nil {
 		return nil, HandleSQLError(err)
 	}
-	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.WithResultsSortedAscending), nil
+	return sqlcommon.NewSQLTupleIterator(poolGetRows, HandleSQLError, options.SortAsc), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -315,6 +315,7 @@ type SQLTupleIterator struct {
 	mu       sync.Mutex
 
 	rowGetter SQLIteratorRowGetter
+	ordered   bool
 }
 
 // Ensures that SQLTupleIterator implements the TupleIterator interface.
@@ -339,13 +340,14 @@ func SQLIteratorColumns() []string {
 }
 
 // NewSQLTupleIterator returns a SQL tuple iterator.
-func NewSQLTupleIterator(rowGetter SQLIteratorRowGetter, errHandler errorHandlerFn) *SQLTupleIterator {
+func NewSQLTupleIterator(rowGetter SQLIteratorRowGetter, errHandler errorHandlerFn, ordered bool) *SQLTupleIterator {
 	return &SQLTupleIterator{
 		rows:           nil,
 		handleSQLError: errHandler,
 		firstRow:       nil,
 		mu:             sync.Mutex{},
 		rowGetter:      rowGetter,
+		ordered:        ordered,
 	}
 }
 
@@ -565,8 +567,7 @@ func (t *SQLTupleIterator) Stop() {
 	}
 }
 
-// IsOrdered conservatively returns false until datastore methods expose ordering guarantees.
-func (t *SQLTupleIterator) IsOrdered() bool { return false }
+func (t *SQLTupleIterator) IsOrdered() bool { return t.ordered }
 
 // DBInfo encapsulates DB information for use in common method.
 type DBInfo struct {
@@ -686,7 +687,7 @@ func selectExistingRowsForWrite(ctx context.Context, dbInfo *DBInfo, store strin
 		Suffix("FOR UPDATE").
 		RunWith(txn) // make sure to run in the same transaction
 
-	iter := NewSQLTupleIterator(NewSBIteratorQuery(selectBuilder), dbInfo.HandleSQLError)
+	iter := NewSQLTupleIterator(NewSBIteratorQuery(selectBuilder), dbInfo.HandleSQLError, false)
 	defer iter.Stop()
 
 	items, _, err := iter.ToArray(ctx, storage.PaginationOptions{PageSize: len(keys)})

--- a/pkg/storage/sqlcommon/sqlcommon_test.go
+++ b/pkg/storage/sqlcommon/sqlcommon_test.go
@@ -256,7 +256,7 @@ func identityErrHandler(err error, _ ...interface{}) error { return err }
 
 func TestFetchBufferMetric(t *testing.T) {
 	t.Run("success_records_true_label", func(t *testing.T) {
-		iter := NewSQLTupleIterator(&stubRowGetter{rows: &stubRows{}}, identityErrHandler)
+		iter := NewSQLTupleIterator(&stubRowGetter{rows: &stubRows{}}, identityErrHandler, false)
 		before := sqlIterQuerySampleCount(t, "true")
 		err := iter.fetchBuffer(context.Background())
 		require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestFetchBufferMetric(t *testing.T) {
 
 	t.Run("infrastructure_error_records_false_label", func(t *testing.T) {
 		dbErr := errors.New("connection reset")
-		iter := NewSQLTupleIterator(&stubRowGetter{err: dbErr}, identityErrHandler)
+		iter := NewSQLTupleIterator(&stubRowGetter{err: dbErr}, identityErrHandler, false)
 		before := sqlIterQuerySampleCount(t, "false")
 		err := iter.fetchBuffer(context.Background())
 		require.Error(t, err)
@@ -275,7 +275,7 @@ func TestFetchBufferMetric(t *testing.T) {
 	t.Run("not_found_error_records_true_label", func(t *testing.T) {
 		// errHandler translates the raw error to the storage sentinel, as real backends do.
 		notFoundHandler := func(err error, _ ...interface{}) error { return storage.ErrNotFound }
-		iter := NewSQLTupleIterator(&stubRowGetter{err: errors.New("no rows")}, notFoundHandler)
+		iter := NewSQLTupleIterator(&stubRowGetter{err: errors.New("no rows")}, notFoundHandler, false)
 		before := sqlIterQuerySampleCount(t, "true")
 		err := iter.fetchBuffer(context.Background())
 		require.ErrorIs(t, err, storage.ErrNotFound)

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -158,10 +158,10 @@ func (s *Datastore) Read(
 	defer span.End()
 
 	sb := s.buildTupleQuery(store, filter)
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sb = sb.OrderBy("user_object_type", "user_object_id", "user_relation")
 	}
-	return NewSQLTupleIterator(sb, HandleSQLError, options.WithResultsSortedAscending), nil
+	return NewSQLTupleIterator(sb, HandleSQLError, options.SortAsc), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -785,11 +785,11 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		sb = sb.OrderBy("user_object_type", "user_object_id", "user_relation")
 	}
 
-	return NewSQLTupleIterator(sb, HandleSQLError, options.WithResultsSortedAscending), nil
+	return NewSQLTupleIterator(sb, HandleSQLError, options.SortAsc), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -829,7 +829,7 @@ func (s *Datastore) ReadStartingWithUser(
 		}).
 		Where(targetUsersArg)
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		builder = builder.OrderBy("object_id")
 	}
 
@@ -841,7 +841,7 @@ func (s *Datastore) ReadStartingWithUser(
 		builder = builder.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
 
-	return NewSQLTupleIterator(builder, HandleSQLError, options.WithResultsSortedAscending), nil
+	return NewSQLTupleIterator(builder, HandleSQLError, options.SortAsc), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -152,12 +152,16 @@ func (s *Datastore) Read(
 	ctx context.Context,
 	store string,
 	filter storage.ReadFilter,
-	_ storage.ReadOptions,
+	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
+	_, span := startTrace(ctx, "Read")
 	defer span.End()
 
-	return s.read(ctx, store, filter, nil)
+	sb := s.buildTupleQuery(store, filter)
+	if options.WithResultsSortedAscending {
+		sb = sb.OrderBy("user_object_type", "user_object_id", "user_relation")
+	}
+	return NewSQLTupleIterator(sb, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
@@ -165,19 +169,19 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 	ctx, span := startTrace(ctx, "ReadPage")
 	defer span.End()
 
-	iter, err := s.read(ctx, store, filter, &options)
-	if err != nil {
-		return nil, "", err
+	sb := s.buildTupleQuery(store, filter).OrderBy("ulid")
+	if options.Pagination.From != "" {
+		sb = sb.Where(sq.GtOrEq{"ulid": options.Pagination.From})
 	}
+	if options.Pagination.PageSize != 0 {
+		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
+	}
+	iter := NewSQLTupleIterator(sb, HandleSQLError, false)
 	defer iter.Stop()
-
 	return iter.ToArray(ctx, options.Pagination)
 }
 
-func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
-
+func (s *Datastore) buildTupleQuery(store string, filter storage.ReadFilter) sq.SelectBuilder {
 	sb := s.stbl.
 		Select(
 			"store", "object_type", "object_id", "relation",
@@ -186,9 +190,6 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 		).
 		From("tuple").
 		Where(sq.Eq{"store": store})
-	if options != nil {
-		sb = sb.OrderBy("ulid")
-	}
 
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
 	if objectType != "" {
@@ -203,38 +204,22 @@ func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadF
 	if filter.User != "" {
 		userObjectType, userObjectID, userRelation := tupleUtils.ToUserParts(filter.User)
 		if userObjectType != "" {
-			sb = sb.Where(sq.Eq{
-				"user_object_type": userObjectType,
-			})
+			sb = sb.Where(sq.Eq{"user_object_type": userObjectType})
 		}
 		if userObjectID != "" {
-			sb = sb.Where(sq.Eq{
-				"user_object_id": userObjectID,
-			})
+			sb = sb.Where(sq.Eq{"user_object_id": userObjectID})
 		}
 		if userRelation != "" {
-			sb = sb.Where(sq.Eq{
-				"user_relation": userRelation,
-			})
+			sb = sb.Where(sq.Eq{"user_relation": userRelation})
 		}
 	}
-
 	if len(filter.Conditions) > 0 {
 		// Use COALESCE to treat NULL and '' as the same value (empty string).
 		// This allows filtering for "no condition" (e.g., filter.Conditions = [""])
 		// to correctly match rows where condition_name is either '' OR NULL.
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
-
-	if options != nil && options.Pagination.From != "" {
-		token := options.Pagination.From
-		sb = sb.Where(sq.GtOrEq{"ulid": token})
-	}
-	if options != nil && options.Pagination.PageSize != 0 {
-		sb = sb.Limit(uint64(options.Pagination.PageSize + 1)) // + 1 is used to determine whether to return a continuation token.
-	}
-
-	return NewSQLTupleIterator(sb, HandleSQLError), nil
+	return sb
 }
 
 // Write see [storage.RelationshipTupleWriter].Write.
@@ -369,7 +354,7 @@ func (s *Datastore) selectExistingRowsForWrite(ctx context.Context, store string
 		Where(sq.Expr("(object_type, object_id, relation, user_object_type, user_object_id, user_relation, user_type) IN "+inExpr, args...)).
 		RunWith(txn) // make sure to run in the same transaction
 
-	iter := NewSQLTupleIterator(selectBuilder, HandleSQLError)
+	iter := NewSQLTupleIterator(selectBuilder, HandleSQLError, false)
 	defer iter.Stop()
 
 	items, _, err := iter.ToArray(ctx, storage.PaginationOptions{PageSize: len(keys)})
@@ -753,7 +738,7 @@ func (s *Datastore) ReadUsersetTuples(
 	ctx context.Context,
 	store string,
 	filter storage.ReadUsersetTuplesFilter,
-	_ storage.ReadUsersetTuplesOptions,
+	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
 	_, span := startTrace(ctx, "ReadUsersetTuples")
 	defer span.End()
@@ -800,8 +785,11 @@ func (s *Datastore) ReadUsersetTuples(
 	if len(filter.Conditions) > 0 {
 		sb = sb.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
+	if options.WithResultsSortedAscending {
+		sb = sb.OrderBy("user_object_type", "user_object_id", "user_relation")
+	}
 
-	return NewSQLTupleIterator(sb, HandleSQLError), nil
+	return NewSQLTupleIterator(sb, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // ReadStartingWithUser see [storage.RelationshipTupleReader].ReadStartingWithUser.
@@ -809,7 +797,7 @@ func (s *Datastore) ReadStartingWithUser(
 	ctx context.Context,
 	store string,
 	filter storage.ReadStartingWithUserFilter,
-	_ storage.ReadStartingWithUserOptions,
+	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
 	_, span := startTrace(ctx, "ReadStartingWithUser")
 	defer span.End()
@@ -839,7 +827,11 @@ func (s *Datastore) ReadStartingWithUser(
 			"object_type": filter.ObjectType,
 			"relation":    filter.Relation,
 		}).
-		Where(targetUsersArg).OrderBy("object_id")
+		Where(targetUsersArg)
+
+	if options.WithResultsSortedAscending {
+		builder = builder.OrderBy("object_id")
+	}
 
 	if filter.ObjectIDs != nil && filter.ObjectIDs.Size() > 0 {
 		builder = builder.Where(sq.Eq{"object_id": filter.ObjectIDs.Values()})
@@ -849,7 +841,7 @@ func (s *Datastore) ReadStartingWithUser(
 		builder = builder.Where(sq.Eq{"COALESCE(condition_name, '')": filter.Conditions})
 	}
 
-	return NewSQLTupleIterator(builder, HandleSQLError), nil
+	return NewSQLTupleIterator(builder, HandleSQLError, options.WithResultsSortedAscending), nil
 }
 
 // MaxTuplesPerWrite see [storage.RelationshipTupleWriter].MaxTuplesPerWrite.

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -31,19 +31,21 @@ type SQLTupleIterator struct {
 	// will use this item instead. Otherwise, the first item will be lost.
 	firstRow *storage.TupleRecord // GUARDED_BY(mu)
 	mu       sync.Mutex
+	ordered  bool
 }
 
 // Ensures that SQLTupleIterator implements the TupleIterator interface.
 var _ storage.TupleIterator = (*SQLTupleIterator)(nil)
 
 // NewSQLTupleIterator returns a SQL tuple iterator.
-func NewSQLTupleIterator(sb sq.SelectBuilder, errHandler errorHandlerFn) *SQLTupleIterator {
+func NewSQLTupleIterator(sb sq.SelectBuilder, errHandler errorHandlerFn, ordered bool) *SQLTupleIterator {
 	return &SQLTupleIterator{
 		sb:             sb,
 		rows:           nil,
 		handleSQLError: errHandler,
 		firstRow:       nil,
 		mu:             sync.Mutex{},
+		ordered:        ordered,
 	}
 }
 
@@ -268,5 +270,4 @@ func (t *SQLTupleIterator) Stop() {
 	}
 }
 
-// IsOrdered conservatively returns false until datastore methods expose ordering guarantees.
-func (t *SQLTupleIterator) IsOrdered() bool { return false }
+func (t *SQLTupleIterator) IsOrdered() bool { return t.ordered }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -113,7 +113,8 @@ type ConsistencyOptions struct {
 // ReadOptions represents the options that can
 // be used with the Read method.
 type ReadOptions struct {
-	Consistency ConsistencyOptions
+	Consistency                ConsistencyOptions
+	WithResultsSortedAscending bool
 }
 
 // ReadUserTupleOptions represents the options that can
@@ -125,7 +126,8 @@ type ReadUserTupleOptions struct {
 // ReadUsersetTuplesOptions represents the options that can
 // be used with the ReadUsersetTuples method.
 type ReadUsersetTuplesOptions struct {
-	Consistency ConsistencyOptions
+	Consistency                ConsistencyOptions
+	WithResultsSortedAscending bool
 }
 
 // ReadStartingWithUserOptions represents the options that can
@@ -156,7 +158,7 @@ type RelationshipTupleReader interface {
 	// or `User` (or both), must be specified in this case.
 	//
 	// The caller must be careful to close the [TupleIterator], either by consuming the entire iterator or by closing it.
-	// There is NO guarantee on the order of the tuples returned on the iterator.
+	// If ReadOptions.WithResultsSortedAscending is set, results are sorted by user ascending; otherwise the order is unspecified.
 	Read(ctx context.Context, store string, filter ReadFilter, options ReadOptions) (TupleIterator, error)
 
 	// ReadPage functions similarly to Read but includes support for pagination. It takes
@@ -182,7 +184,7 @@ type RelationshipTupleReader interface {
 	//	object=document:1, relation=viewer, allowedTypesForUser=[group#member]
 	// this method would return the tuple (document:doc1, viewer, group:eng#member)
 	// If allowedTypesForUser is empty, both tuples would be returned.
-	// There is NO guarantee on the order returned on the iterator.
+	// If ReadUsersetTuplesOptions.WithResultsSortedAscending is set, results are sorted by user ascending; otherwise the order is unspecified.
 	ReadUsersetTuples(
 		ctx context.Context,
 		store string,
@@ -202,7 +204,7 @@ type RelationshipTupleReader interface {
 	// ReadStartingWithUser for ['user:jon', 'group:eng#member'] filtered by 'document#viewer'
 	// and 'document:doc1, document:doc2' would
 	// return ['document:doc1#viewer@user:jon', 'document:doc2#viewer@group:eng#member'].
-	// If ReadStartingWithUserOptions.WithResultsSortedAscending bool is enabled, the tuples returned must be sorted by one or more fields in them.
+	// If ReadStartingWithUserOptions.WithResultsSortedAscending is set, results are sorted by object ID ascending; otherwise the order is unspecified.
 	ReadStartingWithUser(
 		ctx context.Context,
 		store string,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -113,8 +113,8 @@ type ConsistencyOptions struct {
 // ReadOptions represents the options that can
 // be used with the Read method.
 type ReadOptions struct {
-	Consistency                ConsistencyOptions
-	WithResultsSortedAscending bool
+	Consistency ConsistencyOptions
+	SortAsc     bool
 }
 
 // ReadUserTupleOptions represents the options that can
@@ -126,15 +126,15 @@ type ReadUserTupleOptions struct {
 // ReadUsersetTuplesOptions represents the options that can
 // be used with the ReadUsersetTuples method.
 type ReadUsersetTuplesOptions struct {
-	Consistency                ConsistencyOptions
-	WithResultsSortedAscending bool
+	Consistency ConsistencyOptions
+	SortAsc     bool
 }
 
 // ReadStartingWithUserOptions represents the options that can
 // be used with the ReadStartingWithUser method.
 type ReadStartingWithUserOptions struct {
-	Consistency                ConsistencyOptions
-	WithResultsSortedAscending bool
+	Consistency ConsistencyOptions
+	SortAsc     bool
 }
 
 // Writes is a typesafe alias for Write arguments.
@@ -158,7 +158,7 @@ type RelationshipTupleReader interface {
 	// or `User` (or both), must be specified in this case.
 	//
 	// The caller must be careful to close the [TupleIterator], either by consuming the entire iterator or by closing it.
-	// If ReadOptions.WithResultsSortedAscending is set, results are sorted by user ascending; otherwise the order is unspecified.
+	// If ReadOptions.SortAsc is set, results are sorted by user ascending; otherwise the order is unspecified.
 	Read(ctx context.Context, store string, filter ReadFilter, options ReadOptions) (TupleIterator, error)
 
 	// ReadPage functions similarly to Read but includes support for pagination. It takes
@@ -184,7 +184,7 @@ type RelationshipTupleReader interface {
 	//	object=document:1, relation=viewer, allowedTypesForUser=[group#member]
 	// this method would return the tuple (document:doc1, viewer, group:eng#member)
 	// If allowedTypesForUser is empty, both tuples would be returned.
-	// If ReadUsersetTuplesOptions.WithResultsSortedAscending is set, results are sorted by user ascending; otherwise the order is unspecified.
+	// If ReadUsersetTuplesOptions.SortAsc is set, results are sorted by user ascending; otherwise the order is unspecified.
 	ReadUsersetTuples(
 		ctx context.Context,
 		store string,
@@ -204,7 +204,7 @@ type RelationshipTupleReader interface {
 	// ReadStartingWithUser for ['user:jon', 'group:eng#member'] filtered by 'document#viewer'
 	// and 'document:doc1, document:doc2' would
 	// return ['document:doc1#viewer@user:jon', 'document:doc2#viewer@group:eng#member'].
-	// If ReadStartingWithUserOptions.WithResultsSortedAscending is set, results are sorted by object ID ascending; otherwise the order is unspecified.
+	// If ReadStartingWithUserOptions.SortAsc is set, results are sorted by object ID ascending; otherwise the order is unspecified.
 	ReadStartingWithUser(
 		ctx context.Context,
 		store string,

--- a/pkg/storage/storagewrappers/bounded_datastore_test.go
+++ b/pkg/storage/storagewrappers/bounded_datastore_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestCountingTupleIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
 	iter := &countingTupleIterator{TupleIterator: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())

--- a/pkg/storage/storagewrappers/bounded_datastore_test.go
+++ b/pkg/storage/storagewrappers/bounded_datastore_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestCountingTupleIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
+	inner := storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{})
 	iter := &countingTupleIterator{TupleIterator: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -371,7 +371,7 @@ func (c *CachedDatastore) newCachedIterator(
 
 		// TupleIteratorCacheEntry does not store the ordered flag, so IsOrdered() will always return false on cache hits.
 		// This is acceptable because CachedDatastore is currently not used by any code paths that check IsOrdered().
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cacheEntry.Tuples, false)
+		staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cacheEntry.Tuples)
 		currentIteratorCacheCount.WithLabelValues("true").Inc()
 
 		return &cachedTupleIterator{

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -369,7 +369,7 @@ func (c *CachedDatastore) newCachedIterator(
 		tuplesCacheHitCounter.WithLabelValues(operation, c.method).Inc()
 		span.SetAttributes(attribute.Bool("cached", true))
 
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cacheEntry.Tuples)
+		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cacheEntry.Tuples, false)
 		currentIteratorCacheCount.WithLabelValues("true").Inc()
 
 		return &cachedTupleIterator{

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -369,6 +369,8 @@ func (c *CachedDatastore) newCachedIterator(
 		tuplesCacheHitCounter.WithLabelValues(operation, c.method).Inc()
 		span.SetAttributes(attribute.Bool("cached", true))
 
+		// TupleIteratorCacheEntry does not store the ordered flag, so IsOrdered() will always return false on cache hits.
+		// This is acceptable because CachedDatastore is currently not used by any code paths that check IsOrdered().
 		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cacheEntry.Tuples, false)
 		currentIteratorCacheCount.WithLabelValues("true").Inc()
 

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -219,7 +219,7 @@ func TestReadStartingWithUser(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKeys[0]).Return(nil),                     // check if entity invalidated before writing
@@ -342,7 +342,7 @@ func TestReadStartingWithUser(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey),
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKeys[0]).Return(nil),                     // check if entity invalidated before writing
@@ -388,7 +388,7 @@ func TestReadStartingWithUser(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 		)
 
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, opts)
@@ -480,7 +480,7 @@ func TestReadUsersetTuples(t *testing.T) {
 			mockCache.EXPECT().Get(gomock.Any()),
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),                         // check if entity invalidated before writing
@@ -555,7 +555,7 @@ func TestReadUsersetTuples(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -600,7 +600,7 @@ func TestReadUsersetTuples(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 		)
 
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, opts)
@@ -686,7 +686,7 @@ func TestRead(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -761,7 +761,7 @@ func TestRead(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey),
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil),
 			mockCache.EXPECT().Get(cacheKey),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -806,7 +806,7 @@ func TestRead(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 		)
 
 		iter, err := ds.Read(ctx, storeID, filter, opts)
@@ -843,7 +843,7 @@ func TestRead(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, invalidObjectFilter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator(tuples, false), nil),
+				Return(storage.NewUnorderedStaticTupleIterator(tuples), nil),
 		)
 
 		iter, err := ds.Read(ctx, storeID, invalidObjectFilter, storage.ReadOptions{})
@@ -908,7 +908,7 @@ func TestDatastoreIteratorError(t *testing.T) {
 }
 
 func TestCachedIterator_IsOrdered(t *testing.T) {
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
+	inner := storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{})
 	iter := &cachedIterator{iter: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -1010,7 +1010,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1045,7 +1045,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1140,7 +1140,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1203,7 +1203,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1247,7 +1247,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1306,7 +1306,7 @@ func TestCachedIterator(t *testing.T) {
 		var wg sync.WaitGroup
 
 		mockedIter := &mockCalledTupleIterator{
-			iter: storage.NewStaticTupleIterator(tuples, false),
+			iter: storage.NewUnorderedStaticTupleIterator(tuples),
 		}
 
 		iter := &cachedIterator{
@@ -1380,7 +1380,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples, false),
+			iter:              storage.NewUnorderedStaticTupleIterator(tuples),
 			store:             store,
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
@@ -1440,7 +1440,7 @@ func TestCachedIterator(t *testing.T) {
 		var wg sync.WaitGroup
 
 		mockedIter := &mockCalledTupleIterator{
-			iter: storage.NewStaticTupleIterator(tuples, false),
+			iter: storage.NewUnorderedStaticTupleIterator(tuples),
 		}
 
 		iter := &cachedIterator{
@@ -1502,7 +1502,7 @@ func TestCachedIterator(t *testing.T) {
 			var wg sync.WaitGroup
 
 			mockedIter1 := &mockCalledTupleIterator{
-				iter: storage.NewStaticTupleIterator(tuples, false),
+				iter: storage.NewUnorderedStaticTupleIterator(tuples),
 			}
 
 			iter1 := &cachedIterator{
@@ -1526,7 +1526,7 @@ func TestCachedIterator(t *testing.T) {
 			}
 
 			mockedIter2 := &mockCalledTupleIterator{
-				iter: storage.NewStaticTupleIterator(tuples, false),
+				iter: storage.NewUnorderedStaticTupleIterator(tuples),
 			}
 
 			iter2 := &cachedIterator{

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -219,7 +219,7 @@ func TestReadStartingWithUser(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKeys[0]).Return(nil),                     // check if entity invalidated before writing
@@ -342,7 +342,7 @@ func TestReadStartingWithUser(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey),
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil),
+				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKeys[0]).Return(nil),                     // check if entity invalidated before writing
@@ -388,7 +388,7 @@ func TestReadStartingWithUser(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				ReadStartingWithUser(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 		)
 
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, opts)
@@ -480,7 +480,7 @@ func TestReadUsersetTuples(t *testing.T) {
 			mockCache.EXPECT().Get(gomock.Any()),
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),                                 // find while stopping
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil), // check if store invalidated before writing
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),                         // check if entity invalidated before writing
@@ -555,7 +555,7 @@ func TestReadUsersetTuples(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil),
+				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -600,7 +600,7 @@ func TestReadUsersetTuples(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				ReadUsersetTuples(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 		)
 
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, opts)
@@ -686,7 +686,7 @@ func TestRead(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 			mockCache.EXPECT().Get(cacheKey).Return(nil),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -761,7 +761,7 @@ func TestRead(t *testing.T) {
 			mockCache.EXPECT().Get(cacheKey),
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil),
+				Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil),
 			mockCache.EXPECT().Get(cacheKey),
 			mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil),
 			mockCache.EXPECT().Get(invalidEntityKey).Return(nil),
@@ -806,7 +806,7 @@ func TestRead(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, filter, opts).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 		)
 
 		iter, err := ds.Read(ctx, storeID, filter, opts)
@@ -843,7 +843,7 @@ func TestRead(t *testing.T) {
 		gomock.InOrder(
 			mockDatastore.EXPECT().
 				Read(gomock.Any(), storeID, invalidObjectFilter, storage.ReadOptions{}).
-				Return(storage.NewStaticTupleIterator(tuples), nil),
+				Return(storage.NewStaticTupleIterator(tuples, false), nil),
 		)
 
 		iter, err := ds.Read(ctx, storeID, invalidObjectFilter, storage.ReadOptions{})
@@ -908,7 +908,7 @@ func TestDatastoreIteratorError(t *testing.T) {
 }
 
 func TestCachedIterator_IsOrdered(t *testing.T) {
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
 	iter := &cachedIterator{iter: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -1010,7 +1010,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1045,7 +1045,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1140,7 +1140,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1203,7 +1203,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1247,7 +1247,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
 			cacheKey:          cacheKey,
@@ -1306,7 +1306,7 @@ func TestCachedIterator(t *testing.T) {
 		var wg sync.WaitGroup
 
 		mockedIter := &mockCalledTupleIterator{
-			iter: storage.NewStaticTupleIterator(tuples),
+			iter: storage.NewStaticTupleIterator(tuples, false),
 		}
 
 		iter := &cachedIterator{
@@ -1380,7 +1380,7 @@ func TestCachedIterator(t *testing.T) {
 
 		iter := &cachedIterator{
 			ctx:               ctx,
-			iter:              storage.NewStaticTupleIterator(tuples),
+			iter:              storage.NewStaticTupleIterator(tuples, false),
 			store:             store,
 			operation:         "operation",
 			tuples:            make([]*openfgav1.Tuple, 0, maxCacheSize),
@@ -1440,7 +1440,7 @@ func TestCachedIterator(t *testing.T) {
 		var wg sync.WaitGroup
 
 		mockedIter := &mockCalledTupleIterator{
-			iter: storage.NewStaticTupleIterator(tuples),
+			iter: storage.NewStaticTupleIterator(tuples, false),
 		}
 
 		iter := &cachedIterator{
@@ -1502,7 +1502,7 @@ func TestCachedIterator(t *testing.T) {
 			var wg sync.WaitGroup
 
 			mockedIter1 := &mockCalledTupleIterator{
-				iter: storage.NewStaticTupleIterator(tuples),
+				iter: storage.NewStaticTupleIterator(tuples, false),
 			}
 
 			iter1 := &cachedIterator{
@@ -1526,7 +1526,7 @@ func TestCachedIterator(t *testing.T) {
 			}
 
 			mockedIter2 := &mockCalledTupleIterator{
-				iter: storage.NewStaticTupleIterator(tuples),
+				iter: storage.NewStaticTupleIterator(tuples, false),
 			}
 
 			iter2 := &cachedIterator{

--- a/pkg/storage/storagewrappers/cached_iterators_test.go
+++ b/pkg/storage/storagewrappers/cached_iterators_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestCachedTupleIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[*storage.TupleRecord](nil, true)
+	inner := storage.NewOrderedStaticIterator[*storage.TupleRecord](nil)
 	iter := &cachedTupleIterator{objectType: "document", relation: "viewer", iter: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -49,7 +49,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
+		staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cachedTuples)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "1",
@@ -97,7 +97,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
+		staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cachedTuples)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "",
@@ -177,7 +177,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
+		staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cachedTuples)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "1",
@@ -211,7 +211,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
+		staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cachedTuples)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "",

--- a/pkg/storage/storagewrappers/cached_iterators_test.go
+++ b/pkg/storage/storagewrappers/cached_iterators_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestCachedTupleIteratorIsOrdered(t *testing.T) {
-	inner := storage.NewStaticIterator[*storage.TupleRecord](nil)
+	inner := storage.NewStaticIterator[*storage.TupleRecord](nil, true)
 	iter := &cachedTupleIterator{objectType: "document", relation: "viewer", iter: inner}
 	defer iter.Stop()
 	require.True(t, iter.IsOrdered())
@@ -49,7 +49,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples)
+		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "1",
@@ -97,7 +97,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples)
+		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "",
@@ -177,7 +177,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples)
+		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "1",
@@ -211,7 +211,7 @@ func TestCachedTupleIterator(t *testing.T) {
 				ConditionName:  "cond",
 			},
 		}
-		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples)
+		staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedTuples, false)
 		iter := &cachedTupleIterator{
 			objectType: "document",
 			objectID:   "",

--- a/pkg/storage/storagewrappers/cached_reader.go
+++ b/pkg/storage/storagewrappers/cached_reader.go
@@ -110,7 +110,7 @@ func (c *CachedTupleReader) ReadUsersetTuples(
 	v2IterCacheTotal.WithLabelValues("ReadUsersetTuples").Inc()
 
 	// CHECK CACHE FIRST - before any database call
-	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "ReadUsersetTuples", []keys.Key{invalidEntityKey}); iter != nil {
+	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "ReadUsersetTuples", []keys.Key{invalidEntityKey}, opts.SortAsc); iter != nil {
 		span.SetAttributes(attribute.Bool("cached", true))
 		return iter, nil
 	}
@@ -126,7 +126,6 @@ func (c *CachedTupleReader) ReadUsersetTuples(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, objectType, filter.Relation, "ReadUsersetTuples",
-		func(e MinimalCacheEntry) string { return e.User },
 	), nil
 }
 
@@ -161,7 +160,7 @@ func (c *CachedTupleReader) Read(
 	// Track total cache operations (before cache check, like V1)
 	v2IterCacheTotal.WithLabelValues("Read").Inc()
 
-	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "Read", []keys.Key{invalidEntityKey}); iter != nil {
+	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "Read", []keys.Key{invalidEntityKey}, opts.SortAsc); iter != nil {
 		span.SetAttributes(attribute.Bool("cached", true))
 		return iter, nil
 	}
@@ -176,7 +175,6 @@ func (c *CachedTupleReader) Read(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, objectType, filter.Relation, "Read",
-		func(e MinimalCacheEntry) string { return e.User },
 	), nil
 }
 
@@ -210,7 +208,7 @@ func (c *CachedTupleReader) ReadStartingWithUser(
 	// Track total cache operations (before cache check, like V1)
 	v2IterCacheTotal.WithLabelValues("ReadStartingWithUser").Inc()
 
-	if iter := c.tryGetFromCache(cacheKey, storeID, filter.ObjectType, filter.Relation, "ReadStartingWithUser", invalidEntityKeys); iter != nil {
+	if iter := c.tryGetFromCache(cacheKey, storeID, filter.ObjectType, filter.Relation, "ReadStartingWithUser", invalidEntityKeys, opts.SortAsc); iter != nil {
 		span.SetAttributes(attribute.Bool("cached", true))
 		return iter, nil
 	}
@@ -225,15 +223,17 @@ func (c *CachedTupleReader) ReadStartingWithUser(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, filter.ObjectType, filter.Relation, "ReadStartingWithUser",
-		func(e MinimalCacheEntry) string { return e.ObjectID },
 	), nil
 }
 
 // tryGetFromCache checks for cache hit with invalidation support.
-// Returns LockFreeCachedIterator if found and not invalidated.
+// Returns LockFreeCachedIterator if found, not invalidated, and ordered-compatible.
+// Monotonic upgrade: a sorted entry satisfies unsorted requests, but an unsorted entry
+// does not satisfy a sorted request (returns nil so the caller re-queries and upgrades).
 func (c *CachedTupleReader) tryGetFromCache(
 	cacheKey keys.Key, storeID, objectType, relation, operation string,
 	invalidEntityKeys []keys.Key,
+	wantSorted bool,
 ) storage.TupleIterator {
 	entry := c.cache.Get(cacheKey)
 	if entry == nil {
@@ -257,6 +257,14 @@ func (c *CachedTupleReader) tryGetFromCache(
 			c.cache.Delete(cacheKey)
 			return nil
 		}
+	}
+
+	// Monotonic upgrade: if the caller wants sorted results but the cached entry is
+	// unsorted, treat as a miss. Do NOT delete — the existing unsorted entry remains
+	// valid for unsorted requests. The re-query will store a sorted entry via cache.Set,
+	// upgrading the entry once and satisfying both sorted and unsorted callers thereafter.
+	if wantSorted && !cached.Ordered {
+		return nil
 	}
 
 	v2IterCacheHits.WithLabelValues(operation).Inc()

--- a/pkg/storage/storagewrappers/cached_reader.go
+++ b/pkg/storage/storagewrappers/cached_reader.go
@@ -126,6 +126,7 @@ func (c *CachedTupleReader) ReadUsersetTuples(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, objectType, filter.Relation, "ReadUsersetTuples",
+		func(e MinimalCacheEntry) string { return e.User },
 	), nil
 }
 
@@ -175,6 +176,7 @@ func (c *CachedTupleReader) Read(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, objectType, filter.Relation, "Read",
+		func(e MinimalCacheEntry) string { return e.User },
 	), nil
 }
 
@@ -223,6 +225,7 @@ func (c *CachedTupleReader) ReadStartingWithUser(
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
 		c.sf, c.wg, filter.ObjectType, filter.Relation, "ReadStartingWithUser",
+		func(e MinimalCacheEntry) string { return e.ObjectID },
 	), nil
 }
 

--- a/pkg/storage/storagewrappers/cached_reader_test.go
+++ b/pkg/storage/storagewrappers/cached_reader_test.go
@@ -61,7 +61,7 @@ func TestCachedTupleReader_ReadUsersetTuples_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestCachedTupleReader_ReadUsersetTuples_HigherConsistency(t *testing.T) {
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
+	staticIter := storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{})
 
 	// NO cache.Get expected - bypasses cache entirely
 
@@ -227,7 +227,7 @@ func TestCachedTupleReader_ReadUsersetTuples_StoreInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestCachedTupleReader_ReadUsersetTuples_EntityInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -431,7 +431,7 @@ func TestCachedTupleReader_Read_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.Read(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -529,7 +529,7 @@ func TestCachedTupleReader_Read_HigherConsistency(t *testing.T) {
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
+	staticIter := storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{})
 
 	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(staticIter, nil).Times(1)
 
@@ -592,7 +592,7 @@ func TestCachedTupleReader_Read_EntityInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore
-	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.Read(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -642,7 +642,7 @@ func TestCachedTupleReader_ReadStartingWithUser_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.ReadStartingWithUser(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -802,7 +802,7 @@ func TestCachedTupleReader_ReadStartingWithUser_HigherConsistency(t *testing.T) 
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
+	staticIter := storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{})
 
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(staticIter, nil).Times(1)
 
@@ -867,7 +867,7 @@ func TestCachedTupleReader_ReadStartingWithUser_EntityInvalidation(t *testing.T)
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	iter, err := reader.ReadStartingWithUser(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -1090,7 +1090,7 @@ func TestCachedTupleReader_CacheRoundTrip(t *testing.T) {
 
 	// Datastore should only be called ONCE (the cache miss). Second call uses cache.
 	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).
-		Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
+		Return(storage.NewUnorderedStaticTupleIterator(tuples), nil).Times(1)
 
 	// --- First call: cache miss ---
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)

--- a/pkg/storage/storagewrappers/cached_reader_test.go
+++ b/pkg/storage/storagewrappers/cached_reader_test.go
@@ -1144,3 +1144,225 @@ func TestCachedTupleReader_CacheRoundTrip(t *testing.T) {
 
 	iter2.Stop()
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Monotonic upgrade: SortAsc hit-check matrix
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestCachedTupleReader_MonotonicUpgrade_HaveUnsorted_WantSorted treats the entry as a
+// miss and re-queries the delegate, so the sorted result can be stored.
+func TestCachedTupleReader_MonotonicUpgrade_HaveUnsorted_WantSorted(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+	mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+	ctx := context.Background()
+	storeID := ulid.Make().String()
+	sf := &singleflight.Group{}
+	wg := &sync.WaitGroup{}
+
+	reader := NewCachedTupleReader(ctx, mockDatastore, mockCache, 1000, time.Hour, sf, wg, 30*time.Second)
+
+	filter := storage.ReadUsersetTuplesFilter{
+		Object:                      "document:1",
+		Relation:                    "viewer",
+		AllowedUserTypeRestrictions: []*openfgav1.RelationReference{{Type: "user"}},
+	}
+	opts := storage.ReadUsersetTuplesOptions{SortAsc: true}
+
+	// Cached entry is unsorted (Ordered=false)
+	unsortedEntry := &V2IteratorCacheEntry{
+		Entries:      []MinimalCacheEntry{{ObjectID: "1", User: "user:bob"}, {ObjectID: "1", User: "user:alice"}},
+		LastModified: time.Now(),
+		Ordered:      false,
+	}
+
+	cacheKey := storage.ReadUsersetTuplesKey(storeID, filter)
+	entityInvalidKey := storage.InvalidIteratorByObjectRelationCacheKey(storeID, "document:1", "viewer")
+
+	mockCache.EXPECT().Get(cacheKey).Return(unsortedEntry).Times(1)
+	mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil).Times(1)
+	mockCache.EXPECT().Get(entityInvalidKey).Return(nil).Times(1)
+	// Background goroutine (drainInBackground optimization 1) checks cache once more
+	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
+	mockCache.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
+
+	// Delegate MUST be called because the cache entry is unsorted but SortAsc=true
+	tuples := []*openfgav1.Tuple{
+		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
+		{Key: tuple.NewTupleKey("document:1", "viewer", "user:bob")},
+	}
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(
+		storage.NewOrderedStaticTupleIterator(tuples), nil,
+	).Times(1)
+
+	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
+	require.NoError(t, err)
+
+	// Should be a CachingIterator (cache miss path), not LockFreeCachedIterator
+	_, ok := iter.(*CachingIterator)
+	require.True(t, ok, "Expected CachingIterator: have-unsorted + want-sorted must be a miss")
+
+	// Drain so background goroutine detects exhaustion and flushes cleanly
+	for {
+		_, err := iter.Next(ctx)
+		if err != nil {
+			break
+		}
+	}
+	iter.Stop()
+	wg.Wait()
+}
+
+// TestCachedTupleReader_MonotonicUpgrade_HaveSorted_WantUnsorted is a cache hit:
+// a sorted entry satisfies unsorted requests; the delegate is NOT called.
+func TestCachedTupleReader_MonotonicUpgrade_HaveSorted_WantUnsorted(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+	mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+	ctx := context.Background()
+	storeID := ulid.Make().String()
+	sf := &singleflight.Group{}
+	wg := &sync.WaitGroup{}
+
+	reader := NewCachedTupleReader(ctx, mockDatastore, mockCache, 1000, time.Hour, sf, wg, 30*time.Second)
+
+	filter := storage.ReadUsersetTuplesFilter{
+		Object:                      "document:1",
+		Relation:                    "viewer",
+		AllowedUserTypeRestrictions: []*openfgav1.RelationReference{{Type: "user"}},
+	}
+	opts := storage.ReadUsersetTuplesOptions{SortAsc: false} // unsorted request
+
+	// Cached entry is sorted (Ordered=true)
+	sortedEntry := &V2IteratorCacheEntry{
+		Entries:      []MinimalCacheEntry{{ObjectID: "1", User: "user:alice"}, {ObjectID: "1", User: "user:bob"}},
+		LastModified: time.Now(),
+		Ordered:      true,
+	}
+
+	cacheKey := storage.ReadUsersetTuplesKey(storeID, filter)
+	entityInvalidKey := storage.InvalidIteratorByObjectRelationCacheKey(storeID, "document:1", "viewer")
+
+	mockCache.EXPECT().Get(cacheKey).Return(sortedEntry).Times(1)
+	mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil).Times(1)
+	mockCache.EXPECT().Get(entityInvalidKey).Return(nil).Times(1)
+	// NO delegate call expected — sorted entry satisfies unsorted request
+
+	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
+	require.NoError(t, err)
+
+	_, ok := iter.(*LockFreeCachedIterator)
+	require.True(t, ok, "Expected LockFreeCachedIterator: have-sorted + want-unsorted must be a hit")
+	require.True(t, iter.IsOrdered(), "Iterator should report ordered=true (the cached entry is sorted)")
+	iter.Stop()
+}
+
+// TestCachedTupleReader_MonotonicUpgrade_HaveUnsorted_WantUnsorted is a plain cache hit.
+func TestCachedTupleReader_MonotonicUpgrade_HaveUnsorted_WantUnsorted(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+	mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+	ctx := context.Background()
+	storeID := ulid.Make().String()
+	sf := &singleflight.Group{}
+	wg := &sync.WaitGroup{}
+
+	reader := NewCachedTupleReader(ctx, mockDatastore, mockCache, 1000, time.Hour, sf, wg, 30*time.Second)
+
+	filter := storage.ReadUsersetTuplesFilter{
+		Object:                      "document:1",
+		Relation:                    "viewer",
+		AllowedUserTypeRestrictions: []*openfgav1.RelationReference{{Type: "user"}},
+	}
+	opts := storage.ReadUsersetTuplesOptions{SortAsc: false}
+
+	unsortedEntry := &V2IteratorCacheEntry{
+		Entries:      []MinimalCacheEntry{{ObjectID: "1", User: "user:bob"}, {ObjectID: "1", User: "user:alice"}},
+		LastModified: time.Now(),
+		Ordered:      false,
+	}
+
+	cacheKey := storage.ReadUsersetTuplesKey(storeID, filter)
+	entityInvalidKey := storage.InvalidIteratorByObjectRelationCacheKey(storeID, "document:1", "viewer")
+
+	mockCache.EXPECT().Get(cacheKey).Return(unsortedEntry).Times(1)
+	mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil).Times(1)
+	mockCache.EXPECT().Get(entityInvalidKey).Return(nil).Times(1)
+
+	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
+	require.NoError(t, err)
+
+	_, ok := iter.(*LockFreeCachedIterator)
+	require.True(t, ok, "Expected LockFreeCachedIterator: have-unsorted + want-unsorted must be a hit")
+	require.False(t, iter.IsOrdered())
+	iter.Stop()
+}
+
+// TestCachedTupleReader_MonotonicUpgrade_HaveSorted_WantSorted is a plain cache hit.
+func TestCachedTupleReader_MonotonicUpgrade_HaveSorted_WantSorted(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCache := mocks.NewMockInMemoryCache[any](ctrl)
+	mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+
+	ctx := context.Background()
+	storeID := ulid.Make().String()
+	sf := &singleflight.Group{}
+	wg := &sync.WaitGroup{}
+
+	reader := NewCachedTupleReader(ctx, mockDatastore, mockCache, 1000, time.Hour, sf, wg, 30*time.Second)
+
+	filter := storage.ReadUsersetTuplesFilter{
+		Object:                      "document:1",
+		Relation:                    "viewer",
+		AllowedUserTypeRestrictions: []*openfgav1.RelationReference{{Type: "user"}},
+	}
+	opts := storage.ReadUsersetTuplesOptions{SortAsc: true}
+
+	sortedEntry := &V2IteratorCacheEntry{
+		Entries:      []MinimalCacheEntry{{ObjectID: "1", User: "user:alice"}, {ObjectID: "1", User: "user:bob"}},
+		LastModified: time.Now(),
+		Ordered:      true,
+	}
+
+	cacheKey := storage.ReadUsersetTuplesKey(storeID, filter)
+	entityInvalidKey := storage.InvalidIteratorByObjectRelationCacheKey(storeID, "document:1", "viewer")
+
+	mockCache.EXPECT().Get(cacheKey).Return(sortedEntry).Times(1)
+	mockCache.EXPECT().Get(storage.InvalidIteratorCacheKey(storeID)).Return(nil).Times(1)
+	mockCache.EXPECT().Get(entityInvalidKey).Return(nil).Times(1)
+
+	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
+	require.NoError(t, err)
+
+	_, ok := iter.(*LockFreeCachedIterator)
+	require.True(t, ok, "Expected LockFreeCachedIterator: have-sorted + want-sorted must be a hit")
+	require.True(t, iter.IsOrdered())
+	iter.Stop()
+}

--- a/pkg/storage/storagewrappers/cached_reader_test.go
+++ b/pkg/storage/storagewrappers/cached_reader_test.go
@@ -61,7 +61,7 @@ func TestCachedTupleReader_ReadUsersetTuples_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -165,7 +165,7 @@ func TestCachedTupleReader_ReadUsersetTuples_HigherConsistency(t *testing.T) {
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
 
 	// NO cache.Get expected - bypasses cache entirely
 
@@ -227,7 +227,7 @@ func TestCachedTupleReader_ReadUsersetTuples_StoreInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -291,7 +291,7 @@ func TestCachedTupleReader_ReadUsersetTuples_EntityInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -431,7 +431,7 @@ func TestCachedTupleReader_Read_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.Read(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -529,7 +529,7 @@ func TestCachedTupleReader_Read_HigherConsistency(t *testing.T) {
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
 
 	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(staticIter, nil).Times(1)
 
@@ -592,7 +592,7 @@ func TestCachedTupleReader_Read_EntityInvalidation(t *testing.T) {
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore
-	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().Read(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.Read(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -642,7 +642,7 @@ func TestCachedTupleReader_ReadStartingWithUser_CacheMiss(t *testing.T) {
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
 
 	// Delegate to datastore (use gomock.Any() for ctx since tracing adds values)
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.ReadStartingWithUser(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -802,7 +802,7 @@ func TestCachedTupleReader_ReadStartingWithUser_HigherConsistency(t *testing.T) 
 		},
 	}
 
-	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	staticIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
 
 	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(staticIter, nil).Times(1)
 
@@ -867,7 +867,7 @@ func TestCachedTupleReader_ReadStartingWithUser_EntityInvalidation(t *testing.T)
 	mockCache.EXPECT().Delete(cacheKey).Times(1)
 
 	// Fallback to datastore
-	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+	mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, filter, opts).Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	iter, err := reader.ReadStartingWithUser(ctx, storeID, filter, opts)
 	require.NoError(t, err)
@@ -1090,7 +1090,7 @@ func TestCachedTupleReader_CacheRoundTrip(t *testing.T) {
 
 	// Datastore should only be called ONCE (the cache miss). Second call uses cache.
 	mockDatastore.EXPECT().ReadUsersetTuples(gomock.Any(), storeID, filter, opts).
-		Return(storage.NewStaticTupleIterator(tuples), nil).Times(1)
+		Return(storage.NewStaticTupleIterator(tuples, false), nil).Times(1)
 
 	// --- First call: cache miss ---
 	iter, err := reader.ReadUsersetTuples(ctx, storeID, filter, opts)

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -69,11 +69,20 @@ func (c *CombinedTupleReader) Read(
 	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
 	filteredTuples := filterTuples(c.contextualTuplesOrderedByObjectID, filter.Object, filter.Relation, []string{})
-	iter1 := storage.NewStaticTupleIterator(filteredTuples)
+	if options.WithResultsSortedAscending {
+		slices.SortFunc(filteredTuples, func(a, b *openfgav1.Tuple) int {
+			return strings.Compare(a.GetKey().GetUser(), b.GetKey().GetUser())
+		})
+	}
+	iter1 := storage.NewStaticTupleIterator(filteredTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, filter, options)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.WithResultsSortedAscending {
+		return storage.NewOrderedCombinedIterator(storage.UserMapper(), iter1, iter2), nil
 	}
 
 	return storage.NewCombinedIterator(iter1, iter2), nil
@@ -145,11 +154,20 @@ func (c *CombinedTupleReader) ReadUsersetTuples(
 		}
 	}
 
-	iter1 := storage.NewStaticTupleIterator(usersetTuples)
+	if options.WithResultsSortedAscending {
+		slices.SortFunc(usersetTuples, func(a, b *openfgav1.Tuple) int {
+			return strings.Compare(a.GetKey().GetUser(), b.GetKey().GetUser())
+		})
+	}
+	iter1 := storage.NewStaticTupleIterator(usersetTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	if err != nil {
 		return nil, err
+	}
+
+	if options.WithResultsSortedAscending {
+		return storage.NewOrderedCombinedIterator(storage.UserMapper(), iter1, iter2), nil
 	}
 
 	return storage.NewCombinedIterator(iter1, iter2), nil
@@ -179,7 +197,12 @@ func (c *CombinedTupleReader) ReadStartingWithUser(
 		filteredTuples = append(filteredTuples, t)
 	}
 
-	iter1 := storage.NewStaticTupleIterator(filteredTuples)
+	if options.WithResultsSortedAscending {
+		slices.SortFunc(filteredTuples, func(a, b *openfgav1.Tuple) int {
+			return strings.Compare(a.GetKey().GetObject(), b.GetKey().GetObject())
+		})
+	}
+	iter1 := storage.NewStaticTupleIterator(filteredTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	if err != nil {

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -69,19 +69,22 @@ func (c *CombinedTupleReader) Read(
 	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
 	filteredTuples := filterTuples(c.contextualTuplesOrderedByObjectID, filter.Object, filter.Relation, []string{})
-	if options.WithResultsSortedAscending {
+	var iter1 storage.TupleIterator
+	if options.SortAsc {
 		slices.SortFunc(filteredTuples, func(a, b *openfgav1.Tuple) int {
 			return strings.Compare(a.GetKey().GetUser(), b.GetKey().GetUser())
 		})
+		iter1 = storage.NewOrderedStaticTupleIterator(filteredTuples)
+	} else {
+		iter1 = storage.NewUnorderedStaticTupleIterator(filteredTuples)
 	}
-	iter1 := storage.NewStaticTupleIterator(filteredTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.Read(ctx, storeID, filter, options)
 	if err != nil {
 		return nil, err
 	}
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		return storage.NewOrderedCombinedIterator(storage.UserMapper(), iter1, iter2), nil
 	}
 
@@ -154,19 +157,22 @@ func (c *CombinedTupleReader) ReadUsersetTuples(
 		}
 	}
 
-	if options.WithResultsSortedAscending {
+	var iter1 storage.TupleIterator
+	if options.SortAsc {
 		slices.SortFunc(usersetTuples, func(a, b *openfgav1.Tuple) int {
 			return strings.Compare(a.GetKey().GetUser(), b.GetKey().GetUser())
 		})
+		iter1 = storage.NewOrderedStaticTupleIterator(usersetTuples)
+	} else {
+		iter1 = storage.NewUnorderedStaticTupleIterator(usersetTuples)
 	}
-	iter1 := storage.NewStaticTupleIterator(usersetTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.ReadUsersetTuples(ctx, store, filter, options)
 	if err != nil {
 		return nil, err
 	}
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		return storage.NewOrderedCombinedIterator(storage.UserMapper(), iter1, iter2), nil
 	}
 
@@ -197,19 +203,22 @@ func (c *CombinedTupleReader) ReadStartingWithUser(
 		filteredTuples = append(filteredTuples, t)
 	}
 
-	if options.WithResultsSortedAscending {
+	var iter1 storage.TupleIterator
+	if options.SortAsc {
 		slices.SortFunc(filteredTuples, func(a, b *openfgav1.Tuple) int {
 			return strings.Compare(a.GetKey().GetObject(), b.GetKey().GetObject())
 		})
+		iter1 = storage.NewOrderedStaticTupleIterator(filteredTuples)
+	} else {
+		iter1 = storage.NewUnorderedStaticTupleIterator(filteredTuples)
 	}
-	iter1 := storage.NewStaticTupleIterator(filteredTuples, options.WithResultsSortedAscending)
 
 	iter2, err := c.RelationshipTupleReader.ReadStartingWithUser(ctx, store, filter, options)
 	if err != nil {
 		return nil, err
 	}
 
-	if options.WithResultsSortedAscending {
+	if options.SortAsc {
 		// Note that both iter1 and iter2 return sorted by object ID
 		return storage.NewOrderedCombinedIterator(storage.ObjectMapper(), iter1, iter2), nil
 	}

--- a/pkg/storage/storagewrappers/combinedtuplereader_test.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader_test.go
@@ -121,7 +121,7 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 						testTuples["group:1#member@user:13"],
 						testTuples["group:2#member@user:22"],
-					}), nil)
+					}, false), nil)
 			},
 		},
 		{
@@ -150,7 +150,7 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 						testTuples["group:1#member@user:13"],
 						testTuples["group:2#member@user:22"],
-					}), nil)
+					}, false), nil)
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 			setup: func() {
 				mockRelationshipTupleReader.EXPECT().
 					Read(gomock.Any(), "1", storage.ReadFilter{Relation: "member", Object: "group:1"}, gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 		},
 		{
@@ -319,7 +319,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:11"],
@@ -357,7 +357,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:2", "viewer", "user:maria")},
-						{Key: tuple.NewTupleKey("document:4", "viewer", "user:maria")}}), nil)
+						{Key: tuple.NewTupleKey("document:4", "viewer", "user:maria")}}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "viewer", "user:maria")},
@@ -389,7 +389,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:3#member@user:11"],
@@ -425,7 +425,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:11"],
@@ -461,7 +461,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -496,7 +496,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -705,7 +705,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:12"],
@@ -736,7 +736,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:1#member"],
@@ -797,7 +797,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -826,7 +826,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -855,7 +855,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:*"],
@@ -886,7 +886,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -915,7 +915,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -944,7 +944,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -974,7 +974,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:1#member"],
@@ -1005,7 +1005,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}), nil)
+					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,

--- a/pkg/storage/storagewrappers/combinedtuplereader_test.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader_test.go
@@ -118,10 +118,10 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 			setup: func() {
 				mockRelationshipTupleReader.EXPECT().
 					Read(gomock.Any(), "1", storage.ReadFilter{Relation: "member", Object: "group:1"}, gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						testTuples["group:1#member@user:13"],
 						testTuples["group:2#member@user:22"],
-					}, false), nil)
+					}), nil)
 			},
 		},
 		{
@@ -147,10 +147,10 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 			setup: func() {
 				mockRelationshipTupleReader.EXPECT().
 					Read(gomock.Any(), "1", storage.ReadFilter{Relation: "member", Object: "group:1"}, gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						testTuples["group:1#member@user:13"],
 						testTuples["group:2#member@user:22"],
-					}, false), nil)
+					}), nil)
 			},
 		},
 		{
@@ -180,7 +180,7 @@ func Test_combinedTupleReader_Read(t *testing.T) {
 			setup: func() {
 				mockRelationshipTupleReader.EXPECT().
 					Read(gomock.Any(), "1", storage.ReadFilter{Relation: "member", Object: "group:1"}, gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 		},
 		{
@@ -319,7 +319,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:11"],
@@ -349,15 +349,15 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 					},
 				},
 				options: storage.ReadStartingWithUserOptions{
-					WithResultsSortedAscending: true,
+					SortAsc: true,
 				},
 			},
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 						{Key: tuple.NewTupleKey("document:2", "viewer", "user:maria")},
-						{Key: tuple.NewTupleKey("document:4", "viewer", "user:maria")}}, false), nil)
+						{Key: tuple.NewTupleKey("document:4", "viewer", "user:maria")}}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "viewer", "user:maria")},
@@ -389,7 +389,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:3#member@user:11"]}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:3#member@user:11"],
@@ -425,7 +425,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:11"],
@@ -461,7 +461,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -496,7 +496,7 @@ func Test_combinedTupleReader_ReadStartingWithUser(t *testing.T) {
 			setups: func() {
 				mockRelationshipTupleReader.EXPECT().
 					ReadStartingWithUser(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -705,7 +705,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["group:1#member@user:12"],
@@ -736,7 +736,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{testTuples["group:1#member@user:12"]}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:1#member"],
@@ -797,7 +797,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -826,7 +826,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -855,7 +855,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:*"],
@@ -886,7 +886,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -915,7 +915,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -944,7 +944,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,
@@ -974,7 +974,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want: []*openfgav1.Tuple{
 				testTuples["folder:backlog#viewer@group:1#member"],
@@ -1005,7 +1005,7 @@ func Test_combinedTupleReader_ReadUsersetTuples(t *testing.T) {
 				mockRelationshipTupleReader.
 					EXPECT().
 					ReadUsersetTuples(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false), nil)
+					Return(storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}), nil)
 			},
 			want:    []*openfgav1.Tuple{},
 			wantErr: nil,

--- a/pkg/storage/storagewrappers/iterator_cache.go
+++ b/pkg/storage/storagewrappers/iterator_cache.go
@@ -3,6 +3,7 @@ package storagewrappers
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -140,6 +141,10 @@ type CachingIterator struct {
 	objectType string
 	relation   string
 	operation  string
+
+	// sortKey extracts the field to sort by at flush time.
+	// Read/ReadUsersetTuples sort by User; ReadStartingWithUser sorts by ObjectID.
+	sortKey func(MinimalCacheEntry) string
 }
 
 // Ensure CachingIterator implements TupleIterator.
@@ -156,6 +161,7 @@ func newCachingIterator(
 	sf *singleflight.Group,
 	wg *sync.WaitGroup,
 	objectType, relation, operation string,
+	sortKey func(MinimalCacheEntry) string,
 ) *CachingIterator {
 	// Cap initial capacity to avoid over-allocation for large maxSize values.
 	// Most queries return few tuples, so initialBufferCapacity is usually sufficient.
@@ -181,6 +187,7 @@ func newCachingIterator(
 		objectType:   objectType,
 		relation:     relation,
 		operation:    operation,
+		sortKey:      sortKey,
 	}
 }
 
@@ -278,12 +285,21 @@ func (c *CachingIterator) flush() {
 		}
 	}
 
+	// Sort at flush time so cache hits are pre-sorted for v2Check merge algorithms.
+	// Read/ReadUsersetTuples sort by User; ReadStartingWithUser sorts by ObjectID.
+	// Skip if the inner iterator is already ordered — no redundant work needed.
+	if c.sortKey != nil && !c.inner.IsOrdered() {
+		sort.Slice(entries, func(i, j int) bool {
+			return c.sortKey(entries[i]) < c.sortKey(entries[j])
+		})
+	}
+
 	v2IterCacheSize.WithLabelValues(c.operation).Observe(float64(len(entries)))
 
 	c.cache.Set(c.cacheKey, &V2IteratorCacheEntry{
 		Entries:      entries,
 		LastModified: c.createdAt,
-		Ordered:      c.inner.IsOrdered(),
+		Ordered:      c.sortKey != nil || c.inner.IsOrdered(),
 	}, c.ttl)
 
 	c.tuples = nil // Release for GC

--- a/pkg/storage/storagewrappers/iterator_cache.go
+++ b/pkg/storage/storagewrappers/iterator_cache.go
@@ -3,7 +3,6 @@ package storagewrappers
 import (
 	"context"
 	"errors"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -141,10 +140,6 @@ type CachingIterator struct {
 	objectType string
 	relation   string
 	operation  string
-
-	// sortKey extracts the field to sort by at flush time.
-	// Read/ReadUsersetTuples sort by User; ReadStartingWithUser sorts by ObjectID.
-	sortKey func(MinimalCacheEntry) string
 }
 
 // Ensure CachingIterator implements TupleIterator.
@@ -161,7 +156,6 @@ func newCachingIterator(
 	sf *singleflight.Group,
 	wg *sync.WaitGroup,
 	objectType, relation, operation string,
-	sortKey func(MinimalCacheEntry) string,
 ) *CachingIterator {
 	// Cap initial capacity to avoid over-allocation for large maxSize values.
 	// Most queries return few tuples, so initialBufferCapacity is usually sufficient.
@@ -187,7 +181,6 @@ func newCachingIterator(
 		objectType:   objectType,
 		relation:     relation,
 		operation:    operation,
-		sortKey:      sortKey,
 	}
 }
 
@@ -285,21 +278,12 @@ func (c *CachingIterator) flush() {
 		}
 	}
 
-	// Sort at flush time so cache hits are pre-sorted for v2Check merge algorithms.
-	// Read/ReadUsersetTuples sort by User; ReadStartingWithUser sorts by ObjectID.
-	// Skip if the inner iterator is already ordered — no redundant work needed.
-	if c.sortKey != nil && !c.inner.IsOrdered() {
-		sort.Slice(entries, func(i, j int) bool {
-			return c.sortKey(entries[i]) < c.sortKey(entries[j])
-		})
-	}
-
 	v2IterCacheSize.WithLabelValues(c.operation).Observe(float64(len(entries)))
 
 	c.cache.Set(c.cacheKey, &V2IteratorCacheEntry{
 		Entries:      entries,
 		LastModified: c.createdAt,
-		Ordered:      c.sortKey != nil || c.inner.IsOrdered(),
+		Ordered:      c.inner.IsOrdered(),
 	}, c.ttl)
 
 	c.tuples = nil // Release for GC

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -242,7 +242,7 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 
 				iter := newCachingIterator(
 					innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-					sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+					sf, wg, "document", "viewer", "ReadUsersetTuples",
 				)
 
 				for {
@@ -553,7 +553,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 			innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 			cachingIter := newCachingIterator(
 				innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-				sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+				sf, wg, "document", "viewer", "ReadUsersetTuples",
 			)
 
 			for {

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -95,7 +95,7 @@ func BenchmarkV1vsV2_CacheHit_Iteration(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records)
+				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
 				iter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -144,7 +144,7 @@ func BenchmarkV1vsV2_CacheHit_SingleNext(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			staticIter := storage.NewStaticIterator[*storage.TupleRecord](records)
+			staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
 			iter := &cachedTupleIterator{
 				objectType: "document",
 				relation:   "viewer",
@@ -194,7 +194,7 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				innerIter := storage.NewStaticTupleIterator(tuples)
+				innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 				// Simulate cache miss path
 				iter := &cachedIterator{
@@ -238,11 +238,11 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				innerIter := storage.NewStaticTupleIterator(tuples)
+				innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 				iter := newCachingIterator(
 					innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-					sf, wg, "document", "viewer", "ReadUsersetTuples",
+					sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 				)
 
 				for {
@@ -327,7 +327,7 @@ func BenchmarkV1vsV2_Concurrent_Next(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records)
+				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
 				iter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -477,7 +477,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			// Cache miss - collect tuples via cachedIterator
-			innerIter := storage.NewStaticTupleIterator(tuples)
+			innerIter := storage.NewStaticTupleIterator(tuples, false)
 			iter := &cachedIterator{
 				ctx:           ctx,
 				iter:          innerIter,
@@ -506,7 +506,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 			// Cache hit - iterate from cached TupleRecords
 			if cachedRecords != nil {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedRecords)
+				staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedRecords, false)
 				cachedIter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -550,10 +550,10 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			// Cache miss - populate cache
-			innerIter := storage.NewStaticTupleIterator(tuples)
+			innerIter := storage.NewStaticTupleIterator(tuples, false)
 			cachingIter := newCachingIterator(
 				innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-				sf, wg, "document", "viewer", "ReadUsersetTuples",
+				sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 			)
 
 			for {

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -95,7 +95,7 @@ func BenchmarkV1vsV2_CacheHit_Iteration(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
+				staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](records)
 				iter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -144,7 +144,7 @@ func BenchmarkV1vsV2_CacheHit_SingleNext(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
+			staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](records)
 			iter := &cachedTupleIterator{
 				objectType: "document",
 				relation:   "viewer",
@@ -194,7 +194,7 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				innerIter := storage.NewStaticTupleIterator(tuples, false)
+				innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 				// Simulate cache miss path
 				iter := &cachedIterator{
@@ -238,7 +238,7 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				innerIter := storage.NewStaticTupleIterator(tuples, false)
+				innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 				iter := newCachingIterator(
 					innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
@@ -327,7 +327,7 @@ func BenchmarkV1vsV2_Concurrent_Next(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](records, false)
+				staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](records)
 				iter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -477,7 +477,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			// Cache miss - collect tuples via cachedIterator
-			innerIter := storage.NewStaticTupleIterator(tuples, false)
+			innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 			iter := &cachedIterator{
 				ctx:           ctx,
 				iter:          innerIter,
@@ -506,7 +506,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 			// Cache hit - iterate from cached TupleRecords
 			if cachedRecords != nil {
-				staticIter := storage.NewStaticIterator[*storage.TupleRecord](cachedRecords, false)
+				staticIter := storage.NewUnorderedStaticIterator[*storage.TupleRecord](cachedRecords)
 				cachedIter := &cachedTupleIterator{
 					objectType: "document",
 					relation:   "viewer",
@@ -550,7 +550,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			// Cache miss - populate cache
-			innerIter := storage.NewStaticTupleIterator(tuples, false)
+			innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 			cachingIter := newCachingIterator(
 				innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
 				sf, wg, "document", "viewer", "ReadUsersetTuples", nil,

--- a/pkg/storage/storagewrappers/iterator_cache_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_test.go
@@ -356,7 +356,7 @@ func TestCachingIterator_IsOrdered(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	inner := storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{})
-	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read", nil)
+	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read")
 	require.True(t, iter.IsOrdered())
 	iter.Stop()
 	wg.Wait()
@@ -391,7 +391,7 @@ func TestCachingIterator_Next_Basic(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	t1, err := iter.Next(ctx)
@@ -437,7 +437,7 @@ func TestCachingIterator_Next_NonIteratorDoneError_NilsTuples(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// First call succeeds
@@ -483,7 +483,7 @@ func TestCachingIterator_Head_DelegatesToInner(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Head returns first tuple without advancing
@@ -529,7 +529,7 @@ func TestCachingIterator_Head_AfterStop(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	iter.Stop()
@@ -568,7 +568,7 @@ func TestCachingIterator_ExceedsMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume all tuples
@@ -607,7 +607,7 @@ func TestCachingIterator_ConfigurableMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), customMaxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume all tuples
@@ -654,7 +654,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, cacheKey, 1000, ttl, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume all tuples
@@ -698,7 +698,7 @@ func TestCachingIterator_InnerError(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	_, err := iter.Next(ctx)
@@ -733,7 +733,7 @@ func TestCachingIterator_Stop_Idempotent(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume all tuples
@@ -773,7 +773,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 		iter := newCachingIterator(
 			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+			sf, wg, "document", "viewer", "ReadUsersetTuples",
 		)
 
 		// Manually set tuples to nil to simulate abandoned state
@@ -788,7 +788,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 		iter := newCachingIterator(
 			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+			sf, wg, "document", "viewer", "ReadUsersetTuples",
 		)
 
 		// tuples is initialized as empty slice
@@ -829,7 +829,7 @@ func TestCachingIterator_WaitGroup_AddInConstructor(t *testing.T) {
 		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iterators[i] = newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key-"+strconv.Itoa(i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+			sf, wg, "document", "viewer", "ReadUsersetTuples",
 		)
 	}
 
@@ -881,7 +881,7 @@ func TestCachingIterator_WaitGroup_DoneCalledOnNilTuples(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	ctx := context.Background()
@@ -939,7 +939,7 @@ func TestCachingIterator_ConcurrentNextAndStop(t *testing.T) {
 		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey(fmt.Sprintf("test-key-%d", i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+			sf, wg, "document", "viewer", "ReadUsersetTuples",
 		)
 
 		// Concurrent access pattern that previously caused race
@@ -1010,7 +1010,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume just a few tuples (simulating finding a result early)
@@ -1060,7 +1060,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	// Consume just a few tuples (not all)
@@ -1110,7 +1110,7 @@ func TestCachingIterator_DrainTimeout_AbandonsCaching(t *testing.T) {
 		blockIter, mockCache, testCacheKey("test-key"), 1000,
 		time.Hour,
 		1*time.Nanosecond, // Very short drain timeout to trigger context expiry
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	ctx := context.Background()
@@ -1152,7 +1152,7 @@ func TestCachingIterator_DrainError_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	ctx := context.Background()
@@ -1196,7 +1196,7 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
+		sf, wg, "document", "viewer", "ReadUsersetTuples",
 	)
 
 	ctx := context.Background()
@@ -1272,7 +1272,7 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "benchmark", nil,
+			sf, wg, "document", "viewer", "benchmark",
 		)
 
 		// Consume all tuples

--- a/pkg/storage/storagewrappers/iterator_cache_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_test.go
@@ -355,7 +355,7 @@ func TestCachingIterator_IsOrdered(t *testing.T) {
 	sf := &singleflight.Group{}
 	wg := &sync.WaitGroup{}
 
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
+	inner := storage.NewOrderedStaticTupleIterator([]*openfgav1.Tuple{})
 	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read", nil)
 	require.True(t, iter.IsOrdered())
 	iter.Stop()
@@ -382,7 +382,7 @@ func TestCachingIterator_Next_Basic(t *testing.T) {
 	}
 
 	// Use static iterator
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -479,7 +479,7 @@ func TestCachingIterator_Head_DelegatesToInner(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:2", "viewer", "user:bob")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
@@ -525,7 +525,7 @@ func TestCachingIterator_Head_AfterStop(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
@@ -562,7 +562,7 @@ func TestCachingIterator_ExceedsMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// No cache.Set expected because we exceed maxSize
 
@@ -603,7 +603,7 @@ func TestCachingIterator_ConfigurableMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), customMaxSize, time.Hour, 30*time.Second,
@@ -640,7 +640,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
@@ -692,7 +692,7 @@ func TestCachingIterator_InnerError(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	// Empty iterator returns ErrIteratorDone immediately
-	innerIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{})
 
 	// No cache.Set expected on empty iteration
 
@@ -725,7 +725,7 @@ func TestCachingIterator_Stop_Idempotent(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Expect cache operations
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).AnyTimes()
@@ -771,7 +771,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 
 	t.Run("flush_with_nil_tuples_does_not_panic", func(t *testing.T) {
 		iter := newCachingIterator(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false),
+			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
 			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
@@ -786,7 +786,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 
 	t.Run("flush_with_empty_tuples_does_not_cache", func(t *testing.T) {
 		iter := newCachingIterator(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false),
+			storage.NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
 			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
@@ -826,7 +826,7 @@ func TestCachingIterator_WaitGroup_AddInConstructor(t *testing.T) {
 	// is properly incremented at construction time (not at Stop time)
 	iterators := make([]*CachingIterator, 10)
 	for i := 0; i < 10; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples, false)
+		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iterators[i] = newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key-"+strconv.Itoa(i)), 1000, time.Hour, 30*time.Second,
 			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
@@ -877,7 +877,7 @@ func TestCachingIterator_WaitGroup_DoneCalledOnNilTuples(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+strconv.Itoa(i), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
@@ -936,7 +936,7 @@ func TestCachingIterator_ConcurrentNextAndStop(t *testing.T) {
 
 	// Run multiple iterations to increase chance of detecting race
 	for i := 0; i < 100; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples, false)
+		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey(fmt.Sprintf("test-key-%d", i)), 1000, time.Hour, 30*time.Second,
 			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
@@ -1001,7 +1001,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -1051,7 +1051,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -1192,7 +1192,7 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+strconv.Itoa(i), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples, false)
+	innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
@@ -1269,7 +1269,7 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples, false)
+		innerIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
 			sf, wg, "document", "viewer", "benchmark", nil,
@@ -1380,7 +1380,7 @@ func BenchmarkLockFreeCachedIterator_VsStaticIterator(b *testing.B) {
 	b.Run("StaticTupleIterator", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			iter := storage.NewStaticTupleIterator(tuples, false)
+			iter := storage.NewUnorderedStaticTupleIterator(tuples)
 			for {
 				_, err := iter.Next(ctx)
 				if err != nil {

--- a/pkg/storage/storagewrappers/iterator_cache_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_test.go
@@ -355,8 +355,8 @@ func TestCachingIterator_IsOrdered(t *testing.T) {
 	sf := &singleflight.Group{}
 	wg := &sync.WaitGroup{}
 
-	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
-	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read")
+	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, true)
+	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read", nil)
 	require.True(t, iter.IsOrdered())
 	iter.Stop()
 	wg.Wait()
@@ -382,7 +382,7 @@ func TestCachingIterator_Next_Basic(t *testing.T) {
 	}
 
 	// Use static iterator
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -391,7 +391,7 @@ func TestCachingIterator_Next_Basic(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	t1, err := iter.Next(ctx)
@@ -437,7 +437,7 @@ func TestCachingIterator_Next_NonIteratorDoneError_NilsTuples(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// First call succeeds
@@ -479,11 +479,11 @@ func TestCachingIterator_Head_DelegatesToInner(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:2", "viewer", "user:bob")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Head returns first tuple without advancing
@@ -525,11 +525,11 @@ func TestCachingIterator_Head_AfterStop(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	iter.Stop()
@@ -562,13 +562,13 @@ func TestCachingIterator_ExceedsMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// No cache.Set expected because we exceed maxSize
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume all tuples
@@ -603,11 +603,11 @@ func TestCachingIterator_ConfigurableMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), customMaxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume all tuples
@@ -640,7 +640,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(cacheKey).Return(nil).Times(1)
@@ -654,7 +654,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, cacheKey, 1000, ttl, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume all tuples
@@ -692,13 +692,13 @@ func TestCachingIterator_InnerError(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	// Empty iterator returns ErrIteratorDone immediately
-	innerIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
+	innerIter := storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
 
 	// No cache.Set expected on empty iteration
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	_, err := iter.Next(ctx)
@@ -725,7 +725,7 @@ func TestCachingIterator_Stop_Idempotent(t *testing.T) {
 		{Key: tuple.NewTupleKey("document:1", "viewer", "user:alice")},
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Expect cache operations
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).AnyTimes()
@@ -733,7 +733,7 @@ func TestCachingIterator_Stop_Idempotent(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume all tuples
@@ -771,9 +771,9 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 
 	t.Run("flush_with_nil_tuples_does_not_panic", func(t *testing.T) {
 		iter := newCachingIterator(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}),
+			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
 
 		// Manually set tuples to nil to simulate abandoned state
@@ -786,9 +786,9 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 
 	t.Run("flush_with_empty_tuples_does_not_cache", func(t *testing.T) {
 		iter := newCachingIterator(
-			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}),
+			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}, false),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
 
 		// tuples is initialized as empty slice
@@ -826,10 +826,10 @@ func TestCachingIterator_WaitGroup_AddInConstructor(t *testing.T) {
 	// is properly incremented at construction time (not at Stop time)
 	iterators := make([]*CachingIterator, 10)
 	for i := 0; i < 10; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples)
+		innerIter := storage.NewStaticTupleIterator(tuples, false)
 		iterators[i] = newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key-"+strconv.Itoa(i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
 	}
 
@@ -877,11 +877,11 @@ func TestCachingIterator_WaitGroup_DoneCalledOnNilTuples(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+strconv.Itoa(i), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	ctx := context.Background()
@@ -936,10 +936,10 @@ func TestCachingIterator_ConcurrentNextAndStop(t *testing.T) {
 
 	// Run multiple iterations to increase chance of detecting race
 	for i := 0; i < 100; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples)
+		innerIter := storage.NewStaticTupleIterator(tuples, false)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey(fmt.Sprintf("test-key-%d", i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 		)
 
 		// Concurrent access pattern that previously caused race
@@ -1001,7 +1001,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -1010,7 +1010,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume just a few tuples (simulating finding a result early)
@@ -1051,7 +1051,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Expect cache.Get to check if already cached (optimization 1), return nil (not cached)
 	mockCache.EXPECT().Get(testCacheKey("test-key")).Return(nil).Times(1)
@@ -1060,7 +1060,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	// Consume just a few tuples (not all)
@@ -1110,7 +1110,7 @@ func TestCachingIterator_DrainTimeout_AbandonsCaching(t *testing.T) {
 		blockIter, mockCache, testCacheKey("test-key"), 1000,
 		time.Hour,
 		1*time.Nanosecond, // Very short drain timeout to trigger context expiry
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	ctx := context.Background()
@@ -1152,7 +1152,7 @@ func TestCachingIterator_DrainError_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	ctx := context.Background()
@@ -1192,11 +1192,11 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+strconv.Itoa(i), "viewer", "user:test")}
 	}
 
-	innerIter := storage.NewStaticTupleIterator(tuples)
+	innerIter := storage.NewStaticTupleIterator(tuples, false)
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", nil,
 	)
 
 	ctx := context.Background()
@@ -1269,10 +1269,10 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		innerIter := storage.NewStaticTupleIterator(tuples)
+		innerIter := storage.NewStaticTupleIterator(tuples, false)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "benchmark",
+			sf, wg, "document", "viewer", "benchmark", nil,
 		)
 
 		// Consume all tuples
@@ -1380,7 +1380,7 @@ func BenchmarkLockFreeCachedIterator_VsStaticIterator(b *testing.B) {
 	b.Run("StaticTupleIterator", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			iter := storage.NewStaticTupleIterator(tuples)
+			iter := storage.NewStaticTupleIterator(tuples, false)
 			for {
 				_, err := iter.Next(ctx)
 				if err != nil {

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -62,7 +62,7 @@ func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
 	}
 
 	// Create a static iterator as the internal iterator
-	staticIter := storage.NewStaticTupleIterator(tuples, false)
+	staticIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
 	sharedIter := newSharedIterator(staticIter)
@@ -115,7 +115,7 @@ func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
 	}
 
 	// Create a static iterator as the internal iterator
-	staticIter := storage.NewStaticTupleIterator(tuples, false)
+	staticIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 	// Create shared iterator with cleanup function
 	sharedIter := newSharedIterator(staticIter)
@@ -166,7 +166,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 	}
 
 	b.Run("SharedIterator", func(b *testing.B) {
-		staticIter := storage.NewStaticTupleIterator(tuples, false)
+		staticIter := storage.NewUnorderedStaticTupleIterator(tuples)
 		sharedIter := newSharedIterator(staticIter)
 		defer sharedIter.Stop()
 
@@ -196,7 +196,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			staticIter := storage.NewStaticTupleIterator(tuples, false)
+			staticIter := storage.NewUnorderedStaticTupleIterator(tuples)
 
 			for {
 				_, err := staticIter.Next(ctx)
@@ -256,7 +256,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 				DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
 					time.Sleep(5 * time.Millisecond)
 					dbCalls.Add(1)
-					return storage.NewStaticTupleIterator(tuples, false), nil
+					return storage.NewUnorderedStaticTupleIterator(tuples), nil
 				}).AnyTimes()
 
 			for b.Loop() {
@@ -429,7 +429,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.read, iter, tuples)
@@ -447,7 +447,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -501,7 +501,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := dsLimit.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)
 		// this should not come from the map
@@ -526,7 +526,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 				storage.ReadOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -558,7 +558,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 				store string,
 				filter storage.ReadFilter,
 				options storage.ReadOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples, false), nil
+				return storage.NewUnorderedStaticTupleIterator(tuples), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -711,7 +711,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.rut, iter, tuples)
@@ -727,7 +727,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -781,7 +781,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := dsLimit.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
@@ -804,7 +804,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 				storage.ReadUsersetTuplesOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -834,7 +834,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 				store string,
 				filter storage.ReadUsersetTuplesFilter,
 				options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples, false), nil
+				return storage.NewUnorderedStaticTupleIterator(tuples), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -987,7 +987,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.rswu, iter, tuples)
@@ -1003,7 +1003,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -1056,7 +1056,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := dsLimit.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
@@ -1079,7 +1079,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 				storage.ReadStartingWithUserOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -1100,7 +1100,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 		iter1, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 
@@ -1140,7 +1140,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 				store string,
 				filter storage.ReadStartingWithUserFilter,
 				options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples, false), nil
+				return storage.NewUnorderedStaticTupleIterator(tuples), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -1852,7 +1852,7 @@ func TestSharedIterator_IsOrdered(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	tuples := []*openfgav1.Tuple{{Key: tuple.NewTupleKey("doc:1", "viewer", "user:a")}}
-	inner := storage.NewStaticTupleIterator(tuples, true)
+	inner := storage.NewOrderedStaticTupleIterator(tuples)
 	shared := newSharedIterator(inner)
 	defer shared.Stop()
 
@@ -1899,7 +1899,7 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples, false), nil)
+			Return(storage.NewUnorderedStaticTupleIterator(tuples), nil)
 
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -62,7 +62,7 @@ func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
 	}
 
 	// Create a static iterator as the internal iterator
-	staticIter := storage.NewStaticTupleIterator(tuples)
+	staticIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Create shared iterator with cleanup function
 	sharedIter := newSharedIterator(staticIter)
@@ -115,7 +115,7 @@ func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
 	}
 
 	// Create a static iterator as the internal iterator
-	staticIter := storage.NewStaticTupleIterator(tuples)
+	staticIter := storage.NewStaticTupleIterator(tuples, false)
 
 	// Create shared iterator with cleanup function
 	sharedIter := newSharedIterator(staticIter)
@@ -166,7 +166,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 	}
 
 	b.Run("SharedIterator", func(b *testing.B) {
-		staticIter := storage.NewStaticTupleIterator(tuples)
+		staticIter := storage.NewStaticTupleIterator(tuples, false)
 		sharedIter := newSharedIterator(staticIter)
 		defer sharedIter.Stop()
 
@@ -196,7 +196,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			staticIter := storage.NewStaticTupleIterator(tuples)
+			staticIter := storage.NewStaticTupleIterator(tuples, false)
 
 			for {
 				_, err := staticIter.Next(ctx)
@@ -256,7 +256,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 				DoAndReturn(func(_ context.Context, _ string, _ storage.ReadFilter, _ storage.ReadOptions) (storage.TupleIterator, error) {
 					time.Sleep(5 * time.Millisecond)
 					dbCalls.Add(1)
-					return storage.NewStaticTupleIterator(tuples), nil
+					return storage.NewStaticTupleIterator(tuples, false), nil
 				}).AnyTimes()
 
 			for b.Loop() {
@@ -429,7 +429,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.read, iter, tuples)
@@ -447,7 +447,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -501,7 +501,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := dsLimit.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)
 		// this should not come from the map
@@ -526,7 +526,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 				storage.ReadOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -558,7 +558,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 				store string,
 				filter storage.ReadFilter,
 				options storage.ReadOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples), nil
+				return storage.NewStaticTupleIterator(tuples, false), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -711,7 +711,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.rut, iter, tuples)
@@ -727,7 +727,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -781,7 +781,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			ReadUsersetTuples(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := dsLimit.ReadUsersetTuples(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
@@ -804,7 +804,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 				storage.ReadUsersetTuplesOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, storage.ReadUsersetTuplesOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -834,7 +834,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 				store string,
 				filter storage.ReadUsersetTuplesFilter,
 				options storage.ReadUsersetTuplesOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples), nil
+				return storage.NewStaticTupleIterator(tuples, false), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -987,7 +987,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		helperValidateSingleClient(ctx, t, &internalStorage.rswu, iter, tuples)
@@ -1003,7 +1003,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		const numClient = 3
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
@@ -1056,7 +1056,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := dsLimit.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 		// this should not come from the map
@@ -1079,7 +1079,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 				storage.ReadStartingWithUserOptions{
 					Consistency: storage.ConsistencyOptions{
 						Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, storage.ReadStartingWithUserOptions{Consistency: storage.ConsistencyOptions{
 			Preference: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY}})
 		require.NoError(t, err)
@@ -1100,7 +1100,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		ds := NewSharedIteratorDatastore(mockDatastore, internalStorage)
 		mockDatastore.EXPECT().
 			ReadStartingWithUser(gomock.Any(), storeID, filter, options).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 		iter1, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 		require.NoError(t, err)
 
@@ -1140,7 +1140,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 				store string,
 				filter storage.ReadStartingWithUserFilter,
 				options storage.ReadStartingWithUserOptions) (storage.TupleIterator, error) {
-				return storage.NewStaticTupleIterator(tuples), nil
+				return storage.NewStaticTupleIterator(tuples, false), nil
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
@@ -1852,7 +1852,7 @@ func TestSharedIterator_IsOrdered(t *testing.T) {
 	t.Cleanup(func() { goleak.VerifyNone(t) })
 
 	tuples := []*openfgav1.Tuple{{Key: tuple.NewTupleKey("doc:1", "viewer", "user:a")}}
-	inner := storage.NewStaticTupleIterator(tuples)
+	inner := storage.NewStaticTupleIterator(tuples, true)
 	shared := newSharedIterator(inner)
 	defer shared.Stop()
 
@@ -1899,7 +1899,7 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 
 		mockDatastore.EXPECT().
 			Read(gomock.Any(), storeID, filter, storage.ReadOptions{}).
-			Return(storage.NewStaticTupleIterator(tuples), nil)
+			Return(storage.NewStaticTupleIterator(tuples, false), nil)
 
 		iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 		require.NoError(t, err)

--- a/pkg/storage/test/storage.go
+++ b/pkg/storage/test/storage.go
@@ -38,6 +38,7 @@ func RunAllTests(t *testing.T, ds storage.OpenFGADatastore) {
 	t.Run("TestReadChanges", func(t *testing.T) { ReadChangesTest(t, ds) })
 	t.Run("TestReadStartingWithUser", func(t *testing.T) { ReadStartingWithUserTest(t, ds) })
 	t.Run("TestReadAndReadPages", func(t *testing.T) { ReadAndReadPageTest(t, ds) })
+	t.Run("TestReadUsersetTuples", func(t *testing.T) { ReadUsersetTuplesTest(t, ds) })
 
 	// Authorization models.
 	t.Run("TestWriteAndReadAuthorizationModel", func(t *testing.T) { WriteAndReadAuthorizationModelTest(t, ds) })

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1302,317 +1302,6 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
-	t.Run("reading_userset_tuples_that_exists_succeeds", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			{
-				Object:   "doc:readme",
-				Relation: "owner",
-				User:     "org:openfga#member",
-			},
-			{
-				Object:   "doc:readme",
-				Relation: "owner",
-				User:     "domain:iam#member",
-			},
-			{
-				Object:   "doc:readme",
-				Relation: "owner",
-				User:     "user:*",
-			},
-			{
-				Object:   "doc:readme",
-				Relation: "viewer",
-				User:     "org:openfgapb#viewer",
-			},
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "doc:readme",
-			Relation: "owner",
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		var gotTupleKeys []*openfgav1.TupleKey
-		for {
-			tk, err := iter.Next(ctx)
-			if err != nil {
-				if errors.Is(err, storage.ErrIteratorDone) {
-					break
-				}
-
-				require.Fail(t, "unexpected error encountered")
-			}
-
-			gotTupleKeys = append(gotTupleKeys, tk)
-		}
-
-		// Then the iterator should run out.
-		_, err = gotTuples.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-
-		require.Len(t, gotTupleKeys, 3)
-
-		if diff := cmp.Diff(tks[:3], gotTupleKeys, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-	})
-
-	t.Run("reading_userset_tuples_that_don't_exist_should_return_an_empty_iterator", func(t *testing.T) {
-		storeID := ulid.Make().String()
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-		defer gotTuples.Stop()
-
-		_, err = gotTuples.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_with_filter_made_of_direct_relation_reference", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.DirectRelationReference("group", "member"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		gotTk, err := iter.Next(ctx)
-		require.NoError(t, err)
-
-		expected := tuple.NewTupleKey("document:1", "viewer", "group:eng#member")
-		if diff := cmp.Diff(expected, gotTk, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_with_filter_made_of_direct_relation_references", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.DirectRelationReference("group", "member"),
-				typesystem.DirectRelationReference("grouping", "member"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		gotOne, err := iter.Next(ctx)
-		require.NoError(t, err)
-		gotTwo, err := iter.Next(ctx)
-		require.NoError(t, err)
-
-		expected := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_with_filter_made_of_wildcard_relation_reference", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.WildcardRelationReference("user"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		got, err := iter.Next(ctx)
-		require.NoError(t, err)
-
-		expected := tuple.NewTupleKey("document:1", "viewer", "user:*")
-		if diff := cmp.Diff(expected, got, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_with_filter_made_of_mix_references", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.DirectRelationReference("group", "member"),
-				typesystem.WildcardRelationReference("user"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		gotOne, err := iter.Next(ctx)
-		require.NoError(t, err)
-		gotTwo, err := iter.Next(ctx)
-		require.NoError(t, err)
-
-		expected := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-		}
-		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_with_filter_made_of_mix_references_for_same_type", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.DirectRelationReference("group", "member"),
-				typesystem.WildcardRelationReference("group"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		gotOne, err := iter.Next(ctx)
-		require.NoError(t, err)
-		gotTwo, err := iter.Next(ctx)
-		require.NoError(t, err)
-
-		expected := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "group:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-		}
-		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-	})
-
-	t.Run("reading_userset_tuples_distinguish_different_relation_ref", func(t *testing.T) {
-		storeID := ulid.Make().String()
-		tks := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "user:*"),
-			tuple.NewTupleKey("document:1", "viewer", "users:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:*"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#other"),
-			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
-		}
-
-		err := datastore.Write(ctx, storeID, nil, tks)
-		require.NoError(t, err)
-
-		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
-			Object:   "document:1",
-			Relation: "viewer",
-			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
-				typesystem.DirectRelationReference("group", "member"),
-			},
-		}, storage.ReadUsersetTuplesOptions{})
-		require.NoError(t, err)
-
-		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
-		defer iter.Stop()
-
-		gotOne, err := iter.Next(ctx)
-		require.NoError(t, err)
-		_, err = iter.Next(ctx)
-		require.ErrorIs(t, err, storage.ErrIteratorDone)
-
-		expected := []*openfgav1.TupleKey{
-			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
-		}
-		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne}, cmpOpts...); diff != "" {
-			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
-		}
-	})
 
 	t.Run("tuples_with_nil_condition", func(t *testing.T) {
 		// This test ensures we don't normalize nil conditions to an empty value.
@@ -2367,6 +2056,449 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			})
 		})
 	}
+
+	t.Run("enforce_order_of_tuples", func(t *testing.T) {
+		sid := ulid.Make().String()
+
+		// Written in reverse order; WithResultsSortedAscending must return ascending by user.
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:charlie"),
+			tuple.NewTupleKey("document:1", "viewer", "user:bob"),
+			tuple.NewTupleKey("document:1", "viewer", "user:anne"),
+		}
+		err := datastore.Write(ctx, sid, nil, tks)
+		require.NoError(t, err)
+
+		tupleIterator, err := datastore.Read(ctx, sid, storage.ReadFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+		}, storage.ReadOptions{WithResultsSortedAscending: true})
+		require.NoError(t, err)
+		defer tupleIterator.Stop()
+
+		got := iterateThroughAllTuples(t, tupleIterator)
+		var users []string
+		for _, tk := range got {
+			users = append(users, tk.GetUser())
+		}
+		require.Equal(t, []string{"user:anne", "user:bob", "user:charlie"}, users)
+	})
+
+	t.Run("assert_bytewise_ordering_of_tuples", func(t *testing.T) {
+		sid := ulid.Make().String()
+
+		// Users with varying special characters; written in reverse of expected bytewise order.
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:doc_3"),
+			tuple.NewTupleKey("document:1", "viewer", "user:doc-3"),
+			tuple.NewTupleKey("document:1", "viewer", "user:doc6"),
+			tuple.NewTupleKey("document:1", "viewer", "user:Apt"),
+			tuple.NewTupleKey("document:1", "viewer", "user:alt"),
+		}
+		err := datastore.Write(ctx, sid, nil, tks)
+		require.NoError(t, err)
+
+		tupleIterator, err := datastore.Read(ctx, sid, storage.ReadFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+		}, storage.ReadOptions{WithResultsSortedAscending: true})
+		require.NoError(t, err)
+		defer tupleIterator.Stop()
+
+		got := iterateThroughAllTuples(t, tupleIterator)
+		var users []string
+		for _, tk := range got {
+			users = append(users, tk.GetUser())
+		}
+
+		expected := []string{"user:Apt", "user:alt", "user:doc-3", "user:doc_3", "user:doc6"}
+		sort.Strings(expected)
+		require.Equal(t, expected, users)
+	})
+}
+
+func ReadUsersetTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
+	ctx := context.Background()
+
+	t.Run("reading_userset_tuples_that_exists_succeeds", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			{
+				Object:   "doc:readme",
+				Relation: "owner",
+				User:     "org:openfga#member",
+			},
+			{
+				Object:   "doc:readme",
+				Relation: "owner",
+				User:     "domain:iam#member",
+			},
+			{
+				Object:   "doc:readme",
+				Relation: "owner",
+				User:     "user:*",
+			},
+			{
+				Object:   "doc:readme",
+				Relation: "viewer",
+				User:     "org:openfgapb#viewer",
+			},
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "doc:readme",
+			Relation: "owner",
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		var gotTupleKeys []*openfgav1.TupleKey
+		for {
+			tk, err := iter.Next(ctx)
+			if err != nil {
+				if errors.Is(err, storage.ErrIteratorDone) {
+					break
+				}
+
+				require.Fail(t, "unexpected error encountered")
+			}
+
+			gotTupleKeys = append(gotTupleKeys, tk)
+		}
+
+		// Then the iterator should run out.
+		_, err = gotTuples.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+
+		require.Len(t, gotTupleKeys, 3)
+
+		if diff := cmp.Diff(tks[:3], gotTupleKeys, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("reading_userset_tuples_that_don't_exist_should_return_an_empty_iterator", func(t *testing.T) {
+		storeID := ulid.Make().String()
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{Object: "doc:readme", Relation: "owner"}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+		defer gotTuples.Stop()
+
+		_, err = gotTuples.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_direct_relation_reference", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotTk, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := tuple.NewTupleKey("document:1", "viewer", "group:eng#member")
+		if diff := cmp.Diff(expected, gotTk, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_direct_relation_references", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+				typesystem.DirectRelationReference("grouping", "member"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotOne, err := iter.Next(ctx)
+		require.NoError(t, err)
+		gotTwo, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_wildcard_relation_reference", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.WildcardRelationReference("user"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		got, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := tuple.NewTupleKey("document:1", "viewer", "user:*")
+		if diff := cmp.Diff(expected, got, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_mix_references", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+				typesystem.WildcardRelationReference("user"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotOne, err := iter.Next(ctx)
+		require.NoError(t, err)
+		gotTwo, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+		}
+		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_with_filter_made_of_mix_references_for_same_type", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+				typesystem.WildcardRelationReference("group"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotOne, err := iter.Next(ctx)
+		require.NoError(t, err)
+		gotTwo, err := iter.Next(ctx)
+		require.NoError(t, err)
+
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+		}
+		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne, gotTwo}, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+	})
+
+	t.Run("reading_userset_tuples_distinguish_different_relation_ref", func(t *testing.T) {
+		storeID := ulid.Make().String()
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:*"),
+			tuple.NewTupleKey("document:1", "viewer", "users:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:*"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#other"),
+			tuple.NewTupleKey("document:1", "viewer", "grouping:eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+			},
+		}, storage.ReadUsersetTuplesOptions{})
+		require.NoError(t, err)
+
+		iter := storage.NewTupleKeyIteratorFromTupleIterator(gotTuples)
+		defer iter.Stop()
+
+		gotOne, err := iter.Next(ctx)
+		require.NoError(t, err)
+		_, err = iter.Next(ctx)
+		require.ErrorIs(t, err, storage.ErrIteratorDone)
+
+		expected := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:eng#member"),
+		}
+		if diff := cmp.Diff(expected, []*openfgav1.TupleKey{gotOne}, cmpOpts...); diff != "" {
+			require.FailNowf(t, "mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("enforce_order_of_tuples", func(t *testing.T) {
+		storeID := ulid.Make().String()
+
+		// Written in reverse order; WithResultsSortedAscending must return ascending by user.
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:c#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:b#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:a#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+			},
+		}, storage.ReadUsersetTuplesOptions{WithResultsSortedAscending: true})
+		require.NoError(t, err)
+		defer gotTuples.Stop()
+
+		tuples := iterateThroughAllTuples(t, gotTuples)
+		var users []string
+		for _, tk := range tuples {
+			users = append(users, tk.GetUser())
+		}
+		require.Equal(t, []string{"group:a#member", "group:b#member", "group:c#member"}, users)
+	})
+
+	t.Run("assert_bytewise_ordering_of_tuples", func(t *testing.T) {
+		storeID := ulid.Make().String()
+
+		// Users with varying special characters; written in reverse of expected bytewise order.
+		tks := []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:eng_b#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng-b#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:engB#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng9#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:eng2#member"),
+			tuple.NewTupleKey("document:1", "viewer", "group:Eng#member"),
+		}
+
+		err := datastore.Write(ctx, storeID, nil, tks)
+		require.NoError(t, err)
+
+		gotTuples, err := datastore.ReadUsersetTuples(ctx, storeID, storage.ReadUsersetTuplesFilter{
+			Object:   "document:1",
+			Relation: "viewer",
+			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
+				typesystem.DirectRelationReference("group", "member"),
+			},
+		}, storage.ReadUsersetTuplesOptions{WithResultsSortedAscending: true})
+		require.NoError(t, err)
+		defer gotTuples.Stop()
+
+		tuples := iterateThroughAllTuples(t, gotTuples)
+		var users []string
+		for _, tk := range tuples {
+			users = append(users, tk.GetUser())
+		}
+
+		expected := []string{"group:Eng#member", "group:eng-b#member", "group:eng2#member", "group:eng9#member", "group:engB#member", "group:eng_b#member"}
+		sort.Strings(expected)
+		require.Equal(t, expected, users)
+	})
 }
 
 // getObjects returns all the objects from an iterator.

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1302,7 +1302,6 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		require.ErrorIs(t, err, storage.ErrNotFound)
 	})
 
-
 	t.Run("tuples_with_nil_condition", func(t *testing.T) {
 		// This test ensures we don't normalize nil conditions to an empty value.
 		storeID := ulid.Make().String()

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -1721,7 +1721,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 				},
 			},
 			storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
+				SortAsc: true,
 			},
 		)
 		require.NoError(t, err)
@@ -1768,7 +1768,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 				},
 			},
 			storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
+				SortAsc: true,
 			},
 		)
 		require.NoError(t, err)
@@ -1818,7 +1818,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 				},
 			},
 			storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
+				SortAsc: true,
 			},
 		)
 		require.NoError(t, err)
@@ -1874,7 +1874,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 				ObjectIDs: objectIDs,
 			},
 			storage.ReadStartingWithUserOptions{
-				WithResultsSortedAscending: true,
+				SortAsc: true,
 			},
 		)
 		require.NoError(t, err)
@@ -2059,7 +2059,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	t.Run("enforce_order_of_tuples", func(t *testing.T) {
 		sid := ulid.Make().String()
 
-		// Written in reverse order; WithResultsSortedAscending must return ascending by user.
+		// Written in reverse order; SortAsc must return ascending by user.
 		tks := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:charlie"),
 			tuple.NewTupleKey("document:1", "viewer", "user:bob"),
@@ -2071,7 +2071,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		tupleIterator, err := datastore.Read(ctx, sid, storage.ReadFilter{
 			Object:   "document:1",
 			Relation: "viewer",
-		}, storage.ReadOptions{WithResultsSortedAscending: true})
+		}, storage.ReadOptions{SortAsc: true})
 		require.NoError(t, err)
 		defer tupleIterator.Stop()
 
@@ -2100,7 +2100,7 @@ func ReadAndReadPageTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		tupleIterator, err := datastore.Read(ctx, sid, storage.ReadFilter{
 			Object:   "document:1",
 			Relation: "viewer",
-		}, storage.ReadOptions{WithResultsSortedAscending: true})
+		}, storage.ReadOptions{SortAsc: true})
 		require.NoError(t, err)
 		defer tupleIterator.Stop()
 
@@ -2434,7 +2434,7 @@ func ReadUsersetTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	t.Run("enforce_order_of_tuples", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		// Written in reverse order; WithResultsSortedAscending must return ascending by user.
+		// Written in reverse order; SortAsc must return ascending by user.
 		tks := []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "group:c#member"),
 			tuple.NewTupleKey("document:1", "viewer", "group:b#member"),
@@ -2450,7 +2450,7 @@ func ReadUsersetTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.DirectRelationReference("group", "member"),
 			},
-		}, storage.ReadUsersetTuplesOptions{WithResultsSortedAscending: true})
+		}, storage.ReadUsersetTuplesOptions{SortAsc: true})
 		require.NoError(t, err)
 		defer gotTuples.Stop()
 
@@ -2484,7 +2484,7 @@ func ReadUsersetTuplesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			AllowedUserTypeRestrictions: []*openfgav1.RelationReference{
 				typesystem.DirectRelationReference("group", "member"),
 			},
-		}, storage.ReadUsersetTuplesOptions{WithResultsSortedAscending: true})
+		}, storage.ReadUsersetTuplesOptions{SortAsc: true})
 		require.NoError(t, err)
 		defer gotTuples.Stop()
 

--- a/pkg/storage/tuple_iterators.go
+++ b/pkg/storage/tuple_iterators.go
@@ -130,23 +130,13 @@ func NewCombinedIterator[T any](iters ...Iterator[T]) Iterator[T] {
 }
 
 // NewStaticTupleIterator returns a [TupleIterator] that iterates over the provided slice.
-func NewStaticTupleIterator(tuples []*openfgav1.Tuple) TupleIterator {
-	iter := &StaticIterator[*openfgav1.Tuple]{
-		items: tuples,
-		mu:    &sync.Mutex{},
-	}
-
-	return iter
+func NewStaticTupleIterator(tuples []*openfgav1.Tuple, ordered bool) TupleIterator {
+	return NewStaticIterator(tuples, ordered)
 }
 
 // NewStaticTupleKeyIterator returns a [TupleKeyIterator] that iterates over the provided slice.
-func NewStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey) TupleKeyIterator {
-	iter := &StaticIterator[*openfgav1.TupleKey]{
-		items: tupleKeys,
-		mu:    &sync.Mutex{},
-	}
-
-	return iter
+func NewStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey, ordered bool) TupleKeyIterator {
+	return NewStaticIterator(tupleKeys, ordered)
 }
 
 type tupleKeyIterator struct {
@@ -191,8 +181,9 @@ func NewTupleKeyIteratorFromTupleIterator(iter TupleIterator) TupleKeyIterator {
 }
 
 type StaticIterator[T any] struct {
-	items []T // GUARDED_BY(mu)
-	mu    *sync.Mutex
+	items   []T // GUARDED_BY(mu)
+	mu      *sync.Mutex
+	ordered bool
 }
 
 var _ Iterator[any] = (*StaticIterator[any])(nil)
@@ -243,12 +234,10 @@ func (s *StaticIterator[T]) Head(ctx context.Context) (T, error) {
 	return s.items[0], nil
 }
 
-// IsOrdered temporarily assumes the caller provided items in sorted order.
-// This will be made conditional when sources add explicit ordering guarantees.
-func (s *StaticIterator[T]) IsOrdered() bool { return true }
+func (s *StaticIterator[T]) IsOrdered() bool { return s.ordered }
 
-func NewStaticIterator[T any](items []T) Iterator[T] {
-	return &StaticIterator[T]{items: items, mu: &sync.Mutex{}}
+func NewStaticIterator[T any](items []T, ordered bool) Iterator[T] {
+	return &StaticIterator[T]{items: items, mu: &sync.Mutex{}, ordered: ordered}
 }
 
 // TupleKeyFilterFunc is a filter function that is used to filter out

--- a/pkg/storage/tuple_iterators.go
+++ b/pkg/storage/tuple_iterators.go
@@ -129,14 +129,24 @@ func NewCombinedIterator[T any](iters ...Iterator[T]) Iterator[T] {
 	return &combinedIterator[T]{pending: pending, once: &sync.Once{}, mu: &sync.Mutex{}}
 }
 
-// NewStaticTupleIterator returns a [TupleIterator] that iterates over the provided slice.
-func NewStaticTupleIterator(tuples []*openfgav1.Tuple, ordered bool) TupleIterator {
-	return NewStaticIterator(tuples, ordered)
+// NewOrderedStaticTupleIterator returns a [TupleIterator] over the provided slice that reports IsOrdered()==true.
+func NewOrderedStaticTupleIterator(tuples []*openfgav1.Tuple) TupleIterator {
+	return NewOrderedStaticIterator(tuples)
 }
 
-// NewStaticTupleKeyIterator returns a [TupleKeyIterator] that iterates over the provided slice.
-func NewStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey, ordered bool) TupleKeyIterator {
-	return NewStaticIterator(tupleKeys, ordered)
+// NewUnorderedStaticTupleIterator returns a [TupleIterator] over the provided slice that reports IsOrdered()==false.
+func NewUnorderedStaticTupleIterator(tuples []*openfgav1.Tuple) TupleIterator {
+	return NewUnorderedStaticIterator(tuples)
+}
+
+// NewOrderedStaticTupleKeyIterator returns a [TupleKeyIterator] over the provided slice that reports IsOrdered()==true.
+func NewOrderedStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey) TupleKeyIterator {
+	return NewOrderedStaticIterator(tupleKeys)
+}
+
+// NewUnorderedStaticTupleKeyIterator returns a [TupleKeyIterator] over the provided slice that reports IsOrdered()==false.
+func NewUnorderedStaticTupleKeyIterator(tupleKeys []*openfgav1.TupleKey) TupleKeyIterator {
+	return NewUnorderedStaticIterator(tupleKeys)
 }
 
 type tupleKeyIterator struct {
@@ -181,9 +191,8 @@ func NewTupleKeyIteratorFromTupleIterator(iter TupleIterator) TupleKeyIterator {
 }
 
 type StaticIterator[T any] struct {
-	items   []T // GUARDED_BY(mu)
-	mu      *sync.Mutex
-	ordered bool
+	items []T // GUARDED_BY(mu)
+	mu    sync.Mutex
 }
 
 var _ Iterator[any] = (*StaticIterator[any])(nil)
@@ -234,10 +243,22 @@ func (s *StaticIterator[T]) Head(ctx context.Context) (T, error) {
 	return s.items[0], nil
 }
 
-func (s *StaticIterator[T]) IsOrdered() bool { return s.ordered }
+func (s *StaticIterator[T]) IsOrdered() bool { return false }
 
-func NewStaticIterator[T any](items []T, ordered bool) Iterator[T] {
-	return &StaticIterator[T]{items: items, mu: &sync.Mutex{}, ordered: ordered}
+type orderedStaticIterator[T any] struct {
+	StaticIterator[T]
+}
+
+func (o *orderedStaticIterator[T]) IsOrdered() bool { return true }
+
+// NewOrderedStaticIterator returns an [Iterator] over items that reports IsOrdered()==true.
+func NewOrderedStaticIterator[T any](items []T) Iterator[T] {
+	return &orderedStaticIterator[T]{StaticIterator[T]{items: items}}
+}
+
+// NewUnorderedStaticIterator returns an [Iterator] over items that reports IsOrdered()==false.
+func NewUnorderedStaticIterator[T any](items []T) Iterator[T] {
+	return &StaticIterator[T]{items: items}
 }
 
 // TupleKeyFilterFunc is a filter function that is used to filter out

--- a/pkg/storage/tuple_iterators_test.go
+++ b/pkg/storage/tuple_iterators_test.go
@@ -28,7 +28,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		iter := NewStaticTupleKeyIterator(expected, false)
+		iter := NewUnorderedStaticTupleKeyIterator(expected)
 		defer iter.Stop()
 
 		var actual []*openfgav1.TupleKey
@@ -48,7 +48,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 	})
 	t.Run("head_empty", func(t *testing.T) {
 		var expected []*openfgav1.TupleKey
-		iter := NewStaticTupleKeyIterator(expected, false)
+		iter := NewUnorderedStaticTupleKeyIterator(expected)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -60,7 +60,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
-		iter := NewStaticTupleKeyIterator(expected, false)
+		iter := NewUnorderedStaticTupleKeyIterator(expected)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -87,7 +87,7 @@ func TestStaticTupleIterator(t *testing.T) {
 			},
 		}
 
-		iter := NewStaticTupleIterator(expected, false)
+		iter := NewUnorderedStaticTupleIterator(expected)
 		defer iter.Stop()
 
 		var actual []*openfgav1.Tuple
@@ -107,7 +107,7 @@ func TestStaticTupleIterator(t *testing.T) {
 	})
 	t.Run("head_empty", func(t *testing.T) {
 		var expected []*openfgav1.Tuple
-		iter := NewStaticTupleIterator(expected, false)
+		iter := NewUnorderedStaticTupleIterator(expected)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -125,7 +125,7 @@ func TestStaticTupleIterator(t *testing.T) {
 				Timestamp: timestamppb.New(time.Now()),
 			},
 		}
-		iter := NewStaticTupleIterator(expected, false)
+		iter := NewUnorderedStaticTupleIterator(expected)
 		defer iter.Stop()
 		tk, err := iter.Head(context.Background())
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestStaticTupleIterator(t *testing.T) {
 				Timestamp: timestamppb.New(time.Now()),
 			}
 		}
-		iter := NewStaticTupleIterator(tks, false)
+		iter := NewUnorderedStaticTupleIterator(tks)
 		defer iter.Stop()
 
 		var wg errgroup.Group
@@ -197,8 +197,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]}, false)
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]}, false)
+		iter1 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
+		iter2 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]})
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 
@@ -228,8 +228,8 @@ func TestCombinedIterator(t *testing.T) {
 		require.ErrorIs(t, err, ErrIteratorDone)
 	})
 	t.Run("head_empty_slices", func(t *testing.T) {
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{}, false)
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{}, false)
+		iter1 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{})
+		iter2 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{})
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 		tk, err := iter.Head(context.Background())
@@ -257,8 +257,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "charles"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]}, false)
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1], expected[2]}, false)
+		iter1 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
+		iter2 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1], expected[2]})
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 
@@ -289,8 +289,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "charles"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[0]}, false)
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[1], tks[2]}, false)
+		iter1 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[0]})
+		iter2 := NewUnorderedStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[1], tks[2]})
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -600,9 +600,9 @@ var combinedTestCases = map[string]struct {
 
 func TestOrderedCombinedIterator(t *testing.T) {
 	t.Run("Stop", func(t *testing.T) {
-		iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
+		iter1 := NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
-		}, false)
+		})
 		iter := NewOrderedCombinedIterator(UserMapper(), iter1, nil)
 		iter.Stop()
 		require.Len(t, iter.pending, 1)
@@ -619,7 +619,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 						var iters []TupleIterator
 						for _, curIter := range tc.iter {
-							iters = append(iters, NewStaticTupleIterator(curIter, false))
+							iters = append(iters, NewUnorderedStaticTupleIterator(curIter))
 						}
 						iter := NewOrderedCombinedIterator(mapper, iters...)
 						t.Cleanup(func() {
@@ -649,11 +649,11 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 	t.Run("Head", func(t *testing.T) {
 		t.Run("return_err_if_unsorted_input_iterator", func(t *testing.T) {
-			iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
+			iter1 := NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:b")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
-			}, false)
-			iter2 := NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
+			})
+			iter2 := NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{})
 
 			iter := NewOrderedCombinedIterator(UserMapper(), iter1, iter2)
 			t.Cleanup(iter.Stop)
@@ -667,14 +667,14 @@ func TestOrderedCombinedIterator(t *testing.T) {
 			require.ErrorContains(t, err, "iterator 0 is not in ascending order")
 		})
 		t.Run("multiple_calls_to_head_should_return_same_value", func(t *testing.T) {
-			iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
+			iter1 := NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:b")},
-			}, false)
-			iter2 := NewStaticTupleIterator([]*openfgav1.Tuple{
+			})
+			iter2 := NewUnorderedStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:c")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:d")},
-			}, false)
+			})
 			expected := &openfgav1.Tuple{
 				Key: tuple.NewTupleKey("document:1", "2", "user:a"),
 			}
@@ -700,7 +700,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 							var iters []TupleIterator
 							for _, curIter := range tc.iter {
-								iters = append(iters, NewStaticTupleIterator(curIter, false))
+								iters = append(iters, NewUnorderedStaticTupleIterator(curIter))
 							}
 							iter := NewOrderedCombinedIterator(mapper, iters...)
 							t.Cleanup(iter.Stop)
@@ -740,7 +740,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 							var iters []TupleIterator
 							for _, curIter := range tc.iter {
-								iters = append(iters, NewStaticTupleIterator(curIter, false))
+								iters = append(iters, NewUnorderedStaticTupleIterator(curIter))
 							}
 							iter := NewOrderedCombinedIterator(mapper, iters...)
 							t.Cleanup(iter.Stop)
@@ -811,7 +811,7 @@ func TestTupleKeyIteratorFromTupleIterator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			staticTupleIterator := NewStaticTupleIterator(expected, false)
+			staticTupleIterator := NewUnorderedStaticTupleIterator(expected)
 			defer staticTupleIterator.Stop()
 			iter := NewTupleKeyIteratorFromTupleIterator(staticTupleIterator)
 			defer iter.Stop()
@@ -860,7 +860,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "user:charlie"),
 		}
 		iter := NewFilteredTupleKeyIterator(
-			NewStaticTupleKeyIterator(tuples, false),
+			NewUnorderedStaticTupleKeyIterator(tuples),
 			func(tk *openfgav1.TupleKey) bool {
 				return tk.GetRelation() == "editor"
 			},
@@ -893,7 +893,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			var tuples []*openfgav1.TupleKey
 
 			iter := NewFilteredTupleKeyIterator(
-				NewStaticTupleKeyIterator(tuples, false),
+				NewUnorderedStaticTupleKeyIterator(tuples),
 				func(tk *openfgav1.TupleKey) bool {
 					return tk.GetRelation() == "editor"
 				},
@@ -949,7 +949,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 					}
 
 					iter := NewFilteredTupleKeyIterator(
-						NewStaticTupleKeyIterator(tuples, false),
+						NewUnorderedStaticTupleKeyIterator(tuples),
 						func(tk *openfgav1.TupleKey) bool {
 							return tk.GetRelation() == "editor"
 						},
@@ -993,7 +993,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			tuples[i] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "user:jon")
 		}
 		iter := NewFilteredTupleKeyIterator(
-			NewStaticTupleKeyIterator(tuples, false),
+			NewUnorderedStaticTupleKeyIterator(tuples),
 			func(tk *openfgav1.TupleKey) bool {
 				return true
 			},
@@ -1056,7 +1056,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 
 				var actual []*openfgav1.TupleKey
@@ -1128,7 +1128,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition3", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1190,7 +1190,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1248,7 +1248,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				var tuples []*openfgav1.TupleKey
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1309,7 +1309,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition4", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 				if tt.mixed {
 					tk, err := iter.Head(context.Background())
@@ -1343,7 +1343,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				var tuples []*openfgav1.TupleKey
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewUnorderedStaticTupleKeyIterator(tuples), filter)
 				t.Cleanup(iter.Stop)
 
 				ctx, cancel := context.WithCancel(context.Background())
@@ -1368,38 +1368,38 @@ func TestIsOrdered(t *testing.T) {
 	tup := &openfgav1.Tuple{Key: tk}
 
 	t.Run("StaticIterator_true", func(t *testing.T) {
-		require.True(t, NewStaticIterator[string]([]string{"a"}, true).IsOrdered())
-		require.True(t, NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true).IsOrdered())
-		require.True(t, NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true).IsOrdered())
+		require.True(t, NewOrderedStaticIterator[string]([]string{"a"}).IsOrdered())
+		require.True(t, NewOrderedStaticTupleIterator([]*openfgav1.Tuple{tup}).IsOrdered())
+		require.True(t, NewOrderedStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}).IsOrdered())
 	})
 
 	t.Run("combinedIterator_false", func(t *testing.T) {
-		iter := NewCombinedIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
+		iter := NewCombinedIterator(NewOrderedStaticTupleIterator([]*openfgav1.Tuple{tup}))
 		defer iter.Stop()
 		require.False(t, iter.IsOrdered())
 	})
 
 	t.Run("OrderedCombinedIterator_true", func(t *testing.T) {
-		iter := NewOrderedCombinedIterator(ObjectMapper(), NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
+		iter := NewOrderedCombinedIterator(ObjectMapper(), NewOrderedStaticTupleIterator([]*openfgav1.Tuple{tup}))
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("tupleKeyIterator_forwards", func(t *testing.T) {
-		iter := NewTupleKeyIteratorFromTupleIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
+		iter := NewTupleKeyIteratorFromTupleIterator(NewOrderedStaticTupleIterator([]*openfgav1.Tuple{tup}))
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("filteredTupleKeyIterator_forwards", func(t *testing.T) {
-		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true)
+		inner := NewOrderedStaticTupleKeyIterator([]*openfgav1.TupleKey{tk})
 		iter := NewFilteredTupleKeyIterator(inner, func(k *openfgav1.TupleKey) bool { return true })
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("ConditionsFilteredTupleKeyIterator_forwards", func(t *testing.T) {
-		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true)
+		inner := NewOrderedStaticTupleKeyIterator([]*openfgav1.TupleKey{tk})
 		iter := NewConditionsFilteredTupleKeyIterator(inner, func(k *openfgav1.TupleKey) (bool, error) { return true, nil })
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())

--- a/pkg/storage/tuple_iterators_test.go
+++ b/pkg/storage/tuple_iterators_test.go
@@ -28,7 +28,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		iter := NewStaticTupleKeyIterator(expected)
+		iter := NewStaticTupleKeyIterator(expected, false)
 		defer iter.Stop()
 
 		var actual []*openfgav1.TupleKey
@@ -48,7 +48,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 	})
 	t.Run("head_empty", func(t *testing.T) {
 		var expected []*openfgav1.TupleKey
-		iter := NewStaticTupleKeyIterator(expected)
+		iter := NewStaticTupleKeyIterator(expected, false)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -60,7 +60,7 @@ func TestStaticTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc1", "viewer", "bill"),
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
-		iter := NewStaticTupleKeyIterator(expected)
+		iter := NewStaticTupleKeyIterator(expected, false)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -87,7 +87,7 @@ func TestStaticTupleIterator(t *testing.T) {
 			},
 		}
 
-		iter := NewStaticTupleIterator(expected)
+		iter := NewStaticTupleIterator(expected, false)
 		defer iter.Stop()
 
 		var actual []*openfgav1.Tuple
@@ -107,7 +107,7 @@ func TestStaticTupleIterator(t *testing.T) {
 	})
 	t.Run("head_empty", func(t *testing.T) {
 		var expected []*openfgav1.Tuple
-		iter := NewStaticTupleIterator(expected)
+		iter := NewStaticTupleIterator(expected, false)
 		defer iter.Stop()
 
 		tk, err := iter.Head(context.Background())
@@ -125,7 +125,7 @@ func TestStaticTupleIterator(t *testing.T) {
 				Timestamp: timestamppb.New(time.Now()),
 			},
 		}
-		iter := NewStaticTupleIterator(expected)
+		iter := NewStaticTupleIterator(expected, false)
 		defer iter.Stop()
 		tk, err := iter.Head(context.Background())
 		require.NoError(t, err)
@@ -144,7 +144,7 @@ func TestStaticTupleIterator(t *testing.T) {
 				Timestamp: timestamppb.New(time.Now()),
 			}
 		}
-		iter := NewStaticTupleIterator(tks)
+		iter := NewStaticTupleIterator(tks, false)
 		defer iter.Stop()
 
 		var wg errgroup.Group
@@ -197,8 +197,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "bob"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]})
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]}, false)
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1]}, false)
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 
@@ -228,8 +228,8 @@ func TestCombinedIterator(t *testing.T) {
 		require.ErrorIs(t, err, ErrIteratorDone)
 	})
 	t.Run("head_empty_slices", func(t *testing.T) {
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{})
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{})
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{}, false)
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{}, false)
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 		tk, err := iter.Head(context.Background())
@@ -257,8 +257,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "charles"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]})
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1], expected[2]})
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[0]}, false)
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{expected[1], expected[2]}, false)
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 
@@ -289,8 +289,8 @@ func TestCombinedIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "charles"),
 		}
 
-		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[0]})
-		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[1], tks[2]})
+		iter1 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[0]}, false)
+		iter2 := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tks[1], tks[2]}, false)
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 		ctx, cancel := context.WithCancel(context.Background())
@@ -602,7 +602,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 	t.Run("Stop", func(t *testing.T) {
 		iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
 			{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
-		})
+		}, false)
 		iter := NewOrderedCombinedIterator(UserMapper(), iter1, nil)
 		iter.Stop()
 		require.Len(t, iter.pending, 1)
@@ -619,7 +619,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 						var iters []TupleIterator
 						for _, curIter := range tc.iter {
-							iters = append(iters, NewStaticTupleIterator(curIter))
+							iters = append(iters, NewStaticTupleIterator(curIter, false))
 						}
 						iter := NewOrderedCombinedIterator(mapper, iters...)
 						t.Cleanup(func() {
@@ -652,8 +652,8 @@ func TestOrderedCombinedIterator(t *testing.T) {
 			iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:b")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
-			})
-			iter2 := NewStaticTupleIterator([]*openfgav1.Tuple{})
+			}, false)
+			iter2 := NewStaticTupleIterator([]*openfgav1.Tuple{}, false)
 
 			iter := NewOrderedCombinedIterator(UserMapper(), iter1, iter2)
 			t.Cleanup(iter.Stop)
@@ -670,11 +670,11 @@ func TestOrderedCombinedIterator(t *testing.T) {
 			iter1 := NewStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:a")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:b")},
-			})
+			}, false)
 			iter2 := NewStaticTupleIterator([]*openfgav1.Tuple{
 				{Key: tuple.NewTupleKey("document:1", "2", "user:c")},
 				{Key: tuple.NewTupleKey("document:1", "2", "user:d")},
-			})
+			}, false)
 			expected := &openfgav1.Tuple{
 				Key: tuple.NewTupleKey("document:1", "2", "user:a"),
 			}
@@ -700,7 +700,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 							var iters []TupleIterator
 							for _, curIter := range tc.iter {
-								iters = append(iters, NewStaticTupleIterator(curIter))
+								iters = append(iters, NewStaticTupleIterator(curIter, false))
 							}
 							iter := NewOrderedCombinedIterator(mapper, iters...)
 							t.Cleanup(iter.Stop)
@@ -740,7 +740,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 
 							var iters []TupleIterator
 							for _, curIter := range tc.iter {
-								iters = append(iters, NewStaticTupleIterator(curIter))
+								iters = append(iters, NewStaticTupleIterator(curIter, false))
 							}
 							iter := NewOrderedCombinedIterator(mapper, iters...)
 							t.Cleanup(iter.Stop)
@@ -811,7 +811,7 @@ func TestTupleKeyIteratorFromTupleIterator(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			staticTupleIterator := NewStaticTupleIterator(expected)
+			staticTupleIterator := NewStaticTupleIterator(expected, false)
 			defer staticTupleIterator.Stop()
 			iter := NewTupleKeyIteratorFromTupleIterator(staticTupleIterator)
 			defer iter.Stop()
@@ -860,7 +860,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			tuple.NewTupleKey("document:doc2", "editor", "user:charlie"),
 		}
 		iter := NewFilteredTupleKeyIterator(
-			NewStaticTupleKeyIterator(tuples),
+			NewStaticTupleKeyIterator(tuples, false),
 			func(tk *openfgav1.TupleKey) bool {
 				return tk.GetRelation() == "editor"
 			},
@@ -893,7 +893,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			var tuples []*openfgav1.TupleKey
 
 			iter := NewFilteredTupleKeyIterator(
-				NewStaticTupleKeyIterator(tuples),
+				NewStaticTupleKeyIterator(tuples, false),
 				func(tk *openfgav1.TupleKey) bool {
 					return tk.GetRelation() == "editor"
 				},
@@ -949,7 +949,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 					}
 
 					iter := NewFilteredTupleKeyIterator(
-						NewStaticTupleKeyIterator(tuples),
+						NewStaticTupleKeyIterator(tuples, false),
 						func(tk *openfgav1.TupleKey) bool {
 							return tk.GetRelation() == "editor"
 						},
@@ -993,7 +993,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 			tuples[i] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "user:jon")
 		}
 		iter := NewFilteredTupleKeyIterator(
-			NewStaticTupleKeyIterator(tuples),
+			NewStaticTupleKeyIterator(tuples, false),
 			func(tk *openfgav1.TupleKey) bool {
 				return true
 			},
@@ -1056,7 +1056,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 
 				var actual []*openfgav1.TupleKey
@@ -1128,7 +1128,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition3", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition1", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1190,7 +1190,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition2", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition3", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1248,7 +1248,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				var tuples []*openfgav1.TupleKey
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 				var actual []*openfgav1.TupleKey
 				var actualHead []*openfgav1.TupleKey
@@ -1309,7 +1309,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:elbuo", "condition4", nil),
 					tuple.NewTupleKeyWithCondition("document:doc1", "editor", "user:maria", "condition5", nil),
 				}
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 				if tt.mixed {
 					tk, err := iter.Head(context.Background())
@@ -1343,7 +1343,7 @@ func TestConditionsFilteredTupleKeyIterator(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				var tuples []*openfgav1.TupleKey
-				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples), filter)
+				iter := NewConditionsFilteredTupleKeyIterator(NewStaticTupleKeyIterator(tuples, false), filter)
 				t.Cleanup(iter.Stop)
 
 				ctx, cancel := context.WithCancel(context.Background())
@@ -1368,38 +1368,38 @@ func TestIsOrdered(t *testing.T) {
 	tup := &openfgav1.Tuple{Key: tk}
 
 	t.Run("StaticIterator_true", func(t *testing.T) {
-		require.True(t, NewStaticIterator[string]([]string{"a"}).IsOrdered())
-		require.True(t, NewStaticTupleIterator([]*openfgav1.Tuple{tup}).IsOrdered())
-		require.True(t, NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}).IsOrdered())
+		require.True(t, NewStaticIterator[string]([]string{"a"}, true).IsOrdered())
+		require.True(t, NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true).IsOrdered())
+		require.True(t, NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true).IsOrdered())
 	})
 
 	t.Run("combinedIterator_false", func(t *testing.T) {
-		iter := NewCombinedIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}))
+		iter := NewCombinedIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
 		defer iter.Stop()
 		require.False(t, iter.IsOrdered())
 	})
 
 	t.Run("OrderedCombinedIterator_true", func(t *testing.T) {
-		iter := NewOrderedCombinedIterator(ObjectMapper(), NewStaticTupleIterator([]*openfgav1.Tuple{tup}))
+		iter := NewOrderedCombinedIterator(ObjectMapper(), NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("tupleKeyIterator_forwards", func(t *testing.T) {
-		iter := NewTupleKeyIteratorFromTupleIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}))
+		iter := NewTupleKeyIteratorFromTupleIterator(NewStaticTupleIterator([]*openfgav1.Tuple{tup}, true))
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("filteredTupleKeyIterator_forwards", func(t *testing.T) {
-		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk})
+		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true)
 		iter := NewFilteredTupleKeyIterator(inner, func(k *openfgav1.TupleKey) bool { return true })
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())
 	})
 
 	t.Run("ConditionsFilteredTupleKeyIterator_forwards", func(t *testing.T) {
-		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk})
+		inner := NewStaticTupleKeyIterator([]*openfgav1.TupleKey{tk}, true)
 		iter := NewConditionsFilteredTupleKeyIterator(inner, func(k *openfgav1.TupleKey) (bool, error) { return true, nil })
 		defer iter.Stop()
 		require.True(t, iter.IsOrdered())

--- a/pkg/storage/tuple_mappers_test.go
+++ b/pkg/storage/tuple_mappers_test.go
@@ -32,7 +32,7 @@ func TestUsersetTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks, false)
+	innerIter := NewUnorderedStaticTupleKeyIterator(tks)
 
 	mapper := WrapIterator(UsersetKind, innerIter)
 	require.NotNil(t, mapper)
@@ -67,7 +67,7 @@ func TestTTUTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2#member"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks, false)
+	innerIter := NewUnorderedStaticTupleKeyIterator(tks)
 
 	mapper := WrapIterator(TTUKind, innerIter)
 	require.NotNil(t, mapper)
@@ -88,20 +88,20 @@ func TestTTUTupleMapper(t *testing.T) {
 
 func TestMapperIsOrdered(t *testing.T) {
 	tks := []*openfgav1.TupleKey{tuple.NewTupleKey("group:eng", "member", "user:alice#member")}
-	inner := NewStaticTupleKeyIterator(tks, true)
+	inner := NewOrderedStaticTupleKeyIterator(tks)
 
 	t.Run("UsersetMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(UsersetKind, inner)
 		require.True(t, m.IsOrdered())
 	})
 
-	inner2 := NewStaticTupleKeyIterator(tks, true)
+	inner2 := NewOrderedStaticTupleKeyIterator(tks)
 	t.Run("TTUMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(TTUKind, inner2)
 		require.True(t, m.IsOrdered())
 	})
 
-	inner3 := NewStaticTupleKeyIterator(tks, true)
+	inner3 := NewOrderedStaticTupleKeyIterator(tks)
 	t.Run("ObjectIDMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(ObjectIDKind, inner3)
 		require.True(t, m.IsOrdered())
@@ -116,7 +116,7 @@ func TestObjectIDTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2#member"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks, false)
+	innerIter := NewUnorderedStaticTupleKeyIterator(tks)
 
 	mapper := WrapIterator(ObjectIDKind, innerIter)
 	require.NotNil(t, mapper)

--- a/pkg/storage/tuple_mappers_test.go
+++ b/pkg/storage/tuple_mappers_test.go
@@ -32,7 +32,7 @@ func TestUsersetTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks)
+	innerIter := NewStaticTupleKeyIterator(tks, false)
 
 	mapper := WrapIterator(UsersetKind, innerIter)
 	require.NotNil(t, mapper)
@@ -67,7 +67,7 @@ func TestTTUTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2#member"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks)
+	innerIter := NewStaticTupleKeyIterator(tks, false)
 
 	mapper := WrapIterator(TTUKind, innerIter)
 	require.NotNil(t, mapper)
@@ -88,20 +88,20 @@ func TestTTUTupleMapper(t *testing.T) {
 
 func TestMapperIsOrdered(t *testing.T) {
 	tks := []*openfgav1.TupleKey{tuple.NewTupleKey("group:eng", "member", "user:alice#member")}
-	inner := NewStaticTupleKeyIterator(tks)
+	inner := NewStaticTupleKeyIterator(tks, true)
 
 	t.Run("UsersetMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(UsersetKind, inner)
 		require.True(t, m.IsOrdered())
 	})
 
-	inner2 := NewStaticTupleKeyIterator(tks)
+	inner2 := NewStaticTupleKeyIterator(tks, true)
 	t.Run("TTUMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(TTUKind, inner2)
 		require.True(t, m.IsOrdered())
 	})
 
-	inner3 := NewStaticTupleKeyIterator(tks)
+	inner3 := NewStaticTupleKeyIterator(tks, true)
 	t.Run("ObjectIDMapper_forwards", func(t *testing.T) {
 		m := WrapIterator(ObjectIDKind, inner3)
 		require.True(t, m.IsOrdered())
@@ -116,7 +116,7 @@ func TestObjectIDTupleMapper(t *testing.T) {
 		tuple.NewTupleKey("group:fga", "member", "group:2#member"),
 	}
 
-	innerIter := NewStaticTupleKeyIterator(tks)
+	innerIter := NewStaticTupleKeyIterator(tks, false)
 
 	mapper := WrapIterator(ObjectIDKind, innerIter)
 	require.NotNil(t, mapper)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

In experimental `weighted_graph_check` (v2Check), the weight2 pruning optimization requires tuples to be ordered. These tuples could come from a datastore `Read` call in the case of TTU, `ReadUsersetTuples` in the case of userset, and/or `ReadStartingWithUser` in the case of bottom_up. `ReadStartingWithUser` sorted unconditionally while `Read`/`ReadUsersetTuples` never sorted at all. We want these methods to return sorted results only when needed.

#### How is it being solved?

IsOrdered() now tells the truth end-to-end. Storage read methods gain an opt-in WithResultsSortedAscending flag; each iterator type stores and reports the actual ordering of its data. Callers in internal/check request sorted reads only when the weight2 strategy is reachable, so the pruning optimization can fire without paying for unnecessary ORDER BY on every read.

#### What changes are made to solve it?

- Added WithResultsSortedAscending to ReadOptions and ReadUsersetTuplesOptions; made ReadStartingWithUser honour its existing flag (previously it always sorted)                                                                                 
- All backends (postgres, mysql, sqlite, memory) apply ORDER BY conditionally and pass the flag to the iterator constructor                                                                                                                      
- StaticTupleIterator, SQLTupleIterator, and the memory staticIterator store an ordered bool and return it from IsOrdered()                                                                                                                      
- CachingIterator skips the redundant in-memory sort when the inner iterator is already ordered; persists the ordered flag on cache entries                                                                                                      
- CombinedTupleReader explicitly sorts contextual tuples on sorted paths and uses the appropriate merge combiner                                                                                                                                 
- bottom_up.go unconditionally requests sorted reads (correctness requirement for the merge-sort algorithms it feeds)                                                                                                                            
- check.go requests sorted reads only when weight2 pruning is reachable: edge weight is 2, no contextual tuples present, and user is a concrete ID

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added opt-in result ordering for read operations to improve consistency and enable performance optimizations.

* **Performance**
  * Enabled weight2 pruning optimization when results are ordered.

* **Documentation**
  * Updated changelog documenting result ordering behavior and iterator ordering semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->