### PR TITLE
chore(lint): enable spancheck linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - protogetter
     - revive
     - recvcheck
+    - spancheck
     - staticcheck
     - tagalign
     - testifylint
@@ -54,6 +55,14 @@ linters:
     perfsprint:
       err-error: false
       errorf: false
+    spancheck:
+      # The storage adapters wrap tracer.Start in a startTrace helper.
+      # Registering the wrappers lets spancheck verify their call sites
+      # instead of flagging the wrappers themselves.
+      extra-start-span-signatures:
+        - github.com/openfga/openfga/pkg/storage/mysql.startTrace:opentelemetry
+        - github.com/openfga/openfga/pkg/storage/postgres.startTrace:opentelemetry
+        - github.com/openfga/openfga/pkg/storage/sqlite.startTrace:opentelemetry
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
## Description

Part of #598, which asks for one PR per linter. This enables [`spancheck`](https://golangci-lint.run/usage/linters/#spancheck), which catches unended OpenTelemetry spans (probable memory leaks) and related misuse.

**Before** (spancheck run standalone on `main`):

```
pkg/storage/mysql/mysql.go:34:9: span is unassigned, probable memory leak (spancheck)
pkg/storage/postgres/postgres.go:44:9: span is unassigned, probable memory leak (spancheck)
pkg/storage/sqlite/sqlite.go:36:9: span is unassigned, probable memory leak (spancheck)
```

All three findings are the same false-positive pattern: the storage adapters wrap `tracer.Start` in a `startTrace` helper, and spancheck flagged the helper itself rather than its call sites. Registering the wrappers via `extra-start-span-signatures` teaches spancheck that these functions start spans, so it verifies their callers instead — and every caller already does `defer span.End()`.

**After:** `make lint` passes with 0 issues and no Go code changes.

This contribution was developed with AI assistance and reviewed/validated by the contributor, per the [Linux Foundation Generative AI policy](https://www.linuxfoundation.org/legal/generative-ai).

## References

- Part of #598 (do not close; other linters remain)

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected (N/A: lint configuration only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an additional linting check to improve code consistency and catch tracing-related issues earlier.
  * Updated lint configuration to recognize approved tracing wrapper patterns, reducing false positives during validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->