### PR TITLE
test: deflake reducer cancellation subtests in internal/graph

### DIFF
--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -393,19 +393,6 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 		cancel()
 	})
 
-	t.Run("return_allowed:false_if_subtract_handler_evaluated_before_context_cancelled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		t.Cleanup(cancel)
-
-		resp, err := exclusion(ctx, concurrencyLimit, trueHandler, trueHandler)
-		require.NoError(t, err)
-		require.False(t, resp.GetAllowed())
-
-		// Cancel only after the reducer has resolved: a concurrent cancel races
-		// the reducer's select between handler outcomes and ctx.Done() (#3197).
-		cancel()
-	})
-
 	t.Run("return_context_canceled_when_parent_context_is_canceled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -348,47 +348,31 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
 		resp, err := exclusion(ctx, concurrencyLimit, falseHandler, falseHandler)
 		require.NoError(t, err)
 		require.False(t, resp.GetAllowed())
 
-		wg.Wait() // just to make sure to avoid test leaks
+		// Cancel only after the reducer has resolved: a concurrent cancel races
+		// the reducer's select between handler outcomes and ctx.Done() (#3197).
+		cancel()
 	})
 
 	t.Run("return_allowed:false_if_sub_handler_evaluated_before_context_cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
 		resp, err := exclusion(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
 		require.False(t, resp.GetAllowed())
 
-		wg.Wait() // just to make sure to avoid test leaks
+		// Cancel only after the reducer has resolved: a concurrent cancel races
+		// the reducer's select between handler outcomes and ctx.Done() (#3197).
+		cancel()
 	})
 
 	t.Run("return_allowed:false_if_sub_handler_evaluated_before_base_cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-
-		var wg sync.WaitGroup
 
 		slowTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
 			time.Sleep(50 * time.Millisecond)
@@ -398,38 +382,28 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 			}, nil
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
+		// The sub handler resolves immediately and short-circuits the reducer
+		// while the base handler is still in flight; the in-flight base is torn
+		// down by the reducer's internal cancel. Cancelling the external context
+		// concurrently would race the reducer's select instead (#3197).
 		resp, err := exclusion(ctx, concurrencyLimit, slowTrueHandler, trueHandler)
 		require.NoError(t, err)
 		require.False(t, resp.GetAllowed())
 
-		wg.Wait() // just to make sure to avoid test leaks
+		cancel()
 	})
 
 	t.Run("return_allowed:false_if_subtract_handler_evaluated_before_context_cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
 		resp, err := exclusion(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
 		require.False(t, resp.GetAllowed())
 
-		wg.Wait() // just to make sure to avoid test leaks
+		// Cancel only after the reducer has resolved: a concurrent cancel races
+		// the reducer's select between handler outcomes and ctx.Done() (#3197).
+		cancel()
 	})
 
 	t.Run("return_context_canceled_when_parent_context_is_canceled", func(t *testing.T) {
@@ -470,22 +444,30 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
-		slowHandler := func(context.Context) (*ResolveCheckResponse, error) {
-			time.Sleep(50 * time.Millisecond)
+		// The handlers block until released, and the cancel fires only once a
+		// handler is running, so the reducer deterministically observes the
+		// cancellation before any handler outcome (#3197).
+		var startedOnce sync.Once
+		handlerStarted := make(chan struct{})
+		release := make(chan struct{})
+		blockedHandler := func(context.Context) (*ResolveCheckResponse, error) {
+			startedOnce.Do(func() { close(handlerStarted) })
+			<-release
 			return &ResolveCheckResponse{}, nil
 		}
 
-		resp, err := exclusion(ctx, concurrencyLimit, slowHandler, slowHandler)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-handlerStarted
+			cancel()
+		}()
+
+		resp, err := exclusion(ctx, concurrencyLimit, blockedHandler, blockedHandler)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Nil(t, resp)
 
+		close(release)
 		wg.Wait() // just to make sure to avoid test leaks
 	})
 
@@ -760,20 +742,13 @@ func TestIntersectionCheckFuncReducer(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
 		resp, err := intersection(ctx, concurrencyLimit, falseHandler, falseHandler)
 		require.NoError(t, err)
 		require.False(t, resp.GetAllowed())
 
-		wg.Wait() // just to make sure to avoid test leaks
+		// Cancel only after the reducer has resolved: a concurrent cancel races
+		// the reducer's select between handler outcomes and ctx.Done() (#3197).
+		cancel()
 	})
 
 	t.Run("return_context_canceled_when_parent_context_is_canceled", func(t *testing.T) {
@@ -807,24 +782,32 @@ func TestIntersectionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
-		slowTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
-			time.Sleep(50 * time.Millisecond)
+		// The handlers block until released, and the cancel fires only once a
+		// handler is running, so the reducer deterministically observes the
+		// cancellation before any handler outcome (#3197).
+		var startedOnce sync.Once
+		handlerStarted := make(chan struct{})
+		release := make(chan struct{})
+		blockedTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
+			startedOnce.Do(func() { close(handlerStarted) })
+			<-release
 			return &ResolveCheckResponse{
 				Allowed: true,
 			}, nil
 		}
 
-		resp, err := intersection(ctx, concurrencyLimit, slowTrueHandler, slowTrueHandler)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-handlerStarted
+			cancel()
+		}()
+
+		resp, err := intersection(ctx, concurrencyLimit, blockedTrueHandler, blockedTrueHandler)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Nil(t, resp)
 
+		close(release)
 		wg.Wait() // just to make sure to avoid test leaks
 	})
 
@@ -1720,24 +1703,31 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
-		slowTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
-			time.Sleep(50 * time.Millisecond)
+		// The handler blocks until released, and the cancel fires only once the
+		// handler is running, so the reducer deterministically observes the
+		// cancellation before any handler outcome (#3197).
+		handlerStarted := make(chan struct{})
+		release := make(chan struct{})
+		blockedTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
+			close(handlerStarted)
+			<-release
 			return &ResolveCheckResponse{
 				Allowed: true,
 			}, nil
 		}
 
-		resp, err := union(ctx, concurrencyLimit, slowTrueHandler)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-handlerStarted
+			cancel()
+		}()
+
+		resp, err := union(ctx, concurrencyLimit, blockedTrueHandler)
 		require.ErrorIs(t, err, context.Canceled)
 		require.Nil(t, resp)
 
+		close(release)
 		wg.Wait() // just to make sure to avoid test leaks
 	})
 
@@ -1745,19 +1735,13 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
 
-		var wg sync.WaitGroup
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
 		resp, err := union(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
 		require.True(t, resp.GetAllowed())
-		wg.Wait() // just to make sure to avoid test leaks
+
+		// Cancel only after the reducer has resolved: a concurrent cancel races
+		// the reducer's select between handler outcomes and ctx.Done() (#3197).
+		cancel()
 	})
 
 	t.Run("should_error_if_handler_panics", func(t *testing.T) {


### PR DESCRIPTION
## Description

Closes #3197

`TestUnionCheckFuncReducer/return_allowed:true_if_truthy_handler_evaluated_before_context_cancelled` can fail when the test process is starved of CPU for more than 10ms (details and root cause in #3197). The subtest encodes a required ordering — "handler evaluated **before** cancel" — with a `time.Sleep(10 * time.Millisecond)` before `cancel()`, which no scheduler guarantees.

The same sleep-then-cancel pattern appears at **9 sites** across `TestExclusionCheckFuncReducer`, `TestIntersectionCheckFuncReducer`, and `TestUnionCheckFuncReducer` in `internal/graph/check_test.go`, so this PR deflakes the whole pattern rather than just the one subtest that was observed failing. This is the **test-only fix (option 1)** from #3197 — no reducer behavior changes.

The 9 subtests fall into two shapes, fixed with two techniques:

**1. "Handler result wins" subtests (6 sites)** — e.g. `return_allowed:true_if_truthy_handler_evaluated_before_context_cancelled`. These assert that a handler outcome resolved before cancellation is returned. The fix moves `cancel()` to after the reducer returns, which makes the ordering the test name promises *guaranteed* instead of probabilistic:

```go
resp, err := union(ctx, concurrencyLimit, trueHandler, trueHandler)
require.NoError(t, err)
require.True(t, resp.GetAllowed())

// Cancel only after the reducer has resolved: a concurrent cancel races
// the reducer's select between handler outcomes and ctx.Done() (#3197).
cancel()
```

**2. "Cancellation wins" subtests (3 sites)** — the `return_error_if_context_cancelled_before_resolution` variants. These previously relied on a 40ms margin (cancel at 10ms vs. 50ms handler sleeps). The fix removes all sleeps: handlers block on a `release` channel, and the cancel goroutine fires only once a handler is running. At the moment of cancellation the outcome channel is guaranteed empty and open, so the reducer's `select` deterministically observes `ctx.Done()`:

```go
handlerStarted := make(chan struct{})
release := make(chan struct{})
blockedTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
    close(handlerStarted)
    <-release
    return &ResolveCheckResponse{Allowed: true}, nil
}

go func() {
    <-handlerStarted
    cancel()
}()

resp, err := union(ctx, concurrencyLimit, blockedTrueHandler)
require.ErrorIs(t, err, context.Canceled)
require.Nil(t, resp)

close(release) // let the blocked handlers drain before goleak runs
```

Because the handler start happens strictly after the reducer's fast-path `ctx.Err()` check, the cancellation always lands mid-`select`, preserving each test's original intent (mid-flight cancellation, not the already-covered "parent context cancelled before call" fast path).

### Notes for reviewers

- The gated cancel deliberately avoids the interleaving where `concurrency.TrySendThroughChannel` drops an outcome on a cancelled context and the reducer's closed-channel receive races `ctx.Done()` — with the handlers still blocked at cancel time, that interleaving cannot occur.
- A handful of sibling subtests use 10ms context *deadlines* with a similar (but much narrower) timing assumption. They are left untouched to keep this diff focused on the observed flake pattern; happy to follow up if there's interest.

## References

- Fixes #3197
- Related: #3061 fixed a different flaky test with a similar timing-assumption root cause

## Review Checklist

- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR — N/A (test-only change; behavior documented in test comments).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`

## Testing

- `go test ./internal/graph/ -run 'Test(Union|Intersection|Exclusion)CheckFuncReducer' -race -count=50` — pass
- `GOMAXPROCS=1 go test ./internal/graph/ -run 'Test(Union|Intersection|Exclusion)CheckFuncReducer' -race -count=100` — pass (single-P scheduling maximizes the original flake's likelihood)
- `go test ./internal/graph/ -race` (full package) — pass
- `golangci-lint run ./internal/graph/...` — 0 issues

---

*Disclosure: this change was developed with AI assistance (Cursor); all analysis and code were human-reviewed before submission.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made cancellation-related reducer tests deterministic by removing timing-based sleeps and reducing race windows.
  * Reworked cancellation scenarios to use explicit synchronization, ensuring `context.Canceled` is observed in a predictable order relative to handler execution.
  * Improved coverage for cases where handlers complete before or after cancellation, reducing flaky test behavior and strengthening reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->