### PR TITLE
feat(logging): configurable level for grpc_req_complete

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -480,6 +480,13 @@
                     "default": "info",
                     "x-env-variable": "OPENFGA_LOG_LEVEL"
                 },
+                "requestCompleteLevel": {
+                    "description": "The level used for the per-request 'grpc_req_complete' completion log. Lower it to 'debug' to quieten the otherwise per-RPC INFO logs without disabling logging entirely.",
+                    "type": "string",
+                    "enum": ["debug", "info", "warn", "error"],
+                    "default": "info",
+                    "x-env-variable": "OPENFGA_LOG_REQUEST_COMPLETE_LEVEL"
+                },
                 "timestampFormat": {
                     "description": "The timestamp format to use for the log output.",
                     "type": "string",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ## [1.18.2] - 2026-08-03
 ### Added
 - Extended experimental `weighted_graph_check` diagnostic logging to cover the `wildcard_with_exclusion` and `userset_with_exclusion` shapes: the log now fires when v2 Check rejects one of these shapes and Check falls back to v1, and when v2 Check is skipped entirely because the weighted graph fails to build. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3204](https://github.com/openfga/openfga/pull/3204)
+- Added `log.requestCompleteLevel` (`--log-request-complete-level` / `OPENFGA_LOG_REQUEST_COMPLETE_LEVEL`, default `info`) to set the level of the per-request `grpc_req_complete` log. Set it to `debug` to quieten high-cardinality endpoints such as ListObjects without disabling logging entirely. See `pkg/middleware/logging/logging.go`. [#2626](https://github.com/openfga/openfga/issues/2626)
 
 ### Changed
 - Matched experimental `weighted_graph_check` cache metrics with original Check cache metrics: iterator cache metrics renamed to `tuples_cache_total_count`, `tuples_cache_hit_count`, `tuples_cache_discard_count`, `tuples_cache_size`; query cache metrics added as `check_cache_total_count`, `check_cache_hit_count`, `check_cache_invalid_hit_count`. [#3184](https://github.com/openfga/openfga/pull/3184)

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -161,6 +161,9 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("log.level", flags.Lookup("log-level"))
 		util.MustBindEnv("log.level", "OPENFGA_LOG_LEVEL")
 
+		util.MustBindPFlag("log.requestCompleteLevel", flags.Lookup("log-request-complete-level"))
+		util.MustBindEnv("log.requestCompleteLevel", "OPENFGA_LOG_REQUEST_COMPLETE_LEVEL")
+
 		util.MustBindPFlag("log.timestampFormat", flags.Lookup("log-timestamp-format"))
 		util.MustBindEnv("log.timestampFormat", "OPENFGA_LOG_TIMESTAMP_FORMAT")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -238,6 +238,8 @@ func NewRunCommand() *cobra.Command {
 
 	flags.String("log-level", defaultConfig.Log.Level, "the log level to use")
 
+	flags.String("log-request-complete-level", defaultConfig.Log.RequestCompleteLevel, "the log level to use for the per-request 'grpc_req_complete' completion log (e.g. 'debug' to quieten it)")
+
 	flags.String("log-timestamp-format", defaultConfig.Log.TimestampFormat, "the timestamp format to use for log messages")
 
 	flags.Bool("trace-enabled", defaultConfig.Trace.Enabled, "enable tracing")
@@ -598,8 +600,8 @@ func (s *ServerContext) buildServerOpts(ctx context.Context, config *serverconfi
 	serverOpts = append(serverOpts,
 		grpc.ChainUnaryInterceptor(
 			[]grpc.UnaryServerInterceptor{
-				storeid.NewUnaryInterceptor(),           // if available, add store_id to ctxtags
-				logging.NewLoggingInterceptor(s.Logger), // needed to log invalid requests
+				storeid.NewUnaryInterceptor(),                                            // if available, add store_id to ctxtags
+				logging.NewLoggingInterceptor(s.Logger, config.Log.RequestCompleteLevel), // needed to log invalid requests
 				validator.UnaryServerInterceptor(),
 			}...,
 		),
@@ -639,7 +641,7 @@ func (s *ServerContext) buildServerOpts(ctx context.Context, config *serverconfi
 				// The following interceptors wrap the server stream with our own
 				// wrapper and must come last.
 				storeid.NewStreamingInterceptor(),
-				logging.NewStreamingLoggingInterceptor(s.Logger),
+				logging.NewStreamingLoggingInterceptor(s.Logger, config.Log.RequestCompleteLevel),
 			}...,
 		),
 	)

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1246,6 +1246,10 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, val.Exists())
 	require.Equal(t, val.String(), cfg.Log.Format)
 
+	val = res.Get("properties.log.properties.requestCompleteLevel.default")
+	require.True(t, val.Exists())
+	require.Equal(t, val.String(), cfg.Log.RequestCompleteLevel)
+
 	val = res.Get("properties.maxTuplesPerWrite.default")
 	require.True(t, val.Exists())
 	require.EqualValues(t, val.Int(), cfg.MaxTuplesPerWrite)

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -41,21 +42,40 @@ const (
 )
 
 // NewLoggingInterceptor creates a new logging interceptor for gRPC unary server requests.
-func NewLoggingInterceptor(logger logger.Logger) grpc.UnaryServerInterceptor {
-	return interceptors.UnaryServerInterceptor(reportable(logger))
+// The requestCompleteLevel is the level used for the per-request "grpc_req_complete"
+// completion log (e.g. "info" or "debug").
+func NewLoggingInterceptor(logger logger.Logger, requestCompleteLevel string) grpc.UnaryServerInterceptor {
+	return interceptors.UnaryServerInterceptor(reportable(logger, requestCompleteLevel))
 }
 
 // NewStreamingLoggingInterceptor creates a new streaming logging interceptor for gRPC stream server requests.
-func NewStreamingLoggingInterceptor(logger logger.Logger) grpc.StreamServerInterceptor {
-	return interceptors.StreamServerInterceptor(reportable(logger))
+// The requestCompleteLevel is the level used for the per-request "grpc_req_complete"
+// completion log (e.g. "info" or "debug").
+func NewStreamingLoggingInterceptor(logger logger.Logger, requestCompleteLevel string) grpc.StreamServerInterceptor {
+	return interceptors.StreamServerInterceptor(reportable(logger, requestCompleteLevel))
 }
 
 type reporter struct {
-	ctx            context.Context
-	logger         logger.Logger
-	fields         []zap.Field
-	protomarshaler protojson.MarshalOptions
-	serviceName    string
+	ctx                  context.Context
+	logger               logger.Logger
+	fields               []zap.Field
+	protomarshaler       protojson.MarshalOptions
+	serviceName          string
+	requestCompleteLevel zapcore.Level
+}
+
+// logRequestComplete writes the grpc_req_complete completion line at the configured level.
+func (r *reporter) logRequestComplete() {
+	switch r.requestCompleteLevel {
+	case zapcore.DebugLevel:
+		r.logger.Debug(grpcReqCompleteKey, r.fields...)
+	case zapcore.WarnLevel:
+		r.logger.Warn(grpcReqCompleteKey, r.fields...)
+	case zapcore.ErrorLevel:
+		r.logger.Error(grpcReqCompleteKey, r.fields...)
+	default:
+		r.logger.Info(grpcReqCompleteKey, r.fields...)
+	}
 }
 
 // PostCall is invoked after all PostMsgSend operations.
@@ -75,7 +95,7 @@ func (r *reporter) PostCall(err error, rpcDuration time.Duration) {
 			r.logger.Error(err.Error(), r.fields...)
 		} else {
 			r.fields = append(r.fields, zap.Error(err))
-			r.logger.Info(grpcReqCompleteKey, r.fields...)
+			r.logRequestComplete()
 		}
 
 		return
@@ -84,7 +104,7 @@ func (r *reporter) PostCall(err error, rpcDuration time.Duration) {
 	if r.serviceName == healthCheckService {
 		r.logger.Debug(grpcReqCompleteKey, r.fields...)
 	} else {
-		r.logger.Info(grpcReqCompleteKey, r.fields...)
+		r.logRequestComplete()
 	}
 }
 
@@ -133,7 +153,8 @@ func userAgentFromContext(ctx context.Context) (string, bool) {
 	return "", false
 }
 
-func reportable(l logger.Logger) interceptors.CommonReportableFunc {
+func reportable(l logger.Logger, requestCompleteLevel string) interceptors.CommonReportableFunc {
+	level := parseLevel(requestCompleteLevel)
 	return func(ctx context.Context, c interceptors.CallMeta) (interceptors.Reporter, context.Context) {
 		fields := []zap.Field{
 			zap.String(grpcServiceKey, c.Service),
@@ -151,11 +172,26 @@ func reportable(l logger.Logger) interceptors.CommonReportableFunc {
 		}
 
 		return &reporter{
-			ctx:            ctx,
-			logger:         l,
-			fields:         fields,
-			protomarshaler: protojson.MarshalOptions{EmitUnpopulated: true},
-			serviceName:    c.Service,
+			ctx:                  ctx,
+			logger:               l,
+			fields:               fields,
+			protomarshaler:       protojson.MarshalOptions{EmitUnpopulated: true},
+			serviceName:          c.Service,
+			requestCompleteLevel: level,
 		}, ctx
+	}
+}
+
+// parseLevel maps a configured level string to a zap level, defaulting to info.
+func parseLevel(level string) zapcore.Level {
+	switch level {
+	case "debug":
+		return zapcore.DebugLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
 	}
 }

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -104,23 +104,30 @@ func captureCheckLogOutput(t *testing.T, requestCompleteLevel string, enabledLev
 		grpc.ChainUnaryInterceptor(grpc_ctxtags.UnaryServerInterceptor(), requestid.NewUnaryInterceptor(), NewLoggingInterceptor(argLogger, requestCompleteLevel)),
 	}
 
-	listner := bufconn.Listen(1024 * 1024)
+	listener := bufconn.Listen(1024 * 1024)
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
 	srv := grpc.NewServer(serverOpts...)
+	wg := sync.WaitGroup{}
+	t.Cleanup(func() {
+		srv.Stop()
+		wg.Wait()
+	})
 
 	openfgav1.RegisterOpenFGAServiceServer(srv, &fgaServer{})
 
-	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := srv.Serve(listner)
+		err := srv.Serve(listener)
 		if err != nil {
 			t.Errorf("failed to serve: %v", err)
 		}
 	}()
 
 	dialer := func(context.Context, string) (net.Conn, error) {
-		return listner.Dial()
+		return listener.Dial()
 	}
 	opts := []grpc.DialOption{
 		grpc.WithContextDialer(dialer),
@@ -129,14 +136,14 @@ func captureCheckLogOutput(t *testing.T, requestCompleteLevel string, enabledLev
 
 	conn, err := grpc.NewClient("passthrough://buffcon", opts...)
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
 
 	client := openfgav1.NewOpenFGAServiceClient(conn)
 
 	_, err = client.Check(context.Background(), &openfgav1.CheckRequest{})
 	require.NoError(t, err)
-
-	srv.Stop()
-	wg.Wait()
 
 	return gotBuffer
 }

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -40,17 +40,68 @@ type outputCapture struct {
 }
 
 func TestNewLoggingInterceptor_concrete(t *testing.T) {
+	t.Run("default_info_level", func(t *testing.T) {
+		output := captureCheckLog(t, "info", zap.InfoLevel)
+		assert.Equal(t, "info", output.Level)
+	})
+
+	t.Run("debug_level_quietens_completion_log", func(t *testing.T) {
+		output := captureCheckLogOutput(t, "debug", zap.InfoLevel)
+		assert.Empty(t, output.String())
+	})
+
+	t.Run("warn_level", func(t *testing.T) {
+		output := captureCheckLog(t, "warn", zap.WarnLevel)
+		assert.Equal(t, "warn", output.Level)
+	})
+
+	t.Run("error_level", func(t *testing.T) {
+		output := captureCheckLog(t, "error", zap.ErrorLevel)
+		assert.Equal(t, "error", output.Level)
+	})
+
+	output := captureCheckLog(t, "info", zap.InfoLevel)
+	assert.Equal(t, "info", output.Level)
+	assert.NotEmpty(t, output.TS)
+	assert.Equal(t, "grpc_req_complete", output.Msg)
+	assert.Equal(t, "openfga.v1.OpenFGAService", output.GrpcService)
+	assert.Equal(t, "Check", output.GrpcMethod)
+	assert.Equal(t, "unary", output.GrpcType)
+	assert.NotEmpty(t, output.UserAgent)
+	assert.NotEmpty(t, output.RawRequest)
+	assert.NotEmpty(t, output.RawResponse)
+	assert.NotEmpty(t, output.QueryDurationMs)
+	assert.NotEmpty(t, output.PeerAddress)
+	assert.NotEmpty(t, output.RequestID)
+	assert.Equal(t, 0, output.GrpcCode)
+}
+
+// captureCheckLog runs a single Check RPC through the logging interceptor configured with the
+// given requestCompleteLevel and returns the decoded grpc_req_complete log line.
+func captureCheckLog(t *testing.T, requestCompleteLevel string, enabledLevel zapcore.Level) outputCapture {
+	t.Helper()
+	gotBuffer := captureCheckLogOutput(t, requestCompleteLevel, enabledLevel)
+
+	var output outputCapture
+	err := json.NewDecoder(gotBuffer).Decode(&output)
+	require.NoError(t, err)
+
+	return output
+}
+
+func captureCheckLogOutput(t *testing.T, requestCompleteLevel string, enabledLevel zapcore.Level) *bytes.Buffer {
+	t.Helper()
 	gotBuffer := new(bytes.Buffer)
 
 	core := zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
 		zapcore.AddSync(gotBuffer),
-		zap.InfoLevel,
+		enabledLevel,
 	)
 	argLogger := &logger.ZapLogger{Logger: zap.New(core)}
 
 	serverOpts := []grpc.ServerOption{
-		grpc.ChainUnaryInterceptor(grpc_ctxtags.UnaryServerInterceptor(), requestid.NewUnaryInterceptor(), NewLoggingInterceptor(argLogger)),
+		grpc.ChainUnaryInterceptor(grpc_ctxtags.UnaryServerInterceptor(), requestid.NewUnaryInterceptor(), NewLoggingInterceptor(argLogger, requestCompleteLevel)),
 	}
 
 	listner := bufconn.Listen(1024 * 1024)
@@ -84,26 +135,10 @@ func TestNewLoggingInterceptor_concrete(t *testing.T) {
 	_, err = client.Check(context.Background(), &openfgav1.CheckRequest{})
 	require.NoError(t, err)
 
-	var output outputCapture
-	err = json.NewDecoder(gotBuffer).Decode(&output)
-	require.NoError(t, err)
-
-	assert.Equal(t, "info", output.Level)
-	assert.NotEmpty(t, output.TS)
-	assert.Equal(t, "grpc_req_complete", output.Msg)
-	assert.Equal(t, "openfga.v1.OpenFGAService", output.GrpcService)
-	assert.Equal(t, "Check", output.GrpcMethod)
-	assert.Equal(t, "unary", output.GrpcType)
-	assert.NotEmpty(t, output.UserAgent)
-	assert.NotEmpty(t, output.RawRequest)
-	assert.NotEmpty(t, output.RawResponse)
-	assert.NotEmpty(t, output.QueryDurationMs)
-	assert.NotEmpty(t, output.PeerAddress)
-	assert.NotEmpty(t, output.RequestID)
-	assert.Equal(t, 0, output.GrpcCode)
-
 	srv.Stop()
 	wg.Wait()
+
+	return gotBuffer
 }
 
 type fgaServer struct {

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -243,6 +243,11 @@ type LogConfig struct {
 	// Level is the log level to use in the log output (e.g. 'none', 'debug', or 'info')
 	Level string
 
+	// RequestCompleteLevel is the level used for the per-request 'grpc_req_complete'
+	// completion log (e.g. 'info' or 'debug'). Lowering it to 'debug' quietens the
+	// otherwise per-RPC INFO logs without disabling logging entirely.
+	RequestCompleteLevel string
+
 	// Format of the timestamp in the log output (e.g. 'Unix'(default) or 'ISO8601')
 	TimestampFormat string
 }
@@ -592,8 +597,17 @@ func (cfg *Config) VerifyBinarySettings() error {
 		fmt.Println("WARNING: Logging is not enabled. It is highly recommended to enable logging in production environments to avoid masking attacker operations.")
 	}
 
+	if cfg.Log.RequestCompleteLevel != "debug" &&
+		cfg.Log.RequestCompleteLevel != "info" &&
+		cfg.Log.RequestCompleteLevel != "warn" &&
+		cfg.Log.RequestCompleteLevel != "error" {
+		return fmt.Errorf(
+			"config 'log.requestCompleteLevel' must be one of ['debug', 'info', 'warn', 'error']",
+		)
+	}
+
 	if cfg.Log.TimestampFormat != "Unix" && cfg.Log.TimestampFormat != "ISO8601" {
-		return fmt.Errorf("config 'log.TimestampFormat' must be one of ['Unix', 'ISO8601']")
+		return fmt.Errorf("config 'log.timestampFormat' must be one of ['Unix', 'ISO8601']")
 	}
 
 	if cfg.Trace.Enabled {
@@ -909,9 +923,10 @@ func DefaultConfig() *Config {
 			AuthnOIDCConfig:         &AuthnOIDCConfig{},
 		},
 		Log: LogConfig{
-			Format:          "text",
-			Level:           "info",
-			TimestampFormat: "Unix",
+			Format:               "text",
+			Level:                "info",
+			RequestCompleteLevel: "info",
+			TimestampFormat:      "Unix",
 		},
 		Trace: TraceConfig{
 			Enabled: false,

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -108,6 +108,22 @@ func TestVerifyConfig(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("invalid_request_complete_level", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.RequestCompleteLevel = "notalevel"
+
+		err := cfg.Verify()
+		require.Error(t, err)
+	})
+
+	t.Run("debug_request_complete_level_is_valid", func(t *testing.T) {
+		cfg := DefaultConfig()
+		cfg.Log.RequestCompleteLevel = "debug"
+
+		err := cfg.Verify()
+		require.NoError(t, err)
+	})
+
 	t.Run("invalid_log_timestamp_format", func(t *testing.T) {
 		cfg := DefaultConfig()
 		cfg.Log.TimestampFormat = "notatimestampformat"

--- a/pkg/server/config/config_test.go
+++ b/pkg/server/config/config_test.go
@@ -1066,7 +1066,7 @@ func TestVerifyBinarySettings(t *testing.T) {
 		cfg.Log.TimestampFormat = "notatimestampformat"
 
 		err := cfg.VerifyBinarySettings()
-		require.EqualError(t, err, "config 'log.TimestampFormat' must be one of ['Unix', 'ISO8601']")
+		require.EqualError(t, err, "config 'log.timestampFormat' must be one of ['Unix', 'ISO8601']")
 	})
 
 	t.Run("negative_request_timeout_duration", func(t *testing.T) {


### PR DESCRIPTION
Let operators route the per-request `grpc_req_complete` completion log to a quieter
level via a new `log.requestCompleteLevel` option, without disabling logging entirely.

## Description

#### What problem is being solved?

`pkg/middleware/logging/logging.go` logs `grpc_req_complete` at INFO on every
successful (and every non-internal-error) RPC. High-cardinality endpoints such as
ListObjects emit one INFO line per request, which floods logs in production. Today the
only way to quieten it is to lower the global log level or disable logging, and the
productionizing docs warn against turning logging off. There is no way to make just the
per-request completion line less noisy.

#### How is it being solved?

Add a dedicated, config-gated level for that one log line. It defaults to `info`, so
behavior is unchanged unless an operator opts in; setting it to `debug` quietens the
per-RPC line while keeping logging on. This generalizes the selective level control
already merged for the healthcheck service in #2340 (which routes that service's
`grpc_req_complete` to Debug).

#### What changes are made to solve it?

- New `log.requestCompleteLevel` config option, exposed as the
  `--log-request-complete-level` flag and `OPENFGA_LOG_REQUEST_COMPLETE_LEVEL` env var,
  defaulting to `info`. Validated to one of `debug`, `info`, `warn`, `error`
  (deliberately narrower than `log.level`: `none`/`panic`/`fatal` make no sense for a
  per-request completion line).
- Both the unary and streaming logging interceptors now take the configured level and
  emit the success and non-internal-error completion line at it. Health checks stay at
  Debug and internal errors stay at Error, unchanged.
- Added to `.config-schema.json` (with an enum + default) and the `[Unreleased]`
  CHANGELOG. No generated code (`*.pb.go`, `internal/mocks/`) was touched.
- Tests: interceptor tests assert the line is emitted at `info` by default and at
  `debug` when configured; config validation tests cover an invalid value and a valid
  `debug`; `TestDefaultConfig` asserts the schema default matches the Go default so the
  two cannot drift.

## References

closes https://github.com/openfga/openfga/issues/2626
followup https://github.com/openfga/openfga/pull/2340

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `log.requestCompleteLevel` to control per-request completion log severity (`debug`, `info`, `warn`, or `error`; default: `info`).
  * Added the `--log-request-complete-level` CLI flag and `OPENFGA_LOG_REQUEST_COMPLETE_LEVEL` environment variable.
* **Bug Fixes**
  * Applied the configured completion-log severity consistently to unary and streaming requests.
* **Documentation**
  * Documented the new logging configuration.
* **Tests**
  * Added coverage for defaults, validation, and supported log levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->