### PR TITLE
feat: add potential v2 breaking change logs for Expand and ListUsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Added
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
-- Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been created yet for these endpoints, these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182] (https://github.com/openfga/openfga/pull/3182)
+- Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been created yet for these endpoints, these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182](https://github.com/openfga/openfga/pull/3182)
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.18.1] - 2026-06-29
 ### Added
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
-- Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been created yet for these endpoints, these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182](https://github.com/openfga/openfga/pull/3182)
+- Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been implemented yet for these endpoints; these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182](https://github.com/openfga/openfga/pull/3182)
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [Unreleased]
 ### Added
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
+- Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been created yet for these endpoints, these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182] (https://github.com/openfga/openfga/pull/3182)
 
 ### Changed
 - Extended experimental `weighted_graph_check` to `BatchCheck`: when the flag is enabled, each item in the batch is evaluated using the weighted graph algorithm, with per-item fallback to the standard algorithm on non-terminal errors. [#3154](https://github.com/openfga/openfga/pull/3154)

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"errors"
-	"slices"
 	"strconv"
 	"time"
 
@@ -27,11 +26,11 @@ import (
 	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/tuple"
-	"github.com/openfga/openfga/pkg/typesystem"
 )
 
 func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openfgav1.CheckResponse, error) {
@@ -125,9 +124,9 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 			if !res.Allowed && tuple.IsObjectRelation(req.GetTupleKey().GetUser()) {
 				if typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId()); err == nil {
 					tk := req.GetTupleKey()
-					if reason := breakingChangeReason(typesys, tk); reason != "" {
+					if reason := v2breaking.CheckReason(typesys, tk); reason != "" {
 						requestID := requestid.GetRequestIDFromContext(ctx)
-						s.logger.WarnWithContext(ctx, "potential v2Check resolution breaking change: userset request returned false",
+						s.logger.WarnWithContext(ctx, "potential v2Check resolution breaking change",
 							zap.String("store_id", storeID),
 							zap.String("model_id", req.GetAuthorizationModelId()),
 							zap.String("request_id", requestID),
@@ -405,158 +404,6 @@ func (s *Server) v2Check(
 
 	span.SetAttributes(attribute.Bool("allowed", res.Allowed))
 	return res, nil
-}
-
-const (
-	reasonSelfReferentialUserset = "self_referential_userset"
-	reasonAliasUserset           = "alias_userset"
-	reasonComputedUsersetSelfObj = "computed_userset_self_object"
-	reasonTTUUserset             = "ttu_userset"
-)
-
-// breakingChangeReason returns a non-empty reason string when the request shape matches a
-// known v1→v2 Check divergence for userset users. Caller has already verified that the
-// user is a userset (object#relation) and that v2Check returned FALSE.
-//
-// Reasons:
-//
-//   - "alias_userset": the target relation directly accepts T#R' where R' resolves via
-//     computed_userset to the user's relation R, and R is not itself directly assignable
-//     on the target. e.g.
-//     model
-//     type user
-//     type document
-//     relations
-//     define reader: [user]
-//     define allowed: reader
-//     define viewer: [user, document#allowed]
-//     With the query `document:d1, viewer, document3#reader`; v1 follows the allowed→reader
-//     alias from a stored `allowed` tuple, v2 does not.
-//
-//   - "self_referential_userset": v1 unconditionally returned TRUE for this shape
-//     regardless of whether any data existed; v2 evaluates against the schema and
-//     storage and correctly returns FALSE. e.g.
-//     model
-//     type user
-//     type document
-//     relations
-//     define viewer: [user]
-//     `document:d1, viewer, document:d1#viewer` v1 returned TRUE, v2 returns FALSE.
-//
-//   - "computed_userset_self_object": user's object equals the target object, and the user's
-//     relation appears as a ComputedUserset leaf in the target relation's rewrite tree.
-//     e.g.
-//     model
-//     type user
-//     type document
-//     relations
-//     define viewer: editor or writer
-//     define editor: [user]
-//     define writer: [user]
-//     `document:d1, viewer, document:d1#writer` v1 returned TRUE, v2 returns FALSE.`
-//
-//   - "ttu_userset": target relation's rewrite contains a TupleToUserset whose computed
-//     relation equals the user's relation, AND the user's object type is directly-related
-//     to the tupleset relation. e.g. document.viewer = viewer from parent; query
-//     viewer@folder:f2#viewer on document:d1. v1 returned TRUE from schema reachability
-//     plus a parent tuple; v2 requires the userset to be explicit. e.g.
-//     model
-//     type user
-//     type folder
-//     relations
-//     define viewer: [user]
-//     type document
-//     relations
-//     define parent: [folder]
-//     define viewer: viewer from parent
-//     With the query `document:d1, viewer, folder:f2#viewer` and the tuple `document:d1, parent, folder:f2`;
-//     v1 returned TRUE, v2 returns FALSE.
-//
-// All schema-shape filters are necessary conditions only — they may over-report when no
-// matching tuple is actually stored, but never miss a real divergence.
-func breakingChangeReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTupleKey) string {
-	if tk.GetUser() == tk.GetObject()+"#"+tk.GetRelation() {
-		return reasonSelfReferentialUserset
-	}
-	userObject, userRelation := tuple.SplitObjectRelation(tk.GetUser())
-	userObjectType := tuple.GetType(userObject)
-	targetObjectType := tuple.GetType(tk.GetObject())
-	targetRelation := tk.GetRelation()
-
-	if usersetAliasesTargetRelation(typesys, targetObjectType, targetRelation, userObjectType, userRelation) {
-		return reasonAliasUserset
-	}
-	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
-	if err != nil {
-		return ""
-	}
-	rewrite := rel.GetRewrite()
-	if userObject == tk.GetObject() && rewriteContainsComputedUserset(rewrite, userRelation) {
-		return reasonComputedUsersetSelfObj
-	}
-	if rewriteContainsTTUForUser(typesys, targetObjectType, rewrite, userObjectType, userRelation) {
-		return reasonTTUUserset
-	}
-	return ""
-}
-
-// rewriteContainsComputedUserset reports whether any ComputedUserset leaf in the rewrite
-// tree references the given relation name.
-func rewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		if cu, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok && cu.ComputedUserset.GetRelation() == relation {
-			return true
-		}
-		return nil
-	})
-	return result != nil
-}
-
-// rewriteContainsTTUForUser reports whether the target's rewrite contains a TupleToUserset
-// whose computed relation equals the user's relation, where the tupleset relation on the
-// target object type is directly related to the user's object type.
-func rewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType string, rewrite *openfgav1.Userset, userObjectType, userRelation string) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		ttu, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset)
-		if !ok || ttu.TupleToUserset.GetComputedUserset().GetRelation() != userRelation {
-			return nil
-		}
-		tuplesetRel := ttu.TupleToUserset.GetTupleset().GetRelation()
-		// Loose type-only match (ignores relation/wildcard) is intentional: this is an
-		// over-reporting necessary-condition filter. Do not swap in IsDirectlyRelated.
-		directlyRelated, err := ts.GetDirectlyRelatedUserTypes(targetObjectType, tuplesetRel)
-		if err == nil && slices.ContainsFunc(directlyRelated, func(dr *openfgav1.RelationReference) bool {
-			return dr.GetType() == userObjectType
-		}) {
-			return true
-		}
-		return nil
-	})
-	return result != nil
-}
-
-// usersetAliasesTargetRelation reports whether the target's directly-related usersets
-// include some T#R' (where T = user's object type) that is a computed_userset alias for
-// the user's relation R. Excludes the trivial case where T#R is itself directly assignable
-// (since v1 and v2 agree on direct matches).
-func usersetAliasesTargetRelation(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
-	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
-	if err != nil {
-		return false
-	}
-	foundAlias := false
-	for _, ref := range usersets {
-		if ref.GetType() != userObjectType {
-			continue
-		}
-		if ref.GetRelation() == userRelation {
-			return false
-		}
-		if resolved, err := ts.ResolveComputedRelation(ref.GetType(), ref.GetRelation()); err == nil && resolved == userRelation {
-			foundAlias = true
-		}
-	}
-	return foundAlias
 }
 
 func (s *Server) getCheckResolverBuilder(storeID string) *graph.CheckResolverOrderedBuilder {

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -126,7 +126,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 					tk := req.GetTupleKey()
 					if reason := v2breaking.CheckReason(typesys, tk); reason != "" {
 						requestID := requestid.GetRequestIDFromContext(ctx)
-						s.logger.WarnWithContext(ctx, "potential v2Check resolution breaking change",
+						s.logger.WarnWithContext(ctx, "potential v2 Check resolution breaking change",
 							zap.String("store_id", storeID),
 							zap.String("model_id", req.GetAuthorizationModelId()),
 							zap.String("request_id", requestID),

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -120,7 +120,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 			span.SetAttributes(attribute.Bool("allowed", res.Allowed))
 
 			// Flag potential v2Check resolution breaking changes for userset requests.
-			// See breakingChangeReason for the scenarios we detect.
+			// See v2breaking.CheckReason for the scenarios we detect.
 			if !res.Allowed && tuple.IsObjectRelation(req.GetTupleKey().GetUser()) {
 				if typesys, err := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId()); err == nil {
 					tk := req.GetTupleKey()

--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openfga/openfga/internal/modelgraph"
 	"github.com/openfga/openfga/pkg/featureflags"
 	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/storage/cache/keys"
 	"github.com/openfga/openfga/pkg/testutils"
@@ -1133,7 +1134,7 @@ func TestBreakingChangeReason(t *testing.T) {
 			typesys, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), req.GetAuthorizationModelId())
 			require.NoError(t, err)
 			tk := req.GetTupleKey()
-			got := breakingChangeReason(typesys, tk)
+			got := v2breaking.CheckReason(typesys, tk)
 			if negativeCases[tc.name] {
 				require.Empty(t, got, "expected no breaking change reason")
 				return

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -59,7 +59,7 @@ func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTuple
 	targetObjectType := tuple.GetType(tk.GetObject())
 	targetRelation := tk.GetRelation()
 
-	if UsersetAliasesTargetRelation(typesys, targetObjectType, targetRelation, userObjectType, userRelation) {
+	if usersetAliasesTargetRelation(typesys, targetObjectType, targetRelation, userObjectType, userRelation) {
 		return ReasonAliasUserset
 	}
 	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
@@ -67,10 +67,10 @@ func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTuple
 		return ""
 	}
 	rewrite := rel.GetRewrite()
-	if userObject == tk.GetObject() && RewriteContainsComputedUserset(rewrite, userRelation) {
+	if userObject == tk.GetObject() && rewriteContainsComputedUserset(rewrite, userRelation) {
 		return ReasonComputedUsersetSelfObj
 	}
-	if RewriteContainsTTUForUser(typesys, targetObjectType, rewrite, userObjectType, userRelation) {
+	if rewriteContainsTTUForUser(typesys, targetObjectType, rewrite, userObjectType, userRelation) {
 		return ReasonTTUUserset
 	}
 	return ""
@@ -81,12 +81,20 @@ func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTuple
 // Expand has no user input — only (object, relation) — so detection is purely
 // schema-shape against the target relation's rewrite.
 //
-// Self-reference is intentionally excluded: Expand is already v2-aligned for
-// that case (it returns an empty Leaf_Users; v1's TRUE comes from a Check-side
-// shortcut not encoded in the tree).
+// ExpandReason only covers shapes that produce a structurally different tree
+// under v2: the two exclusion shapes (which v2 rejects at request time and
+// therefore surface as user-visible errors) and `alias_userset` (where v1
+// follows a `T#R' → R` alias from a stored userset tuple when materializing
+// the Leaf, and v2 does not).
+//
+// The Check-side shortcuts for `computed_userset_self_object`, `ttu_userset`,
+// and `self_referential_userset` are boolean evaluation rules — they affect
+// Check's TRUE/FALSE answer, but they never materialize a tuple or change
+// which tuples Expand reads from storage. The Expand tree is identical under
+// v1 and v2 for those shapes, so they are deliberately not flagged here.
 //
 // Priority order if multiple shapes match: exclusion shapes first (v2 errors,
-// most severe), then alias, then TTU, then ComputedUserset.
+// most severe), then alias.
 func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string) string {
 	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
 	if err != nil {
@@ -105,14 +113,6 @@ func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelati
 		return ReasonAliasUserset
 	}
 
-	if rewriteContainsAnyTTU(rewrite) {
-		return ReasonTTUUserset
-	}
-
-	if rewriteContainsAnyComputedUserset(rewrite) {
-		return ReasonComputedUsersetSelfObj
-	}
-
 	return ""
 }
 
@@ -127,30 +127,6 @@ func anyTypeWildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targ
 		}
 	}
 	return false
-}
-
-// rewriteContainsAnyTTU reports whether the rewrite contains any TupleToUserset
-// node, regardless of the computed relation.
-func rewriteContainsAnyTTU(rewrite *openfgav1.Userset) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		if _, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset); ok {
-			return true
-		}
-		return nil
-	})
-	return result != nil
-}
-
-// rewriteContainsAnyComputedUserset reports whether the rewrite contains any
-// ComputedUserset node, regardless of the referenced relation.
-func rewriteContainsAnyComputedUserset(rewrite *openfgav1.Userset) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		if _, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
-			return true
-		}
-		return nil
-	})
-	return result != nil
 }
 
 // relationHasAliasedDirectlyRelatedUserset reports whether any of the target
@@ -197,7 +173,7 @@ func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, r
 		if targetObjectType == filterType && relation == filterRelation {
 			return ReasonSelfReferentialUserset
 		}
-		if UsersetAliasesTargetRelation(typesys, targetObjectType, relation, filterType, filterRelation) {
+		if usersetAliasesTargetRelation(typesys, targetObjectType, relation, filterType, filterRelation) {
 			return ReasonAliasUserset
 		}
 	}
@@ -209,10 +185,10 @@ func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, r
 	rewrite := rel.GetRewrite()
 
 	if filterRelation != "" {
-		if targetObjectType == filterType && RewriteContainsComputedUserset(rewrite, filterRelation) {
+		if targetObjectType == filterType && rewriteContainsComputedUserset(rewrite, filterRelation) {
 			return ReasonComputedUsersetSelfObj
 		}
-		if RewriteContainsTTUForUser(typesys, targetObjectType, rewrite, filterType, filterRelation) {
+		if rewriteContainsTTUForUser(typesys, targetObjectType, rewrite, filterType, filterRelation) {
 			return ReasonTTUUserset
 		}
 		if rewriteContainsDifference(rewrite) {
@@ -228,9 +204,9 @@ func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, r
 	return ""
 }
 
-// RewriteContainsComputedUserset reports whether any ComputedUserset leaf in
+// rewriteContainsComputedUserset reports whether any ComputedUserset leaf in
 // the rewrite tree references the given relation name.
-func RewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string) bool {
+func rewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string) bool {
 	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
 		if cu, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok && cu.ComputedUserset.GetRelation() == relation {
 			return true
@@ -240,11 +216,11 @@ func RewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string)
 	return result != nil
 }
 
-// RewriteContainsTTUForUser reports whether the target's rewrite contains a
+// rewriteContainsTTUForUser reports whether the target's rewrite contains a
 // TupleToUserset whose computed relation equals userRelation, where the
 // tupleset relation on the target object type is directly related to
 // userObjectType.
-func RewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType string, rewrite *openfgav1.Userset, userObjectType, userRelation string) bool {
+func rewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType string, rewrite *openfgav1.Userset, userObjectType, userRelation string) bool {
 	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
 		ttu, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset)
 		if !ok || ttu.TupleToUserset.GetComputedUserset().GetRelation() != userRelation {
@@ -265,11 +241,11 @@ func RewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType strin
 	return result != nil
 }
 
-// UsersetAliasesTargetRelation reports whether the target's directly-related
+// usersetAliasesTargetRelation reports whether the target's directly-related
 // usersets include some T#R' (where T = userObjectType) that is a
 // computed_userset alias for userRelation. Excludes the trivial case where
 // T#R is itself directly assignable (since v1 and v2 agree on direct matches).
-func UsersetAliasesTargetRelation(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
+func usersetAliasesTargetRelation(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
 	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
 	if err != nil {
 		return false

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -466,10 +466,18 @@ func rewriteContainsDifference(rewrite *openfgav1.Userset) bool {
 // related user types include userObjectType:*. This is a necessary condition
 // only — it may over-report.
 func wildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targetObjectType, relation string, rewrite *openfgav1.Userset, userObjectType string) bool {
-	return walkForWildcardUnderDifference(ts, targetObjectType, relation, rewrite, userObjectType)
+	return walkForWildcardUnderDifference(ts, targetObjectType, relation, rewrite, userObjectType, map[string]struct{}{})
 }
 
-func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string) bool {
+// walkForWildcardUnderDifference searches for a Difference node whose base
+// branch can accept userObjectType:*. Visited prevents infinite recursion
+// through computed/TTU cycles (e.g. recursive `viewer from parent` where
+// parent points back to the same type) and mirrors the guard in
+// branchAcceptsWildcard: it is only updated when crossing a relation edge
+// (ComputedUserset / TTU), not on structural nodes — otherwise
+// Union/Intersection/Difference children that share the parent's
+// (objectType, relation) would short-circuit before being evaluated.
+func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string, visited map[string]struct{}) bool {
 	if rewrite == nil {
 		return false
 	}
@@ -480,25 +488,32 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 		}
 		// A Difference may itself be nested inside another Difference's base;
 		// keep walking for outer occurrences.
-		return walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetBase(), userObjectType) ||
-			walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetSubtract(), userObjectType)
+		return walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetBase(), userObjectType, visited) ||
+			walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetSubtract(), userObjectType, visited)
 	case *openfgav1.Userset_Union:
 		for _, c := range v.Union.GetChild() {
-			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType) {
+			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType, visited) {
 				return true
 			}
 		}
 	case *openfgav1.Userset_Intersection:
 		for _, c := range v.Intersection.GetChild() {
-			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType) {
+			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType, visited) {
 				return true
 			}
 		}
 	case *openfgav1.Userset_ComputedUserset:
 		nextRel := v.ComputedUserset.GetRelation()
-		if r, err := ts.GetRelation(objectType, nextRel); err == nil {
-			return walkForWildcardUnderDifference(ts, objectType, nextRel, r.GetRewrite(), userObjectType)
+		key := objectType + "#" + nextRel
+		if _, ok := visited[key]; ok {
+			return false
 		}
+		r, err := ts.GetRelation(objectType, nextRel)
+		if err != nil {
+			return false
+		}
+		visited[key] = struct{}{}
+		return walkForWildcardUnderDifference(ts, objectType, nextRel, r.GetRewrite(), userObjectType, visited)
 	case *openfgav1.Userset_TupleToUserset:
 		tuplesetRel := v.TupleToUserset.GetTupleset().GetRelation()
 		computedRel := v.TupleToUserset.GetComputedUserset().GetRelation()
@@ -507,11 +522,16 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 			return false
 		}
 		for _, dr := range directlyRelated {
+			key := dr.GetType() + "#" + computedRel
+			if _, ok := visited[key]; ok {
+				continue
+			}
 			r, err := ts.GetRelation(dr.GetType(), computedRel)
 			if err != nil {
 				continue
 			}
-			if walkForWildcardUnderDifference(ts, dr.GetType(), computedRel, r.GetRewrite(), userObjectType) {
+			visited[key] = struct{}{}
+			if walkForWildcardUnderDifference(ts, dr.GetType(), computedRel, r.GetRewrite(), userObjectType, visited) {
 				return true
 			}
 		}

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -127,43 +127,31 @@ func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelati
 		return ReasonAliasUserset
 	}
 
-	if rewriteContainsAnyComputedUserset(rewrite) {
-		return ReasonComputedUsersetSelfObj
-	}
-
-	if rewriteContainsAnyTTU(rewrite) {
-		return ReasonTTUUserset
+	if reason := computedUsersetOrTTUReason(rewrite); reason != "" {
+		return reason
 	}
 
 	return ""
 }
 
-// rewriteContainsAnyComputedUserset reports whether the rewrite tree contains
-// any ComputedUserset leaf. Used by ExpandReason to detect the
-// computed_userset_self_object shape on Expand — where the v1 tree surfaces
-// the sibling-relation reference as a member of the target.
-func rewriteContainsAnyComputedUserset(rewrite *openfgav1.Userset) bool {
+// computedUsersetOrTTUReason walks the rewrite tree once and returns
+// ReasonComputedUsersetSelfObj if any ComputedUserset leaf is present, or
+// ReasonTTUUserset if any TupleToUserset node is present, or "".
+func computedUsersetOrTTUReason(rewrite *openfgav1.Userset) string {
 	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		if _, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
-			return true
+		switch r.GetUserset().(type) {
+		case *openfgav1.Userset_ComputedUserset:
+			return ReasonComputedUsersetSelfObj
+		case *openfgav1.Userset_TupleToUserset:
+			return ReasonTTUUserset
 		}
 		return nil
 	})
-	return result != nil
-}
+	if reason, ok := result.(string); ok {
+		return reason
+	}
 
-// rewriteContainsAnyTTU reports whether the rewrite tree contains any
-// TupleToUserset node. Used by ExpandReason to detect the ttu_userset shape
-// on Expand — where v1 surfaces a TTU leaf naming the tupleset relation in
-// the tree even when no parent tuples exist.
-func rewriteContainsAnyTTU(rewrite *openfgav1.Userset) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
-		if _, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset); ok {
-			return true
-		}
-		return nil
-	})
-	return result != nil
+	return ""
 }
 
 // anyTypeWildcardReachableUnderDifferenceBase walks every type defined in the

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -517,7 +517,7 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 
 // branchAcceptsWildcard walks a Difference's base branch and reports whether
 // userObjectType:* is reachable as a directly-related type of some leaf
-// relation. visited prevents infinite recursion through computed/TTU cycles
+// relation. Visited prevents infinite recursion through computed/TTU cycles
 // and is only updated when crossing a relation edge (ComputedUserset / TTU),
 // not on structural nodes — otherwise Union/Intersection/Difference children
 // that share the parent's (objectType, relation) would short-circuit before

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -499,6 +499,22 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 		if r, err := ts.GetRelation(objectType, nextRel); err == nil {
 			return walkForWildcardUnderDifference(ts, objectType, nextRel, r.GetRewrite(), userObjectType)
 		}
+	case *openfgav1.Userset_TupleToUserset:
+		tuplesetRel := v.TupleToUserset.GetTupleset().GetRelation()
+		computedRel := v.TupleToUserset.GetComputedUserset().GetRelation()
+		directlyRelated, err := ts.GetDirectlyRelatedUserTypes(objectType, tuplesetRel)
+		if err != nil {
+			return false
+		}
+		for _, dr := range directlyRelated {
+			r, err := ts.GetRelation(dr.GetType(), computedRel)
+			if err != nil {
+				continue
+			}
+			if walkForWildcardUnderDifference(ts, dr.GetType(), computedRel, r.GetRewrite(), userObjectType) {
+				return true
+			}
+		}
 	}
 	return false
 }

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -1,0 +1,422 @@
+// Package v2breaking detects request shapes whose v1 vs v2 (weighted-graph)
+// resolution behavior is known to differ. It exists so the server can emit
+// telemetry about potential breaking-change exposure before the weighted-graph
+// resolver becomes the default — see the openfga.dev breaking-change writeup.
+//
+// All predicates here are schema-shape filters only: they read the model, not
+// stored tuples. They may over-report (the request shape matches but no tuple
+// triggers the divergence) but never miss a real divergence.
+package v2breaking
+
+import (
+	"slices"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
+)
+
+// Reason constants are stable strings emitted in logs/metrics. Do not rename
+// without coordinating with downstream dashboards.
+const (
+	ReasonSelfReferentialUserset  = "self_referential_userset"
+	ReasonAliasUserset            = "alias_userset"
+	ReasonComputedUsersetSelfObj  = "computed_userset_self_object"
+	ReasonTTUUserset              = "ttu_userset"
+	ReasonUsersetWithExclusion    = "userset_with_exclusion"
+	ReasonWildcardWithExclusion   = "wildcard_with_exclusion"
+)
+
+// CheckReason returns a non-empty reason string when the Check request shape
+// matches a known v1→v2 divergence for userset users. The caller is expected
+// to have already verified that the user is a userset (object#relation) and
+// that v2Check returned FALSE — this function does not re-check those.
+//
+// Shape catalogue:
+//
+//   - "self_referential_userset": v1 unconditionally returned TRUE for
+//     check(o#r, r, o); v2 evaluates against the schema and returns FALSE.
+//
+//   - "alias_userset": the target relation directly accepts T#R' where R'
+//     resolves via computed_userset to the user's relation R, and R is not
+//     itself directly assignable on the target. v1 follows the alias from a
+//     stored tuple, v2 does not.
+//
+//   - "computed_userset_self_object": user's object equals the target object,
+//     and the user's relation appears as a ComputedUserset leaf in the target
+//     relation's rewrite tree.
+//
+//   - "ttu_userset": target relation's rewrite contains a TupleToUserset whose
+//     computed relation equals the user's relation, AND the user's object type
+//     is directly-related to the tupleset relation.
+func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTupleKey) string {
+	if tk.GetUser() == tk.GetObject()+"#"+tk.GetRelation() {
+		return ReasonSelfReferentialUserset
+	}
+	userObject, userRelation := tuple.SplitObjectRelation(tk.GetUser())
+	userObjectType := tuple.GetType(userObject)
+	targetObjectType := tuple.GetType(tk.GetObject())
+	targetRelation := tk.GetRelation()
+
+	if UsersetAliasesTargetRelation(typesys, targetObjectType, targetRelation, userObjectType, userRelation) {
+		return ReasonAliasUserset
+	}
+	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
+	if err != nil {
+		return ""
+	}
+	rewrite := rel.GetRewrite()
+	if userObject == tk.GetObject() && RewriteContainsComputedUserset(rewrite, userRelation) {
+		return ReasonComputedUsersetSelfObj
+	}
+	if RewriteContainsTTUForUser(typesys, targetObjectType, rewrite, userObjectType, userRelation) {
+		return ReasonTTUUserset
+	}
+	return ""
+}
+
+// ExpandReason returns a non-empty reason string when the Expand request shape
+// matches a known v1→v2 resolution divergence. Compared to Check/ListUsers,
+// Expand has no user input — only (object, relation) — so detection is purely
+// schema-shape against the target relation's rewrite.
+//
+// Self-reference is intentionally excluded: Expand is already v2-aligned for
+// that case (it returns an empty Leaf_Users; v1's TRUE comes from a Check-side
+// shortcut not encoded in the tree).
+//
+// Priority order if multiple shapes match: exclusion shapes first (v2 errors,
+// most severe), then alias, then TTU, then ComputedUserset.
+func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string) string {
+	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
+	if err != nil {
+		return ""
+	}
+	rewrite := rel.GetRewrite()
+
+	if rewriteContainsDifference(rewrite) {
+		if anyTypeWildcardReachableUnderDifferenceBase(typesys, targetObjectType, targetRelation, rewrite) {
+			return ReasonWildcardWithExclusion
+		}
+		return ReasonUsersetWithExclusion
+	}
+
+	if relationHasAliasedDirectlyRelatedUserset(typesys, targetObjectType, targetRelation) {
+		return ReasonAliasUserset
+	}
+
+	if rewriteContainsAnyTTU(rewrite) {
+		return ReasonTTUUserset
+	}
+
+	if rewriteContainsAnyComputedUserset(rewrite) {
+		return ReasonComputedUsersetSelfObj
+	}
+
+	return ""
+}
+
+// anyTypeWildcardReachableUnderDifferenceBase walks every type defined in the
+// model and reports whether any of them has a typed wildcard reachable under
+// the rewrite's Difference base. Used by ExpandReason where there is no filter
+// to anchor the wildcard search.
+func anyTypeWildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targetObjectType, relation string, rewrite *openfgav1.Userset) bool {
+	for userObjectType := range ts.GetAllRelations() {
+		if wildcardReachableUnderDifferenceBase(ts, targetObjectType, relation, rewrite, userObjectType) {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteContainsAnyTTU reports whether the rewrite contains any TupleToUserset
+// node, regardless of the computed relation.
+func rewriteContainsAnyTTU(rewrite *openfgav1.Userset) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if _, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset); ok {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// rewriteContainsAnyComputedUserset reports whether the rewrite contains any
+// ComputedUserset node, regardless of the referenced relation.
+func rewriteContainsAnyComputedUserset(rewrite *openfgav1.Userset) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if _, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// relationHasAliasedDirectlyRelatedUserset reports whether any of the target
+// relation's directly-related usersets is itself a computed_userset alias for
+// another relation. v1 follows that alias when expanding stored userset tuples;
+// v2 does not.
+func relationHasAliasedDirectlyRelatedUserset(ts *typesystem.TypeSystem, targetObjectType, targetRelation string) bool {
+	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
+	if err != nil {
+		return false
+	}
+	for _, ref := range usersets {
+		rel, err := ts.GetRelation(ref.GetType(), ref.GetRelation())
+		if err != nil {
+			continue
+		}
+		if _, ok := rel.GetRewrite().GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ListUsersReason returns a non-empty reason string when the ListUsers request
+// shape matches a known v1→v2 divergence. Compared to CheckReason, it also
+// detects the two exclusion-shape cases that v2Check rejects at request time
+// (rather than silently returning FALSE):
+//
+//   - "userset_with_exclusion": the filter is a userset and the target
+//     relation's rewrite contains a Difference node.
+//
+//   - "wildcard_with_exclusion": the filter is a non-userset of type T and the
+//     target relation's rewrite contains a Difference whose base branch can
+//     accept a typed wildcard T:*.
+func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, relation string, filter *openfgav1.UserTypeFilter) string {
+	if object == nil || filter == nil {
+		return ""
+	}
+	targetObjectType := object.GetType()
+	filterType := filter.GetType()
+	filterRelation := filter.GetRelation()
+
+	if filterRelation != "" {
+		if targetObjectType == filterType && relation == filterRelation {
+			return ReasonSelfReferentialUserset
+		}
+		if UsersetAliasesTargetRelation(typesys, targetObjectType, relation, filterType, filterRelation) {
+			return ReasonAliasUserset
+		}
+	}
+
+	rel, err := typesys.GetRelation(targetObjectType, relation)
+	if err != nil {
+		return ""
+	}
+	rewrite := rel.GetRewrite()
+
+	if filterRelation != "" {
+		if targetObjectType == filterType && RewriteContainsComputedUserset(rewrite, filterRelation) {
+			return ReasonComputedUsersetSelfObj
+		}
+		if RewriteContainsTTUForUser(typesys, targetObjectType, rewrite, filterType, filterRelation) {
+			return ReasonTTUUserset
+		}
+		if rewriteContainsDifference(rewrite) {
+			return ReasonUsersetWithExclusion
+		}
+		return ""
+	}
+
+	// Non-userset filter: only the wildcard-with-exclusion shape is in play.
+	if wildcardReachableUnderDifferenceBase(typesys, targetObjectType, relation, rewrite, filterType) {
+		return ReasonWildcardWithExclusion
+	}
+	return ""
+}
+
+// RewriteContainsComputedUserset reports whether any ComputedUserset leaf in
+// the rewrite tree references the given relation name.
+func RewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if cu, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok && cu.ComputedUserset.GetRelation() == relation {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// RewriteContainsTTUForUser reports whether the target's rewrite contains a
+// TupleToUserset whose computed relation equals userRelation, where the
+// tupleset relation on the target object type is directly related to
+// userObjectType.
+func RewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType string, rewrite *openfgav1.Userset, userObjectType, userRelation string) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		ttu, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset)
+		if !ok || ttu.TupleToUserset.GetComputedUserset().GetRelation() != userRelation {
+			return nil
+		}
+		tuplesetRel := ttu.TupleToUserset.GetTupleset().GetRelation()
+		// Loose type-only match (ignores relation/wildcard) is intentional:
+		// this is an over-reporting necessary-condition filter. Do not swap
+		// in IsDirectlyRelated.
+		directlyRelated, err := ts.GetDirectlyRelatedUserTypes(targetObjectType, tuplesetRel)
+		if err == nil && slices.ContainsFunc(directlyRelated, func(dr *openfgav1.RelationReference) bool {
+			return dr.GetType() == userObjectType
+		}) {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// UsersetAliasesTargetRelation reports whether the target's directly-related
+// usersets include some T#R' (where T = userObjectType) that is a
+// computed_userset alias for userRelation. Excludes the trivial case where
+// T#R is itself directly assignable (since v1 and v2 agree on direct matches).
+func UsersetAliasesTargetRelation(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
+	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
+	if err != nil {
+		return false
+	}
+	foundAlias := false
+	for _, ref := range usersets {
+		if ref.GetType() != userObjectType {
+			continue
+		}
+		if ref.GetRelation() == userRelation {
+			return false
+		}
+		if resolved, err := ts.ResolveComputedRelation(ref.GetType(), ref.GetRelation()); err == nil && resolved == userRelation {
+			foundAlias = true
+		}
+	}
+	return foundAlias
+}
+
+// rewriteContainsDifference reports whether the rewrite tree contains any
+// Userset_Difference node.
+func rewriteContainsDifference(rewrite *openfgav1.Userset) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if _, ok := r.GetUserset().(*openfgav1.Userset_Difference); ok {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// wildcardReachableUnderDifferenceBase walks rewrite (which belongs to
+// `targetObjectType#relation`) and reports whether any Difference node it
+// contains has a base branch that can accept a typed wildcard of
+// userObjectType. "Can accept" means: somewhere in the base branch there is a
+// relation reachable through This / ComputedUserset / TTU whose directly-
+// related user types include userObjectType:*. This is a necessary condition
+// only — it may over-report.
+func wildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targetObjectType, relation string, rewrite *openfgav1.Userset, userObjectType string) bool {
+	return walkForWildcardUnderDifference(ts, targetObjectType, relation, rewrite, userObjectType)
+}
+
+func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string) bool {
+	if rewrite == nil {
+		return false
+	}
+	switch v := rewrite.GetUserset().(type) {
+	case *openfgav1.Userset_Difference:
+		if branchAcceptsWildcard(ts, objectType, relation, v.Difference.GetBase(), userObjectType, map[string]struct{}{}) {
+			return true
+		}
+		// A Difference may itself be nested inside another Difference's base;
+		// keep walking for outer occurrences.
+		return walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetBase(), userObjectType) ||
+			walkForWildcardUnderDifference(ts, objectType, relation, v.Difference.GetSubtract(), userObjectType)
+	case *openfgav1.Userset_Union:
+		for _, c := range v.Union.GetChild() {
+			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType) {
+				return true
+			}
+		}
+	case *openfgav1.Userset_Intersection:
+		for _, c := range v.Intersection.GetChild() {
+			if walkForWildcardUnderDifference(ts, objectType, relation, c, userObjectType) {
+				return true
+			}
+		}
+	case *openfgav1.Userset_ComputedUserset:
+		nextRel := v.ComputedUserset.GetRelation()
+		if r, err := ts.GetRelation(objectType, nextRel); err == nil {
+			return walkForWildcardUnderDifference(ts, objectType, nextRel, r.GetRewrite(), userObjectType)
+		}
+	}
+	return false
+}
+
+// branchAcceptsWildcard walks a Difference's base branch and reports whether
+// userObjectType:* is reachable as a directly-related type of some leaf
+// relation. visited prevents infinite recursion through computed/TTU cycles.
+func branchAcceptsWildcard(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string, visited map[string]struct{}) bool {
+	if rewrite == nil {
+		return false
+	}
+	key := objectType + "#" + relation
+	if _, ok := visited[key]; ok {
+		return false
+	}
+	visited[key] = struct{}{}
+
+	switch v := rewrite.GetUserset().(type) {
+	case *openfgav1.Userset_This:
+		return relationAcceptsWildcardForType(ts, objectType, relation, userObjectType)
+	case *openfgav1.Userset_ComputedUserset:
+		nextRel := v.ComputedUserset.GetRelation()
+		r, err := ts.GetRelation(objectType, nextRel)
+		if err != nil {
+			return false
+		}
+		return branchAcceptsWildcard(ts, objectType, nextRel, r.GetRewrite(), userObjectType, visited)
+	case *openfgav1.Userset_TupleToUserset:
+		tuplesetRel := v.TupleToUserset.GetTupleset().GetRelation()
+		computedRel := v.TupleToUserset.GetComputedUserset().GetRelation()
+		directlyRelated, err := ts.GetDirectlyRelatedUserTypes(objectType, tuplesetRel)
+		if err != nil {
+			return false
+		}
+		for _, dr := range directlyRelated {
+			r, err := ts.GetRelation(dr.GetType(), computedRel)
+			if err != nil {
+				continue
+			}
+			if branchAcceptsWildcard(ts, dr.GetType(), computedRel, r.GetRewrite(), userObjectType, visited) {
+				return true
+			}
+		}
+		return false
+	case *openfgav1.Userset_Union:
+		for _, c := range v.Union.GetChild() {
+			if branchAcceptsWildcard(ts, objectType, relation, c, userObjectType, visited) {
+				return true
+			}
+		}
+		return false
+	case *openfgav1.Userset_Intersection:
+		for _, c := range v.Intersection.GetChild() {
+			if branchAcceptsWildcard(ts, objectType, relation, c, userObjectType, visited) {
+				return true
+			}
+		}
+		return false
+	case *openfgav1.Userset_Difference:
+		return branchAcceptsWildcard(ts, objectType, relation, v.Difference.GetBase(), userObjectType, visited)
+	}
+	return false
+}
+
+// relationAcceptsWildcardForType reports whether the given (objectType,
+// relation) is directly related to userObjectType:* (typed wildcard).
+func relationAcceptsWildcardForType(ts *typesystem.TypeSystem, objectType, relation, userObjectType string) bool {
+	directlyRelated, err := ts.GetDirectlyRelatedUserTypes(objectType, relation)
+	if err != nil {
+		return false
+	}
+	for _, dr := range directlyRelated {
+		if dr.GetType() == userObjectType && dr.GetWildcard() != nil {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -517,26 +517,30 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 
 // branchAcceptsWildcard walks a Difference's base branch and reports whether
 // userObjectType:* is reachable as a directly-related type of some leaf
-// relation. Visited prevents infinite recursion through computed/TTU cycles.
+// relation. visited prevents infinite recursion through computed/TTU cycles
+// and is only updated when crossing a relation edge (ComputedUserset / TTU),
+// not on structural nodes — otherwise Union/Intersection/Difference children
+// that share the parent's (objectType, relation) would short-circuit before
+// being evaluated.
 func branchAcceptsWildcard(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string, visited map[string]struct{}) bool {
 	if rewrite == nil {
 		return false
 	}
-	key := objectType + "#" + relation
-	if _, ok := visited[key]; ok {
-		return false
-	}
-	visited[key] = struct{}{}
 
 	switch v := rewrite.GetUserset().(type) {
 	case *openfgav1.Userset_This:
 		return relationAcceptsWildcardForType(ts, objectType, relation, userObjectType)
 	case *openfgav1.Userset_ComputedUserset:
 		nextRel := v.ComputedUserset.GetRelation()
+		key := objectType + "#" + nextRel
+		if _, ok := visited[key]; ok {
+			return false
+		}
 		r, err := ts.GetRelation(objectType, nextRel)
 		if err != nil {
 			return false
 		}
+		visited[key] = struct{}{}
 		return branchAcceptsWildcard(ts, objectType, nextRel, r.GetRewrite(), userObjectType, visited)
 	case *openfgav1.Userset_TupleToUserset:
 		tuplesetRel := v.TupleToUserset.GetTupleset().GetRelation()
@@ -546,10 +550,15 @@ func branchAcceptsWildcard(ts *typesystem.TypeSystem, objectType, relation strin
 			return false
 		}
 		for _, dr := range directlyRelated {
+			key := dr.GetType() + "#" + computedRel
+			if _, ok := visited[key]; ok {
+				continue
+			}
 			r, err := ts.GetRelation(dr.GetType(), computedRel)
 			if err != nil {
 				continue
 			}
+			visited[key] = struct{}{}
 			if branchAcceptsWildcard(ts, dr.GetType(), computedRel, r.GetRewrite(), userObjectType, visited) {
 				return true
 			}

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -93,8 +93,8 @@ func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTuple
 // which tuples Expand reads from storage. The Expand tree is identical under
 // v1 and v2 for those shapes, so they are deliberately not flagged here.
 //
-// Priority order if multiple shapes match: exclusion shapes first (v2 errors,
-// most severe), then alias.
+// Exclusion shapes are checked before alias since they are the more severe
+// divergence (v2 returns a request-time error).
 func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string) string {
 	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
 	if err != nil {
@@ -133,6 +133,31 @@ func anyTypeWildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targ
 // relation's directly-related usersets is itself a computed_userset alias for
 // another relation. v1 follows that alias when expanding stored userset tuples;
 // v2 does not.
+// isAliasedDirectlyRelatedUserset reports whether (userObjectType, userRelation)
+// is a directly-related userset on (targetObjectType, targetRelation) whose
+// rewrite is a ComputedUserset alias (i.e. R' on T where `define R' = R`).
+// Used to confirm that an Expand response leaf contains an aliased userset
+// that v2 would not surface.
+func isAliasedDirectlyRelatedUserset(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
+	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
+	if err != nil {
+		return false
+	}
+	for _, ref := range usersets {
+		if ref.GetType() != userObjectType || ref.GetRelation() != userRelation {
+			continue
+		}
+		rel, err := ts.GetRelation(ref.GetType(), ref.GetRelation())
+		if err != nil {
+			continue
+		}
+		if _, ok := rel.GetRewrite().GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
+			return true
+		}
+	}
+	return false
+}
+
 func relationHasAliasedDirectlyRelatedUserset(ts *typesystem.TypeSystem, targetObjectType, targetRelation string) bool {
 	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
 	if err != nil {
@@ -202,6 +227,190 @@ func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, r
 		return ReasonWildcardWithExclusion
 	}
 	return ""
+}
+
+// ListUsersResponseConfirmsReason reports whether the ListUsers response is
+// consistent with v1 having actually traversed the divergent path for the
+// given reason. It is used to suppress false-positive logs on shape-matched
+// requests whose responses didn't observably exercise the v1 behavior.
+//
+// For the four per-user-shape reasons, this looks for the specific user that
+// v1 surfaces via the divergent path. For the exclusion-shape reasons, v2
+// would reject the request at request time — so any non-empty v1 response on
+// a Difference-containing relation means v1 actually walked the exclusion
+// path to produce it.
+//
+// Returns true for unknown reasons, so the caller's logic stays simple.
+func ListUsersResponseConfirmsReason(reason string, object *openfgav1.Object, relation string, filter *openfgav1.UserTypeFilter, users []*openfgav1.User) bool {
+	switch reason {
+	case ReasonSelfReferentialUserset:
+		// v1 synthesizes <object>#<relation> as a user of itself.
+		return responseContainsUserset(users, object.GetType(), object.GetId(), relation)
+	case ReasonComputedUsersetSelfObj:
+		// v1 synthesizes <object>#<filter.relation> when filter.relation
+		// appears as a ComputedUserset leaf on the target.
+		return responseContainsUserset(users, object.GetType(), object.GetId(), filter.GetRelation())
+	case ReasonAliasUserset:
+		// v1 surfaces a userset of type filter.type whose relation is some R'
+		// that aliases (via computed_userset) to filter.relation. The exact
+		// alias relation depends on the model; we accept any userset of the
+		// filter's type whose relation is not the filter's relation as a
+		// necessary-condition signal.
+		return responseContainsAliasUserset(users, filter.GetType(), filter.GetRelation())
+	case ReasonTTUUserset:
+		// v1 surfaces a userset of (filter.type, filter.relation) via the TTU
+		// edge. We can only confirm that *some* userset of that shape came
+		// back, not that it came specifically via the TTU.
+		return responseContainsUsersetOfType(users, filter.GetType(), filter.GetRelation())
+	case ReasonUsersetWithExclusion, ReasonWildcardWithExclusion:
+		// v2 would reject the request at request time. Any non-empty v1
+		// response means v1 actually walked the Difference-containing rewrite
+		// to produce a result that v2 would never have returned.
+		return len(users) > 0
+	}
+	return true
+}
+
+func responseContainsUserset(users []*openfgav1.User, typ, id, relation string) bool {
+	for _, u := range users {
+		us := u.GetUserset()
+		if us == nil {
+			continue
+		}
+		if us.GetType() == typ && us.GetId() == id && us.GetRelation() == relation {
+			return true
+		}
+	}
+	return false
+}
+
+func responseContainsUsersetOfType(users []*openfgav1.User, typ, relation string) bool {
+	for _, u := range users {
+		us := u.GetUserset()
+		if us == nil {
+			continue
+		}
+		if us.GetType() == typ && us.GetRelation() == relation {
+			return true
+		}
+	}
+	return false
+}
+
+func responseContainsAliasUserset(users []*openfgav1.User, filterType, filterRelation string) bool {
+	for _, u := range users {
+		us := u.GetUserset()
+		if us == nil {
+			continue
+		}
+		if us.GetType() == filterType && us.GetRelation() != "" && us.GetRelation() != filterRelation {
+			return true
+		}
+	}
+	return false
+}
+
+// ExpandResponseConfirmsReason reports whether the Expand response tree is
+// consistent with v1 having actually traversed the divergent path for the
+// given reason. It mirrors ListUsersResponseConfirmsReason: shape predicates
+// fire on schema alone (which may over-report), and this function suppresses
+// the log when the response shows the v1 path wasn't actually exercised.
+//
+// For the exclusion shapes, any non-empty leaf in the tree means v1 walked
+// the Difference-containing rewrite to produce a result that v2 would have
+// rejected at request time. For alias_userset, we confirm that v1 surfaced
+// an aliased directly-related userset (T#R' where R' resolves via
+// ComputedUserset to the queried relation) — that exact userset will not
+// appear in a v2 expansion of the same call.
+//
+// Returns true for unknown reasons, so the caller's logic stays simple.
+func ExpandResponseConfirmsReason(reason string, typesys *typesystem.TypeSystem, targetObjectType, targetRelation string, tree *openfgav1.UsersetTree) bool {
+	switch reason {
+	case ReasonUsersetWithExclusion, ReasonWildcardWithExclusion:
+		return treeHasAnyLeafUser(tree.GetRoot())
+	case ReasonAliasUserset:
+		return treeHasAliasedUserset(typesys, targetObjectType, targetRelation, tree.GetRoot())
+	}
+	return true
+}
+
+func treeHasAnyLeafUser(node *openfgav1.UsersetTree_Node) bool {
+	if node == nil {
+		return false
+	}
+	if leaf := node.GetLeaf(); leaf != nil {
+		if users := leaf.GetUsers(); users != nil && len(users.GetUsers()) > 0 {
+			return true
+		}
+		return false
+	}
+	if union := node.GetUnion(); union != nil {
+		for _, child := range union.GetNodes() {
+			if treeHasAnyLeafUser(child) {
+				return true
+			}
+		}
+	}
+	if inter := node.GetIntersection(); inter != nil {
+		for _, child := range inter.GetNodes() {
+			if treeHasAnyLeafUser(child) {
+				return true
+			}
+		}
+	}
+	if diff := node.GetDifference(); diff != nil {
+		if treeHasAnyLeafUser(diff.GetBase()) {
+			return true
+		}
+		if treeHasAnyLeafUser(diff.GetSubtract()) {
+			return true
+		}
+	}
+	return false
+}
+
+func treeHasAliasedUserset(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string, node *openfgav1.UsersetTree_Node) bool {
+	if node == nil {
+		return false
+	}
+	if leaf := node.GetLeaf(); leaf != nil {
+		if users := leaf.GetUsers(); users != nil {
+			for _, u := range users.GetUsers() {
+				userObject, userRelation := tuple.SplitObjectRelation(u)
+				if userRelation == "" {
+					continue
+				}
+				userObjectType := tuple.GetType(userObject)
+				if isAliasedDirectlyRelatedUserset(typesys, targetObjectType, targetRelation, userObjectType, userRelation) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	if union := node.GetUnion(); union != nil {
+		for _, child := range union.GetNodes() {
+			if treeHasAliasedUserset(typesys, targetObjectType, targetRelation, child) {
+				return true
+			}
+		}
+	}
+	if inter := node.GetIntersection(); inter != nil {
+		for _, child := range inter.GetNodes() {
+			if treeHasAliasedUserset(typesys, targetObjectType, targetRelation, child) {
+				return true
+			}
+		}
+	}
+	if diff := node.GetDifference(); diff != nil {
+		if treeHasAliasedUserset(typesys, targetObjectType, targetRelation, diff.GetBase()) {
+			return true
+		}
+		if treeHasAliasedUserset(typesys, targetObjectType, targetRelation, diff.GetSubtract()) {
+			return true
+		}
+	}
+	return false
 }
 
 // rewriteContainsComputedUserset reports whether any ComputedUserset leaf in

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -508,7 +508,7 @@ func walkForWildcardUnderDifference(ts *typesystem.TypeSystem, objectType, relat
 
 // branchAcceptsWildcard walks a Difference's base branch and reports whether
 // userObjectType:* is reachable as a directly-related type of some leaf
-// relation. visited prevents infinite recursion through computed/TTU cycles.
+// relation. Visited prevents infinite recursion through computed/TTU cycles.
 func branchAcceptsWildcard(ts *typesystem.TypeSystem, objectType, relation string, rewrite *openfgav1.Userset, userObjectType string, visited map[string]struct{}) bool {
 	if rewrite == nil {
 		return false

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -81,20 +81,34 @@ func CheckReason(typesys *typesystem.TypeSystem, tk *openfgav1.CheckRequestTuple
 // Expand has no user input — only (object, relation) — so detection is purely
 // schema-shape against the target relation's rewrite.
 //
-// ExpandReason only covers shapes that produce a structurally different tree
-// under v2: the two exclusion shapes (which v2 rejects at request time and
-// therefore surface as user-visible errors) and `alias_userset` (where v1
-// follows a `T#R' → R` alias from a stored userset tuple when materializing
-// the Leaf, and v2 does not).
+// ExpandReason covers the shapes whose v1 Expand tree exposes a divergence
+// from v2:
 //
-// The Check-side shortcuts for `computed_userset_self_object`, `ttu_userset`,
-// and `self_referential_userset` are boolean evaluation rules — they affect
-// Check's TRUE/FALSE answer, but they never materialize a tuple or change
-// which tuples Expand reads from storage. The Expand tree is identical under
-// v1 and v2 for those shapes, so they are deliberately not flagged here.
+//   - The two exclusion shapes (userset_with_exclusion, wildcard_with_exclusion):
+//     v2 rejects the request at request time, so any v1 Expand response on a
+//     Difference-containing rewrite is itself the divergence signal.
 //
-// Exclusion shapes are checked before alias since they are the more severe
-// divergence (v2 returns a request-time error).
+//   - alias_userset: v1 follows `T#R' → R` aliases when materializing leaves,
+//     surfacing aliased usersets that v2's strict storage-validation path
+//     would not.
+//
+//   - computed_userset_self_object: the rewrite contains a ComputedUserset
+//     leaf referring to a sibling relation. v1 Expand emits this leaf as a
+//     direct member of the target relation (e.g. `viewer: editor or writer`
+//     produces a Union with `document:d1#writer` as a leaf), which is
+//     exactly the v1 inference v2's strict resolution would not surface.
+//
+//   - ttu_userset: the rewrite contains a TupleToUserset. v1 Expand emits a
+//     TTU leaf naming the tupleset relation (e.g. `viewer: viewer from
+//     parent` produces a leaf referencing `document:d1#parent`) even when no
+//     parent tuples exist in storage — surfacing structural detail that v2's
+//     strict resolution would not.
+//
+// `self_referential_userset` remains a Check-only boolean shortcut — it
+// doesn't change Expand's emitted tree.
+//
+// Exclusion shapes are checked before the others since they are the more
+// severe divergence (v2 returns a request-time error).
 func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string) string {
 	rel, err := typesys.GetRelation(targetObjectType, targetRelation)
 	if err != nil {
@@ -113,7 +127,43 @@ func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelati
 		return ReasonAliasUserset
 	}
 
+	if rewriteContainsAnyComputedUserset(rewrite) {
+		return ReasonComputedUsersetSelfObj
+	}
+
+	if rewriteContainsAnyTTU(rewrite) {
+		return ReasonTTUUserset
+	}
+
 	return ""
+}
+
+// rewriteContainsAnyComputedUserset reports whether the rewrite tree contains
+// any ComputedUserset leaf. Used by ExpandReason to detect the
+// computed_userset_self_object shape on Expand — where the v1 tree surfaces
+// the sibling-relation reference as a member of the target.
+func rewriteContainsAnyComputedUserset(rewrite *openfgav1.Userset) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if _, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
+			return true
+		}
+		return nil
+	})
+	return result != nil
+}
+
+// rewriteContainsAnyTTU reports whether the rewrite tree contains any
+// TupleToUserset node. Used by ExpandReason to detect the ttu_userset shape
+// on Expand — where v1 surfaces a TTU leaf naming the tupleset relation in
+// the tree even when no parent tuples exist.
+func rewriteContainsAnyTTU(rewrite *openfgav1.Userset) bool {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+		if _, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset); ok {
+			return true
+		}
+		return nil
+	})
+	return result != nil
 }
 
 // anyTypeWildcardReachableUnderDifferenceBase walks every type defined in the
@@ -232,19 +282,11 @@ func ListUsersResponseConfirmsReason(reason string, typesys *typesystem.TypeSyst
 		// appears as a ComputedUserset leaf on the target.
 		return responseContainsUserset(users, object.GetType(), object.GetId(), filter.GetRelation())
 	case ReasonAliasUserset:
-		// v1 surfaces a userset (T#R') where (T, R') is a directly-related
-		// userset on the target whose rewrite aliases (via ComputedUserset)
-		// to the filter's relation.
-		for _, u := range users {
-			us := u.GetUserset()
-			if us == nil {
-				continue
-			}
-			if isAliasedDirectlyRelatedUserset(typesys, object.GetType(), relation, us.GetType(), us.GetRelation()) {
-				return true
-			}
-		}
-		return false
+		// v1 surfaces a userset of the filter shape because it walked
+		// (T#R' alias) → filter.relation. ListUsers normalizes results to
+		// the filter's (type, relation), so any matching userset confirms
+		// the alias path was traversed.
+		return responseContainsUsersetOfType(users, filter.GetType(), filter.GetRelation())
 	case ReasonTTUUserset:
 		// v1 surfaces a userset of (filter.type, filter.relation) via the TTU
 		// edge. We can only confirm that *some* userset of that shape came
@@ -291,57 +333,24 @@ func responseContainsUsersetOfType(users []*openfgav1.User, typ, relation string
 // fire on schema alone (which may over-report), and this function suppresses
 // the log when the response shows the v1 path wasn't actually exercised.
 //
-// For the exclusion shapes, any non-empty leaf in the tree means v1 walked
-// the Difference-containing rewrite to produce a result that v2 would have
-// rejected at request time. For alias_userset, we confirm that v1 surfaced
-// an aliased directly-related userset (T#R' where R' resolves via
-// ComputedUserset to the queried relation) — that exact userset will not
-// appear in a v2 expansion of the same call.
+// For the exclusion shapes, v2 would reject the request at request time, so
+// any successful response means v1 actually walked the divergent path.
+// For alias_userset, we confirm that v1 surfaced an aliased directly-related
+// userset (T#R' where R' resolves via ComputedUserset to the queried
+// relation) — that exact userset will not appear in a v2 expansion of the
+// same call.
 //
 // Returns true for unknown reasons, so the caller's logic stays simple.
 func ExpandResponseConfirmsReason(reason string, typesys *typesystem.TypeSystem, targetObjectType, targetRelation string, tree *openfgav1.UsersetTree) bool {
 	switch reason {
-	case ReasonUsersetWithExclusion, ReasonWildcardWithExclusion:
-		return treeHasAnyLeafUser(tree.GetRoot())
+	case ReasonUsersetWithExclusion, ReasonWildcardWithExclusion, ReasonComputedUsersetSelfObj, ReasonTTUUserset:
+		// v2 has not yet been ported to Expand, so any response on a shape
+		// known to diverge means the client is observing v1 behavior.
+		return tree.GetRoot() != nil
 	case ReasonAliasUserset:
 		return treeHasAliasedUserset(typesys, targetObjectType, targetRelation, tree.GetRoot())
 	}
 	return true
-}
-
-func treeHasAnyLeafUser(node *openfgav1.UsersetTree_Node) bool {
-	if node == nil {
-		return false
-	}
-	if leaf := node.GetLeaf(); leaf != nil {
-		if users := leaf.GetUsers(); users != nil && len(users.GetUsers()) > 0 {
-			return true
-		}
-		return false
-	}
-	if union := node.GetUnion(); union != nil {
-		for _, child := range union.GetNodes() {
-			if treeHasAnyLeafUser(child) {
-				return true
-			}
-		}
-	}
-	if inter := node.GetIntersection(); inter != nil {
-		for _, child := range inter.GetNodes() {
-			if treeHasAnyLeafUser(child) {
-				return true
-			}
-		}
-	}
-	if diff := node.GetDifference(); diff != nil {
-		if treeHasAnyLeafUser(diff.GetBase()) {
-			return true
-		}
-		if treeHasAnyLeafUser(diff.GetSubtract()) {
-			return true
-		}
-	}
-	return false
 }
 
 func treeHasAliasedUserset(typesys *typesystem.TypeSystem, targetObjectType, targetRelation string, node *openfgav1.UsersetTree_Node) bool {

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -20,12 +20,12 @@ import (
 // Reason constants are stable strings emitted in logs/metrics. Do not rename
 // without coordinating with downstream dashboards.
 const (
-	ReasonSelfReferentialUserset  = "self_referential_userset"
-	ReasonAliasUserset            = "alias_userset"
-	ReasonComputedUsersetSelfObj  = "computed_userset_self_object"
-	ReasonTTUUserset              = "ttu_userset"
-	ReasonUsersetWithExclusion    = "userset_with_exclusion"
-	ReasonWildcardWithExclusion   = "wildcard_with_exclusion"
+	ReasonSelfReferentialUserset = "self_referential_userset"
+	ReasonAliasUserset           = "alias_userset"
+	ReasonComputedUsersetSelfObj = "computed_userset_self_object"
+	ReasonTTUUserset             = "ttu_userset"
+	ReasonUsersetWithExclusion   = "userset_with_exclusion"
+	ReasonWildcardWithExclusion  = "wildcard_with_exclusion"
 )
 
 // CheckReason returns a non-empty reason string when the Check request shape
@@ -109,7 +109,7 @@ func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelati
 		return ReasonUsersetWithExclusion
 	}
 
-	if relationHasAliasedDirectlyRelatedUserset(typesys, targetObjectType, targetRelation) {
+	if isAliasedDirectlyRelatedUserset(typesys, targetObjectType, targetRelation, "", "") {
 		return ReasonAliasUserset
 	}
 
@@ -129,41 +129,22 @@ func anyTypeWildcardReachableUnderDifferenceBase(ts *typesystem.TypeSystem, targ
 	return false
 }
 
-// relationHasAliasedDirectlyRelatedUserset reports whether any of the target
-// relation's directly-related usersets is itself a computed_userset alias for
-// another relation. v1 follows that alias when expanding stored userset tuples;
-// v2 does not.
 // isAliasedDirectlyRelatedUserset reports whether (userObjectType, userRelation)
 // is a directly-related userset on (targetObjectType, targetRelation) whose
-// rewrite is a ComputedUserset alias (i.e. R' on T where `define R' = R`).
-// Used to confirm that an Expand response leaf contains an aliased userset
-// that v2 would not surface.
+// rewrite is a ComputedUserset alias (i.e. `define R' = R` on T). When both
+// userObjectType and userRelation are empty the function returns true if ANY
+// directly-related userset on the target is so aliased — the schema-shape
+// check used by ExpandReason.
 func isAliasedDirectlyRelatedUserset(ts *typesystem.TypeSystem, targetObjectType, targetRelation, userObjectType, userRelation string) bool {
 	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
 	if err != nil {
 		return false
 	}
+	matchAny := userObjectType == "" && userRelation == ""
 	for _, ref := range usersets {
-		if ref.GetType() != userObjectType || ref.GetRelation() != userRelation {
+		if !matchAny && (ref.GetType() != userObjectType || ref.GetRelation() != userRelation) {
 			continue
 		}
-		rel, err := ts.GetRelation(ref.GetType(), ref.GetRelation())
-		if err != nil {
-			continue
-		}
-		if _, ok := rel.GetRewrite().GetUserset().(*openfgav1.Userset_ComputedUserset); ok {
-			return true
-		}
-	}
-	return false
-}
-
-func relationHasAliasedDirectlyRelatedUserset(ts *typesystem.TypeSystem, targetObjectType, targetRelation string) bool {
-	usersets, err := ts.DirectlyRelatedUsersets(targetObjectType, targetRelation)
-	if err != nil {
-		return false
-	}
-	for _, ref := range usersets {
 		rel, err := ts.GetRelation(ref.GetType(), ref.GetRelation())
 		if err != nil {
 			continue
@@ -241,7 +222,7 @@ func ListUsersReason(typesys *typesystem.TypeSystem, object *openfgav1.Object, r
 // path to produce it.
 //
 // Returns true for unknown reasons, so the caller's logic stays simple.
-func ListUsersResponseConfirmsReason(reason string, object *openfgav1.Object, relation string, filter *openfgav1.UserTypeFilter, users []*openfgav1.User) bool {
+func ListUsersResponseConfirmsReason(reason string, typesys *typesystem.TypeSystem, object *openfgav1.Object, relation string, filter *openfgav1.UserTypeFilter, users []*openfgav1.User) bool {
 	switch reason {
 	case ReasonSelfReferentialUserset:
 		// v1 synthesizes <object>#<relation> as a user of itself.
@@ -251,12 +232,19 @@ func ListUsersResponseConfirmsReason(reason string, object *openfgav1.Object, re
 		// appears as a ComputedUserset leaf on the target.
 		return responseContainsUserset(users, object.GetType(), object.GetId(), filter.GetRelation())
 	case ReasonAliasUserset:
-		// v1 surfaces a userset of type filter.type whose relation is some R'
-		// that aliases (via computed_userset) to filter.relation. The exact
-		// alias relation depends on the model; we accept any userset of the
-		// filter's type whose relation is not the filter's relation as a
-		// necessary-condition signal.
-		return responseContainsAliasUserset(users, filter.GetType(), filter.GetRelation())
+		// v1 surfaces a userset (T#R') where (T, R') is a directly-related
+		// userset on the target whose rewrite aliases (via ComputedUserset)
+		// to the filter's relation.
+		for _, u := range users {
+			us := u.GetUserset()
+			if us == nil {
+				continue
+			}
+			if isAliasedDirectlyRelatedUserset(typesys, object.GetType(), relation, us.GetType(), us.GetRelation()) {
+				return true
+			}
+		}
+		return false
 	case ReasonTTUUserset:
 		// v1 surfaces a userset of (filter.type, filter.relation) via the TTU
 		// edge. We can only confirm that *some* userset of that shape came
@@ -291,19 +279,6 @@ func responseContainsUsersetOfType(users []*openfgav1.User, typ, relation string
 			continue
 		}
 		if us.GetType() == typ && us.GetRelation() == relation {
-			return true
-		}
-	}
-	return false
-}
-
-func responseContainsAliasUserset(users []*openfgav1.User, filterType, filterRelation string) bool {
-	for _, u := range users {
-		us := u.GetUserset()
-		if us == nil {
-			continue
-		}
-		if us.GetType() == filterType && us.GetRelation() != "" && us.GetRelation() != filterRelation {
 			return true
 		}
 	}

--- a/pkg/server/expand.go
+++ b/pkg/server/expand.go
@@ -69,15 +69,19 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 	}
 
 	// Flag potential v2 (weighted-graph) resolution breaking changes for this
-	// request shape. The predicates are schema-shape filters only, so this can
-	// over-report. See v2breaking.ExpandReason for the catalogue.
-	if reason := v2breaking.ExpandReason(typesys, tuple.GetType(tk.GetObject()), tk.GetRelation()); reason != "" {
-		s.logger.WarnWithContext(ctx, "potential v2 Expand resolution breaking change",
-			zap.String("store_id", storeID),
-			zap.String("model_id", req.GetAuthorizationModelId()),
-			zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
-			zap.String("reason", reason),
-		)
+	// request shape. Shape predicates may over-report; we additionally confirm
+	// the response tree shows v1 actually walked the divergent path.
+	// See v2breaking.ExpandReason / ExpandResponseConfirmsReason.
+	targetObjectType := tuple.GetType(tk.GetObject())
+	if reason := v2breaking.ExpandReason(typesys, targetObjectType, tk.GetRelation()); reason != "" {
+		if v2breaking.ExpandResponseConfirmsReason(reason, typesys, targetObjectType, tk.GetRelation(), resp.GetTree()) {
+			s.logger.WarnWithContext(ctx, "potential v2 Expand resolution breaking change",
+				zap.String("store_id", storeID),
+				zap.String("model_id", req.GetAuthorizationModelId()),
+				zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
+				zap.String("reason", reason),
+			)
+		}
 	}
 
 	return resp, nil

--- a/pkg/server/expand.go
+++ b/pkg/server/expand.go
@@ -69,8 +69,8 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 	}
 
 	// Flag potential v2 (weighted-graph) resolution breaking changes for this
-	// request shape. Shape predicates may over-report; we additionally confirm
-	// the response tree shows v1 actually walked the divergent path.
+	// request shape. Shape predicates may over-report; where possible we also
+	// confirm the response contains evidence of the v1 behavior.
 	// See v2breaking.ExpandReason / ExpandResponseConfirmsReason.
 	targetObjectType := tuple.GetType(tk.GetObject())
 	if reason := v2breaking.ExpandReason(typesys, targetObjectType, tk.GetRelation()); reason != "" {

--- a/pkg/server/expand.go
+++ b/pkg/server/expand.go
@@ -5,6 +5,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -12,8 +13,11 @@ import (
 
 	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/internal/utils/apimethod"
+	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
+	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
@@ -52,7 +56,7 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 	req.AuthorizationModelId = typesys.GetAuthorizationModelID() // the resolved model id
 
 	q := commands.NewExpandQuery(s.datastore, commands.WithExpandQueryLogger(s.logger))
-	return q.Execute(
+	resp, err := q.Execute(
 		typesystem.ContextWithTypesystem(ctx, typesys),
 		&openfgav1.ExpandRequest{
 			StoreId:          storeID,
@@ -60,4 +64,21 @@ func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*ope
 			Consistency:      req.GetConsistency(),
 			ContextualTuples: req.GetContextualTuples(),
 		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Flag potential v2 (weighted-graph) resolution breaking changes for this
+	// request shape. The predicates are schema-shape filters only, so this can
+	// over-report. See v2breaking.ExpandReason for the catalogue.
+	if reason := v2breaking.ExpandReason(typesys, tuple.GetType(tk.GetObject()), tk.GetRelation()); reason != "" {
+		s.logger.WarnWithContext(ctx, "potential v2 Expand resolution breaking change",
+			zap.String("store_id", storeID),
+			zap.String("model_id", req.GetAuthorizationModelId()),
+			zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
+			zap.String("reason", reason),
+		)
+	}
+
+	return resp, nil
 }

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -225,6 +225,32 @@ func TestExpandBreakingChangeLog(t *testing.T) {
 			wantReason: v2breaking.ReasonWildcardWithExclusion,
 		},
 		{
+			// Regression: recursive TTU (folder#parent points back to folder)
+			// combined with an exclusion. Without the visited-set guard in
+			// walkForWildcardUnderDifference, the wildcard reachability walk
+			// would recurse forever through folder#viewer → folder#viewer →
+			// … and crash. The test asserts termination AND that the correct
+			// reason is still logged.
+			name: "wildcard_with_exclusion_recursive_ttu_terminates",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define parent: [folder]
+						define blocked: [user]
+						define local_viewer: [user, user:*]
+						define viewer: (local_viewer or viewer from parent) but not blocked
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("folder:f1", "local_viewer", "user:*"),
+			},
+			object:     "folder:f1",
+			relation:   "viewer",
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
 			name: "no_match_alias_userset",
 			modelDSL: `
 				model

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -2,18 +2,21 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"github.com/openfga/openfga/cmd/util"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
-	"github.com/openfga/openfga/pkg/typesystem"
 )
 
 // setupExpandServer mirrors setupCheckServer in check_test.go but for the
@@ -21,7 +24,7 @@ import (
 // store and model IDs populated. Callers fill in the tuple key. Defaults
 // (when modelDSL == "" / tuples == nil) match a simple `viewer: [user]`
 // model with `document:1#viewer @ user:alice`.
-func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey) (*Server, *openfgav1.ExpandRequest) {
+func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ExpandRequest) {
 	t.Helper()
 
 	if modelDSL == "" {
@@ -43,7 +46,8 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 
 	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
 
-	s := MustNewServerWithOpts(WithDatastore(ds))
+	defaultOpts := append([]OpenFGAServiceV1Option{WithDatastore(ds)}, opts...)
+	s := MustNewServerWithOpts(defaultOpts...)
 	t.Cleanup(s.Close)
 
 	ctx := context.Background()
@@ -74,24 +78,29 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 	}
 }
 
-// TestExpandBreakingChangeReason mirrors check_test.go's TestBreakingChangeReason
-// but exercises v2breaking.ExpandReason. Expand has no user input, so detection
-// is purely against the target relation's rewrite (and its directly-related
-// usersets, for the alias shape). See ExpandReason's doc comment for why the
-// Check-side shapes (self_referential_userset, computed_userset_self_object,
-// ttu_userset) are not in the catalogue.
-func TestExpandBreakingChangeReason(t *testing.T) {
+// TestExpandBreakingChangeLog drives an end-to-end Expand call with an in-memory
+// store, captures emitted logs via a zap observer, and asserts that the
+// "potential v2 Expand resolution breaking change" log fires (or doesn't) for
+// each shape — combining the shape predicate (v2breaking.ExpandReason) and the
+// response-side confirmation (ExpandResponseConfirmsReason) in a single test.
+//
+// See ExpandReason's doc comment for why the Check-side shapes
+// (self_referential_userset, computed_userset_self_object, ttu_userset) are
+// not in the catalogue.
+func TestExpandBreakingChangeLog(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
 	})
 
+	const logMessage = "potential v2 Expand resolution breaking change"
+
 	tests := []struct {
 		name       string
 		modelDSL   string
-		seedTuple  *openfgav1.TupleKey
-		objectType string
+		tuples     []*openfgav1.TupleKey
+		object     string
 		relation   string
-		want       string
+		wantReason string // empty means: expect no log
 	}{
 		{
 			name: "alias_userset",
@@ -105,10 +114,52 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 						define allowed: reader
 						define viewer: [user, document#allowed]
 			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "reader", "user:seed"),
-			objectType: "document",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "document:d2#allowed"),
+			},
+			object:     "document:d1",
 			relation:   "viewer",
-			want:       v2breaking.ReasonAliasUserset,
+			wantReason: v2breaking.ReasonAliasUserset,
+		},
+		{
+			name: "computed_userset_self_object",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define editor: [user]
+						define writer: [user]
+						define viewer: editor or writer
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d2", "editor", "user:alice"),
+			},
+			object:     "document:d1",
+			relation:   "viewer",
+			wantReason: v2breaking.ReasonComputedUsersetSelfObj,
+		},
+		{
+			name: "ttu_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define viewer: [user]
+				type document
+					relations
+						define parent: [folder]
+						define viewer: viewer from parent
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("folder:seed", "viewer", "user:seed"),
+			},
+			object:     "document:d1",
+			relation:   "viewer",
+			wantReason: v2breaking.ReasonTTUUserset,
 		},
 		{
 			name: "userset_with_exclusion",
@@ -122,10 +173,13 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 						define owner: [user]
 						define viewer: [user, document#owner] but not member
 			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "owner", "user:seed"),
-			objectType: "document",
+			tuples: []*openfgav1.TupleKey{
+				// Direct viewer tuple so the difference's base leaf has a user.
+				tuple.NewTupleKey("document:d1", "viewer", "user:alice"),
+			},
+			object:     "document:d1",
 			relation:   "viewer",
-			want:       v2breaking.ReasonUsersetWithExclusion,
+			wantReason: v2breaking.ReasonUsersetWithExclusion,
 		},
 		{
 			name: "wildcard_with_exclusion",
@@ -139,14 +193,50 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 						define blocked: [user]
 						define viewer: public but not blocked
 			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "public", "user:*"),
-			objectType: "document",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "public", "user:*"),
+			},
+			object:     "document:d1",
 			relation:   "viewer",
-			want:       v2breaking.ReasonWildcardWithExclusion,
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
 		},
 		{
-			// Direct-assignment relation has no Difference and no aliased
-			// directly-related userset → no shape matches.
+			name: "no_match_alias_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define reader: [user]
+						define allowed: reader
+						define viewer: [user, document#allowed]
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "user:alice"),
+			},
+			object:     "document:d1",
+			relation:   "viewer",
+			wantReason: "",
+		},
+		{
+			name: "no_match_user_is_not_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "user:alice"),
+			},
+			object:     "document:d1",
+			relation:   "viewer",
+			wantReason: "",
+		},
+		{
 			name: "no_match_direct_assignment",
 			modelDSL: `
 				model
@@ -156,15 +246,14 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 					relations
 						define viewer: [user]
 			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			objectType: "document",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "user:alice"),
+			},
+			object:     "document:d1",
 			relation:   "viewer",
-			want:       "",
+			wantReason: "",
 		},
 		{
-			// Direct userset assignment without any aliasing — the directly-
-			// related userset's rewrite is `This`, not a ComputedUserset, so
-			// alias_userset must NOT fire.
 			name: "no_match_direct_userset_assignable",
 			modelDSL: `
 				model
@@ -177,183 +266,41 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 					relations
 						define viewer: [user, group#member]
 			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			objectType: "document",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			},
+			object:     "document:d1",
 			relation:   "viewer",
-			want:       "",
-		},
-		{
-			// Difference exists in the model, but on a *sibling* relation —
-			// the queried relation's rewrite has no Difference of its own.
-			// Must NOT fire userset_with_exclusion (or wildcard_with_exclusion).
-			name: "no_match_difference_on_sibling_relation",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define blocked: [user]
-						define editor: [user] but not blocked
-						define viewer: [user]
-			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "blocked", "user:seed"),
-			objectType: "document",
-			relation:   "viewer",
-			want:       "",
-		},
-		{
-			// Difference present, but no branch reachable under the base is
-			// directly related to any user:* wildcard. wildcard_with_exclusion
-			// must NOT fire — and since there's a Difference, the fallback is
-			// userset_with_exclusion (the more conservative reason).
-			name: "difference_with_no_wildcard_falls_back_to_userset_with_exclusion",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define a: [user]
-						define b: [user]
-						define viewer: a but not b
-			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "a", "user:seed"),
-			objectType: "document",
-			relation:   "viewer",
-			want:       v2breaking.ReasonUsersetWithExclusion,
+			wantReason: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, baseReq := setupExpandServer(t, tc.modelDSL, []*openfgav1.TupleKey{tc.seedTuple})
+			core, logs := observer.New(zap.WarnLevel)
+			testLogger := &logger.ZapLogger{Logger: zap.New(core)}
 
-			typesys, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+			s, baseReq := setupExpandServer(t, tc.modelDSL, tc.tuples, WithLogger(testLogger))
+
+			res, err := s.Expand(context.Background(), &openfgav1.ExpandRequest{
+				StoreId:              baseReq.GetStoreId(),
+				AuthorizationModelId: baseReq.GetAuthorizationModelId(),
+				TupleKey: &openfgav1.ExpandRequestTupleKey{
+					Object:   tc.object,
+					Relation: tc.relation,
+				},
+			})
+			fmt.Printf("%s", res)
 			require.NoError(t, err)
 
-			got := v2breaking.ExpandReason(typesys, tc.objectType, tc.relation)
-			require.Equal(t, tc.want, got)
-		})
-	}
-}
-
-// TestExpandResponseConfirmsReason covers the response-side filter for Expand.
-// Exclusion shapes confirm on any non-empty leaf; alias_userset confirms only
-// when a leaf contains an aliased directly-related userset.
-func TestExpandResponseConfirmsReason(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
-	leafUsersNode := func(users ...string) *openfgav1.UsersetTree_Node {
-		return &openfgav1.UsersetTree_Node{
-			Value: &openfgav1.UsersetTree_Node_Leaf{
-				Leaf: &openfgav1.UsersetTree_Leaf{
-					Value: &openfgav1.UsersetTree_Leaf_Users{
-						Users: &openfgav1.UsersetTree_Users{Users: users},
-					},
-				},
-			},
-		}
-	}
-	emptyLeaf := leafUsersNode()
-	unionNode := func(children ...*openfgav1.UsersetTree_Node) *openfgav1.UsersetTree_Node {
-		return &openfgav1.UsersetTree_Node{
-			Value: &openfgav1.UsersetTree_Node_Union{
-				Union: &openfgav1.UsersetTree_Nodes{Nodes: children},
-			},
-		}
-	}
-
-	aliasModel := `
-		model
-			schema 1.1
-		type user
-		type document
-			relations
-				define reader: [user]
-				define allowed: reader
-				define viewer: [user, document#allowed]
-	`
-	s, baseReq := setupExpandServer(t,
-		aliasModel,
-		[]*openfgav1.TupleKey{tuple.NewTupleKey("document:seed", "reader", "user:seed")},
-	)
-	aliasTS, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
-	require.NoError(t, err)
-
-	tests := []struct {
-		name             string
-		reason           string
-		targetObjectType string
-		targetRelation   string
-		typesys          *typesystem.TypeSystem
-		tree             *openfgav1.UsersetTree
-		expected         bool
-	}{
-		{
-			name:             "userset_with_exclusion_non_empty_leaf",
-			reason:           v2breaking.ReasonUsersetWithExclusion,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:alice")},
-			expected:         true,
-		},
-		{
-			name:             "userset_with_exclusion_empty_tree",
-			reason:           v2breaking.ReasonUsersetWithExclusion,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			tree:             &openfgav1.UsersetTree{Root: emptyLeaf},
-			expected:         false,
-		},
-		{
-			name:             "wildcard_with_exclusion_non_empty_leaf",
-			reason:           v2breaking.ReasonWildcardWithExclusion,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:*")},
-			expected:         true,
-		},
-		{
-			name:             "wildcard_with_exclusion_empty_tree",
-			reason:           v2breaking.ReasonWildcardWithExclusion,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			tree:             &openfgav1.UsersetTree{Root: emptyLeaf},
-			expected:         false,
-		},
-		{
-			// document#allowed is a directly-related userset on `viewer` and
-			// `allowed`'s rewrite is ComputedUserset(reader) → aliased.
-			name:             "alias_userset_aliased_leaf_present",
-			reason:           v2breaking.ReasonAliasUserset,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			typesys:          aliasTS,
-			tree: &openfgav1.UsersetTree{Root: unionNode(
-				leafUsersNode("user:alice"),
-				leafUsersNode("document:d2#allowed"),
-			)},
-			expected: true,
-		},
-		{
-			// Tree has users but no aliased userset — only direct users.
-			name:             "alias_userset_no_aliased_leaf",
-			reason:           v2breaking.ReasonAliasUserset,
-			targetObjectType: "document",
-			targetRelation:   "viewer",
-			typesys:          aliasTS,
-			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:alice")},
-			expected:         false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := v2breaking.ExpandResponseConfirmsReason(tc.reason, tc.typesys, tc.targetObjectType, tc.targetRelation, tc.tree)
-			require.Equal(t, tc.expected, got)
+			breakingLogs := logs.FilterMessage(logMessage)
+			if tc.wantReason == "" {
+				require.Equal(t, 0, breakingLogs.Len(), "expected no breaking-change log")
+				return
+			}
+			require.Equal(t, 1, breakingLogs.Len(), "expected exactly one breaking-change log")
+			fields := fieldMap(breakingLogs.All()[0].Context)
+			require.Equal(t, tc.wantReason, fields["reason"])
 		})
 	}
 }

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -37,7 +37,7 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 		`
 	}
 
-	if len(tuples) == 0 {
+	if tuples == nil {
 		tuples = []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:alice"),
 		}
@@ -64,12 +64,14 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 	require.NoError(t, err)
 	modelID := writeModelResp.GetAuthorizationModelId()
 
-	_, err = s.Write(ctx, &openfgav1.WriteRequest{
-		StoreId:              storeID,
-		AuthorizationModelId: modelID,
-		Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
-	})
-	require.NoError(t, err)
+	if len(tuples) > 0 {
+		_, err = s.Write(ctx, &openfgav1.WriteRequest{
+			StoreId:              storeID,
+			AuthorizationModelId: modelID,
+			Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
+		})
+		require.NoError(t, err)
+	}
 
 	return s, &openfgav1.ExpandRequest{
 		StoreId:              storeID,
@@ -194,6 +196,29 @@ func TestExpandBreakingChangeLog(t *testing.T) {
 			`,
 			tuples: []*openfgav1.TupleKey{
 				tuple.NewTupleKey("document:d1", "public", "user:*"),
+			},
+			object:     "document:d1",
+			relation:   "viewer",
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
+			// Regression: the Difference's base is a Union whose `This` child
+			// is the leaf that accepts user:*. branchAcceptsWildcard must not
+			// short-circuit on (document, viewer) when recursing into the
+			// structural Union children, otherwise this case is missed.
+			name: "wildcard_with_exclusion_union_base",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define editor: [user]
+						define blocked: [user]
+						define viewer: ([user:*] or editor) but not blocked
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "user:*"),
 			},
 			object:     "document:d1",
 			relation:   "viewer",

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+
+	"github.com/openfga/openfga/cmd/util"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
+	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/tuple"
+)
+
+// setupExpandServer mirrors setupCheckServer in check_test.go but for the
+// Expand entrypoint. It returns the server and a base ExpandRequest with
+// store and model IDs populated. Callers fill in the tuple key. Defaults
+// (when modelDSL == "" / tuples == nil) match a simple `viewer: [user]`
+// model with `document:1#viewer @ user:alice`.
+func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ExpandRequest) {
+	t.Helper()
+
+	if modelDSL == "" {
+		modelDSL = `
+			model
+				schema 1.1
+			type user
+			type document
+				relations
+					define viewer: [user]
+		`
+	}
+
+	if len(tuples) == 0 {
+		tuples = []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:alice"),
+		}
+	}
+
+	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
+
+	defaultOpts := []OpenFGAServiceV1Option{WithDatastore(ds)}
+	defaultOpts = append(defaultOpts, opts...)
+
+	s := MustNewServerWithOpts(defaultOpts...)
+	t.Cleanup(s.Close)
+
+	ctx := context.Background()
+
+	createStoreResp, err := s.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: "expand-test"})
+	require.NoError(t, err)
+	storeID := createStoreResp.GetId()
+
+	model := testutils.MustTransformDSLToProtoWithID(modelDSL)
+	writeModelResp, err := s.WriteAuthorizationModel(ctx, &openfgav1.WriteAuthorizationModelRequest{
+		StoreId:         storeID,
+		SchemaVersion:   model.GetSchemaVersion(),
+		TypeDefinitions: model.GetTypeDefinitions(),
+	})
+	require.NoError(t, err)
+	modelID := writeModelResp.GetAuthorizationModelId()
+
+	_, err = s.Write(ctx, &openfgav1.WriteRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
+	})
+	require.NoError(t, err)
+
+	return s, &openfgav1.ExpandRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+	}
+}
+
+// TestExpandBreakingChangeReason mirrors check_test.go's TestBreakingChangeReason
+// but exercises v2breaking.ExpandReason. Expand has no user input, so detection
+// is purely against the target relation's rewrite (and its directly-related
+// usersets, for the alias shape). Self-reference is intentionally absent from
+// the catalogue — Expand is already v2-aligned for that case.
+func TestExpandBreakingChangeReason(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	tests := []struct {
+		name       string
+		modelDSL   string
+		seedTuple  *openfgav1.TupleKey
+		objectType string
+		relation   string
+		want       string
+	}{
+		{
+			name: "alias_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define reader: [user]
+						define allowed: reader
+						define viewer: [user, document#allowed]
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "reader", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonAliasUserset,
+		},
+		{
+			name: "computed_userset_self_object",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define editor: [user]
+						define writer: [user]
+						define viewer: editor or writer
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "editor", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonComputedUsersetSelfObj,
+		},
+		{
+			name: "ttu_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define viewer: [user]
+				type document
+					relations
+						define parent: [folder]
+						define viewer: viewer from parent
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonTTUUserset,
+		},
+		{
+			name: "userset_with_exclusion",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define member: [user]
+						define owner: [user]
+						define viewer: [user, document#owner] but not member
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "owner", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonUsersetWithExclusion,
+		},
+		{
+			name: "wildcard_with_exclusion",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define public: [user:*]
+						define blocked: [user]
+						define viewer: public but not blocked
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "public", "user:*"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
+			// Direct-assignment relation has no Difference, no ComputedUserset,
+			// no TTU, no aliased directly-related userset → no shape matches.
+			name: "no_match_direct_assignment",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       "",
+		},
+		{
+			// Direct userset assignment without any aliasing — the directly-
+			// related userset's rewrite is `This`, not a ComputedUserset, so
+			// alias_userset must NOT fire.
+			name: "no_match_direct_userset_assignable",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type group
+					relations
+						define member: [user]
+				type document
+					relations
+						define viewer: [user, group#member]
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       "",
+		},
+		{
+			// Difference exists in the model, but on a *sibling* relation —
+			// the queried relation's rewrite has no Difference of its own.
+			// Must NOT fire userset_with_exclusion (or wildcard_with_exclusion).
+			name: "no_match_difference_on_sibling_relation",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define blocked: [user]
+						define editor: [user] but not blocked
+						define viewer: [user]
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "blocked", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       "",
+		},
+		{
+			// Difference present, but no branch reachable under the base is
+			// directly related to any user:* wildcard. wildcard_with_exclusion
+			// must NOT fire — and since there's a Difference, the fallback is
+			// userset_with_exclusion (the more conservative reason).
+			name: "difference_with_no_wildcard_falls_back_to_userset_with_exclusion",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define a: [user]
+						define b: [user]
+						define viewer: a but not b
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "a", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       v2breaking.ReasonUsersetWithExclusion,
+		},
+		{
+			// Self-reference is intentionally NOT in ExpandReason's catalogue.
+			// A relation with `define viewer: [user]` queried as document#viewer
+			// should not fire any reason.
+			name: "no_match_self_reference_excluded",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			objectType: "document",
+			relation:   "viewer",
+			want:       "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, baseReq := setupExpandServer(t, tc.modelDSL, []*openfgav1.TupleKey{tc.seedTuple})
+
+			typesys, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+			require.NoError(t, err)
+
+			got := v2breaking.ExpandReason(typesys, tc.objectType, tc.relation)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
+	"github.com/openfga/openfga/pkg/typesystem"
 )
 
 // setupExpandServer mirrors setupCheckServer in check_test.go but for the
@@ -233,6 +234,126 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 
 			got := v2breaking.ExpandReason(typesys, tc.objectType, tc.relation)
 			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestExpandResponseConfirmsReason covers the response-side filter for Expand.
+// Exclusion shapes confirm on any non-empty leaf; alias_userset confirms only
+// when a leaf contains an aliased directly-related userset.
+func TestExpandResponseConfirmsReason(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	leafUsersNode := func(users ...string) *openfgav1.UsersetTree_Node {
+		return &openfgav1.UsersetTree_Node{
+			Value: &openfgav1.UsersetTree_Node_Leaf{
+				Leaf: &openfgav1.UsersetTree_Leaf{
+					Value: &openfgav1.UsersetTree_Leaf_Users{
+						Users: &openfgav1.UsersetTree_Users{Users: users},
+					},
+				},
+			},
+		}
+	}
+	emptyLeaf := leafUsersNode()
+	unionNode := func(children ...*openfgav1.UsersetTree_Node) *openfgav1.UsersetTree_Node {
+		return &openfgav1.UsersetTree_Node{
+			Value: &openfgav1.UsersetTree_Node_Union{
+				Union: &openfgav1.UsersetTree_Nodes{Nodes: children},
+			},
+		}
+	}
+
+	aliasModel := `
+		model
+			schema 1.1
+		type user
+		type document
+			relations
+				define reader: [user]
+				define allowed: reader
+				define viewer: [user, document#allowed]
+	`
+	s, baseReq := setupExpandServer(t,
+		aliasModel,
+		[]*openfgav1.TupleKey{tuple.NewTupleKey("document:seed", "reader", "user:seed")},
+	)
+	aliasTS, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name             string
+		reason           string
+		targetObjectType string
+		targetRelation   string
+		typesys          *typesystem.TypeSystem
+		tree             *openfgav1.UsersetTree
+		expected         bool
+	}{
+		{
+			name:             "userset_with_exclusion_non_empty_leaf",
+			reason:           v2breaking.ReasonUsersetWithExclusion,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:alice")},
+			expected:         true,
+		},
+		{
+			name:             "userset_with_exclusion_empty_tree",
+			reason:           v2breaking.ReasonUsersetWithExclusion,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			tree:             &openfgav1.UsersetTree{Root: emptyLeaf},
+			expected:         false,
+		},
+		{
+			name:             "wildcard_with_exclusion_non_empty_leaf",
+			reason:           v2breaking.ReasonWildcardWithExclusion,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:*")},
+			expected:         true,
+		},
+		{
+			name:             "wildcard_with_exclusion_empty_tree",
+			reason:           v2breaking.ReasonWildcardWithExclusion,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			tree:             &openfgav1.UsersetTree{Root: emptyLeaf},
+			expected:         false,
+		},
+		{
+			// document#allowed is a directly-related userset on `viewer` and
+			// `allowed`'s rewrite is ComputedUserset(reader) → aliased.
+			name:             "alias_userset_aliased_leaf_present",
+			reason:           v2breaking.ReasonAliasUserset,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			typesys:          aliasTS,
+			tree: &openfgav1.UsersetTree{Root: unionNode(
+				leafUsersNode("user:alice"),
+				leafUsersNode("document:d2#allowed"),
+			)},
+			expected: true,
+		},
+		{
+			// Tree has users but no aliased userset — only direct users.
+			name:             "alias_userset_no_aliased_leaf",
+			reason:           v2breaking.ReasonAliasUserset,
+			targetObjectType: "document",
+			targetRelation:   "viewer",
+			typesys:          aliasTS,
+			tree:             &openfgav1.UsersetTree{Root: leafUsersNode("user:alice")},
+			expected:         false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := v2breaking.ExpandResponseConfirmsReason(tc.reason, tc.typesys, tc.targetObjectType, tc.targetRelation, tc.tree)
+			require.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -282,7 +281,7 @@ func TestExpandBreakingChangeLog(t *testing.T) {
 
 			s, baseReq := setupExpandServer(t, tc.modelDSL, tc.tuples, WithLogger(testLogger))
 
-			res, err := s.Expand(context.Background(), &openfgav1.ExpandRequest{
+			_, err := s.Expand(context.Background(), &openfgav1.ExpandRequest{
 				StoreId:              baseReq.GetStoreId(),
 				AuthorizationModelId: baseReq.GetAuthorizationModelId(),
 				TupleKey: &openfgav1.ExpandRequestTupleKey{
@@ -290,7 +289,6 @@ func TestExpandBreakingChangeLog(t *testing.T) {
 					Relation: tc.relation,
 				},
 			})
-			fmt.Printf("%s", res)
 			require.NoError(t, err)
 
 			breakingLogs := logs.FilterMessage(logMessage)

--- a/pkg/server/expand_test.go
+++ b/pkg/server/expand_test.go
@@ -20,7 +20,7 @@ import (
 // store and model IDs populated. Callers fill in the tuple key. Defaults
 // (when modelDSL == "" / tuples == nil) match a simple `viewer: [user]`
 // model with `document:1#viewer @ user:alice`.
-func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ExpandRequest) {
+func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey) (*Server, *openfgav1.ExpandRequest) {
 	t.Helper()
 
 	if modelDSL == "" {
@@ -42,10 +42,7 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 
 	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
 
-	defaultOpts := []OpenFGAServiceV1Option{WithDatastore(ds)}
-	defaultOpts = append(defaultOpts, opts...)
-
-	s := MustNewServerWithOpts(defaultOpts...)
+	s := MustNewServerWithOpts(WithDatastore(ds))
 	t.Cleanup(s.Close)
 
 	ctx := context.Background()
@@ -79,8 +76,9 @@ func setupExpandServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleK
 // TestExpandBreakingChangeReason mirrors check_test.go's TestBreakingChangeReason
 // but exercises v2breaking.ExpandReason. Expand has no user input, so detection
 // is purely against the target relation's rewrite (and its directly-related
-// usersets, for the alias shape). Self-reference is intentionally absent from
-// the catalogue — Expand is already v2-aligned for that case.
+// usersets, for the alias shape). See ExpandReason's doc comment for why the
+// Check-side shapes (self_referential_userset, computed_userset_self_object,
+// ttu_userset) are not in the catalogue.
 func TestExpandBreakingChangeReason(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
@@ -110,42 +108,6 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 			objectType: "document",
 			relation:   "viewer",
 			want:       v2breaking.ReasonAliasUserset,
-		},
-		{
-			name: "computed_userset_self_object",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define editor: [user]
-						define writer: [user]
-						define viewer: editor or writer
-			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "editor", "user:seed"),
-			objectType: "document",
-			relation:   "viewer",
-			want:       v2breaking.ReasonComputedUsersetSelfObj,
-		},
-		{
-			name: "ttu_userset",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type folder
-					relations
-						define viewer: [user]
-				type document
-					relations
-						define parent: [folder]
-						define viewer: viewer from parent
-			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
-			objectType: "document",
-			relation:   "viewer",
-			want:       v2breaking.ReasonTTUUserset,
 		},
 		{
 			name: "userset_with_exclusion",
@@ -182,8 +144,8 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 			want:       v2breaking.ReasonWildcardWithExclusion,
 		},
 		{
-			// Direct-assignment relation has no Difference, no ComputedUserset,
-			// no TTU, no aliased directly-related userset → no shape matches.
+			// Direct-assignment relation has no Difference and no aliased
+			// directly-related userset → no shape matches.
 			name: "no_match_direct_assignment",
 			modelDSL: `
 				model
@@ -259,24 +221,6 @@ func TestExpandBreakingChangeReason(t *testing.T) {
 			objectType: "document",
 			relation:   "viewer",
 			want:       v2breaking.ReasonUsersetWithExclusion,
-		},
-		{
-			// Self-reference is intentionally NOT in ExpandReason's catalogue.
-			// A relation with `define viewer: [user]` queried as document#viewer
-			// should not fire any reason.
-			name: "no_match_self_reference_excluded",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define viewer: [user]
-			`,
-			seedTuple:  tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			objectType: "document",
-			relation:   "viewer",
-			want:       "",
 		},
 	}
 

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -9,6 +9,7 @@ import (
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -20,8 +21,10 @@ import (
 	"github.com/openfga/openfga/internal/throttler/threshold"
 	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/internal/utils/apimethod"
+	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands/listusers"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	serverconfig "github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -154,6 +157,20 @@ func (s *Server) ListUsers(
 	wasDatastoreThrottled := resp.GetMetadata().WasDatastoreThrottled.Load()
 	if wasDatastoreThrottled {
 		throttledRequestCounter.WithLabelValues(s.serviceName, methodName, throttleTypeDatastore).Inc()
+	}
+
+	// Flag potential v2 (weighted-graph) resolution breaking changes for this
+	// request shape. The predicates are schema-shape filters only, so this can
+	// over-report. See v2breaking.ListUsersReason for the catalogue.
+	if len(req.GetUserFilters()) > 0 {
+		if reason := v2breaking.ListUsersReason(typesys, req.GetObject(), req.GetRelation(), req.GetUserFilters()[0]); reason != "" {
+			s.logger.WarnWithContext(ctx, "potential v2 ListUsers resolution breaking change",
+				zap.String("store_id", storeID),
+				zap.String("model_id", req.GetAuthorizationModelId()),
+				zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
+				zap.String("reason", reason),
+			)
+		}
 	}
 
 	return &openfgav1.ListUsersResponse{

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -168,7 +168,7 @@ func (s *Server) ListUsers(
 		if reason == "" {
 			continue
 		}
-		if !v2breaking.ListUsersResponseConfirmsReason(reason, req.GetObject(), req.GetRelation(), filter, resp.GetUsers()) {
+		if !v2breaking.ListUsersResponseConfirmsReason(reason, typesys, req.GetObject(), req.GetRelation(), filter, resp.GetUsers()) {
 			continue
 		}
 		s.logger.WarnWithContext(ctx, "potential v2 ListUsers resolution breaking change",

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -160,11 +160,15 @@ func (s *Server) ListUsers(
 	}
 
 	// Flag potential v2 (weighted-graph) resolution breaking changes for this
-	// request shape. The predicates are schema-shape filters only, so this can
-	// over-report. See v2breaking.ListUsersReason for the catalogue.
+	// request shape. Shape predicates may over-report; for the response-
+	// conditional reasons we additionally confirm the v1-only user actually
+	// came back. See v2breaking.ListUsersReason / ListUsersResponseConfirmsReason.
 	for _, filter := range req.GetUserFilters() {
 		reason := v2breaking.ListUsersReason(typesys, req.GetObject(), req.GetRelation(), filter)
 		if reason == "" {
+			continue
+		}
+		if !v2breaking.ListUsersResponseConfirmsReason(reason, req.GetObject(), req.GetRelation(), filter, resp.GetUsers()) {
 			continue
 		}
 		s.logger.WarnWithContext(ctx, "potential v2 ListUsers resolution breaking change",

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -162,15 +162,17 @@ func (s *Server) ListUsers(
 	// Flag potential v2 (weighted-graph) resolution breaking changes for this
 	// request shape. The predicates are schema-shape filters only, so this can
 	// over-report. See v2breaking.ListUsersReason for the catalogue.
-	if len(req.GetUserFilters()) > 0 {
-		if reason := v2breaking.ListUsersReason(typesys, req.GetObject(), req.GetRelation(), req.GetUserFilters()[0]); reason != "" {
-			s.logger.WarnWithContext(ctx, "potential v2 ListUsers resolution breaking change",
-				zap.String("store_id", storeID),
-				zap.String("model_id", req.GetAuthorizationModelId()),
-				zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
-				zap.String("reason", reason),
-			)
+	for _, filter := range req.GetUserFilters() {
+		reason := v2breaking.ListUsersReason(typesys, req.GetObject(), req.GetRelation(), filter)
+		if reason == "" {
+			continue
 		}
+		s.logger.WarnWithContext(ctx, "potential v2 ListUsers resolution breaking change",
+			zap.String("store_id", storeID),
+			zap.String("model_id", req.GetAuthorizationModelId()),
+			zap.String("request_id", requestid.GetRequestIDFromContext(ctx)),
+			zap.String("reason", reason),
+		)
 	}
 
 	return &openfgav1.ListUsersResponse{

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -16,7 +16,9 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	parser "github.com/openfga/language/pkg/go/transformer"
 
+	"github.com/openfga/openfga/cmd/util"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/memory"
@@ -635,4 +637,307 @@ func TestListUsers_WithListUsersDatabaseThrottle(t *testing.T) {
 		require.NotNil(t, resp)
 		require.Len(t, resp.GetUsers(), 1)
 	})
+}
+
+// setupListUsersServer mirrors setupCheckServer in check_test.go but for the
+// ListUsers entrypoint. It returns the server and a base ListUsersRequest with
+// store and model IDs populated. Callers fill in object, relation, and user
+// filters. Defaults (when modelDSL == "" / tuples == nil) match a simple
+// `viewer: [user]` model with `document:1#viewer @ user:alice`.
+func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ListUsersRequest) {
+	t.Helper()
+
+	if modelDSL == "" {
+		modelDSL = `
+			model
+				schema 1.1
+			type user
+			type document
+				relations
+					define viewer: [user]
+		`
+	}
+
+	if len(tuples) == 0 {
+		tuples = []*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "user:alice"),
+		}
+	}
+
+	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
+
+	defaultOpts := []OpenFGAServiceV1Option{WithDatastore(ds)}
+	defaultOpts = append(defaultOpts, opts...)
+
+	s := MustNewServerWithOpts(defaultOpts...)
+	t.Cleanup(s.Close)
+
+	ctx := context.Background()
+
+	createStoreResp, err := s.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: "list-users-test"})
+	require.NoError(t, err)
+	storeID := createStoreResp.GetId()
+
+	model := testutils.MustTransformDSLToProtoWithID(modelDSL)
+	writeModelResp, err := s.WriteAuthorizationModel(ctx, &openfgav1.WriteAuthorizationModelRequest{
+		StoreId:         storeID,
+		SchemaVersion:   model.GetSchemaVersion(),
+		TypeDefinitions: model.GetTypeDefinitions(),
+	})
+	require.NoError(t, err)
+	modelID := writeModelResp.GetAuthorizationModelId()
+
+	_, err = s.Write(ctx, &openfgav1.WriteRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
+	})
+	require.NoError(t, err)
+
+	return s, &openfgav1.ListUsersRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+	}
+}
+
+// TestListUsersBreakingChangeReason mirrors check_test.go's TestBreakingChangeReason
+// but exercises v2breaking.ListUsersReason against the ListUsers request shape
+// (object + relation + user filter). Each positive case asserts the expected
+// reason; each `no_match_*` case asserts the empty string.
+func TestListUsersBreakingChangeReason(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	tests := []struct {
+		name      string
+		modelDSL  string
+		seedTuple *openfgav1.TupleKey
+		object    *openfgav1.Object
+		relation  string
+		filter    *openfgav1.UserTypeFilter
+		want      string
+	}{
+		{
+			name: "self_referential_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
+			want:      v2breaking.ReasonSelfReferentialUserset,
+		},
+		{
+			name: "alias_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define reader: [user]
+						define allowed: reader
+						define viewer: [user, document#allowed]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "reader", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			want:      v2breaking.ReasonAliasUserset,
+		},
+		{
+			name: "computed_userset_self_object",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define editor: [user]
+						define writer: [user]
+						define viewer: editor or writer
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "editor", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
+			want:      v2breaking.ReasonComputedUsersetSelfObj,
+		},
+		{
+			name: "ttu_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define viewer: [user]
+				type document
+					relations
+						define parent: [folder]
+						define viewer: viewer from parent
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			want:      v2breaking.ReasonTTUUserset,
+		},
+		{
+			name: "userset_with_exclusion",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define member: [user]
+						define owner: [user]
+						define viewer: [user, document#owner] but not member
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "owner", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "report"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
+			want:      v2breaking.ReasonUsersetWithExclusion,
+		},
+		{
+			name: "wildcard_with_exclusion",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define public: [user:*]
+						define blocked: [user]
+						define viewer: public but not blocked
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "public", "user:*"),
+			object:    &openfgav1.Object{Type: "document", Id: "report"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "user"},
+			want:      v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
+			// Plain user filter with no relation against a benign direct-assignment
+			// relation: no shape matches.
+			name: "no_match_direct_user_filter",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "user"},
+			want:      "",
+		},
+		{
+			// Userset filter, but the filter's type is directly assignable on the
+			// target relation — no alias and no other shape matches.
+			name: "no_match_direct_userset_assignable",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type group
+					relations
+						define member: [user]
+				type document
+					relations
+						define viewer: [user, group#member]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "group", Relation: "member"},
+			want:      "",
+		},
+		{
+			// Userset filter, but the *target* relation's rewrite has no
+			// Difference (the Difference lives on a sibling relation). Must NOT
+			// fire userset_with_exclusion — the predicate is scoped to the
+			// queried relation, not the whole model.
+			name: "no_match_userset_filter_target_has_no_difference",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define blocked: [user]
+						define editor: [user] but not blocked
+						define viewer: [user, document#editor]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "blocked", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "editor"},
+			want:      "",
+		},
+		{
+			// Plain user filter against a relation with a Difference, but no
+			// branch in the rewrite is directly related to user:* — the
+			// wildcard is unreachable. Must NOT fire wildcard_with_exclusion.
+			name: "no_match_wildcard_filter_difference_no_wildcard_in_base",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define a: [user]
+						define b: [user]
+						define viewer: a but not b
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "a", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "user"},
+			want:      "",
+		},
+		{
+			// Self-reference shape requires (filter.type, filter.relation) ==
+			// (object.type, relation). Different relation → must NOT fire.
+			name: "no_match_self_referential_different_relation",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define editor: [user]
+						define viewer: [user, document#editor]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "editor", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "editor"},
+			want:      "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s, baseReq := setupListUsersServer(t, tc.modelDSL, []*openfgav1.TupleKey{tc.seedTuple})
+
+			typesys, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+			require.NoError(t, err)
+
+			got := v2breaking.ListUsersReason(typesys, tc.object, tc.relation, tc.filter)
+			require.Equal(t, tc.want, got)
+		})
+	}
 }

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -965,6 +965,10 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 // suppresses false-positive logs on response-conditional reasons. Exclusion
 // shapes are not exercised here — they are not gated on the response.
 func TestListUsersResponseConfirmsReason(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
 	obj := &openfgav1.Object{Type: "document", Id: "d1"}
 	usersetUser := func(typ, id, relation string) *openfgav1.User {
 		return &openfgav1.User{User: &openfgav1.User_Userset{Userset: &openfgav1.UsersetUser{Type: typ, Id: id, Relation: relation}}}
@@ -973,9 +977,26 @@ func TestListUsersResponseConfirmsReason(t *testing.T) {
 		return &openfgav1.User{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: typ, Id: id}}}
 	}
 
+	// aliasTS is a typesystem where document#viewer accepts document#allowed
+	// (which itself aliases via ComputedUserset to `reader`). Used for the
+	// alias_userset cases — the only reason that consults the typesystem.
+	s, baseReq := setupListUsersServer(t, `
+		model
+			schema 1.1
+		type user
+		type document
+			relations
+				define reader: [user]
+				define allowed: reader
+				define viewer: [user, document#allowed]
+	`, []*openfgav1.TupleKey{tuple.NewTupleKey("document:seed", "reader", "user:seed")})
+	aliasTS, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+	require.NoError(t, err)
+
 	tests := []struct {
 		name     string
 		reason   string
+		typesys  *typesystem.TypeSystem
 		filter   *openfgav1.UserTypeFilter
 		users    []*openfgav1.User
 		expected bool
@@ -1009,17 +1030,35 @@ func TestListUsersResponseConfirmsReason(t *testing.T) {
 			expected: false,
 		},
 		{
+			// document#allowed is a directly-related userset on viewer and
+			// `allowed`'s rewrite is ComputedUserset(reader) → aliased.
 			name:     "alias_userset_confirmed",
 			reason:   v2breaking.ReasonAliasUserset,
+			typesys:  aliasTS,
 			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			users:    []*openfgav1.User{usersetUser("document", "d1", "allowed")},
+			users:    []*openfgav1.User{usersetUser("document", "d2", "allowed")},
 			expected: true,
 		},
 		{
+			// document#reader IS the filter's relation, not the alias — it is
+			// not a directly-related userset on viewer (only user and
+			// document#allowed are). Must NOT confirm.
 			name:     "alias_userset_not_present_only_filter_relation",
 			reason:   v2breaking.ReasonAliasUserset,
+			typesys:  aliasTS,
 			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			users:    []*openfgav1.User{usersetUser("document", "d1", "reader")},
+			users:    []*openfgav1.User{usersetUser("document", "d2", "reader")},
+			expected: false,
+		},
+		{
+			// Userset of an unrelated relation (`other`) — not a directly-
+			// related userset on viewer. The old loose check would have
+			// confirmed this; the tightened check correctly rejects it.
+			name:     "alias_userset_unrelated_userset",
+			reason:   v2breaking.ReasonAliasUserset,
+			typesys:  aliasTS,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			users:    []*openfgav1.User{usersetUser("document", "d2", "other")},
 			expected: false,
 		},
 		{
@@ -1068,7 +1107,7 @@ func TestListUsersResponseConfirmsReason(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := v2breaking.ListUsersResponseConfirmsReason(tc.reason, obj, "viewer", tc.filter, tc.users)
+			got := v2breaking.ListUsersResponseConfirmsReason(tc.reason, tc.typesys, obj, "viewer", tc.filter, tc.users)
 			require.Equal(t, tc.expected, got)
 		})
 	}

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -644,7 +644,7 @@ func TestListUsers_WithListUsersDatabaseThrottle(t *testing.T) {
 // store and model IDs populated. Callers fill in object, relation, and user
 // filters. Defaults (when modelDSL == "" / tuples == nil) match a simple
 // `viewer: [user]` model with `document:1#viewer @ user:alice`.
-func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ListUsersRequest) {
+func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey) (*Server, *openfgav1.ListUsersRequest) {
 	t.Helper()
 
 	if modelDSL == "" {
@@ -666,10 +666,7 @@ func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.Tup
 
 	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
 
-	defaultOpts := []OpenFGAServiceV1Option{WithDatastore(ds)}
-	defaultOpts = append(defaultOpts, opts...)
-
-	s := MustNewServerWithOpts(defaultOpts...)
+	s := MustNewServerWithOpts(WithDatastore(ds))
 	t.Cleanup(s.Close)
 
 	ctx := context.Background()

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -18,6 +20,7 @@ import (
 
 	"github.com/openfga/openfga/cmd/util"
 	mockstorage "github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
@@ -644,7 +647,7 @@ func TestListUsers_WithListUsersDatabaseThrottle(t *testing.T) {
 // store and model IDs populated. Callers fill in object, relation, and user
 // filters. Defaults (when modelDSL == "" / tuples == nil) match a simple
 // `viewer: [user]` model with `document:1#viewer @ user:alice`.
-func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey) (*Server, *openfgav1.ListUsersRequest) {
+func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKey, opts ...OpenFGAServiceV1Option) (*Server, *openfgav1.ListUsersRequest) {
 	t.Helper()
 
 	if modelDSL == "" {
@@ -666,7 +669,8 @@ func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.Tup
 
 	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
 
-	s := MustNewServerWithOpts(WithDatastore(ds))
+	defaultOpts := append([]OpenFGAServiceV1Option{WithDatastore(ds)}, opts...)
+	s := MustNewServerWithOpts(defaultOpts...)
 	t.Cleanup(s.Close)
 
 	ctx := context.Background()
@@ -697,40 +701,28 @@ func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.Tup
 	}
 }
 
-// TestListUsersBreakingChangeReason mirrors check_test.go's TestBreakingChangeReason
-// but exercises v2breaking.ListUsersReason against the ListUsers request shape
-// (object + relation + user filter). Each positive case asserts the expected
-// reason; each `no_match_*` case asserts the empty string.
-func TestListUsersBreakingChangeReason(t *testing.T) {
+// TestListUsersBreakingChangeLog drives an end-to-end ListUsers call with an
+// in-memory store, captures emitted logs via a zap observer, and asserts that
+// the "potential v2 ListUsers resolution breaking change" log fires (or
+// doesn't) for each shape — combining the shape predicate
+// (v2breaking.ListUsersReason) and the response-side confirmation
+// (ListUsersResponseConfirmsReason) in a single test.
+func TestListUsersBreakingChangeLog(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
 	})
 
+	const logMessage = "potential v2 ListUsers resolution breaking change"
+
 	tests := []struct {
-		name      string
-		modelDSL  string
-		seedTuple *openfgav1.TupleKey
-		object    *openfgav1.Object
-		relation  string
-		filter    *openfgav1.UserTypeFilter
-		want      string
+		name       string
+		modelDSL   string
+		tuples     []*openfgav1.TupleKey
+		object     *openfgav1.Object
+		relation   string
+		filter     *openfgav1.UserTypeFilter
+		wantReason string // empty means: expect no log
 	}{
-		{
-			name: "self_referential_userset",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define viewer: [user]
-			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
-			want:      v2breaking.ReasonSelfReferentialUserset,
-		},
 		{
 			name: "alias_userset",
 			modelDSL: `
@@ -743,11 +735,29 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 						define allowed: reader
 						define viewer: [user, document#allowed]
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "reader", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			want:      v2breaking.ReasonAliasUserset,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "document:d2#allowed"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			wantReason: v2breaking.ReasonAliasUserset,
+		},
+		{
+			name: "self_referential_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define viewer: [user]
+			`,
+			tuples:     []*openfgav1.TupleKey{},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
+			wantReason: v2breaking.ReasonSelfReferentialUserset,
 		},
 		{
 			name: "computed_userset_self_object",
@@ -761,11 +771,13 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 						define writer: [user]
 						define viewer: editor or writer
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "editor", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
-			want:      v2breaking.ReasonComputedUsersetSelfObj,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "editor", "user:alice"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
+			wantReason: v2breaking.ReasonComputedUsersetSelfObj,
 		},
 		{
 			name: "ttu_userset",
@@ -781,11 +793,13 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 						define parent: [folder]
 						define viewer: viewer from parent
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
-			want:      v2breaking.ReasonTTUUserset,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "parent", "folder:f1"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			wantReason: v2breaking.ReasonTTUUserset,
 		},
 		{
 			name: "userset_with_exclusion",
@@ -799,11 +813,14 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 						define owner: [user]
 						define viewer: [user, document#owner] but not member
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "owner", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "report"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
-			want:      v2breaking.ReasonUsersetWithExclusion,
+			tuples: []*openfgav1.TupleKey{
+				// Direct viewer tuple so the difference's base leaf has a user.
+				tuple.NewTupleKey("document:d1", "viewer", "document:d2#owner"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
+			wantReason: v2breaking.ReasonUsersetWithExclusion,
 		},
 		{
 			name: "wildcard_with_exclusion",
@@ -817,16 +834,56 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 						define blocked: [user]
 						define viewer: public but not blocked
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "public", "user:*"),
-			object:    &openfgav1.Object{Type: "document", Id: "report"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "user"},
-			want:      v2breaking.ReasonWildcardWithExclusion,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "public", "user:*"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "user"},
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
 		},
 		{
-			// Plain user filter with no relation against a benign direct-assignment
-			// relation: no shape matches.
-			name: "no_match_direct_user_filter",
+			name: "no_match_alias_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type document
+					relations
+						define reader: [user]
+						define allowed: reader
+						define viewer: [user, document#allowed]
+			`,
+			tuples:     []*openfgav1.TupleKey{},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			wantReason: "",
+		},
+		{
+			name: "no_match_ttu_userset",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define viewer: [user]
+				type document
+					relations
+						define parent: [folder]
+						define viewer: viewer from parent
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			wantReason: "",
+		},
+		{
+			name: "no_match_user_is_not_userset",
 			modelDSL: `
 				model
 					schema 1.1
@@ -835,15 +892,15 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 					relations
 						define viewer: [user]
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "user"},
-			want:      "",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "viewer", "user:alice"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "user"},
+			wantReason: "",
 		},
 		{
-			// Userset filter, but the filter's type is directly assignable on the
-			// target relation — no alias and no other shape matches.
 			name: "no_match_direct_userset_assignable",
 			modelDSL: `
 				model
@@ -856,59 +913,18 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 					relations
 						define viewer: [user, group#member]
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "group", Relation: "member"},
-			want:      "",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "group", Relation: "member"},
+			wantReason: "",
 		},
 		{
-			// Userset filter, but the *target* relation's rewrite has no
-			// Difference (the Difference lives on a sibling relation). Must NOT
-			// fire userset_with_exclusion — the predicate is scoped to the
-			// queried relation, not the whole model.
-			name: "no_match_userset_filter_target_has_no_difference",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define blocked: [user]
-						define editor: [user] but not blocked
-						define viewer: [user, document#editor]
-			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "blocked", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "editor"},
-			want:      "",
-		},
-		{
-			// Plain user filter against a relation with a Difference, but no
-			// branch in the rewrite is directly related to user:* — the
-			// wildcard is unreachable. Must NOT fire wildcard_with_exclusion.
-			name: "no_match_wildcard_filter_difference_no_wildcard_in_base",
-			modelDSL: `
-				model
-					schema 1.1
-				type user
-				type document
-					relations
-						define a: [user]
-						define b: [user]
-						define viewer: a but not b
-			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "a", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "user"},
-			want:      "",
-		},
-		{
-			// Self-reference shape requires (filter.type, filter.relation) ==
-			// (object.type, relation). Different relation → must NOT fire.
-			name: "no_match_self_referential_different_relation",
+			// Same object as target, but user's relation is not a ComputedUserset leaf
+			// in the rewrite. computed_userset_self_object must NOT fire.
+			name: "no_match_computed_userset_relation_not_in_rewrite",
 			modelDSL: `
 				model
 					schema 1.1
@@ -916,19 +932,22 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 				type document
 					relations
 						define editor: [user]
-						define viewer: [user, document#editor]
+						define writer: [user]
+						define other: [user]
+						define viewer: editor or writer
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "editor", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "editor"},
-			want:      "",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:seed", "editor", "user:seed"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "document", Relation: "other"},
+			wantReason: "",
 		},
 		{
-			// Self-reference shape requires (filter.type, filter.relation) ==
-			// (object.type, relation). Same relation name but different type
-			// → must NOT fire.
-			name: "no_match_self_referential_different_type",
+			// TTU exists (viewer from parent) but the user's relation does not match
+			// the TTU's computed relation. ttu_userset must NOT fire.
+			name: "no_match_ttu_user_relation_mismatch",
 			modelDSL: `
 				model
 					schema 1.1
@@ -936,179 +955,47 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 				type folder
 					relations
 						define viewer: [user]
+						define editor: [user]
 				type document
 					relations
-						define viewer: [user, folder#viewer]
+						define parent: [folder]
+						define viewer: viewer from parent
 			`,
-			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
-			object:    &openfgav1.Object{Type: "document", Id: "d1"},
-			relation:  "viewer",
-			filter:    &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
-			want:      "",
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:seed", "parent", "folder:seed"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "folder", Relation: "editor"},
+			wantReason: "",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			s, baseReq := setupListUsersServer(t, tc.modelDSL, []*openfgav1.TupleKey{tc.seedTuple})
+			core, logs := observer.New(zap.WarnLevel)
+			testLogger := &logger.ZapLogger{Logger: zap.New(core)}
 
-			typesys, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
+			s, baseReq := setupListUsersServer(t, tc.modelDSL, tc.tuples, WithLogger(testLogger))
+
+			res, err := s.ListUsers(context.Background(), &openfgav1.ListUsersRequest{
+				StoreId:              baseReq.GetStoreId(),
+				AuthorizationModelId: baseReq.GetAuthorizationModelId(),
+				Object:               tc.object,
+				Relation:             tc.relation,
+				UserFilters:          []*openfgav1.UserTypeFilter{tc.filter},
+			})
+			fmt.Printf("%s", res)
 			require.NoError(t, err)
 
-			got := v2breaking.ListUsersReason(typesys, tc.object, tc.relation, tc.filter)
-			require.Equal(t, tc.want, got)
-		})
-	}
-}
-
-// TestListUsersResponseConfirmsReason covers the response-side filter that
-// suppresses false-positive logs on response-conditional reasons. Exclusion
-// shapes are not exercised here — they are not gated on the response.
-func TestListUsersResponseConfirmsReason(t *testing.T) {
-	t.Cleanup(func() {
-		goleak.VerifyNone(t)
-	})
-
-	obj := &openfgav1.Object{Type: "document", Id: "d1"}
-	usersetUser := func(typ, id, relation string) *openfgav1.User {
-		return &openfgav1.User{User: &openfgav1.User_Userset{Userset: &openfgav1.UsersetUser{Type: typ, Id: id, Relation: relation}}}
-	}
-	plainUser := func(typ, id string) *openfgav1.User {
-		return &openfgav1.User{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: typ, Id: id}}}
-	}
-
-	// aliasTS is a typesystem where document#viewer accepts document#allowed
-	// (which itself aliases via ComputedUserset to `reader`). Used for the
-	// alias_userset cases — the only reason that consults the typesystem.
-	s, baseReq := setupListUsersServer(t, `
-		model
-			schema 1.1
-		type user
-		type document
-			relations
-				define reader: [user]
-				define allowed: reader
-				define viewer: [user, document#allowed]
-	`, []*openfgav1.TupleKey{tuple.NewTupleKey("document:seed", "reader", "user:seed")})
-	aliasTS, err := s.resolveTypesystem(context.Background(), baseReq.GetStoreId(), baseReq.GetAuthorizationModelId())
-	require.NoError(t, err)
-
-	tests := []struct {
-		name     string
-		reason   string
-		typesys  *typesystem.TypeSystem
-		filter   *openfgav1.UserTypeFilter
-		users    []*openfgav1.User
-		expected bool
-	}{
-		{
-			name:     "self_referential_userset_confirmed",
-			reason:   v2breaking.ReasonSelfReferentialUserset,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
-			users:    []*openfgav1.User{usersetUser("document", "d1", "viewer")},
-			expected: true,
-		},
-		{
-			name:     "self_referential_userset_not_present",
-			reason:   v2breaking.ReasonSelfReferentialUserset,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
-			users:    []*openfgav1.User{plainUser("user", "alice")},
-			expected: false,
-		},
-		{
-			name:     "computed_userset_self_object_confirmed",
-			reason:   v2breaking.ReasonComputedUsersetSelfObj,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
-			users:    []*openfgav1.User{usersetUser("document", "d1", "writer")},
-			expected: true,
-		},
-		{
-			name:     "computed_userset_self_object_not_present",
-			reason:   v2breaking.ReasonComputedUsersetSelfObj,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
-			users:    []*openfgav1.User{usersetUser("document", "d2", "writer")},
-			expected: false,
-		},
-		{
-			// document#allowed is a directly-related userset on viewer and
-			// `allowed`'s rewrite is ComputedUserset(reader) → aliased.
-			name:     "alias_userset_confirmed",
-			reason:   v2breaking.ReasonAliasUserset,
-			typesys:  aliasTS,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			users:    []*openfgav1.User{usersetUser("document", "d2", "allowed")},
-			expected: true,
-		},
-		{
-			// document#reader IS the filter's relation, not the alias — it is
-			// not a directly-related userset on viewer (only user and
-			// document#allowed are). Must NOT confirm.
-			name:     "alias_userset_not_present_only_filter_relation",
-			reason:   v2breaking.ReasonAliasUserset,
-			typesys:  aliasTS,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			users:    []*openfgav1.User{usersetUser("document", "d2", "reader")},
-			expected: false,
-		},
-		{
-			// Userset of an unrelated relation (`other`) — not a directly-
-			// related userset on viewer. The old loose check would have
-			// confirmed this; the tightened check correctly rejects it.
-			name:     "alias_userset_unrelated_userset",
-			reason:   v2breaking.ReasonAliasUserset,
-			typesys:  aliasTS,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
-			users:    []*openfgav1.User{usersetUser("document", "d2", "other")},
-			expected: false,
-		},
-		{
-			name:     "ttu_userset_confirmed",
-			reason:   v2breaking.ReasonTTUUserset,
-			filter:   &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
-			users:    []*openfgav1.User{usersetUser("folder", "f1", "viewer")},
-			expected: true,
-		},
-		{
-			name:     "ttu_userset_not_present",
-			reason:   v2breaking.ReasonTTUUserset,
-			filter:   &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
-			users:    []*openfgav1.User{plainUser("user", "alice")},
-			expected: false,
-		},
-		{
-			name:     "userset_with_exclusion_non_empty_response",
-			reason:   v2breaking.ReasonUsersetWithExclusion,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
-			users:    []*openfgav1.User{usersetUser("document", "d2", "owner")},
-			expected: true,
-		},
-		{
-			name:     "userset_with_exclusion_empty_response",
-			reason:   v2breaking.ReasonUsersetWithExclusion,
-			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
-			users:    nil,
-			expected: false,
-		},
-		{
-			name:     "wildcard_with_exclusion_non_empty_response",
-			reason:   v2breaking.ReasonWildcardWithExclusion,
-			filter:   &openfgav1.UserTypeFilter{Type: "user"},
-			users:    []*openfgav1.User{plainUser("user", "alice")},
-			expected: true,
-		},
-		{
-			name:     "wildcard_with_exclusion_empty_response",
-			reason:   v2breaking.ReasonWildcardWithExclusion,
-			filter:   &openfgav1.UserTypeFilter{Type: "user"},
-			users:    nil,
-			expected: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := v2breaking.ListUsersResponseConfirmsReason(tc.reason, tc.typesys, obj, "viewer", tc.filter, tc.users)
-			require.Equal(t, tc.expected, got)
+			breakingLogs := logs.FilterMessage(logMessage)
+			if tc.wantReason == "" {
+				require.Equal(t, 0, breakingLogs.Len(), "expected no breaking-change log")
+				return
+			}
+			require.Equal(t, 1, breakingLogs.Len(), "expected exactly one breaking-change log")
+			fields := fieldMap(breakingLogs.All()[0].Context)
+			require.Equal(t, tc.wantReason, fields["reason"])
 		})
 	}
 }

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -845,6 +845,30 @@ func TestListUsersBreakingChangeLog(t *testing.T) {
 			wantReason: v2breaking.ReasonWildcardWithExclusion,
 		},
 		{
+			name: "wildcard_with_exclusion_via_ttu",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define blocked: [user]
+						define viewer: [user, user:*] but not blocked
+				type document
+					relations
+						define parent: [folder]
+						define viewer: viewer from parent and member
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:d1", "parent", "folder:f1"),
+				tuple.NewTupleKey("folder:f1", "viewer", "user:*"),
+			},
+			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "user"},
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
 			name: "no_match_alias_userset",
 			modelDSL: `
 				model

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -857,13 +857,39 @@ func TestListUsersBreakingChangeLog(t *testing.T) {
 				type document
 					relations
 						define parent: [folder]
-						define viewer: viewer from parent and member
+						define viewer: viewer from parent
 			`,
 			tuples: []*openfgav1.TupleKey{
 				tuple.NewTupleKey("document:d1", "parent", "folder:f1"),
 				tuple.NewTupleKey("folder:f1", "viewer", "user:*"),
 			},
 			object:     &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:   "viewer",
+			filter:     &openfgav1.UserTypeFilter{Type: "user"},
+			wantReason: v2breaking.ReasonWildcardWithExclusion,
+		},
+		{
+			// Regression: recursive TTU (folder#parent points to folder) used
+			// to cause unbounded recursion in walkForWildcardUnderDifference
+			// when the target rewrite already contains a Difference. The
+			// visited-set guard must terminate the walk while still returning
+			// the correct reason.
+			name: "wildcard_with_exclusion_recursive_ttu_terminates",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define parent: [folder]
+						define blocked: [user]
+						define local_viewer: [user, user:*]
+						define viewer: (local_viewer or viewer from parent) but not blocked
+			`,
+			tuples: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("folder:f1", "local_viewer", "user:*"),
+			},
+			object:     &openfgav1.Object{Type: "folder", Id: "f1"},
 			relation:   "viewer",
 			filter:     &openfgav1.UserTypeFilter{Type: "user"},
 			wantReason: v2breaking.ReasonWildcardWithExclusion,

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -924,6 +924,28 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 			filter:    &openfgav1.UserTypeFilter{Type: "document", Relation: "editor"},
 			want:      "",
 		},
+		{
+			// Self-reference shape requires (filter.type, filter.relation) ==
+			// (object.type, relation). Same relation name but different type
+			// → must NOT fire.
+			name: "no_match_self_referential_different_type",
+			modelDSL: `
+				model
+					schema 1.1
+				type user
+				type folder
+					relations
+						define viewer: [user]
+				type document
+					relations
+						define viewer: [user, folder#viewer]
+			`,
+			seedTuple: tuple.NewTupleKey("document:seed", "viewer", "user:seed"),
+			object:    &openfgav1.Object{Type: "document", Id: "d1"},
+			relation:  "viewer",
+			filter:    &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			want:      "",
+		},
 	}
 
 	for _, tc := range tests {
@@ -935,6 +957,119 @@ func TestListUsersBreakingChangeReason(t *testing.T) {
 
 			got := v2breaking.ListUsersReason(typesys, tc.object, tc.relation, tc.filter)
 			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestListUsersResponseConfirmsReason covers the response-side filter that
+// suppresses false-positive logs on response-conditional reasons. Exclusion
+// shapes are not exercised here — they are not gated on the response.
+func TestListUsersResponseConfirmsReason(t *testing.T) {
+	obj := &openfgav1.Object{Type: "document", Id: "d1"}
+	usersetUser := func(typ, id, relation string) *openfgav1.User {
+		return &openfgav1.User{User: &openfgav1.User_Userset{Userset: &openfgav1.UsersetUser{Type: typ, Id: id, Relation: relation}}}
+	}
+	plainUser := func(typ, id string) *openfgav1.User {
+		return &openfgav1.User{User: &openfgav1.User_Object{Object: &openfgav1.Object{Type: typ, Id: id}}}
+	}
+
+	tests := []struct {
+		name     string
+		reason   string
+		filter   *openfgav1.UserTypeFilter
+		users    []*openfgav1.User
+		expected bool
+	}{
+		{
+			name:     "self_referential_userset_confirmed",
+			reason:   v2breaking.ReasonSelfReferentialUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
+			users:    []*openfgav1.User{usersetUser("document", "d1", "viewer")},
+			expected: true,
+		},
+		{
+			name:     "self_referential_userset_not_present",
+			reason:   v2breaking.ReasonSelfReferentialUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "viewer"},
+			users:    []*openfgav1.User{plainUser("user", "alice")},
+			expected: false,
+		},
+		{
+			name:     "computed_userset_self_object_confirmed",
+			reason:   v2breaking.ReasonComputedUsersetSelfObj,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
+			users:    []*openfgav1.User{usersetUser("document", "d1", "writer")},
+			expected: true,
+		},
+		{
+			name:     "computed_userset_self_object_not_present",
+			reason:   v2breaking.ReasonComputedUsersetSelfObj,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "writer"},
+			users:    []*openfgav1.User{usersetUser("document", "d2", "writer")},
+			expected: false,
+		},
+		{
+			name:     "alias_userset_confirmed",
+			reason:   v2breaking.ReasonAliasUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			users:    []*openfgav1.User{usersetUser("document", "d1", "allowed")},
+			expected: true,
+		},
+		{
+			name:     "alias_userset_not_present_only_filter_relation",
+			reason:   v2breaking.ReasonAliasUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "reader"},
+			users:    []*openfgav1.User{usersetUser("document", "d1", "reader")},
+			expected: false,
+		},
+		{
+			name:     "ttu_userset_confirmed",
+			reason:   v2breaking.ReasonTTUUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			users:    []*openfgav1.User{usersetUser("folder", "f1", "viewer")},
+			expected: true,
+		},
+		{
+			name:     "ttu_userset_not_present",
+			reason:   v2breaking.ReasonTTUUserset,
+			filter:   &openfgav1.UserTypeFilter{Type: "folder", Relation: "viewer"},
+			users:    []*openfgav1.User{plainUser("user", "alice")},
+			expected: false,
+		},
+		{
+			name:     "userset_with_exclusion_non_empty_response",
+			reason:   v2breaking.ReasonUsersetWithExclusion,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
+			users:    []*openfgav1.User{usersetUser("document", "d2", "owner")},
+			expected: true,
+		},
+		{
+			name:     "userset_with_exclusion_empty_response",
+			reason:   v2breaking.ReasonUsersetWithExclusion,
+			filter:   &openfgav1.UserTypeFilter{Type: "document", Relation: "owner"},
+			users:    nil,
+			expected: false,
+		},
+		{
+			name:     "wildcard_with_exclusion_non_empty_response",
+			reason:   v2breaking.ReasonWildcardWithExclusion,
+			filter:   &openfgav1.UserTypeFilter{Type: "user"},
+			users:    []*openfgav1.User{plainUser("user", "alice")},
+			expected: true,
+		},
+		{
+			name:     "wildcard_with_exclusion_empty_response",
+			reason:   v2breaking.ReasonWildcardWithExclusion,
+			filter:   &openfgav1.UserTypeFilter{Type: "user"},
+			users:    nil,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := v2breaking.ListUsersResponseConfirmsReason(tc.reason, obj, "viewer", tc.filter, tc.users)
+			require.Equal(t, tc.expected, got)
 		})
 	}
 }

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -661,7 +661,7 @@ func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.Tup
 		`
 	}
 
-	if len(tuples) == 0 {
+	if tuples == nil {
 		tuples = []*openfgav1.TupleKey{
 			tuple.NewTupleKey("document:1", "viewer", "user:alice"),
 		}
@@ -688,12 +688,14 @@ func setupListUsersServer(t *testing.T, modelDSL string, tuples []*openfgav1.Tup
 	require.NoError(t, err)
 	modelID := writeModelResp.GetAuthorizationModelId()
 
-	_, err = s.Write(ctx, &openfgav1.WriteRequest{
-		StoreId:              storeID,
-		AuthorizationModelId: modelID,
-		Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
-	})
-	require.NoError(t, err)
+	if len(tuples) > 0 {
+		_, err = s.Write(ctx, &openfgav1.WriteRequest{
+			StoreId:              storeID,
+			AuthorizationModelId: modelID,
+			Writes:               &openfgav1.WriteRequestWrites{TupleKeys: tuples},
+		})
+		require.NoError(t, err)
+	}
 
 	return s, &openfgav1.ListUsersRequest{
 		StoreId:              storeID,

--- a/pkg/server/list_users_test.go
+++ b/pkg/server/list_users_test.go
@@ -978,14 +978,13 @@ func TestListUsersBreakingChangeLog(t *testing.T) {
 
 			s, baseReq := setupListUsersServer(t, tc.modelDSL, tc.tuples, WithLogger(testLogger))
 
-			res, err := s.ListUsers(context.Background(), &openfgav1.ListUsersRequest{
+			_, err := s.ListUsers(context.Background(), &openfgav1.ListUsersRequest{
 				StoreId:              baseReq.GetStoreId(),
 				AuthorizationModelId: baseReq.GetAuthorizationModelId(),
 				Object:               tc.object,
 				Relation:             tc.relation,
 				UserFilters:          []*openfgav1.UserTypeFilter{tc.filter},
 			})
-			fmt.Printf("%s", res)
 			require.NoError(t, err)
 
 			breakingLogs := logs.FilterMessage(logMessage)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?
Adds observability for potential v1 → v2 (weighted-graph) resolution breaking changes on the ListUsers and Expand endpoints, mirroring the Check-side logs added in #3149.

Note: Expand has no difference in behaviour for `self_referential_userset ` from v1 to v2.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured diagnostic warning logs for potential v2 (weighted-graph) resolution breaking changes in **Expand** and **ListUsers**, including a computed `reason`.
  * Introduced centralized logic to compute and confirm divergence reasons for `Check`, `Expand`, and `ListUsers`.
* **Bug Fixes**
  * Aligned `Check`’s breaking-change warning reason computation for userset-shaped queries.
* **Documentation**
  * Updated the changelog under **Unreleased** to reflect the new diagnostic logging.
* **Tests**
  * Added/updated end-to-end tests validating the warning message and that the logged `reason` matches expected outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->