### PR TITLE
chore: Consolidate caching metrics in v2Check with v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 ### Added
+- Added metrics in experimental `weighted_graph_check` for weighted graph edge result caching.
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Matched experimental `weighted_graph_check` cache metrics with original Check cache metrics: iterator cache metrics renamed to `tuples_cache_total_count`, `tuples_cache_hit_count`, `tuples_cache_discard_count`, `tuples_cache_size`; query cache metrics added as `check_cache_total_count`, `check_cache_hit_count`, `check_cache_invalid_hit_count`. [#3184](https://github.com/openfga/openfga/pull/3184)
 
 ## [1.18.1] - 2026-06-29
 ### Added
-- Added metrics in experimental `weighted_graph_check` for weighted graph edge result caching. [#3184](https://github.com/openfga/openfga/pull/3184)
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
 - Added diagnostic logging in `Expand` and `ListUsers` when v2 resolution might produce a different result than v1 for the same query. Note that v2 has not been implemented yet for these endpoints; these logs purely add visibility for a future v1 deprecation, and no operator action is required. [#3182](https://github.com/openfga/openfga/pull/3182)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 ### Added
-- Added metrics in experimental `weighted_graph_check` for weighted graph edge result caching.
+- Added metrics in experimental `weighted_graph_check` for weighted graph edge result caching. [#3184](https://github.com/openfga/openfga/pull/3184)
 - Added diagnostic logging in experimental `weighted_graph_check` when v2 Check resolution might produce a different result than v1 for the same query. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3149](https://github.com/openfga/openfga/pull/3149)
 
 ### Changed

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -36,19 +36,19 @@ var tracer = otel.Tracer("internal/check")
 var (
 	checkV2CacheTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: build.ProjectName,
-		Name:      "check_v2_edge_cache_total_count",
+		Name:      "check_edge_cache_lookups_total",
 		Help:      "The total number of edge cache lookups attempted by v2 check (excluding HIGHER_CONSISTENCY requests).",
 	})
 
 	checkV2CacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: build.ProjectName,
-		Name:      "check_v2_edge_cache_hit_count",
+		Name:      "check_edge_cache_hits_total",
 		Help:      "The total number of valid edge cache hits in v2 check.",
 	})
 
 	checkV2CacheInvalidHitCounter = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: build.ProjectName,
-		Name:      "check_v2_edge_cache_invalid_hit_count",
+		Name:      "check_edge_cache_invalid_hits_total",
 		Help:      "The total number of edge cache hits in v2 check that were discarded because they were invalidated.",
 	})
 )

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -17,6 +19,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	authzGraph "github.com/openfga/language/pkg/go/graph"
 
+	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/internal/concurrency"
 	"github.com/openfga/openfga/internal/iterator"
 	"github.com/openfga/openfga/internal/modelgraph"
@@ -29,6 +32,26 @@ import (
 )
 
 var tracer = otel.Tracer("internal/check")
+
+var (
+	checkV2CacheTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_v2_edge_cache_total_count",
+		Help:      "The total number of edge cache lookups attempted by v2 check (excluding HIGHER_CONSISTENCY requests).",
+	})
+
+	checkV2CacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_v2_edge_cache_hit_count",
+		Help:      "The total number of valid edge cache hits in v2 check.",
+	})
+
+	checkV2CacheInvalidHitCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_v2_edge_cache_invalid_hit_count",
+		Help:      "The total number of edge cache hits in v2 check that were discarded because they were invalidated.",
+	})
+)
 
 var ErrValidation = errors.New("object relation does not exist")
 var ErrUsersetInvalidRequest = errors.New("userset request cannot be resolved when exclusion operation is involved")
@@ -158,6 +181,7 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 	if consistency == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		return nil, false
 	}
+	checkV2CacheTotalCounter.Inc()
 	v := r.cache.Get(key)
 	if v == nil {
 		return nil, false
@@ -167,8 +191,10 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 		return nil, false
 	}
 	if !res.LastModified.After(r.lastCacheInvalidationTime) {
+		checkV2CacheInvalidHitCounter.Inc()
 		return nil, false
 	}
+	checkV2CacheHitCounter.Inc()
 	return res.Res, true
 }
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -8,8 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -19,7 +17,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	authzGraph "github.com/openfga/language/pkg/go/graph"
 
-	"github.com/openfga/openfga/internal/build"
+	"github.com/openfga/openfga/internal/checkmetrics"
 	"github.com/openfga/openfga/internal/concurrency"
 	"github.com/openfga/openfga/internal/iterator"
 	"github.com/openfga/openfga/internal/modelgraph"
@@ -32,26 +30,6 @@ import (
 )
 
 var tracer = otel.Tracer("internal/check")
-
-var (
-	checkV2CacheTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_edge_cache_lookups_total",
-		Help:      "The total number of edge cache lookups attempted by v2 check (excluding HIGHER_CONSISTENCY requests).",
-	})
-
-	checkV2CacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_edge_cache_hits_total",
-		Help:      "The total number of valid edge cache hits in v2 check.",
-	})
-
-	checkV2CacheInvalidHitCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_edge_cache_invalid_hits_total",
-		Help:      "The total number of edge cache hits in v2 check that were discarded because they were invalidated.",
-	})
-)
 
 var ErrValidation = errors.New("object relation does not exist")
 var ErrUsersetInvalidRequest = errors.New("userset request cannot be resolved when exclusion operation is involved")
@@ -181,7 +159,7 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 	if consistency == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		return nil, false
 	}
-	checkV2CacheTotalCounter.Inc()
+	checkmetrics.CacheLookupCounter.Inc()
 	v := r.cache.Get(key)
 	if v == nil {
 		return nil, false
@@ -191,10 +169,10 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 		return nil, false
 	}
 	if !res.LastModified.After(r.lastCacheInvalidationTime) {
-		checkV2CacheInvalidHitCounter.Inc()
+		checkmetrics.CacheInvalidHitCounter.Inc()
 		return nil, false
 	}
-	checkV2CacheHitCounter.Inc()
+	checkmetrics.CacheHitCounter.Inc()
 	return res.Res, true
 }
 

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -17,7 +17,7 @@ import (
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	authzGraph "github.com/openfga/language/pkg/go/graph"
 
-	"github.com/openfga/openfga/internal/checkmetrics"
+	"github.com/openfga/openfga/internal/check/metrics"
 	"github.com/openfga/openfga/internal/concurrency"
 	"github.com/openfga/openfga/internal/iterator"
 	"github.com/openfga/openfga/internal/modelgraph"
@@ -159,7 +159,7 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 	if consistency == openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY {
 		return nil, false
 	}
-	checkmetrics.CacheLookupCounter.Inc()
+	metrics.CacheLookupCounter.Inc()
 	v := r.cache.Get(key)
 	if v == nil {
 		return nil, false
@@ -169,10 +169,10 @@ func (r *Resolver) isCached(consistency openfgav1.ConsistencyPreference, key key
 		return nil, false
 	}
 	if !res.LastModified.After(r.lastCacheInvalidationTime) {
-		checkmetrics.CacheInvalidHitCounter.Inc()
+		metrics.CacheInvalidHitCounter.Inc()
 		return nil, false
 	}
-	checkmetrics.CacheHitCounter.Inc()
+	metrics.CacheHitCounter.Inc()
 	return res.Res, true
 }
 

--- a/internal/check/metrics/metrics.go
+++ b/internal/check/metrics/metrics.go
@@ -1,6 +1,6 @@
-// Package checkmetrics holds Prometheus counters shared across the v1 and v2
+// Package metrics holds Prometheus counters shared across the v1 and v2
 // Check cache implementations so both paths report into the same metric names.
-package checkmetrics
+package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/internal/check/response.go
+++ b/internal/check/response.go
@@ -27,3 +27,7 @@ type ResponseCacheEntry struct {
 	LastModified time.Time
 	Res          *Response
 }
+
+func (e *ResponseCacheEntry) CacheEntityType() string {
+	return "check_response"
+}

--- a/internal/checkmetrics/checkmetrics.go
+++ b/internal/checkmetrics/checkmetrics.go
@@ -1,0 +1,30 @@
+// Package checkmetrics holds Prometheus counters shared across the v1 and v2
+// Check cache implementations so both paths report into the same metric names.
+package checkmetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/openfga/openfga/internal/build"
+)
+
+var (
+	CacheLookupCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_cache_total_count",
+		Help:      "The total number of Check cache lookups (excluding HIGHER_CONSISTENCY requests).",
+	})
+
+	CacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_cache_hit_count",
+		Help:      "The total number of valid Check Query cache hits.",
+	})
+
+	CacheInvalidHitCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: build.ProjectName,
+		Name:      "check_cache_invalid_hit_count",
+		Help:      "The total number of Check Query cache hits discarded because they were invalidated.",
+	})
+)

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -10,7 +10,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
-	"github.com/openfga/openfga/internal/checkmetrics"
+	"github.com/openfga/openfga/internal/check/metrics"
 	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
@@ -151,7 +151,7 @@ func (c *CachedCheckResolver) ResolveCheck(
 	tryCache := req.Consistency != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 
 	if tryCache {
-		checkmetrics.CacheLookupCounter.Inc()
+		metrics.CacheLookupCounter.Inc()
 		if cachedResp := c.cache.Get(cacheKey); cachedResp != nil {
 			res := cachedResp.(*CheckResponseCacheEntry)
 			isValid := res.LastModified.After(req.LastCacheInvalidationTime)
@@ -163,13 +163,13 @@ func (c *CachedCheckResolver) ResolveCheck(
 
 			span.SetAttributes(attribute.Bool("cached", isValid))
 			if isValid {
-				checkmetrics.CacheHitCounter.Inc()
+				metrics.CacheHitCounter.Inc()
 				// return a copy to avoid races across goroutines
 				return res.CheckResponse.clone(), nil
 			}
 
 			// we tried the cache and hit an invalid entry
-			checkmetrics.CacheInvalidHitCounter.Inc()
+			metrics.CacheInvalidHitCounter.Inc()
 		} else {
 			c.logger.Debug("CachedCheckResolver not found cache key",
 				zap.String("store_id", req.GetStoreID()),

--- a/internal/graph/cached_resolver.go
+++ b/internal/graph/cached_resolver.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
-	"github.com/openfga/openfga/internal/build"
+	"github.com/openfga/openfga/internal/checkmetrics"
 	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
@@ -21,26 +19,6 @@ import (
 const (
 	defaultMaxCacheSize = 10000
 	defaultCacheTTL     = 10 * time.Second
-)
-
-var (
-	checkCacheTotalCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_cache_total_count",
-		Help:      "The total number of calls to ResolveCheck with caching enabled (including any recursive calls).",
-	})
-
-	checkCacheHitCounter = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_cache_hit_count",
-		Help:      "The total number of valid Check Query cache hits for ResolveCheck (including any recursive calls).",
-	})
-
-	checkCacheInvalidHit = promauto.NewCounter(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "check_cache_invalid_hit_count",
-		Help:      "The total number of Check Query cache hits for ResolveCheck (including any recursive calls) that were discarded because they were invalidated.",
-	})
 )
 
 var _ storage.CacheItem = (*CheckResponseCacheEntry)(nil)
@@ -173,7 +151,7 @@ func (c *CachedCheckResolver) ResolveCheck(
 	tryCache := req.Consistency != openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY
 
 	if tryCache {
-		checkCacheTotalCounter.Inc()
+		checkmetrics.CacheLookupCounter.Inc()
 		if cachedResp := c.cache.Get(cacheKey); cachedResp != nil {
 			res := cachedResp.(*CheckResponseCacheEntry)
 			isValid := res.LastModified.After(req.LastCacheInvalidationTime)
@@ -185,13 +163,13 @@ func (c *CachedCheckResolver) ResolveCheck(
 
 			span.SetAttributes(attribute.Bool("cached", isValid))
 			if isValid {
-				checkCacheHitCounter.Inc()
+				checkmetrics.CacheHitCounter.Inc()
 				// return a copy to avoid races across goroutines
 				return res.CheckResponse.clone(), nil
 			}
 
 			// we tried the cache and hit an invalid entry
-			checkCacheInvalidHit.Inc()
+			checkmetrics.CacheInvalidHitCounter.Inc()
 		} else {
 			c.logger.Debug("CachedCheckResolver not found cache key",
 				zap.String("store_id", req.GetStoreID()),

--- a/pkg/server/commands/check.go
+++ b/pkg/server/commands/check.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openfga/openfga/internal/planner"
 	"github.com/openfga/openfga/internal/shared"
 	"github.com/openfga/openfga/internal/utils"
+	"github.com/openfga/openfga/internal/utils/apimethod"
 	"github.com/openfga/openfga/pkg/logger"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
 	"github.com/openfga/openfga/pkg/storage"
@@ -164,7 +165,7 @@ func NewCheckQuery(opts ...CheckQueryV2Option) *CheckQueryV2 {
 	q := &CheckQueryV2{
 		logger: logger.NewNoopLogger(),
 		datastoreOp: storagewrappers.Operation{
-			Method:      V2CheckMethodName, // Must be different from base Check to avoid metric pollution when both Check algorithms are running
+			Method:      apimethod.Check,
 			Concurrency: defaultMaxConcurrentReadsForCheck,
 		},
 	}
@@ -241,6 +242,7 @@ func (q *CheckQueryV2) resolve(ctx context.Context, params *CheckCommandParams) 
 			q.sharedResources.SingleflightGroup, // SHARED across requests
 			q.sharedResources.WaitGroup,         // SHARED across requests
 			q.sharedResources.V2IteratorDrainTimeout,
+			storagewrappers.WithMethod(apimethod.Check.String()),
 		)
 	}
 

--- a/pkg/storage/storagewrappers/cached_reader.go
+++ b/pkg/storage/storagewrappers/cached_reader.go
@@ -32,10 +32,20 @@ type CachedTupleReader struct {
 	drainTimeout time.Duration // Timeout for background drain operations
 	sf           *singleflight.Group
 	wg           *sync.WaitGroup
+	method       string
 }
 
 // Ensure CachedTupleReader implements RelationshipTupleReader.
 var _ storage.RelationshipTupleReader = (*CachedTupleReader)(nil)
+
+type CachedTupleReaderOpt func(*CachedTupleReader)
+
+// WithMethod is used in metric differentiation to tell us which caller (e.g. Check) this is.
+func WithMethod(method string) CachedTupleReaderOpt {
+	return func(c *CachedTupleReader) {
+		c.method = method
+	}
+}
 
 // NewCachedTupleReader creates a new CachedTupleReader.
 // The drainTimeout parameter controls how long background drain operations can run.
@@ -49,6 +59,7 @@ func NewCachedTupleReader(
 	sf *singleflight.Group,
 	wg *sync.WaitGroup,
 	drainTimeout time.Duration,
+	opts ...CachedTupleReaderOpt,
 ) *CachedTupleReader {
 	if maxSize <= 0 {
 		maxSize = maxCachedElements // Default to 1000
@@ -64,7 +75,7 @@ func NewCachedTupleReader(
 	if sf == nil {
 		sf = &singleflight.Group{}
 	}
-	return &CachedTupleReader{
+	c := &CachedTupleReader{
 		delegate:     delegate,
 		cache:        cache,
 		maxSize:      maxSize,
@@ -73,6 +84,10 @@ func NewCachedTupleReader(
 		sf:           sf,
 		wg:           wg,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // ReadUsersetTuples reads userset tuples with caching.
@@ -107,7 +122,7 @@ func (c *CachedTupleReader) ReadUsersetTuples(
 	invalidEntityKey := buildInvalidationKey(storeID, filter.Object, filter.Relation)
 
 	// Track total cache operations (before cache check, like V1)
-	v2IterCacheTotal.WithLabelValues("ReadUsersetTuples").Inc()
+	tuplesCacheTotalCounter.WithLabelValues("ReadUsersetTuples", c.method).Inc()
 
 	// CHECK CACHE FIRST - before any database call
 	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "ReadUsersetTuples", []keys.Key{invalidEntityKey}); iter != nil {
@@ -125,7 +140,7 @@ func (c *CachedTupleReader) ReadUsersetTuples(
 	// Return caching iterator
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
-		c.sf, c.wg, objectType, filter.Relation, "ReadUsersetTuples",
+		c.sf, c.wg, objectType, filter.Relation, "ReadUsersetTuples", c.method,
 	), nil
 }
 
@@ -158,7 +173,7 @@ func (c *CachedTupleReader) Read(
 	invalidEntityKey := buildInvalidationKey(storeID, filter.Object, filter.Relation)
 
 	// Track total cache operations (before cache check, like V1)
-	v2IterCacheTotal.WithLabelValues("Read").Inc()
+	tuplesCacheTotalCounter.WithLabelValues("Read", c.method).Inc()
 
 	if iter := c.tryGetFromCache(cacheKey, storeID, objectType, filter.Relation, "Read", []keys.Key{invalidEntityKey}); iter != nil {
 		span.SetAttributes(attribute.Bool("cached", true))
@@ -174,7 +189,7 @@ func (c *CachedTupleReader) Read(
 
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
-		c.sf, c.wg, objectType, filter.Relation, "Read",
+		c.sf, c.wg, objectType, filter.Relation, "Read", c.method,
 	), nil
 }
 
@@ -206,7 +221,7 @@ func (c *CachedTupleReader) ReadStartingWithUser(
 	invalidEntityKeys := buildInvalidationKeysForUser(storeID, filter.UserFilter, filter.ObjectType)
 
 	// Track total cache operations (before cache check, like V1)
-	v2IterCacheTotal.WithLabelValues("ReadStartingWithUser").Inc()
+	tuplesCacheTotalCounter.WithLabelValues("ReadStartingWithUser", c.method).Inc()
 
 	if iter := c.tryGetFromCache(cacheKey, storeID, filter.ObjectType, filter.Relation, "ReadStartingWithUser", invalidEntityKeys); iter != nil {
 		span.SetAttributes(attribute.Bool("cached", true))
@@ -222,7 +237,7 @@ func (c *CachedTupleReader) ReadStartingWithUser(
 
 	return newCachingIterator(
 		dbIter, c.cache, cacheKey, c.maxSize, c.ttl, c.drainTimeout,
-		c.sf, c.wg, filter.ObjectType, filter.Relation, "ReadStartingWithUser",
+		c.sf, c.wg, filter.ObjectType, filter.Relation, "ReadStartingWithUser", c.method,
 	), nil
 }
 
@@ -256,7 +271,7 @@ func (c *CachedTupleReader) tryGetFromCache(
 		}
 	}
 
-	v2IterCacheHits.WithLabelValues(operation).Inc()
+	tuplesCacheHitCounter.WithLabelValues(operation, c.method).Inc()
 	return NewLockFreeCachedIterator(cached.Entries, objectType, relation, cached.Ordered)
 }
 

--- a/pkg/storage/storagewrappers/iterator_cache.go
+++ b/pkg/storage/storagewrappers/iterator_cache.go
@@ -8,14 +8,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
-	"github.com/openfga/openfga/internal/build"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/cache/keys"
 )
@@ -35,33 +32,6 @@ const (
 // ─────────────────────────────────────────────────────────────────────────────
 // Metrics
 // ─────────────────────────────────────────────────────────────────────────────
-
-var (
-	v2IterCacheTotal = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "v2_iterator_cache_total",
-		Help:      "Total v2 iterator cache operations.",
-	}, []string{"operation"})
-
-	v2IterCacheHits = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "v2_iterator_cache_hits",
-		Help:      "Total v2 iterator cache hits.",
-	}, []string{"operation"})
-
-	v2IterCacheAbandoned = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: build.ProjectName,
-		Name:      "v2_iterator_cache_abandoned",
-		Help:      "Total v2 iterator cache entries abandoned (exceeded max size).",
-	}, []string{"operation"})
-
-	v2IterCacheSize = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: build.ProjectName,
-		Name:      "v2_iterator_cache_entry_size",
-		Help:      "Number of tuples in cached iterator entries.",
-		Buckets:   []float64{1, 10, 50, 100, 250, 500, 1000},
-	}, []string{"operation"})
-)
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MinimalCacheEntry - Optimized storage for cached tuples
@@ -140,6 +110,7 @@ type CachingIterator struct {
 	objectType string
 	relation   string
 	operation  string
+	method     string
 }
 
 // Ensure CachingIterator implements TupleIterator.
@@ -155,7 +126,7 @@ func newCachingIterator(
 	drainTimeout time.Duration,
 	sf *singleflight.Group,
 	wg *sync.WaitGroup,
-	objectType, relation, operation string,
+	objectType, relation, operation, method string,
 ) *CachingIterator {
 	// Cap initial capacity to avoid over-allocation for large maxSize values.
 	// Most queries return few tuples, so initialBufferCapacity is usually sufficient.
@@ -181,6 +152,7 @@ func newCachingIterator(
 		objectType:   objectType,
 		relation:     relation,
 		operation:    operation,
+		method:       method,
 	}
 }
 
@@ -206,7 +178,7 @@ func (c *CachingIterator) Next(ctx context.Context) (*openfgav1.Tuple, error) {
 	if c.tuples != nil {
 		c.tuples = append(c.tuples, t)
 		if len(c.tuples) > c.maxSize {
-			v2IterCacheAbandoned.WithLabelValues(c.operation).Inc()
+			tuplesCacheDiscardCounter.WithLabelValues(c.operation, c.method).Inc()
 			c.tuples = nil // Exceeded max size, abandon caching
 		}
 	}
@@ -278,7 +250,7 @@ func (c *CachingIterator) flush() {
 		}
 	}
 
-	v2IterCacheSize.WithLabelValues(c.operation).Observe(float64(len(entries)))
+	tuplesCacheSizeHistogram.WithLabelValues(c.operation, c.method).Observe(float64(len(entries)))
 
 	c.cache.Set(c.cacheKey, &V2IteratorCacheEntry{
 		Entries:      entries,
@@ -335,7 +307,7 @@ func (c *CachingIterator) drainInBackground() {
 		for {
 			// Check for timeout before each iteration
 			if drainCtx.Err() != nil {
-				v2IterCacheAbandoned.WithLabelValues(c.operation).Inc()
+				tuplesCacheDiscardCounter.WithLabelValues(c.operation, c.method).Inc()
 				c.mu.Lock()
 				c.tuples = nil // Don't cache incomplete results
 				c.mu.Unlock()
@@ -353,7 +325,7 @@ func (c *CachingIterator) drainInBackground() {
 				// On timeout or other errors, don't cache
 				c.tuples = nil
 				c.mu.Unlock()
-				v2IterCacheAbandoned.WithLabelValues(c.operation).Inc()
+				tuplesCacheDiscardCounter.WithLabelValues(c.operation, c.method).Inc()
 				return nil, nil
 			}
 
@@ -364,7 +336,7 @@ func (c *CachingIterator) drainInBackground() {
 			}
 			c.tuples = append(c.tuples, t)
 			if len(c.tuples) > c.maxSize {
-				v2IterCacheAbandoned.WithLabelValues(c.operation).Inc()
+				tuplesCacheDiscardCounter.WithLabelValues(c.operation, c.method).Inc()
 				c.tuples = nil
 				c.mu.Unlock()
 				return nil, nil

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -7,13 +7,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/openfga/openfga/internal/utils/apimethod"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/singleflight"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
 	"github.com/openfga/openfga/internal/mocks"
+	"github.com/openfga/openfga/internal/utils/apimethod"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/cache/keys"
@@ -554,7 +554,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 			innerIter := storage.NewStaticTupleIterator(tuples)
 			cachingIter := newCachingIterator(
 				innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-				sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
+				sf, wg, "document", "viewer", "ReadUsersetTuples", apimethod.Check.String(),
 			)
 
 			for {

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openfga/openfga/internal/utils/apimethod"
 	"go.uber.org/mock/gomock"
 	"golang.org/x/sync/singleflight"
 
@@ -242,7 +243,7 @@ func BenchmarkV1vsV2_CacheMiss_Collection(b *testing.B) {
 
 				iter := newCachingIterator(
 					innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-					sf, wg, "document", "viewer", "ReadUsersetTuples",
+					sf, wg, "document", "viewer", "ReadUsersetTuples", apimethod.Check.String(),
 				)
 
 				for {
@@ -553,7 +554,7 @@ func BenchmarkV1vsV2_EndToEnd(b *testing.B) {
 			innerIter := storage.NewStaticTupleIterator(tuples)
 			cachingIter := newCachingIterator(
 				innerIter, mockCache, testCacheKey("test-key"), size+100, time.Hour, 30*time.Second,
-				sf, wg, "document", "viewer", "ReadUsersetTuples",
+				sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 			)
 
 			for {

--- a/pkg/storage/storagewrappers/iterator_cache_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_test.go
@@ -356,7 +356,7 @@ func TestCachingIterator_IsOrdered(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	inner := storage.NewStaticTupleIterator([]*openfgav1.Tuple{})
-	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read")
+	iter := newCachingIterator(inner, mockCache, testCacheKey("key"), 100, time.Hour, 30*time.Second, sf, wg, "document", "viewer", "Read", "Check")
 	require.True(t, iter.IsOrdered())
 	iter.Stop()
 	wg.Wait()
@@ -391,7 +391,7 @@ func TestCachingIterator_Next_Basic(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	t1, err := iter.Next(ctx)
@@ -437,7 +437,7 @@ func TestCachingIterator_Next_NonIteratorDoneError_NilsTuples(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// First call succeeds
@@ -483,7 +483,7 @@ func TestCachingIterator_Head_DelegatesToInner(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Head returns first tuple without advancing
@@ -529,7 +529,7 @@ func TestCachingIterator_Head_AfterStop(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	iter.Stop()
@@ -568,7 +568,7 @@ func TestCachingIterator_ExceedsMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume all tuples
@@ -607,7 +607,7 @@ func TestCachingIterator_ConfigurableMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), customMaxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume all tuples
@@ -654,7 +654,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, cacheKey, 1000, ttl, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume all tuples
@@ -698,7 +698,7 @@ func TestCachingIterator_InnerError(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	_, err := iter.Next(ctx)
@@ -733,7 +733,7 @@ func TestCachingIterator_Stop_Idempotent(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume all tuples
@@ -773,7 +773,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 		iter := newCachingIterator(
 			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 		)
 
 		// Manually set tuples to nil to simulate abandoned state
@@ -788,7 +788,7 @@ func TestCachingIterator_Flush_EmptyAndNil(t *testing.T) {
 		iter := newCachingIterator(
 			storage.NewStaticTupleIterator([]*openfgav1.Tuple{}),
 			mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 		)
 
 		// tuples is initialized as empty slice
@@ -829,7 +829,7 @@ func TestCachingIterator_WaitGroup_AddInConstructor(t *testing.T) {
 		innerIter := storage.NewStaticTupleIterator(tuples)
 		iterators[i] = newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key-"+strconv.Itoa(i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 		)
 	}
 
@@ -881,7 +881,7 @@ func TestCachingIterator_WaitGroup_DoneCalledOnNilTuples(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	ctx := context.Background()
@@ -939,7 +939,7 @@ func TestCachingIterator_ConcurrentNextAndStop(t *testing.T) {
 		innerIter := storage.NewStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey(fmt.Sprintf("test-key-%d", i)), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "ReadUsersetTuples",
+			sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 		)
 
 		// Concurrent access pattern that previously caused race
@@ -1010,7 +1010,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume just a few tuples (simulating finding a result early)
@@ -1060,7 +1060,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	// Consume just a few tuples (not all)
@@ -1110,7 +1110,7 @@ func TestCachingIterator_DrainTimeout_AbandonsCaching(t *testing.T) {
 		blockIter, mockCache, testCacheKey("test-key"), 1000,
 		time.Hour,
 		1*time.Nanosecond, // Very short drain timeout to trigger context expiry
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	ctx := context.Background()
@@ -1152,7 +1152,7 @@ func TestCachingIterator_DrainError_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	ctx := context.Background()
@@ -1196,7 +1196,7 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 
 	iter := newCachingIterator(
 		innerIter, mockCache, testCacheKey("test-key"), maxSize, time.Hour, 30*time.Second,
-		sf, wg, "document", "viewer", "ReadUsersetTuples",
+		sf, wg, "document", "viewer", "ReadUsersetTuples", "Check",
 	)
 
 	ctx := context.Background()
@@ -1272,7 +1272,7 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 		innerIter := storage.NewStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key"), 1000, time.Hour, 30*time.Second,
-			sf, wg, "document", "viewer", "benchmark",
+			sf, wg, "document", "viewer", "benchmark", "Check",
 		)
 
 		// Consume all tuples


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

The experimental `weighted_graph_check` engine had no aggregate visibility into its edge cache effectiveness. Cache hits were recorded only as per-request OpenTelemetry span events, making it impossible to dashboard or alert on hit rate across the fleet — a gap compared to v1's `check_cache_*` Prometheus counters.

Also, the v2 iterator cache used different metric names from v1 - when v2 is enabled, this could cause downstream observability tooling to break.

#### How is it being solved?

v2Check uses the same metrics as v1 Check, so that no downstream observability tooling updates are needed.

v2's edge caching is analogous to v1's subproblem caching, and that metric is incremented in v2Check inside `Resolver.isCached` where the three cache outcomes (attempted lookup, valid hit, invalidated hit) are already distinguished by existing control flow. No new logic is introduced.

#### What changes are made to solve it?

See files changed

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added weighted graph check cache metrics for total lookup attempts, valid cache hits, and stale-entry discards.
  * Enhanced cache instrumentation to attribute iterator/tuple and check cache activity by API method, including discard and cache entry size tracking.

* **Documentation**
  * Updated the changelog’s **[Unreleased]** section to document the new weighted graph check metrics.

* **Tests**
  * Updated caching iterator unit tests and benchmarks to use the new method-aware iterator construction and metric labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->