### PR TITLE
test(check): add Expand tests for condition parameter of type any

### DIFF
--- a/tests/check/condition_any_test.go
+++ b/tests/check/condition_any_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -14,6 +15,14 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 	"github.com/openfga/openfga/tests"
 )
+
+// expandCapableClient is a tests.ClientInterface that also supports the
+// Expand API. The gRPC service client returned by tests.BuildClientInterface
+// satisfies this interface.
+type expandCapableClient interface {
+	tests.ClientInterface
+	Expand(ctx context.Context, in *openfgav1.ExpandRequest, opts ...grpc.CallOption) (*openfgav1.ExpandResponse, error)
+}
 
 // conditionAnyModel returns an authorization model with a condition that has
 // a parameter of type 'any'. The DSL parser does not support 'any' as a
@@ -240,6 +249,63 @@ func runConditionAnyTests(t *testing.T, client tests.ClientInterface) {
 				} else {
 					require.Empty(t, resp.GetObjects())
 				}
+			})
+		}
+	})
+
+	// The Expand API has no request-level 'context' field and does not
+	// evaluate conditions: it returns the userset tree derived from stored
+	// and contextual tuples regardless of condition outcomes. These tests
+	// confirm that a model with an 'any'-typed condition parameter does not
+	// break Expand, and that condition context of arbitrary complexity is
+	// accepted on contextual tuples.
+	t.Run("Expand", func(t *testing.T) {
+		expandClient, ok := client.(expandCapableClient)
+		require.True(t, ok, "test client does not implement the Expand API")
+
+		t.Run("no_context_returns_conditioned_tuple_in_tree", func(t *testing.T) {
+			t.Parallel()
+			resp, err := expandClient.Expand(ctx, &openfgav1.ExpandRequest{
+				StoreId:              storeID,
+				AuthorizationModelId: modelID,
+				TupleKey:             tuple.NewExpandRequestTupleKey("document:1", "viewer"),
+			})
+			require.NoError(t, err)
+
+			root := resp.GetTree().GetRoot()
+			require.Equal(t, "document:1#viewer", root.GetName())
+			require.Equal(t, []string{"user:jon"}, root.GetLeaf().GetUsers().GetUsers())
+		})
+
+		for _, tc := range testCases {
+			t.Run("contextual_tuple_condition_context_"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				resp, err := expandClient.Expand(ctx, &openfgav1.ExpandRequest{
+					StoreId:              storeID,
+					AuthorizationModelId: modelID,
+					TupleKey:             tuple.NewExpandRequestTupleKey("document:1", "viewer"),
+					ContextualTuples: &openfgav1.ContextualTupleKeys{
+						TupleKeys: []*openfgav1.TupleKey{
+							{
+								User:     "user:anne",
+								Relation: "viewer",
+								Object:   "document:1",
+								Condition: &openfgav1.RelationshipCondition{
+									Name:    "any_cond",
+									Context: tc.context,
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				// Expand returns users sorted; the conditioned contextual
+				// tuple must appear alongside the stored tuple even though
+				// no condition is evaluated.
+				root := resp.GetTree().GetRoot()
+				require.Equal(t, "document:1#viewer", root.GetName())
+				require.Equal(t, []string{"user:anne", "user:jon"}, root.GetLeaf().GetUsers().GetUsers())
 			})
 		}
 	})


### PR DESCRIPTION
## Description

Closes #1291

#2959 added integration tests confirming support for condition parameters of type `any` across **Check**, **ListObjects**, and **ListUsers**, but #1291 asks for **Expand** coverage as well. This PR completes that.

One important difference from the other three APIs: `ExpandRequest` has no request-level `context` field, and `ExpandQuery` does not evaluate conditions — it returns the userset tree derived from stored and contextual tuples regardless of condition outcomes. So instead of asserting condition evaluation results (which is not possible for Expand), these tests assert the tree behavior that *is* observable:

- `no_context_returns_conditioned_tuple_in_tree` — a stored tuple conditioned on an `any`-typed parameter always appears in the expanded tree (where Check with no context returns error code 2000, Expand succeeds).
- `contextual_tuple_condition_context_*` (10 subtests) — a contextual tuple carrying condition context of each shape from the existing test matrix (string, int, bool, lists, nested lists, maps, nested maps, null, and the complex nested structure from the issue) passes tuple validation on the Expand path and appears in the tree alongside the stored tuple.

The second group exercises `validateCondition` → `CastContextToTypedParameters` with `AnyParamType` for arbitrarily complex context values through a full server round-trip.

Note: the test file uses a local `expandCapableClient` interface (embedding `tests.ClientInterface`) rather than adding `Expand` to the exported `tests.ClientInterface`, to avoid a breaking change for external users of the exported matrix tests.

Test plan:

```
$ go test -count=1 -run "TestConditionAnyTypeMemory" -v ./tests/check/
--- PASS: TestConditionAnyTypeMemory
    --- PASS: TestConditionAnyTypeMemory/condition_any_type
        --- PASS: .../Check (10 subtests)
        --- PASS: .../ListObjects (10 subtests)
        --- PASS: .../Expand (11 subtests)   <- new
        --- PASS: .../ListUsers (10 subtests)
PASS
ok  	github.com/openfga/openfga/tests/check

$ make lint
0 issues.
```

This contribution was developed with AI assistance and reviewed/validated by the contributor, per the [Linux Foundation Generative AI policy](https://www.linuxfoundation.org/legal/generative-ai).

## References

- Closes #1291
- Extends #2959

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for `Expand` when condition parameters are `any`-typed.
  * Verified returned trees both when contextual tuples are absent (stored tuple user included) and when contextual tuples are present (merged users included).
  * Confirmed `Expand` operates correctly alongside existing condition scenarios without enforcing/evaluating condition outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->