### PR TITLE
feat: add FIPS 140-3 build variant with dedicated test matrix and image tags

### DIFF
--- a/.github/instructions/dockerfile-goreleaser-sync.instructions.md
+++ b/.github/instructions/dockerfile-goreleaser-sync.instructions.md
@@ -1,12 +1,16 @@
 ---
-applyTo: "Dockerfile"
+applyTo: "Dockerfile*"
 excludeAgent: "coding-agent"
 ---
 
-# Dockerfile.goreleaser grpc-health-probe Sync Check
+# Dockerfile.goreleaser / Dockerfile.goreleaser-fips grpc-health-probe Sync Check
 
 When reviewing changes to `Dockerfile`, check whether the `ghcr.io/grpc-ecosystem/grpc-health-probe` image reference (version tag and/or digest) was modified.
 
-If it was changed, verify that `Dockerfile.goreleaser` was also updated in the same PR so that its `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:...` line uses the identical image reference (same version tag and digest) as the `FROM ghcr.io/grpc-ecosystem/grpc-health-probe:...` line in `Dockerfile`.
+If it was changed, verify that **all three** of the following files were also updated in the same PR so that their grpc-health-probe reference uses the identical image reference (same version tag and digest):
 
-If `Dockerfile.goreleaser` was not updated to match, flag this as a required change: "The grpc-health-probe image in `Dockerfile.goreleaser` must be updated to match the version in `Dockerfile`."
+- `Dockerfile.goreleaser` — `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:...` line
+- `Dockerfile.goreleaser-fips` — `COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:...` line
+- `Dockerfile.fips` — `FROM ghcr.io/grpc-ecosystem/grpc-health-probe:...` line
+
+If any of these files were not updated to match, flag them as required changes.

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,8 +9,19 @@ permissions:
 
 jobs:
   tests-unit:
+    name: Unit tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -40,14 +51,25 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: unit
+          flags: unit-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   tests-storage:
+    name: Storage integration tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -77,14 +99,25 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: storage
+          flags: storage-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   tests-matrix:
+    name: Matrix integration tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -114,7 +147,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: matrix
+          flags: matrix-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,8 +30,19 @@ jobs:
 
   # Fast unit tests — all packages except storage backends and integration tests
   tests-unit:
+    name: Unit tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -62,15 +73,26 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: unit
+          flags: unit-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   # Storage integration tests — sqlite, mysql, postgres, memory
   tests-storage:
+    name: Storage integration tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -101,15 +123,26 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: storage
+          flags: storage-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
   # Matrix / integration tests — check, listobjects, listusers, authzen, run, validatemodels
   tests-matrix:
+    name: Matrix integration tests (${{ matrix.test-mode.name }})
     runs-on: ubuntu-latest-4-cores
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        test-mode:
+          - name: standard
+            gofips140: "off"
+          - name: fips
+            gofips140: "v1.0.0"
+    env:
+      GOFIPS140: ${{ matrix.test-mode.gofips140 }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -140,7 +173,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./coverageunit.out
-          flags: matrix
+          flags: matrix-${{ matrix.test-mode.name }}
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
@@ -175,7 +208,9 @@ jobs:
             release:
               - '.goreleaser.yaml'
               - 'Dockerfile'
+              - 'Dockerfile.fips'
               - 'Dockerfile.goreleaser'
+              - 'Dockerfile.goreleaser-fips'
               - 'cmd/openfga/**'
 
       - name: Set up Go

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     - make generate-mocks
 
 builds:
-  -
+  - id: openfga
     main: ./cmd/openfga
     binary: openfga
     env:
@@ -26,8 +26,31 @@ builds:
     flags:
       - -trimpath
 
+  - id: openfga-fips
+    main: ./cmd/openfga
+    binary: openfga
+    env:
+      - CGO_ENABLED=0
+      - GOFIPS140=v1.0.0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - "-s -w"
+      - "-X github.com/openfga/openfga/internal/build.Version=v{{ .Version }}"
+      - "-X github.com/openfga/openfga/internal/build.Commit={{.Commit}}"
+      - "-X github.com/openfga/openfga/internal/build.Date={{.CommitDate}}"
+      - "-X github.com/openfga/openfga/internal/build.ProjectName={{.ProjectName}}"
+      - "-X github.com/openfga/openfga/internal/build.fipsEnabled=true"
+    mod_timestamp: "{{.CommitTimestamp}}"
+    flags:
+      - -trimpath
+
 dockers:
-  - goos: linux
+  - ids: [openfga]
+    goos: linux
     goarch: amd64
 
     dockerfile: Dockerfile.goreleaser
@@ -54,7 +77,8 @@ dockers:
     extra_files:
       - assets
 
-  - goos: linux
+  - ids: [openfga]
+    goos: linux
     goarch: arm64
 
     dockerfile: Dockerfile.goreleaser
@@ -73,6 +97,64 @@ dockers:
       - "ghcr.io/openfga/openfga:v{{ .Major }}-arm64"
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-arm64"
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+
+    use: buildx
+
+    build_flag_templates:
+      - "--platform=linux/arm64"
+
+    extra_files:
+      - assets
+
+  # FIPS 140-3 variant images (built with GOFIPS140=v1.0.0)
+  - ids: [openfga-fips]
+    goos: linux
+    goarch: amd64
+
+    dockerfile: Dockerfile.goreleaser-fips
+
+    image_templates:
+      - "openfga/openfga:latest-fips-amd64"
+      - "openfga/openfga:{{ .Tag }}-fips-amd64"
+      - "openfga/openfga:v{{ .Version }}-fips-amd64"
+      - "openfga/openfga:v{{ .Major }}-fips-amd64"
+      - "openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-amd64"
+      - "openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-amd64"
+      # ghcr.io
+      - "ghcr.io/openfga/openfga:latest-fips-amd64"
+      - "ghcr.io/openfga/openfga:{{ .Tag }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-amd64"
+
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+
+    extra_files:
+      - assets
+
+  - ids: [openfga-fips]
+    goos: linux
+    goarch: arm64
+
+    dockerfile: Dockerfile.goreleaser-fips
+
+    image_templates:
+      - "openfga/openfga:latest-fips-arm64"
+      - "openfga/openfga:{{ .Tag }}-fips-arm64"
+      - "openfga/openfga:v{{ .Version }}-fips-arm64"
+      - "openfga/openfga:v{{ .Major }}-fips-arm64"
+      - "openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-arm64"
+      - "openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-arm64"
+      # ghcr.io
+      - "ghcr.io/openfga/openfga:latest-fips-arm64"
+      - "ghcr.io/openfga/openfga:{{ .Tag }}-fips-arm64"
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-fips-arm64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-fips-arm64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-arm64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-arm64"
 
     use: buildx
 
@@ -123,6 +205,48 @@ docker_manifests:
     image_templates:
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-amd64"
       - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-arm64"
+
+  # FIPS 140-3 variant manifests
+  - name_template: openfga/openfga:latest-fips
+    image_templates:
+      - openfga/openfga:latest-fips-amd64
+      - openfga/openfga:latest-fips-arm64
+  - name_template: openfga/openfga:v{{ .Version }}-fips
+    image_templates:
+      - openfga/openfga:v{{ .Version }}-fips-amd64
+      - openfga/openfga:v{{ .Version }}-fips-arm64
+  - name_template: openfga/openfga:v{{ .Major }}-fips
+    image_templates:
+      - openfga/openfga:v{{ .Major }}-fips-amd64
+      - openfga/openfga:v{{ .Major }}-fips-arm64
+  - name_template: openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips
+    image_templates:
+      - openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-amd64
+      - openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-arm64
+  - name_template: openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips
+    image_templates:
+      - openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-amd64
+      - openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-arm64
+  - name_template: ghcr.io/openfga/openfga:latest-fips
+    image_templates:
+      - "ghcr.io/openfga/openfga:latest-fips-amd64"
+      - "ghcr.io/openfga/openfga:latest-fips-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Version }}-fips
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Version }}-fips-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}-fips
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}-fips-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}-fips-arm64"
+  - name_template: ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips
+    image_templates:
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-amd64"
+      - "ghcr.io/openfga/openfga:v{{ .Major }}.{{ .Minor }}.{{ .Patch }}-fips-arm64"
 
 release:
   draft: true
@@ -185,7 +309,8 @@ brews:
       system "#{bin}/openfga version"
 
 archives:
-  - files:
+  - ids: [openfga]
+    files:
       - assets
 
 checksum:

--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,0 +1,34 @@
+FROM ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52@sha256:0303b506a288d544ed99fef17a55c8c5ce872f498f643c396b532b3595089ac9 AS grpc_health_probe
+# Please manually update the Dockerfile.goreleaser-fips whenever the grpc health probe is updated
+FROM cgr.dev/chainguard/go:1.26.4@sha256:e100be9286b2fb0d161e375426aded92c39ffeb716fdddce4d4ca7e7f00a045c AS builder
+
+WORKDIR /app
+
+# install and cache dependencies
+RUN --mount=type=cache,target=/root/go/pkg/mod \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
+
+# build with FIPS 140-3 module (GOFIPS140=v1.0.0 requires Go 1.24+)
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/go/pkg/mod \
+    --mount=type=bind,target=. \
+    CGO_ENABLED=0 GOFIPS140=v1.0.0 go build \
+    -ldflags="-X github.com/openfga/openfga/internal/build.fipsEnabled=true" \
+    -o /bin/openfga ./cmd/openfga
+
+FROM cgr.dev/chainguard/static@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b
+
+EXPOSE 8081
+EXPOSE 8080
+EXPOSE 3000
+
+COPY --from=grpc_health_probe /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+COPY --from=builder /bin/openfga /openfga
+
+# Healthcheck configuration for the container using grpc_health_probe
+# The container will be considered healthy if the gRPC health probe returns a successful response.
+HEALTHCHECK --interval=5s --timeout=30s --retries=3 CMD ["/usr/local/bin/grpc_health_probe", "-addr=:8081"]
+
+ENTRYPOINT ["/openfga"]

--- a/Dockerfile.goreleaser-fips
+++ b/Dockerfile.goreleaser-fips
@@ -1,0 +1,11 @@
+FROM cgr.dev/chainguard/static@sha256:77d8b8925dc27970ec2f48243f44c7a260d52c49cd778288e4ee97566e0cb75b
+COPY assets /assets
+COPY openfga /
+
+# Goreleaser does not support multi-stage builds. See:
+# https://github.com/goreleaser/goreleaser/issues/609
+#
+# Dependabot is also not capable of updating inline image copies at this time, so
+# this needs to be updated manually until one of these issues is resolved.
+COPY --from=ghcr.io/grpc-ecosystem/grpc-health-probe:v0.4.52@sha256:0303b506a288d544ed99fef17a55c8c5ce872f498f643c396b532b3595089ac9 /ko-app/grpc-health-probe /usr/local/bin/grpc_health_probe
+ENTRYPOINT ["/openfga"]

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -23,6 +23,10 @@ func NewVersionCommand() *cobra.Command {
 
 // print out the built version.
 func version(_ *cobra.Command, _ []string) error {
-	log.Printf("OpenFGA version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
+	if build.FIPSEnabled {
+		log.Printf("OpenFGA version `%s` build from `%s` on `%s` (FIPS 140-3)", build.Version, build.Commit, build.Date)
+	} else {
+		log.Printf("OpenFGA version `%s` build from `%s` on `%s` ", build.Version, build.Commit, build.Date)
+	}
 	return nil
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -13,6 +13,13 @@ var (
 	// Date is the date when the app was built.
 	Date = "unknown"
 
+	// fipsEnabled is "true" when the binary was compiled with GOFIPS140=v1.0.0.
+	// Set via -ldflags at build time; do not edit directly. Use FIPSEnabled instead.
+	fipsEnabled = "false"
+
+	// FIPSEnabled reports whether the binary was compiled with GOFIPS140=v1.0.0.
+	FIPSEnabled = fipsEnabled == "true"
+
 	// MinimumSupportedDatastoreSchemaRevision refers to the minimum schema version that is required to run
 	// this specific build of OpenFGA. Refer to the `assets/migrations` artifacts for more information.
 	MinimumSupportedDatastoreSchemaRevision int64 = 4


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

#### What problem is being solved?

Some OpenFGA deployments (e.g. regulated or government environments) require cryptographic operations to run through a FIPS 140-3 validated module. There is no such Docker image available for the users.
                                                                     
#### How is it being solved?

Go 1.24+ supports building against an in-process FIPS 140-3 validated crypto module natively via `GOFIPS140=v1.0.0`, with `CGO_ENABLED=0` — no CGO/OpenSSL toolchain needed. This adds that build as an additional artifact without touching the standard build path: the standard binary/image is unchanged, and the FIPS variant ships as an additional `-fips` suffixed image.

#### What changes are made to solve it?

- `internal/build`: adds a `FIPSEnabled` bool, derived from an unexported `fipsEnabled` string stamped via `-ldflags -X` at build time (ldflags can only patch strings, hence the indirection).
- `cmd/version`: prints `(FIPS 140-3)` in `openfga version` output when the FIPS variant is running.
- `Dockerfile.fips`: new multi-stage Dockerfile for local FIPS builds.
- `Dockerfile.goreleaser-fips`: new single-stage Dockerfile for the goreleaser pipeline (goreleaser doesn't support multi-stage builds).
- `.goreleaser.yaml`: adds an `openfga-fips` build (`GOFIPS140=v1.0.0`, linux/amd64 + linux/arm64), four new Docker build stanzas (`-fips-amd64`/`-fips-arm64` for both `openfga/openfga` and `ghcr.io/openfga/openfga`), and matching `*-fips` manifest tags (`latest-fips`, `vX-fips`, `vX.Y-fips`, `vX.Y.Z-fips`) across both registries. Standard release archives are unaffected — FIPS is Docker-image-only.
- CI: `tests-unit`, `tests-storage`, and `tests-matrix` now run as a `standard`/`fips` matrix (`GOFIPS140=off` vs `v1.0.0`) in both `pull_request.yaml` and `main.yaml`, named `Unit tests (standard/fips)`, `Storage integration tests (standard/fips)`, `Matrix integration tests (standard/fips)`, with per-leg codecov flags (e.g. `unit-standard`, `unit-fips`) so coverage reporting stays separated.
- The GoReleaser-changed-files path filter and the `dockerfile-goreleaser-sync` instructions now also cover `Dockerfile.fips` / `Dockerfile.goreleaser-fips`, so future `grpc-health-probe` version bumps get flagged across all four Dockerfiles instead of just the original two.

## References
<!-- none yet -->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected