### PR TITLE
chore: update todo comment string in migration guide

### DIFF
--- a/assets/migrations/mysql/collation_migrations.md
+++ b/assets/migrations/mysql/collation_migrations.md
@@ -1,7 +1,6 @@
 ## Operator runbook
 
-<!-- TODO: update with correct release version -->
-The vX.Y.Z release ships the 008 goose migration that converts identifier columns to the `utf8mb4_bin` collation so that case-distinct OpenFGA identities (e.g. `user:Alice` vs `user:alice`) are stored and compared as distinct values:
+The v1.18.0 release ships the 008 goose migration that converts identifier columns to the `utf8mb4_bin` collation so that case-distinct OpenFGA identities (e.g. `user:Alice` vs `user:alice`) are stored and compared as distinct values:
 
 - `008_collate_identifiers.sql` 
    — `tuple` (`object_type`, `relation`, `_user`, `condition_name`)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
Updates a TODO doc string for `v1.18.0` mysql migration guide


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration runbook to specify that the collation migration is available in v1.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->