### PR TITLE
chore: create draft release and publish after provenance succeeds for immutable tags/releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,7 +149,9 @@ jobs:
     with:
       base64-subjects-as-file: "${{ needs.goreleaser.outputs.subjects-as-file }}"
       provenance-name: "openfga.intoto.jsonl"
-      upload-assets: true # upload to a new release
+      upload-assets: true # upload to the draft release created by goreleaser
+      upload-tag-name: ${{ github.ref_name }}
+      draft-release: true
 
   image-provenance:
     needs: [ goreleaser ]
@@ -167,8 +169,14 @@ jobs:
       registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+  undraft-release:
+    needs: [ binary-provenance, image-provenance ]
+    permissions:
+      contents: write
+    uses: openfga/.github/.github/workflows/undraft-release.yml@15d8dd0e50827f4233abbbc3c394413940ba8db4 # pin@main
+
   verification-with-slsa-verifier:
-    needs: [ goreleaser, binary-provenance ]
+    needs: [ undraft-release, binary-provenance ]
     runs-on: ubuntu-latest
     permissions: read-all
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,9 +149,32 @@ jobs:
     with:
       base64-subjects-as-file: "${{ needs.goreleaser.outputs.subjects-as-file }}"
       provenance-name: "openfga.intoto.jsonl"
-      upload-assets: true # upload to the draft release created by goreleaser
-      upload-tag-name: ${{ github.ref_name }}
-      draft-release: "true"
+      # Don't let the generator attach the provenance:
+      # - it uses softprops/action-gh-release@v2.2.1, whose paginated draft lookup
+      #   creates a duplicate draft once a repo has >100 releases (2 pages)
+      # - the provenance is still published as a workflow artifact, so the
+      #   release-provenance job attaches it via `gh release upload` (by tag)
+      upload-assets: false
+
+  release-provenance:
+    needs: [ binary-provenance ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To add the provenance asset to the draft release.
+    steps:
+      - name: Download the provenance
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          name: ${{ needs.binary-provenance.outputs.provenance-name }}
+
+      - name: Attach provenance to the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: ${{ needs.binary-provenance.outputs.provenance-name }}
+        run: |
+          set -euo pipefail
+          gh release upload "$GITHUB_REF_NAME" "$PROVENANCE" \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
   image-provenance:
     needs: [ goreleaser ]
@@ -170,7 +193,7 @@ jobs:
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
   undraft-release:
-    needs: [ binary-provenance, image-provenance ]
+    needs: [ release-provenance, image-provenance ]
     permissions:
       contents: write
     uses: openfga/.github/.github/workflows/undraft-release.yml@15d8dd0e50827f4233abbbc3c394413940ba8db4 # pin@main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
-      contents: write # To add assets to a release.
+      contents: read
 
     # Note: this _must_ be referenced by tag. See: https://github.com/slsa-framework/slsa-verifier/issues/12
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -151,7 +151,7 @@ jobs:
       provenance-name: "openfga.intoto.jsonl"
       upload-assets: true # upload to the draft release created by goreleaser
       upload-tag-name: ${{ github.ref_name }}
-      draft-release: true
+      draft-release: "true"
 
   image-provenance:
     needs: [ goreleaser ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -159,6 +159,7 @@ jobs:
   release-provenance:
     needs: [ binary-provenance ]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # To add the provenance asset to the draft release.
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
     permissions:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
-      contents: read
+      contents: write # https://github.com/slsa-framework/slsa-github-generator/issues/2044
 
     # Note: this _must_ be referenced by tag. See: https://github.com/slsa-framework/slsa-verifier/issues/12
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -125,6 +125,7 @@ docker_manifests:
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
 
 release:
+  draft: true
   github:
     owner: openfga
     name: openfga

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)
-- Release flow now creates the GitHub release as a draft, attaches SLSA provenance, and publishes only after provenance jobs succeed. This avoids public releases with missing provenance and enables GitHub immutable releases. [#3178](https://github.com/openfga/openfga/pull/3178)
 
 ## [1.18.0] - 2026-06-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)
+- Release flow now creates the GitHub release as a draft, attaches SLSA provenance, and publishes only after provenance jobs succeed. This avoids public releases with missing provenance and enables GitHub immutable releases. [#3172](https://github.com/openfga/openfga/issues/3172)
 
 ## [1.18.0] - 2026-06-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)
-- Release flow now creates the GitHub release as a draft, attaches SLSA provenance, and publishes only after provenance jobs succeed. This avoids public releases with missing provenance and enables GitHub immutable releases. [#3172](https://github.com/openfga/openfga/issues/3172)
+- Release flow now creates the GitHub release as a draft, attaches SLSA provenance, and publishes only after provenance jobs succeed. This avoids public releases with missing provenance and enables GitHub immutable releases. [#3178](https://github.com/openfga/openfga/pull/3178)
 
 ## [1.18.0] - 2026-06-16
 ### Fixed


### PR DESCRIPTION
Mark the GitHub release as a draft in goreleaser, upload SLSA provenance to the draft, and undraft only after both provenance jobs pass. This closes the window where a release is public without provenance and unblocks enabling GitHub immutable releases.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release pipeline to publish GitHub releases as drafts by default before they’re finalized.
  * Improved provenance publication by generating provenance separately and attaching it to the release for the current tag.
  * Added an explicit step to undraft/complete the release before running downstream verification.
  * Adjusted workflow permissions and execution flow to ensure verification occurs after the draft is converted to its final state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->