### PR TITLE
chore: add modernize linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Changed
+- Added the `modernize` linter and applied its fixes across the codebase, simplifying code using newer Go features with no behavior change. [#3202](https://github.com/openfga/openfga/pull/3202)
 
 ## [1.18.1] - 2026-06-29
 ### Added

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -220,8 +220,7 @@ func TestBuildServiceWithNoAuth(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -250,8 +249,7 @@ func TestBuildServiceWithPresharedKeyAuthentication(t *testing.T) {
 		Keys: []string{"KEYONE", "KEYTWO"},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -458,8 +456,7 @@ func TestHTTPServerWithCORS(t *testing.T) {
 	cfg.HTTP.CORSAllowedOrigins = []string{"http://openfga.dev", "http://localhost"}
 	cfg.HTTP.CORSAllowedHeaders = []string{"Origin", "Accept", "Content-Type", "X-Requested-With", "Authorization", "X-Custom-Header"}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -570,8 +567,7 @@ func TestBuildServerWithOIDCAuthentication(t *testing.T) {
 	trustedToken, err := trustedIssuerServer.GetToken("openfga.dev", "some-user")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -651,8 +647,7 @@ func TestBuildServerWithOIDCAuthenticationAlias(t *testing.T) {
 	trustedTokenFromAlias, err := trustedIssuerServer2.GetToken("openfga.dev", "some-user")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -694,8 +689,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		}
 		cfg.HTTP.Addr = "localhost:8080"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -718,8 +712,7 @@ func TestHTTPServingTLS(t *testing.T) {
 		}
 		cfg.HTTP.Addr = "localhost:8080"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -759,8 +752,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		}
 		cfg.GRPC.Addr = "localhost:8082"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -784,8 +776,7 @@ func TestGRPCServingTLS(t *testing.T) {
 		}
 		cfg.GRPC.Addr = "localhost:8082"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -817,8 +808,7 @@ func TestHTTPServerWithGRPCTLSEnabled(t *testing.T) {
 		}
 		cfg.GRPC.Addr = "localhost:8082"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -856,8 +846,7 @@ func TestHTTPServerWithGRPCTLSEnabled(t *testing.T) {
 		}
 		cfg.GRPC.Addr = "localhost:8082"
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		go func() {
 			if err := runServer(ctx, cfg); err != nil {
@@ -1030,7 +1019,7 @@ func testServerMetricsReporting(t *testing.T, engine string, connectionMetricNam
 	checkResp, err := client.Check(ctx, &openfgav1.CheckRequest{
 		StoreId:  storeID,
 		TupleKey: tuple.NewCheckRequestTupleKey("document:1", "viewer", "user:jon"),
-		Context: testutils.MustNewStruct(t, map[string]interface{}{
+		Context: testutils.MustNewStruct(t, map[string]any{
 			"x": 10,
 		}),
 	})
@@ -1042,7 +1031,7 @@ func testServerMetricsReporting(t *testing.T, engine string, connectionMetricNam
 		Type:     "document",
 		Relation: "viewer",
 		User:     "user:jon",
-		Context: testutils.MustNewStruct(t, map[string]interface{}{
+		Context: testutils.MustNewStruct(t, map[string]any{
 			"x": 10,
 		}),
 	})
@@ -1083,8 +1072,7 @@ func TestHTTPServerDisabled(t *testing.T) {
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 	cfg.HTTP.Enabled = false
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -1105,8 +1093,7 @@ func TestHTTPServerEnabled(t *testing.T) {
 	})
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	go func() {
 		if err := runServer(ctx, cfg); err != nil {
@@ -1124,17 +1111,14 @@ func TestPlaygroundEnabled(t *testing.T) {
 	cfg := testutils.MustDefaultConfigWithRandomPorts()
 	cfg.Playground.Enabled = true
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		if err := runServer(ctx, cfg); err != nil {
 			log.Fatal(err)
 		}
-	}()
+	})
 	t.Cleanup(func() {
 		wg.Wait()
 	})
@@ -1789,7 +1773,7 @@ func TestServerContext_datastoreConfig(t *testing.T) {
 	tests := []struct {
 		name           string
 		config         *serverconfig.Config
-		wantDSType     interface{}
+		wantDSType     any
 		wantSerializer encoder.ContinuationTokenSerializer
 		wantErr        error
 	}{

--- a/cmd/validatemodels/validate_models_test.go
+++ b/cmd/validatemodels/validate_models_test.go
@@ -32,7 +32,7 @@ func TestValidationResult(t *testing.T) {
 
 			// write a bunch of stores (to trigger pagination)
 			var storeID string
-			for i := 0; i < totalStores; i++ {
+			for i := range totalStores {
 				storeID = ulid.Make().String()
 				_, err := ds.CreateStore(ctx, &openfgav1.Store{
 					Id:   storeID,
@@ -43,7 +43,7 @@ func TestValidationResult(t *testing.T) {
 			}
 
 			// for the last store, write a bunch of models (to trigger pagination)
-			for j := 0; j < totalModelsForOneStore; j++ {
+			for range totalModelsForOneStore {
 				modelID := ulid.Make().String()
 				err := ds.WriteAuthorizationModel(ctx, storeID, &openfgav1.AuthorizationModel{
 					Id:            modelID,

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -169,8 +169,8 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 	// optional scopes
 	if scopeKey, ok := claims["scope"]; ok {
 		if scope, ok := scopeKey.(string); ok {
-			scopes := strings.Split(scope, " ")
-			for _, s := range scopes {
+			scopes := strings.SplitSeq(scope, " ")
+			for s := range scopes {
 				principal.Scopes[s] = true
 			}
 		}

--- a/internal/authn/oidc/oidc_test.go
+++ b/internal/authn/oidc/oidc_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"maps"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -668,7 +669,7 @@ func TestRemoteOidcAuthenticator_RefreshRateLimit(t *testing.T) {
 	hitsBeforeBurst := server.hits()
 
 	// Burst several JWTs with distinct unknown kids in quick succession.
-	for i := 0; i < burst; i++ {
+	for i := range burst {
 		token := generateJWT(privKey, fmt.Sprintf("unknown_kid_%d", i), jwt.MapClaims{
 			"iss": server.server.URL,
 			"aud": "aud",
@@ -709,19 +710,17 @@ func rsaPublicKeyToJWK(kid string, pub *rsa.PublicKey) map[string]string {
 type jwksTestServer struct {
 	mu       sync.Mutex
 	keys     map[string]*rsa.PublicKey
-	jwksHits int32
+	jwksHits atomic.Int32
 	server   *httptest.Server
 }
 
 func newJWKSTestServer(initial map[string]*rsa.PublicKey) *jwksTestServer {
 	j := &jwksTestServer{keys: make(map[string]*rsa.PublicKey)}
-	for k, v := range initial {
-		j.keys[k] = v
-	}
+	maps.Copy(j.keys, initial)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
-		atomic.AddInt32(&j.jwksHits, 1)
+		j.jwksHits.Add(1)
 		j.mu.Lock()
 		defer j.mu.Unlock()
 		jwkList := make([]map[string]string, 0, len(j.keys))
@@ -750,7 +749,7 @@ func (j *jwksTestServer) setKey(kid string, pk *rsa.PublicKey) {
 }
 
 func (j *jwksTestServer) hits() int32 {
-	return atomic.LoadInt32(&j.jwksHits)
+	return j.jwksHits.Load()
 }
 
 func (j *jwksTestServer) close() {

--- a/internal/cachecontroller/cache_controller.go
+++ b/internal/cachecontroller/cache_controller.go
@@ -217,14 +217,12 @@ func (c *InMemoryCacheController) InvalidateIfNeeded(ctx context.Context, storeI
 
 	span.SetAttributes(attribute.Bool("cache_controller_invalidation", true))
 
-	c.wg.Add(1)
-	go func() {
+	c.wg.Go(func() {
 		// we do not want to propagate context to avoid early cancellation
 		// and pollute span.
 		c.findChangesAndInvalidateIfNecessary(ctx, storeID)
 		c.inflightInvalidations.Delete(storeID)
-		c.wg.Done()
-	}()
+	})
 }
 
 type changelogResultMsg struct {
@@ -263,12 +261,10 @@ func (c *InMemoryCacheController) findChangesAndInvalidateIfNecessary(parentCtx 
 	defer cancel()
 	done := make(chan changelogResultMsg, 1)
 
-	c.wg.Add(1)
-	go func() {
+	c.wg.Go(func() {
 		changes, _, err := c.findChangesDescending(ctx, storeID)
 		concurrency.TrySendThroughChannel(ctx, changelogResultMsg{err: err, changes: changes}, done)
-		c.wg.Done()
-	}()
+	})
 
 	var changes []*openfgav1.TupleChange
 	select {

--- a/internal/cachecontroller/cache_controller_test.go
+++ b/internal/cachecontroller/cache_controller_test.go
@@ -269,7 +269,7 @@ func TestInMemoryCacheController_DetermineInvalidationTime(t *testing.T) {
 
 func generateChanges(object, relation, user string, count int) []*openfgav1.TupleChange {
 	changes := make([]*openfgav1.TupleChange, 0, count)
-	for i := 0; i < count; i++ {
+	for range count {
 		changes = append(changes, &openfgav1.TupleChange{
 			TupleKey: &openfgav1.TupleKey{
 				User:     user,

--- a/internal/check/bottom_up_test.go
+++ b/internal/check/bottom_up_test.go
@@ -795,10 +795,10 @@ func TestBottomUpResolveUnion(t *testing.T) {
 
 		const numItems = 2000
 
-		for i := 0; i < numStream; i++ {
+		for range numStream {
 			producer := make(chan *iterator.Msg, 1)
 			var keys []string
-			for j := 0; j < numItems; j++ {
+			for j := range numItems {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
 			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
@@ -828,7 +828,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		err := pool.Wait()
 		require.NoError(t, err)
 		var expectedObjects []string
-		for j := 0; j < numItems; j++ {
+		for j := range numItems {
 			expectedObjects = append(expectedObjects, "obj:"+strconv.Itoa(j))
 		}
 		require.Equal(t, expectedObjects, ids)
@@ -1120,10 +1120,10 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 
 		const numItems = 2000
 
-		for i := 0; i < numStream; i++ {
+		for range numStream {
 			producer := make(chan *iterator.Msg, 1)
 			var keys []string
-			for j := 0; j < numItems; j++ {
+			for j := range numItems {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
 			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
@@ -1153,7 +1153,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		err := pool.Wait()
 		require.NoError(t, err)
 		var expectedObjects []string
-		for j := 0; j < numItems; j++ {
+		for j := range numItems {
 			expectedObjects = append(expectedObjects, "obj:"+strconv.Itoa(j))
 		}
 		require.Equal(t, expectedObjects, ids)
@@ -1556,7 +1556,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 
 		numItems := 2002
 		var object1 []string
-		for i := 0; i < numItems; i++ {
+		for i := range numItems {
 			object1 = append(object1, "obj:"+strconv.Itoa(i))
 		}
 		object2 := []string{"obj:0"}

--- a/internal/check/check.go
+++ b/internal/check/check.go
@@ -675,14 +675,12 @@ func (r *Resolver) ResolveExclusion(ctx context.Context, req *Request, node *aut
 	var wg sync.WaitGroup
 
 	scheduledHandlers := 1
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// exclusion is never part of a cycle or recursion
 		res, err := r.ResolveEdge(ctx, req, edges[0], nil)
 		concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res, Err: err}, base)
 		close(base)
-	}()
+	})
 	defer func() {
 		cancel()
 		wg.Wait()
@@ -699,14 +697,12 @@ func (r *Resolver) ResolveExclusion(ctx context.Context, req *Request, node *aut
 	if ok {
 		scheduledHandlers++
 		subtract = make(chan ResponseMsg, 1)
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			// exclusion is never part of a cycle or recursion
 			res, err := r.ResolveEdge(ctx, req, edges[1], nil)
 			concurrency.TrySendThroughChannel(ctx, ResponseMsg{Res: res, Err: err}, subtract)
 			close(subtract)
-		}()
+		})
 	}
 
 	// Loop until we have received the necessary results to determine the outcome.

--- a/internal/check/check_test.go
+++ b/internal/check/check_test.go
@@ -2872,7 +2872,7 @@ func TestSpecificType(t *testing.T) {
 			"viewer",
 			"user:maria",
 			"non_expired",
-			testutils.MustNewStruct(t, map[string]interface{}{"expiration": expiredTime.Format(time.RFC3339)}))
+			testutils.MustNewStruct(t, map[string]any{"expiration": expiredTime.Format(time.RFC3339)}))
 
 		mockDatastore.EXPECT().ReadUserTuple(
 			gomock.Any(),
@@ -2892,7 +2892,7 @@ func TestSpecificType(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -2936,7 +2936,7 @@ func TestSpecificType(t *testing.T) {
 			"viewer",
 			"user:maria",
 			"non_expired",
-			testutils.MustNewStruct(t, map[string]interface{}{"expiration": futureTime.Format(time.RFC3339)}))
+			testutils.MustNewStruct(t, map[string]any{"expiration": futureTime.Format(time.RFC3339)}))
 
 		mockDatastore.EXPECT().ReadUserTuple(
 			gomock.Any(),
@@ -2956,7 +2956,7 @@ func TestSpecificType(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -2998,7 +2998,7 @@ func TestSpecificType(t *testing.T) {
 			"viewer",
 			"user:maria",
 			"non_expired",
-			testutils.MustNewStruct(t, map[string]interface{}{"expiration": "invalid-timestamp"}))
+			testutils.MustNewStruct(t, map[string]any{"expiration": "invalid-timestamp"}))
 
 		mockDatastore.EXPECT().ReadUserTuple(
 			gomock.Any(),
@@ -3018,7 +3018,7 @@ func TestSpecificType(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -3439,7 +3439,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 			"viewer",
 			"user:*",
 			"non_expired",
-			testutils.MustNewStruct(t, map[string]interface{}{"expiration": expiredTime.Format(time.RFC3339)}))
+			testutils.MustNewStruct(t, map[string]any{"expiration": expiredTime.Format(time.RFC3339)}))
 
 		mockDatastore.EXPECT().ReadUsersetTuples(
 			gomock.Any(),
@@ -3464,7 +3464,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -3509,7 +3509,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 				User:     "user:*",
 				Condition: &openfgav1.RelationshipCondition{
 					Name: "non_expired",
-					Context: testutils.MustNewStruct(t, map[string]interface{}{
+					Context: testutils.MustNewStruct(t, map[string]any{
 						"expiration": futureTime.Format(time.RFC3339),
 					}),
 				},
@@ -3539,7 +3539,7 @@ func TestSpecificTypeWildcard(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -4077,7 +4077,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				"viewer",
 				"document:2#owner",
 				"validTime",
-				testutils.MustNewStruct(t, map[string]interface{}{"expiration": expiredTime.Format(time.RFC3339)})),
+				testutils.MustNewStruct(t, map[string]any{"expiration": expiredTime.Format(time.RFC3339)})),
 		}}), nil).Times(1)
 
 		resolver := New(Config{
@@ -4092,7 +4092,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -4158,7 +4158,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 				"viewer",
 				"document:2#owner",
 				"validTime",
-				testutils.MustNewStruct(t, map[string]interface{}{"expiration": futureTime.Format(time.RFC3339)})),
+				testutils.MustNewStruct(t, map[string]any{"expiration": futureTime.Format(time.RFC3339)})),
 		}}), nil).Times(1)
 
 		resolver := New(Config{
@@ -4173,7 +4173,7 @@ func TestSpecificTypeAndRelation(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -4687,7 +4687,7 @@ func TestTTU(t *testing.T) {
 				User:     "document:2",
 				Condition: &openfgav1.RelationshipCondition{
 					Name: "non_expired",
-					Context: testutils.MustNewStruct(t, map[string]interface{}{
+					Context: testutils.MustNewStruct(t, map[string]any{
 						"expiration": expiredTime.Format(time.RFC3339),
 					}),
 				},
@@ -4706,7 +4706,7 @@ func TestTTU(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -4766,7 +4766,7 @@ func TestTTU(t *testing.T) {
 				User:     "document:2",
 				Condition: &openfgav1.RelationshipCondition{
 					Name: "non_expired",
-					Context: testutils.MustNewStruct(t, map[string]interface{}{
+					Context: testutils.MustNewStruct(t, map[string]any{
 						"expiration": futureTime.Format(time.RFC3339),
 					}),
 				},
@@ -4785,7 +4785,7 @@ func TestTTU(t *testing.T) {
 			StoreID:  storeID,
 			Model:    mg,
 			TupleKey: tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"current_time": time.Now().Format(time.RFC3339),
 			}),
 		})
@@ -5929,7 +5929,7 @@ func TestResolveCheck(t *testing.T) {
 					User:     "user:u1",
 					Condition: &openfgav1.RelationshipCondition{
 						Name: "xcond",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{
+						Context: testutils.MustNewStruct(t, map[string]any{
 							"x": "1",
 						}),
 					},

--- a/internal/check/recursive_test.go
+++ b/internal/check/recursive_test.go
@@ -1212,7 +1212,7 @@ func TestRecursiveTTUWithTupleCycles(t *testing.T) {
 				Key: tuple.NewTupleKey("group:2", "public_restricted", "user:*"),
 			},
 		}
-		contextStruct := testutils.MustNewStruct(t, map[string]interface{}{"tcond": "restricted"})
+		contextStruct := testutils.MustNewStruct(t, map[string]any{"tcond": "restricted"})
 		readStartingWithUserRestricted := []*openfgav1.Tuple{
 			{
 				Key: &openfgav1.TupleKey{
@@ -1378,7 +1378,7 @@ func TestRecursiveUsersetWithTupleCycles(t *testing.T) {
 				Key: tuple.NewTupleKey("group:2", "public_restricted", "user:*"),
 			},
 		}
-		contextStruct := testutils.MustNewStruct(t, map[string]interface{}{"tcond": "restricted"})
+		contextStruct := testutils.MustNewStruct(t, map[string]any{"tcond": "restricted"})
 		readStartingWithUserRestricted := []*openfgav1.Tuple{
 			{
 				Key: &openfgav1.TupleKey{

--- a/internal/check/weight2_test.go
+++ b/internal/check/weight2_test.go
@@ -383,7 +383,7 @@ func TestWeight2Userset(t *testing.T) {
 				Key: tuple.NewTupleKey("group:2", "public_restricted", "user:*"),
 			},
 		}
-		contextStruct := testutils.MustNewStruct(t, map[string]interface{}{"tcond": "restricted"})
+		contextStruct := testutils.MustNewStruct(t, map[string]any{"tcond": "restricted"})
 		readStartingWithUserRestricted := []*openfgav1.Tuple{
 			{
 				Key: &openfgav1.TupleKey{
@@ -840,7 +840,7 @@ func TestWeight2TTU(t *testing.T) {
 				Key: tuple.NewTupleKey("group:2", "public_restricted", "user:*"),
 			},
 		}
-		contextStruct := testutils.MustNewStruct(t, map[string]interface{}{"tcond": "restricted"})
+		contextStruct := testutils.MustNewStruct(t, map[string]any{"tcond": "restricted"})
 		readStartingWithUserRestricted := []*openfgav1.Tuple{
 			{
 				Key: &openfgav1.TupleKey{

--- a/internal/checkutil/checkutil_test.go
+++ b/internal/checkutil/checkutil_test.go
@@ -26,7 +26,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 		name         string
 		tupleKey     *openfgav1.TupleKey
 		model        *openfgav1.AuthorizationModel
-		context      map[string]interface{}
+		context      map[string]any
 		conditionMet bool
 		expectedErr  error
 	}{
@@ -42,7 +42,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 				type document
 					relations
 						define can_view: [user]`),
-			context:      map[string]interface{}{},
+			context:      map[string]any{},
 			conditionMet: true,
 			expectedErr:  nil,
 		},
@@ -58,7 +58,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 				type document
 					relations
 						define can_view: [user]`),
-			context:      map[string]interface{}{},
+			context:      map[string]any{},
 			conditionMet: false,
 			expectedErr:  condition.NewEvaluationError("correct_ip", fmt.Errorf("condition was not found")),
 		},
@@ -79,7 +79,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 					x == 1
 				}
 `),
-			context:      map[string]interface{}{"x": 1},
+			context:      map[string]any{"x": 1},
 			conditionMet: true,
 			expectedErr:  nil,
 		},
@@ -100,7 +100,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 					x == 1
 				}
 `),
-			context:      map[string]interface{}{"x": 15},
+			context:      map[string]any{"x": 15},
 			conditionMet: false,
 			expectedErr:  nil,
 		},
@@ -121,7 +121,7 @@ func TestBuildTupleKeyConditionFilter(t *testing.T) {
 					x == 1 && y == 0
 				}
 `),
-			context:      map[string]interface{}{"x": 5},
+			context:      map[string]any{"x": 5},
 			conditionMet: false,
 			expectedErr: condition.NewEvaluationError("x_y",
 				fmt.Errorf("tuple 'document:1#can_view@user:maria' is missing context parameters '[y]'")),

--- a/internal/condition/condition.go
+++ b/internal/condition/condition.go
@@ -264,7 +264,7 @@ func (e *EvaluableCondition) Evaluate(
 		}, nil
 	}
 
-	conditionMetVal, err := out.ConvertToNative(reflect.TypeOf(false))
+	conditionMetVal, err := out.ConvertToNative(reflect.TypeFor[bool]())
 	if err != nil {
 		return emptyEvaluationResult, NewEvaluationError(
 			e.Name,

--- a/internal/condition/condition_test.go
+++ b/internal/condition/condition_test.go
@@ -113,7 +113,7 @@ func TestEvaluate(t *testing.T) {
 	var tests = []struct {
 		name      string
 		condition *openfgav1.Condition
-		context   map[string]interface{}
+		context   map[string]any
 		result    condition.EvaluationResult
 		err       *condition.EvaluationError
 	}{
@@ -128,7 +128,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"param1": "ok",
 			},
 			result: condition.EvaluationResult{ConditionMet: true},
@@ -144,7 +144,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{"param1": "notok"},
+			context: map[string]any{"param1": "notok"},
 			result:  condition.EvaluationResult{ConditionMet: false},
 		},
 		{
@@ -175,7 +175,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{},
+			context: map[string]any{},
 			result: condition.EvaluationResult{
 				ConditionMet:      false,
 				MissingParameters: []string{"param1"},
@@ -192,7 +192,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"param2": "ok",
 			},
 			result: condition.EvaluationResult{
@@ -214,7 +214,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"param1": "ok",
 			},
 			result: condition.EvaluationResult{
@@ -236,7 +236,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"param1": "ok",
 			},
 			result: condition.EvaluationResult{
@@ -255,7 +255,7 @@ func TestEvaluate(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"param1": true,
 			},
 			result: condition.EvaluationResult{ConditionMet: false},
@@ -274,7 +274,7 @@ func TestEvaluate(t *testing.T) {
 				Expression: `ipaddress("192.168.0.1").in_cidr("192.168.0.0/24")`,
 				Parameters: map[string]*openfgav1.ConditionParamTypeRef{},
 			},
-			context: map[string]interface{}{},
+			context: map[string]any{},
 			result:  condition.EvaluationResult{ConditionMet: true},
 		},
 		{
@@ -284,7 +284,7 @@ func TestEvaluate(t *testing.T) {
 				Expression: `ipaddress("192.168.0").in_cidr("192.168.0.0/24")`,
 				Parameters: map[string]*openfgav1.ConditionParamTypeRef{},
 			},
-			context: map[string]interface{}{},
+			context: map[string]any{},
 			result:  condition.EvaluationResult{ConditionMet: false},
 			err: &condition.EvaluationError{
 				Condition: "condition1",
@@ -339,7 +339,7 @@ func TestEvaluateWithMaxCost(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"x": int64(1),
 				"y": int64(2),
 			},
@@ -360,7 +360,7 @@ func TestEvaluateWithMaxCost(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"x": int64(1),
 				"y": int64(2),
 			},
@@ -384,7 +384,7 @@ func TestEvaluateWithMaxCost(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
+			context: map[string]any{
 				"x": "ab",
 				"y": "ab",
 			},
@@ -407,8 +407,8 @@ func TestEvaluateWithMaxCost(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
-				"strlist": []interface{}{"c", "b", "a"},
+			context: map[string]any{
+				"strlist": []any{"c", "b", "a"},
 			},
 			maxCost: 3,
 			err:     fmt.Errorf("operation cancelled: actual cost limit exceeded"),
@@ -429,8 +429,8 @@ func TestEvaluateWithMaxCost(t *testing.T) {
 					},
 				},
 			},
-			context: map[string]interface{}{
-				"strlist": []interface{}{"a", "b", "c"},
+			context: map[string]any{
+				"strlist": []any{"a", "b", "c"},
 			},
 			maxCost: 4,
 			result: condition.EvaluationResult{
@@ -549,9 +549,9 @@ func TestCastContextToTypedParameters(t *testing.T) {
 }
 
 func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
-	makeItems := func(size int) []interface{} {
-		items := make([]interface{}, size)
-		for i := int(0); i < size; i++ {
+	makeItems := func(size int) []any {
+		items := make([]any, size)
+		for i := range size {
 			items[i] = i
 		}
 		return items
@@ -587,7 +587,7 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 				},
 			},
 			checkFrequency: uint(numLoops),
-			context: map[string]interface{}{
+			context: map[string]any{
 				"items": makeItems(numLoops),
 			},
 			result: condition.EvaluationResult{
@@ -612,7 +612,7 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 				},
 			},
 			checkFrequency: uint(numLoops),
-			context: map[string]interface{}{
+			context: map[string]any{
 				"items": makeItems(numLoops - 1),
 			},
 			result: condition.EvaluationResult{
@@ -637,7 +637,7 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 				},
 			},
 			checkFrequency: uint(numLoops),
-			context: map[string]interface{}{
+			context: map[string]any{
 				"items": makeItems(numLoops),
 			},
 			result: condition.EvaluationResult{
@@ -662,7 +662,7 @@ func TestEvaluateWithInterruptCheckFrequency(t *testing.T) {
 				},
 			},
 			checkFrequency: uint(numLoops),
-			context: map[string]interface{}{
+			context: map[string]any{
 				"items": makeItems(numLoops - 1),
 			},
 			result: condition.EvaluationResult{

--- a/internal/condition/eval/eval_test.go
+++ b/internal/condition/eval/eval_test.go
@@ -20,7 +20,7 @@ func TestEvaluateTupleCondition(t *testing.T) {
 		name         string
 		tupleKey     *openfgav1.TupleKey
 		model        *openfgav1.AuthorizationModel
-		context      map[string]interface{}
+		context      map[string]any
 		conditionMet bool
 		expectedErr  string
 	}{
@@ -40,7 +40,7 @@ func TestEvaluateTupleCondition(t *testing.T) {
 				condition correct_ip(ip: string) {
 					ip == "192.168.0.1"
 				}`),
-			context:      map[string]interface{}{"ip": "192.168.0.1"},
+			context:      map[string]any{"ip": "192.168.0.1"},
 			conditionMet: false,
 			expectedErr:  "'unknown' - condition was not found",
 		},
@@ -60,7 +60,7 @@ func TestEvaluateTupleCondition(t *testing.T) {
 				condition correct_ip(ip: string) {
 					ip == "192.168.0.1"
 				}`),
-			context:      map[string]interface{}{"ip": "not_met"},
+			context:      map[string]any{"ip": "not_met"},
 			conditionMet: false,
 			expectedErr:  "",
 		},
@@ -80,7 +80,7 @@ func TestEvaluateTupleCondition(t *testing.T) {
 				condition correct_ip(ip: string) {
 					ip == "192.168.0.1"
 				}`),
-			context:      map[string]interface{}{"ip": "192.168.0.1"},
+			context:      map[string]any{"ip": "192.168.0.1"},
 			conditionMet: true,
 			expectedErr:  "",
 		},

--- a/internal/condition/types/ipaddress.go
+++ b/internal/condition/types/ipaddress.go
@@ -75,12 +75,12 @@ var ipaddrCelType = cel.ObjectType("IPAddress", traits.ReceiverType)
 //
 // See https://pkg.go.dev/github.com/google/cel-go/common/types/ref#Val
 func (ip IPAddress) ConvertToNative(typeDesc reflect.Type) (any, error) {
-	if reflect.TypeOf(ip).AssignableTo(typeDesc) {
+	if reflect.TypeFor[IPAddress]().AssignableTo(typeDesc) {
 		return ip, nil
 	}
 
 	switch typeDesc {
-	case reflect.TypeOf(""):
+	case reflect.TypeFor[string]():
 		return ip.addr.String(), nil
 	default:
 		return nil, fmt.Errorf("failed to convert from type '%s' to native Go type 'IPAddress'", typeDesc)

--- a/internal/containers/mpmc/queue_test.go
+++ b/internal/containers/mpmc/queue_test.go
@@ -44,18 +44,14 @@ func BenchmarkQueue(b *testing.B) {
 			var count atomic.Uint64
 			var wg sync.WaitGroup
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				feedN(p, benchMessageCount)
 				p.Close()
-			}()
+			})
 
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				consume(p, &count)
-			}()
+			})
 
 			wg.Wait()
 
@@ -73,18 +69,14 @@ func BenchmarkQueue(b *testing.B) {
 			var cwg sync.WaitGroup
 
 			for range 4 {
-				swg.Add(1)
-				go func() {
-					defer swg.Done()
+				swg.Go(func() {
 					feedN(p, benchMessageCount)
-				}()
+				})
 			}
 
-			cwg.Add(1)
-			go func() {
-				defer cwg.Done()
+			cwg.Go(func() {
 				consume(p, &count)
-			}()
+			})
 
 			swg.Wait()
 			p.Close()
@@ -103,18 +95,14 @@ func BenchmarkQueue(b *testing.B) {
 			var swg sync.WaitGroup
 			var cwg sync.WaitGroup
 
-			swg.Add(1)
-			go func() {
-				defer swg.Done()
+			swg.Go(func() {
 				feedN(p, benchMessageCount)
-			}()
+			})
 
 			for range 4 {
-				cwg.Add(1)
-				go func() {
-					defer cwg.Done()
+				cwg.Go(func() {
 					consume(p, &count)
-				}()
+				})
 			}
 
 			swg.Wait()
@@ -135,19 +123,15 @@ func BenchmarkQueue(b *testing.B) {
 			var cwg sync.WaitGroup
 
 			for range 4 {
-				swg.Add(1)
-				go func() {
-					defer swg.Done()
+				swg.Go(func() {
 					feedN(p, benchMessageCount)
-				}()
+				})
 			}
 
 			for range 4 {
-				cwg.Add(1)
-				go func() {
-					defer cwg.Done()
+				cwg.Go(func() {
 					consume(p, &count)
-				}()
+				})
 			}
 
 			swg.Wait()
@@ -253,18 +237,14 @@ func TestQueue(t *testing.T) {
 		var count atomic.Uint64
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			feedN(p, testMessageCount)
 			p.Close()
-		}()
+		})
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			consume(p, &count)
-		}()
+		})
 
 		wg.Wait()
 
@@ -280,18 +260,14 @@ func TestQueue(t *testing.T) {
 		var cwg sync.WaitGroup
 
 		for range 4 {
-			swg.Add(1)
-			go func() {
-				defer swg.Done()
+			swg.Go(func() {
 				feedN(p, testMessageCount)
-			}()
+			})
 		}
 
-		cwg.Add(1)
-		go func() {
-			defer cwg.Done()
+		cwg.Go(func() {
 			consume(p, &count)
-		}()
+		})
 
 		swg.Wait()
 		p.Close()
@@ -308,18 +284,14 @@ func TestQueue(t *testing.T) {
 		var swg sync.WaitGroup
 		var cwg sync.WaitGroup
 
-		swg.Add(1)
-		go func() {
-			defer swg.Done()
+		swg.Go(func() {
 			feedN(p, testMessageCount)
-		}()
+		})
 
 		for range 4 {
-			cwg.Add(1)
-			go func() {
-				defer cwg.Done()
+			cwg.Go(func() {
 				consume(p, &count)
-			}()
+			})
 		}
 
 		swg.Wait()
@@ -338,19 +310,15 @@ func TestQueue(t *testing.T) {
 		var cwg sync.WaitGroup
 
 		for range 4 {
-			swg.Add(1)
-			go func() {
-				defer swg.Done()
+			swg.Go(func() {
 				feedN(p, testMessageCount)
-			}()
+			})
 		}
 
 		for range 4 {
-			cwg.Add(1)
-			go func() {
-				defer cwg.Done()
+			cwg.Go(func() {
 				consume(p, &count)
-			}()
+			})
 		}
 
 		swg.Wait()

--- a/internal/graph/cached_resolver_test.go
+++ b/internal/graph/cached_resolver_test.go
@@ -477,7 +477,7 @@ func TestResolveCheck_ConcurrentCachedReadsAndWrites(t *testing.T) {
 	require.NoError(t, err)
 
 	// run multiple times to increase probability of ensuring we detect the race
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		var wg sync.WaitGroup
 		wg.Add(2)
 

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -184,7 +184,7 @@ func union(ctx context.Context, concurrencyLimit int, handlers ...CheckHandlerFu
 	var finalErr error
 	finalResult := &ResolveCheckResponse{Allowed: false}
 
-	for i := 0; i < len(handlers); i++ {
+	for range handlers {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -252,7 +252,7 @@ func intersection(ctx context.Context, concurrencyLimit int, handlers ...CheckHa
 		Allowed: true,
 	}
 
-	for i := 0; i < len(handlers); i++ {
+	for range handlers {
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()

--- a/internal/graph/check_test.go
+++ b/internal/graph/check_test.go
@@ -350,12 +350,10 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := exclusion(ctx, concurrencyLimit, falseHandler, falseHandler)
 		require.NoError(t, err)
@@ -370,12 +368,10 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := exclusion(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
@@ -398,12 +394,10 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 			}, nil
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := exclusion(ctx, concurrencyLimit, slowTrueHandler, trueHandler)
 		require.NoError(t, err)
@@ -418,12 +412,10 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := exclusion(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
@@ -470,12 +462,10 @@ func TestExclusionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		slowHandler := func(context.Context) (*ResolveCheckResponse, error) {
 			time.Sleep(50 * time.Millisecond)
@@ -762,12 +752,10 @@ func TestIntersectionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := intersection(ctx, concurrencyLimit, falseHandler, falseHandler)
 		require.NoError(t, err)
@@ -807,12 +795,10 @@ func TestIntersectionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		slowTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
 			time.Sleep(50 * time.Millisecond)
@@ -961,7 +947,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 
 		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
-		for i := 0; i < 2000; i++ {
+		for range 2000 {
 			// subtract branch resolves to {allowed: true} even though the base branch
 			// results in an error. Outcome should be falsey, not an error.
 			resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
@@ -1007,7 +993,7 @@ func TestResolveCheckDeterministic(t *testing.T) {
 
 		ctx := setRequestContext(context.Background(), ts, ds, nil)
 
-		for i := 0; i < 2000; i++ {
+		for range 2000 {
 			// base should resolve to {allowed: false} even though the subtract branch
 			// results in an error. Outcome should be falsey, not an error.
 			resp, err := checker.ResolveCheck(ctx, &ResolveCheckRequest{
@@ -1079,7 +1065,7 @@ func TestCheckConditions(t *testing.T) {
 
 	storeID := ulid.Make().String()
 
-	tkConditionContext, err := structpb.NewStruct(map[string]interface{}{
+	tkConditionContext, err := structpb.NewStruct(map[string]any{
 		"param1": "ok",
 	})
 	require.NoError(t, err)
@@ -1132,7 +1118,7 @@ func TestCheckConditions(t *testing.T) {
 
 	ctx := setRequestContext(context.Background(), typesys, ds, nil)
 
-	conditionContext, err := structpb.NewStruct(map[string]interface{}{
+	conditionContext, err := structpb.NewStruct(map[string]any{
 		"param1": "notok",
 	})
 	require.NoError(t, err)
@@ -1219,7 +1205,7 @@ func TestCheckTTUWithCondition(t *testing.T) {
 			ds := memory.New()
 			storeID := ulid.Make().String()
 
-			tkConditionContext, err := structpb.NewStruct(map[string]interface{}{
+			tkConditionContext, err := structpb.NewStruct(map[string]any{
 				"expiry": "2099-01-01T00:00:00Z",
 			})
 			require.NoError(t, err)
@@ -1237,7 +1223,7 @@ func TestCheckTTUWithCondition(t *testing.T) {
 
 			ctx := setRequestContext(context.Background(), typesys, ds, nil)
 
-			requestContext, err := structpb.NewStruct(map[string]interface{}{
+			requestContext, err := structpb.NewStruct(map[string]any{
 				"current_time": tc.currentTime,
 			})
 			require.NoError(t, err)
@@ -1720,12 +1706,10 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		slowTrueHandler := func(context.Context) (*ResolveCheckResponse, error) {
 			time.Sleep(50 * time.Millisecond)
@@ -1747,12 +1731,10 @@ func TestUnionCheckFuncReducer(t *testing.T) {
 
 		var wg sync.WaitGroup
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			time.Sleep(10 * time.Millisecond)
 			cancel()
-		}()
+		})
 
 		resp, err := union(ctx, concurrencyLimit, trueHandler, trueHandler)
 		require.NoError(t, err)
@@ -2042,7 +2024,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 		readUserTuple      *openfgav1.Tuple
 		readUserTupleError error
 		reqTupleKey        *openfgav1.TupleKey
-		context            map[string]interface{}
+		context            map[string]any
 		expected           *ResolveCheckResponse
 		expectedError      error
 	}{
@@ -2054,7 +2036,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			},
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
-			context:            map[string]interface{}{"x": "2"},
+			context:            map[string]any{"x": "2"},
 			expected: &ResolveCheckResponse{
 				Allowed: true,
 			},
@@ -2068,7 +2050,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			},
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
-			context:            map[string]interface{}{"x": "200"},
+			context:            map[string]any{"x": "200"},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
 			},
@@ -2082,7 +2064,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			},
 			readUserTupleError: nil,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
-			context:            map[string]interface{}{},
+			context:            map[string]any{},
 			expected:           nil,
 			expectedError: condition.NewEvaluationError(
 				"condX",
@@ -2095,7 +2077,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTuple:      nil,
 			readUserTupleError: storage.ErrNotFound,
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
-			context:            map[string]interface{}{"x": "200"},
+			context:            map[string]any{"x": "200"},
 			expected: &ResolveCheckResponse{
 				Allowed: false,
 			},
@@ -2107,7 +2089,7 @@ func TestCheckDirectUserTuple(t *testing.T) {
 			readUserTuple:      nil,
 			readUserTupleError: fmt.Errorf("mock_erorr"),
 			reqTupleKey:        tuple.NewTupleKey("group:1", "member", "user:bob"),
-			context:            map[string]interface{}{"x": "200"},
+			context:            map[string]any{"x": "200"},
 			expected:           nil,
 			expectedError:      fmt.Errorf("mock_erorr"),
 		},
@@ -2413,7 +2395,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 		name                   string
 		readUsersetTuples      []*openfgav1.Tuple
 		readUsersetTuplesError error
-		context                map[string]interface{}
+		context                map[string]any
 		model                  *openfgav1.AuthorizationModel
 		expected               *ResolveCheckResponse
 		expectedError          error
@@ -2426,7 +2408,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 				},
 			},
 			readUsersetTuplesError: nil,
-			context:                map[string]interface{}{},
+			context:                map[string]any{},
 			model:                  modelWithNoCond,
 			expected: &ResolveCheckResponse{
 				Allowed: true,
@@ -2439,7 +2421,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 				{},
 			},
 			readUsersetTuplesError: nil,
-			context:                map[string]interface{}{},
+			context:                map[string]any{},
 			model:                  modelWithNoCond,
 			expected: &ResolveCheckResponse{
 				Allowed: false,
@@ -2452,7 +2434,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 				{},
 			},
 			readUsersetTuplesError: fmt.Errorf("mock_error"),
-			context:                map[string]interface{}{},
+			context:                map[string]any{},
 			model:                  modelWithNoCond,
 			expected:               nil,
 			expectedError:          fmt.Errorf("mock_error"),
@@ -2465,7 +2447,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 				},
 			},
 			readUsersetTuplesError: nil,
-			context:                map[string]interface{}{"x": "5"},
+			context:                map[string]any{"x": "5"},
 			model:                  modelWithCond,
 			expected: &ResolveCheckResponse{
 				Allowed: true,
@@ -2480,7 +2462,7 @@ func TestCheckPublicAssignable(t *testing.T) {
 				},
 			},
 			readUsersetTuplesError: nil,
-			context:                map[string]interface{}{"x": "200"},
+			context:                map[string]any{"x": "200"},
 			model:                  modelWithCond,
 			expected: &ResolveCheckResponse{
 				Allowed: false,

--- a/internal/graph/recursive_resolver.go
+++ b/internal/graph/recursive_resolver.go
@@ -215,11 +215,9 @@ func (c *LocalChecker) recursiveMatchUserUserset(ctx context.Context, req *Resol
 		// We need to wait always to avoid a goroutine leak.
 		wg.Wait()
 	}()
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		c.breadthFirstRecursiveMatch(cancellableCtx, req, mapping, &sync.Map{}, currentLevelFromObject, usersetFromUser, checkOutcomeChan)
-		wg.Done()
-	}()
+	})
 
 	var finalErr error
 	finalResult := &ResolveCheckResponse{

--- a/internal/graph/recursive_resolver_test.go
+++ b/internal/graph/recursive_resolver_test.go
@@ -1176,7 +1176,7 @@ func TestBuildRecursiveMapper(t *testing.T) {
 		res, err := buildRecursiveMapper(ctx, &ResolveCheckRequest{
 			StoreID:     storeID,
 			TupleKey:    tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context:     testutils.MustNewStruct(t, map[string]interface{}{"x": "2"}),
+			Context:     testutils.MustNewStruct(t, map[string]any{"x": "2"}),
 			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 		}, mapping)
 		require.NoError(t, err)
@@ -1198,7 +1198,7 @@ func TestBuildRecursiveMapper(t *testing.T) {
 		res, err := buildRecursiveMapper(ctx, &ResolveCheckRequest{
 			StoreID:     storeID,
 			TupleKey:    tuple.NewTupleKey("document:1", "viewer", "user:maria"),
-			Context:     testutils.MustNewStruct(t, map[string]interface{}{"x": "2"}),
+			Context:     testutils.MustNewStruct(t, map[string]any{"x": "2"}),
 			Consistency: openfgav1.ConsistencyPreference_HIGHER_CONSISTENCY,
 		}, mapping)
 		require.NoError(t, err)

--- a/internal/graph/resolve_check_request_test.go
+++ b/internal/graph/resolve_check_request_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCloneResolveCheckRequest(t *testing.T) {
 	t.Run("non_empty_clone", func(t *testing.T) {
-		contextStruct, err := structpb.NewStruct(map[string]interface{}{
+		contextStruct, err := structpb.NewStruct(map[string]any{
 			"x": 10,
 		})
 		require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestCloneResolveCheckRequest(t *testing.T) {
 	})
 
 	t.Run("thread_safe_clone", func(t *testing.T) {
-		contextStruct, err := structpb.NewStruct(map[string]interface{}{
+		contextStruct, err := structpb.NewStruct(map[string]any{
 			"x": 10,
 		})
 		require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestCloneResolveCheckRequest(t *testing.T) {
 
 		clones := make([]*ResolveCheckRequest, clonesCount)
 
-		for i := 0; i < clonesCount; i++ {
+		for i := range clonesCount {
 			go func(i int) {
 				defer wg.Done()
 				cloned := orig.clone()

--- a/internal/graph/shadow_resolver.go
+++ b/internal/graph/shadow_resolver.go
@@ -56,10 +56,7 @@ func (s ShadowResolver) ResolveCheck(ctx context.Context, req *ResolveCheckReque
 	resClone := res.clone()
 	reqClone := req.clone()
 	reqClone.VisitedPaths = nil // reset completely for evaluation
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-
+	s.wg.Go(func() {
 		defer func() {
 			if r := recover(); r != nil {
 				s.logger.ErrorWithContext(ctx, "panic recovered",
@@ -107,7 +104,7 @@ func (s ShadowResolver) ResolveCheck(ctx context.Context, req *ResolveCheckReque
 				zap.Int64("shadow_latency", shadowDuration.Milliseconds()),
 			)
 		}
-	}()
+	})
 
 	return res, nil
 }

--- a/internal/graph/weight_two_resolver_test.go
+++ b/internal/graph/weight_two_resolver_test.go
@@ -386,10 +386,10 @@ func TestFastPathUnion(t *testing.T) {
 
 		const numItems = 2000
 
-		for i := 0; i < numStream; i++ {
+		for range numStream {
 			producer := make(chan *iterator.Msg, 1)
 			var keys []string
-			for j := 0; j < numItems; j++ {
+			for j := range numItems {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
 			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
@@ -419,7 +419,7 @@ func TestFastPathUnion(t *testing.T) {
 		err := pool.Wait()
 		require.NoError(t, err)
 		var expectedObjects []string
-		for j := 0; j < numItems; j++ {
+		for j := range numItems {
 			expectedObjects = append(expectedObjects, "obj:"+strconv.Itoa(j))
 		}
 		require.Equal(t, expectedObjects, ids)
@@ -707,10 +707,10 @@ func TestFastPathIntersection(t *testing.T) {
 
 		const numItems = 2000
 
-		for i := 0; i < numStream; i++ {
+		for range numStream {
 			producer := make(chan *iterator.Msg, 1)
 			var keys []string
-			for j := 0; j < numItems; j++ {
+			for j := range numItems {
 				keys = append(keys, "obj:"+strconv.Itoa(j))
 			}
 			producer <- &iterator.Msg{Iter: storage.NewStaticIterator[string](keys)}
@@ -740,7 +740,7 @@ func TestFastPathIntersection(t *testing.T) {
 		err := pool.Wait()
 		require.NoError(t, err)
 		var expectedObjects []string
-		for j := 0; j < numItems; j++ {
+		for j := range numItems {
 			expectedObjects = append(expectedObjects, "obj:"+strconv.Itoa(j))
 		}
 		require.Equal(t, expectedObjects, ids)
@@ -1142,7 +1142,7 @@ func TestFastPathDifference(t *testing.T) {
 
 		numItems := 2002
 		var object1 []string
-		for i := 0; i < numItems; i++ {
+		for i := range numItems {
 			object1 = append(object1, "obj:"+strconv.Itoa(i))
 		}
 		object2 := []string{"obj:0"}

--- a/internal/iterator/channel.go
+++ b/internal/iterator/channel.go
@@ -13,15 +13,13 @@ func Drain(ch <-chan *Msg) *sync.WaitGroup {
 	if ch == nil {
 		return wg
 	}
-	wg.Add(1)
-	go func() {
+	wg.Go(func() {
 		for msg := range ch {
 			if msg.Iter != nil {
 				msg.Iter.Stop()
 			}
 		}
-		wg.Done()
-	}()
+	})
 	return wg
 }
 

--- a/internal/iterator/channel_test.go
+++ b/internal/iterator/channel_test.go
@@ -27,7 +27,7 @@ func TestDrain(t *testing.T) {
 			name: "should_drain_channel_with_iterators",
 			setupChan: func(ctrl *gomock.Controller) <-chan *Msg {
 				ch := make(chan *Msg, 3)
-				for i := 0; i < 3; i++ {
+				for range 3 {
 					iter := mocks.NewMockIterator[string](ctrl)
 					iter.EXPECT().Stop().Times(1)
 					ch <- &Msg{Iter: iter}

--- a/internal/iterator/stream_test.go
+++ b/internal/iterator/stream_test.go
@@ -360,7 +360,7 @@ func TestIteratorStreams(t *testing.T) {
 			ctx := context.Background()
 			streams := make([]*Stream, 0)
 			expectedLen := 0
-			for i := 0; i < 5; i++ {
+			for i := range 5 {
 				c := make(chan *Msg, 1)
 				producer := NewStream(0, c)
 				if i%2 == 0 {
@@ -380,7 +380,7 @@ func TestIteratorStreams(t *testing.T) {
 		t.Run("should_return_empty_when_fully_drained", func(t *testing.T) {
 			ctx := context.Background()
 			streams := make([]*Stream, 0)
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				producer := &Stream{buffer: nil, sourceIsClosed: true}
 				streams = append(streams, producer)
 			}
@@ -392,7 +392,7 @@ func TestIteratorStreams(t *testing.T) {
 	})
 	t.Run("Stop", func(t *testing.T) {
 		streams := make([]*Stream, 3)
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			buf := storage.NewStaticIterator[string]([]string{"obj:0", "obj:1", "obj:3"})
 			c := make(chan *Msg, 1)
 			close(c)

--- a/internal/listobjects/pipeline/pipeline.go
+++ b/internal/listobjects/pipeline/pipeline.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 
 	"go.opentelemetry.io/otel"
@@ -349,11 +350,11 @@ func (b *Builder) Build(
 			continue
 		}
 
-		for i := len(edges) - 1; i >= 0; i-- {
+		for _, v := range slices.Backward(edges) {
 			var newStack stacker
-			newStack.node = edges[i].GetTo()
-			newStack.edge = edges[i]
-			if worker.IsCyclical(edges[i]) {
+			newStack.node = v.GetTo()
+			newStack.edge = v
+			if worker.IsCyclical(v) {
 				newStack.group = current.group
 			}
 			newStack.next = stack

--- a/internal/mocks/mock_oidc_server.go
+++ b/internal/mocks/mock_oidc_server.go
@@ -74,7 +74,7 @@ func createHTTPServer(issuerURL string, publicKey *rsa.PublicKey) *http.Server {
 	})
 
 	mockHandler.HandleFunc("/jwks.json", func(w http.ResponseWriter, r *http.Request) {
-		err := json.NewEncoder(w).Encode(map[string]interface{}{
+		err := json.NewEncoder(w).Encode(map[string]any{
 			"keys": []map[string]string{
 				{
 					"kid": kidHeader,

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -35,7 +35,7 @@ func New(config *Config) *Planner {
 		stopCleanup:       make(chan struct{}),
 		wg:                sync.WaitGroup{},
 	}
-	p.rngPool.New = func() interface{} {
+	p.rngPool.New = func() any {
 		// Each new RNG is seeded to ensure different sequences.
 		return rand.New(rand.NewSource(time.Now().UnixNano()))
 	}
@@ -53,7 +53,7 @@ func NewNoopPlanner() *Planner {
 		stopCleanup:       make(chan struct{}),
 		wg:                sync.WaitGroup{},
 	}
-	p.rngPool.New = func() interface{} {
+	p.rngPool.New = func() any {
 		// Each new RNG is seeded to ensure different sequences.
 		return rand.New(rand.NewSource(time.Now().UnixNano()))
 	}
@@ -98,7 +98,7 @@ func (p *Planner) evictStaleKeys() {
 
 	// NOTE: Consider also bounding the total number of keys stored.
 
-	p.keys.Range(func(key, value interface{}) bool {
+	p.keys.Range(func(key, value any) bool {
 		kp := value.(*keyPlan)
 		lastAccessed := kp.lastAccessed.Load()
 		if (nowNano - lastAccessed) > evictionThresholdNano {

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -41,7 +41,7 @@ func TestPlanner_SelectResolver(t *testing.T) {
 
 	// Test probabilistically over multiple runs instead of expecting deterministic behavior
 	counts := make(map[string]int)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		key := testPlanKey(fmt.Sprintf("test_key_%d", i))
 		kp := p.GetPlanSelector(key)
 		choice := kp.Select(resolvers)
@@ -81,18 +81,18 @@ func TestProfiler_Update(t *testing.T) {
 			Beta:         1,
 		}}
 	// Heavily reward the "fast" strategy
-	for i := 0; i < 150; i++ {
+	for range 150 {
 		kp.UpdateStats(resolvers["fast"], 10*time.Millisecond)
 	}
 	// Heavily penalize the "slow" strategy
-	for i := 0; i < 150; i++ {
+	for range 150 {
 		kp.UpdateStats(resolvers["slow"], 50*time.Millisecond)
 	}
 
 	// After sufficient updates, Thompson sampling should almost always choose the better option.
 	// We test this by seeing if it's chosen a high percentage of the time.
 	counts := make(map[string]int)
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		choice := kp.Select(resolvers)
 		counts[choice.Name]++
 	}

--- a/internal/planner/thompson_test.go
+++ b/internal/planner/thompson_test.go
@@ -39,7 +39,7 @@ func TestThompsonStats_Sample(t *testing.T) {
 		// Helper to calculate Median
 		getMedian := func() float64 {
 			samples := make([]float64, numSamples)
-			for i := 0; i < numSamples; i++ {
+			for i := range numSamples {
 				samples[i] = stats.Sample(r)
 			}
 			sort.Float64s(samples) // Requires "sort" package
@@ -50,7 +50,7 @@ func TestThompsonStats_Sample(t *testing.T) {
 		medianBefore := getMedian()
 
 		// 2. Update with high latency (500ms)
-		for i := 0; i < 20; i++ {
+		for range 20 {
 			stats.Update(500 * time.Millisecond)
 		}
 
@@ -68,7 +68,7 @@ func BenchmarkThompsonStats_SampleParallel(b *testing.B) {
 	ts := NewThompsonStats(10*time.Millisecond, 1, 1, 1)
 
 	// Add some sample data
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		ts.Update(time.Duration(5+i) * time.Millisecond)
 	}
 

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -1161,7 +1161,7 @@ func BenchmarkValidateTupleForWrite(b *testing.B) {
 func TestValidateStruct(t *testing.T) {
 	tests := []struct {
 		name    string
-		context map[string]interface{}
+		context map[string]any
 		wantErr bool
 	}{
 		{
@@ -1171,43 +1171,43 @@ func TestValidateStruct(t *testing.T) {
 		},
 		{
 			name:    "clean_context",
-			context: map[string]interface{}{"key": "value"},
+			context: map[string]any{"key": "value"},
 			wantErr: false,
 		},
 		{
 			name:    "control_char_in_key",
-			context: map[string]interface{}{"key\x00bad": "value"},
+			context: map[string]any{"key\x00bad": "value"},
 			wantErr: true,
 		},
 		{
 			name:    "control_char_in_string_value",
-			context: map[string]interface{}{"key": "value\x01bad"},
+			context: map[string]any{"key": "value\x01bad"},
 			wantErr: true,
 		},
 		{
 			name: "control_char_in_nested_struct_key",
-			context: map[string]interface{}{
-				"nested": map[string]interface{}{"inner\x02key": "value"},
+			context: map[string]any{
+				"nested": map[string]any{"inner\x02key": "value"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "control_char_in_list_value",
-			context: map[string]interface{}{
-				"items": []interface{}{"good", "bad\x03item"},
+			context: map[string]any{
+				"items": []any{"good", "bad\x03item"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "clean_nested_struct",
-			context: map[string]interface{}{
-				"nested": map[string]interface{}{"innerKey": "innerValue"},
+			context: map[string]any{
+				"nested": map[string]any{"innerKey": "innerValue"},
 			},
 			wantErr: false,
 		},
 		{
 			name: "number_and_bool_values_pass",
-			context: map[string]interface{}{
+			context: map[string]any{
 				"count":  42.0,
 				"active": true,
 			},

--- a/pkg/encoder/token_serializer.go
+++ b/pkg/encoder/token_serializer.go
@@ -32,7 +32,7 @@ func (ts *StringContinuationTokenSerializer) Serialize(ulid string, objType stri
 	if ulid == "" {
 		return nil, errors.New("empty ulid provided for continuation token")
 	}
-	return []byte(fmt.Sprintf("%s|%s", ulid, objType)), nil
+	return fmt.Appendf(nil, "%s|%s", ulid, objType), nil
 }
 
 // Deserialize deserializes the continuation token from a string, as ulid & type concatenated by a pipe.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -52,7 +52,7 @@ func TestWithoutContext(t *testing.T) {
 		actualMessage := logs.All()[0]
 		require.Equal(t, testMessage, actualMessage.Message)
 
-		expectedZapFields := map[string]interface{}{}
+		expectedZapFields := map[string]any{}
 		require.Equal(t, expectedZapFields, actualMessage.ContextMap())
 		require.Equal(t, tc.expectedLevel, actualMessage.Level)
 	}
@@ -101,7 +101,7 @@ func TestWithContext(t *testing.T) {
 			actualMessage := logs.All()[0]
 			require.Equal(t, testMessage, actualMessage.Message)
 
-			expectedZapFields := map[string]interface{}{}
+			expectedZapFields := map[string]any{}
 			require.Equal(t, expectedZapFields, actualMessage.ContextMap())
 			require.Equal(t, tc.expectedLevel, actualMessage.Level)
 		})
@@ -121,7 +121,7 @@ func TestWithFields(t *testing.T) {
 	newLogger.Info(testMessage)
 
 	// Check that child message carries the context fields
-	expectedZapFields := map[string]interface{}{
+	expectedZapFields := map[string]any{
 		"TestOption": "Message",
 	}
 	childMessage := logs.All()[0]

--- a/pkg/middleware/logging/logging.go
+++ b/pkg/middleware/logging/logging.go
@@ -90,7 +90,7 @@ func (r *reporter) PostCall(err error, rpcDuration time.Duration) {
 
 // PostMsgSend is invoked once after a unary response or multiple times in
 // streaming requests after each message has been sent.
-func (r *reporter) PostMsgSend(msg interface{}, err error, _ time.Duration) {
+func (r *reporter) PostMsgSend(msg any, err error, _ time.Duration) {
 	if err != nil {
 		// This is the actual error that customers see.
 		intCode := serverErrors.ConvertToEncodedErrorCode(status.Convert(err))
@@ -110,7 +110,7 @@ func (r *reporter) PostMsgSend(msg interface{}, err error, _ time.Duration) {
 }
 
 // PostMsgReceive is invoked after receiving a message in streaming requests.
-func (r *reporter) PostMsgReceive(msg interface{}, _ error, _ time.Duration) {
+func (r *reporter) PostMsgReceive(msg any, _ error, _ time.Duration) {
 	protomsg, ok := msg.(protoreflect.ProtoMessage)
 	if ok {
 		if req, err := r.protomarshaler.Marshal(protomsg); err == nil {

--- a/pkg/middleware/logging/logging_test.go
+++ b/pkg/middleware/logging/logging_test.go
@@ -59,14 +59,12 @@ func TestNewLoggingInterceptor_concrete(t *testing.T) {
 	openfgav1.RegisterOpenFGAServiceServer(srv, &fgaServer{})
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		err := srv.Serve(listner)
 		if err != nil {
 			t.Errorf("failed to serve: %v", err)
 		}
-	}()
+	})
 
 	dialer := func(context.Context, string) (net.Conn, error) {
 		return listner.Dial()

--- a/pkg/middleware/storeid/storeid.go
+++ b/pkg/middleware/storeid/storeid.go
@@ -42,7 +42,7 @@ func contextWithHandle(ctx context.Context) context.Context {
 }
 
 // SetStoreIDInContext sets the store ID in the provided context based on information from the request.
-func SetStoreIDInContext(ctx context.Context, req interface{}) {
+func SetStoreIDInContext(ctx context.Context, req any) {
 	handle := ctx.Value(storeIDCtxKey)
 	if handle == nil {
 		return
@@ -79,10 +79,10 @@ type reporter struct {
 func (r *reporter) PostCall(error, time.Duration) {}
 
 // PostMsgSend is a placeholder for handling actions after sending a message in streaming requests.
-func (r *reporter) PostMsgSend(interface{}, error, time.Duration) {}
+func (r *reporter) PostMsgSend(any, error, time.Duration) {}
 
 // PostMsgReceive is invoked after receiving a message in streaming requests.
-func (r *reporter) PostMsgReceive(msg interface{}, _ error, _ time.Duration) {
+func (r *reporter) PostMsgReceive(msg any, _ error, _ time.Duration) {
 	if m, ok := msg.(hasGetStoreID); ok {
 		storeID := m.GetStoreId()
 

--- a/pkg/middleware/storeid/storeid_test.go
+++ b/pkg/middleware/storeid/storeid_test.go
@@ -14,7 +14,7 @@ func TestUnaryInterceptor(t *testing.T) {
 	t.Run("unary_interceptor_with_no_storeID_in_request", func(t *testing.T) {
 		interceptor := NewUnaryInterceptor()
 
-		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handler := func(ctx context.Context, req any) (any, error) {
 			storeID, ok := StoreIDFromContext(ctx)
 			require.True(t, ok)
 			require.Empty(t, storeID)
@@ -30,7 +30,7 @@ func TestUnaryInterceptor(t *testing.T) {
 		storeID := "abc"
 		interceptor := NewUnaryInterceptor()
 
-		handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		handler := func(ctx context.Context, req any) (any, error) {
 			got, ok := StoreIDFromContext(ctx)
 			require.True(t, ok)
 			require.Equal(t, storeID, got)
@@ -52,13 +52,13 @@ func (s *mockServerStream) Context() context.Context {
 	return s.ctx
 }
 
-func (s *mockServerStream) RecvMsg(interface{}) error {
+func (s *mockServerStream) RecvMsg(any) error {
 	return nil
 }
 
 func TestStreamingInterceptor(t *testing.T) {
 	t.Run("streaming_interceptor_with_no_GetStoreId_in_request", func(t *testing.T) {
-		handler := func(srv interface{}, stream grpc.ServerStream) error {
+		handler := func(srv any, stream grpc.ServerStream) error {
 			err := stream.RecvMsg(nil)
 			require.NoError(t, err)
 
@@ -75,7 +75,7 @@ func TestStreamingInterceptor(t *testing.T) {
 	})
 
 	t.Run("streaming_interceptor_with_GetStoreId_in_request", func(t *testing.T) {
-		handler := func(srv interface{}, stream grpc.ServerStream) error {
+		handler := func(srv any, stream grpc.ServerStream) error {
 			err := stream.RecvMsg(&openfgav1.CheckRequest{StoreId: "abc"})
 			require.NoError(t, err)
 

--- a/pkg/middleware/timeout.go
+++ b/pkg/middleware/timeout.go
@@ -29,7 +29,7 @@ func NewTimeoutInterceptor(timeout time.Duration, logger logger.Logger) *Timeout
 // We need to use this middleware instead of relying on runtime.DefaultContextTimeout to allow us
 // to return proper error code.
 func (h *TimeoutInterceptor) NewUnaryTimeoutInterceptor() grpc.UnaryServerInterceptor {
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		ctx, cancel := context.WithTimeout(ctx, h.timeout)
 		defer cancel()
 		return handler(ctx, req)
@@ -41,8 +41,8 @@ func (h *TimeoutInterceptor) NewUnaryTimeoutInterceptor() grpc.UnaryServerInterc
 // to return proper error code.
 func (h *TimeoutInterceptor) NewStreamTimeoutInterceptor() grpc.StreamServerInterceptor {
 	validator := grpcvalidator.StreamServerInterceptor()
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return validator(srv, stream, info, func(srv any, ss grpc.ServerStream) error {
 			ctx, cancel := context.WithTimeout(stream.Context(), h.timeout)
 			defer cancel()
 

--- a/pkg/middleware/validator/validator.go
+++ b/pkg/middleware/validator/validator.go
@@ -29,8 +29,8 @@ func RequestIsValidatedFromContext(ctx context.Context) bool {
 func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	validator := grpcvalidator.UnaryServerInterceptor()
 
-	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		return validator(ctx, req, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		return validator(ctx, req, info, func(ctx context.Context, req any) (any, error) {
 			return handler(contextWithRequestIsValidated(ctx), req)
 		})
 	}
@@ -41,8 +41,8 @@ func UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 func StreamServerInterceptor() grpc.StreamServerInterceptor {
 	validator := grpcvalidator.StreamServerInterceptor()
 
-	return func(srv interface{}, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		return validator(srv, stream, info, func(srv interface{}, ss grpc.ServerStream) error {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		return validator(srv, stream, info, func(srv any, ss grpc.ServerStream) error {
 			return handler(srv, &recvWrapper{
 				ctx:          contextWithRequestIsValidated(stream.Context()),
 				ServerStream: ss,

--- a/pkg/server/authzen.go
+++ b/pkg/server/authzen.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"maps"
 	"regexp"
 	"sort"
 	"strconv"
@@ -64,9 +65,7 @@ func mergePropertiesToContext(
 	}
 
 	if requestContext != nil {
-		for k, v := range requestContext.AsMap() {
-			merged[k] = v
-		}
+		maps.Copy(merged, requestContext.AsMap())
 	}
 
 	if len(merged) == 0 {

--- a/pkg/server/authzen_utils_test.go
+++ b/pkg/server/authzen_utils_test.go
@@ -95,7 +95,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("merges_subject_properties_with_prefix", func(t *testing.T) {
-		subjectProps, err := structpb.NewStruct(map[string]interface{}{
+		subjectProps, err := structpb.NewStruct(map[string]any{
 			"department": "engineering",
 			"level":      "senior",
 		})
@@ -117,7 +117,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("merges_resource_properties_with_prefix", func(t *testing.T) {
-		resourceProps, err := structpb.NewStruct(map[string]interface{}{
+		resourceProps, err := structpb.NewStruct(map[string]any{
 			"classification": "confidential",
 			"owner":          "bob",
 		})
@@ -139,7 +139,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("merges_action_properties_with_prefix", func(t *testing.T) {
-		actionProps, err := structpb.NewStruct(map[string]interface{}{
+		actionProps, err := structpb.NewStruct(map[string]any{
 			"requires_approval": true,
 			"max_size":          float64(1000),
 		})
@@ -160,7 +160,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("request_context_takes_precedence", func(t *testing.T) {
-		subjectProps, err := structpb.NewStruct(map[string]interface{}{
+		subjectProps, err := structpb.NewStruct(map[string]any{
 			"department": "engineering",
 		})
 		require.NoError(t, err)
@@ -171,7 +171,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 			Properties: subjectProps,
 		}
 
-		requestContext, err := structpb.NewStruct(map[string]interface{}{
+		requestContext, err := structpb.NewStruct(map[string]any{
 			"subject_department": "overridden_value",
 			"custom_field":       "custom_value",
 		})
@@ -187,10 +187,10 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("merges_all_sources_with_correct_precedence", func(t *testing.T) {
-		subjectProps, _ := structpb.NewStruct(map[string]interface{}{"role": "admin"})
-		resourceProps, _ := structpb.NewStruct(map[string]interface{}{"type": "secret"})
-		actionProps, _ := structpb.NewStruct(map[string]interface{}{"audit": true})
-		requestContext, _ := structpb.NewStruct(map[string]interface{}{"ip_address": "192.168.1.1"})
+		subjectProps, _ := structpb.NewStruct(map[string]any{"role": "admin"})
+		resourceProps, _ := structpb.NewStruct(map[string]any{"type": "secret"})
+		actionProps, _ := structpb.NewStruct(map[string]any{"audit": true})
+		requestContext, _ := structpb.NewStruct(map[string]any{"ip_address": "192.168.1.1"})
 
 		subject := &authzenv1.Subject{Type: "user", Id: "alice", Properties: subjectProps}
 		resource := &authzenv1.Resource{Type: "document", Id: "doc1", Properties: resourceProps}
@@ -208,7 +208,7 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("handles_request_context_only", func(t *testing.T) {
-		requestContext, _ := structpb.NewStruct(map[string]interface{}{"timestamp": "2024-01-01T00:00:00Z"})
+		requestContext, _ := structpb.NewStruct(map[string]any{"timestamp": "2024-01-01T00:00:00Z"})
 
 		result, err := mergePropertiesToContext(requestContext, nil, nil, nil)
 		require.NoError(t, err)
@@ -217,15 +217,15 @@ func TestMergePropertiesToContext(t *testing.T) {
 	})
 
 	t.Run("handles_complex_nested_types", func(t *testing.T) {
-		subjectProps, _ := structpb.NewStruct(map[string]interface{}{
-			"tags": []interface{}{"vip", "verified"},
-			"profile": map[string]interface{}{
+		subjectProps, _ := structpb.NewStruct(map[string]any{
+			"tags": []any{"vip", "verified"},
+			"profile": map[string]any{
 				"display_name": "Alice Smith",
 			},
 		})
-		resourceProps, _ := structpb.NewStruct(map[string]interface{}{
-			"acl": []interface{}{
-				map[string]interface{}{"principal": "user:alice", "permission": "owner"},
+		resourceProps, _ := structpb.NewStruct(map[string]any{
+			"acl": []any{
+				map[string]any{"principal": "user:alice", "permission": "owner"},
 			},
 		})
 
@@ -237,25 +237,25 @@ func TestMergePropertiesToContext(t *testing.T) {
 		require.NotNil(t, result)
 
 		resultMap := result.AsMap()
-		tags, ok := resultMap["subject_tags"].([]interface{})
+		tags, ok := resultMap["subject_tags"].([]any)
 		require.True(t, ok)
-		require.Equal(t, []interface{}{"vip", "verified"}, tags)
+		require.Equal(t, []any{"vip", "verified"}, tags)
 
-		profile, ok := resultMap["subject_profile"].(map[string]interface{})
+		profile, ok := resultMap["subject_profile"].(map[string]any)
 		require.True(t, ok)
 		require.Equal(t, "Alice Smith", profile["display_name"])
 
-		acl, ok := resultMap["resource_acl"].([]interface{})
+		acl, ok := resultMap["resource_acl"].([]any)
 		require.True(t, ok)
 		require.Len(t, acl, 1)
 	})
 
 	t.Run("handles_null_and_empty_values", func(t *testing.T) {
-		subjectProps, _ := structpb.NewStruct(map[string]interface{}{
+		subjectProps, _ := structpb.NewStruct(map[string]any{
 			"department": "engineering",
 			"manager":    nil,
-			"roles":      []interface{}{},
-			"metadata":   map[string]interface{}{},
+			"roles":      []any{},
+			"metadata":   map[string]any{},
 		})
 
 		subject := &authzenv1.Subject{Type: "user", Id: "alice", Properties: subjectProps}
@@ -267,10 +267,10 @@ func TestMergePropertiesToContext(t *testing.T) {
 		resultMap := result.AsMap()
 		require.Equal(t, "engineering", resultMap["subject_department"])
 		require.Nil(t, resultMap["subject_manager"])
-		roles, ok := resultMap["subject_roles"].([]interface{})
+		roles, ok := resultMap["subject_roles"].([]any)
 		require.True(t, ok)
 		require.Empty(t, roles)
-		metadata, ok := resultMap["subject_metadata"].(map[string]interface{})
+		metadata, ok := resultMap["subject_metadata"].(map[string]any)
 		require.True(t, ok)
 		require.Empty(t, metadata)
 	})

--- a/pkg/server/batch_check_test.go
+++ b/pkg/server/batch_check_test.go
@@ -201,7 +201,7 @@ func TestBatchCheckFailsIfTooManyChecks(t *testing.T) {
 	require.NoError(t, err)
 
 	checks := make([]*openfgav1.BatchCheckItem, numChecks)
-	for i := 0; i < numChecks; i++ {
+	for i := range numChecks {
 		checks[i] = &openfgav1.BatchCheckItem{
 			TupleKey: &openfgav1.CheckRequestTupleKey{
 				Object:   "doc:doc1",

--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -335,7 +335,7 @@ func TestCheck_ShadowV2CheckGoroutine(t *testing.T) {
 }
 
 // fieldMap converts a slice of zap.Field into a map for easy lookup in assertions.
-func fieldMap(fields []zap.Field) map[string]interface{} {
+func fieldMap(fields []zap.Field) map[string]any {
 	enc := zapcore.NewMapObjectEncoder()
 	for _, f := range fields {
 		f.AddTo(enc)

--- a/pkg/server/commands/batch_check_command_test.go
+++ b/pkg/server/commands/batch_check_command_test.go
@@ -47,7 +47,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		cmd := NewBatchCheckCommand(NewCheckCommand(ds, mockCheckResolver, ts))
 		numChecks := int(maxChecks)
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			checks[i] = &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					Object:   fmt.Sprintf("doc:doc%d", i),
@@ -88,7 +88,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		numChecks := 10
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
 		var ids []string
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			correlationID := fmt.Sprintf("fakeid%d", i)
 			ids = append(ids, correlationID)
 			checks[i] = &openfgav1.BatchCheckItem{
@@ -133,7 +133,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		)
 		numChecks := int(maxChecks) + 1
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			checks[i] = &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					Object:   "doc:doc1",
@@ -176,7 +176,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		cmd := NewBatchCheckCommand(NewCheckCommand(ds, mockCheckResolver, ts))
 		numChecks := 2
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			checks[i] = &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					Object:   "doc:doc1",
@@ -205,7 +205,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		cmd := NewBatchCheckCommand(NewCheckCommand(ds, mockCheckResolver, ts))
 		numChecks := 3
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			checks[i] = &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					Object:   "doc:doc1",
@@ -234,7 +234,7 @@ func TestBatchCheckCommand(t *testing.T) {
 		cmd := NewBatchCheckCommand(NewCheckCommand(ds, mockCheckResolver, ts))
 		numChecks := 3
 		checks := make([]*openfgav1.BatchCheckItem, numChecks)
-		for i := 0; i < numChecks; i++ {
+		for i := range numChecks {
 			checks[i] = &openfgav1.BatchCheckItem{
 				TupleKey: &openfgav1.CheckRequestTupleKey{
 					Object:   "doc:doc1",
@@ -434,7 +434,7 @@ func TestGenerateCacheKeyFromCheck(t *testing.T) {
 	}
 
 	t.Run("context_affects_key", func(t *testing.T) {
-		ctx, err := structpb.NewStruct(map[string]interface{}{
+		ctx, err := structpb.NewStruct(map[string]any{
 			"ip_address": "10.0.0.1",
 		})
 		require.NoError(t, err)
@@ -453,13 +453,13 @@ func TestGenerateCacheKeyFromCheck(t *testing.T) {
 		// A single-element list whose string contains a comma should NOT
 		// collide with a multi-element list whose elements are separated
 		// by that same comma.
-		singleElement, err := structpb.NewStruct(map[string]interface{}{
-			"roles": []interface{}{"editor,viewer"},
+		singleElement, err := structpb.NewStruct(map[string]any{
+			"roles": []any{"editor,viewer"},
 		})
 		require.NoError(t, err)
 
-		twoElements, err := structpb.NewStruct(map[string]interface{}{
-			"roles": []interface{}{"editor", "viewer"},
+		twoElements, err := structpb.NewStruct(map[string]any{
+			"roles": []any{"editor", "viewer"},
 		})
 		require.NoError(t, err)
 
@@ -695,7 +695,7 @@ func BenchmarkBatchCheckCommand(b *testing.B) {
 	)
 
 	checks := make([]*openfgav1.BatchCheckItem, maxChecks)
-	for i := 0; i < maxChecks; i++ {
+	for i := range maxChecks {
 		correlationID := fmt.Sprintf("fakeid%d", i)
 		checks[i] = &openfgav1.BatchCheckItem{
 			TupleKey: &openfgav1.CheckRequestTupleKey{

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -3,7 +3,7 @@ package commands
 import (
 	"context"
 	"errors"
-	"sort"
+	"slices"
 	"strconv"
 	"testing"
 	"time"
@@ -537,9 +537,7 @@ func TestListObjectsSeqError(t *testing.T) {
 
 func reportLatencies(b *testing.B, latencies []time.Duration) {
 	// Sort latencies ascending
-	sort.Slice(latencies, func(i, j int) bool {
-		return latencies[i] < latencies[j]
-	})
+	slices.Sort(latencies)
 
 	p95 := latencies[len(latencies)*95/100]
 	p99 := latencies[len(latencies)*99/100]

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -855,7 +855,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param": true}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param": true}),
 			},
 			model: model,
 			tuples: []*openfgav1.TupleKey{
@@ -875,7 +875,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param": false}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param": false}),
 			},
 			model: model,
 			tuples: []*openfgav1.TupleKey{
@@ -896,7 +896,7 @@ func TestListUsersConditions(t *testing.T) {
 						Relation: "member",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param": true}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param": true}),
 			},
 			model: `
 				model
@@ -934,7 +934,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param": true}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param": true}),
 			},
 			model: `
 				model
@@ -972,7 +972,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param": true}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param": true}),
 			},
 			model: `
 				model
@@ -1009,7 +1009,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{}),
+				Context: testutils.MustNewStruct(t, map[string]any{}),
 			},
 			model: `
 				model
@@ -1044,7 +1044,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": 5}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param1": 5}),
 			},
 			model: `
 				model
@@ -1078,7 +1078,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": 5, "param2": 10}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param1": 5, "param2": 10}),
 			},
 			model: `
 				model
@@ -1112,7 +1112,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"x": "1.79769313486231570814527423731704356798070e+309"}),
+				Context: testutils.MustNewStruct(t, map[string]any{"x": "1.79769313486231570814527423731704356798070e+309"}),
 			},
 			model: `
 				model
@@ -1141,7 +1141,7 @@ func TestListUsersConditions(t *testing.T) {
 						Type: "user",
 					},
 				},
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"x": "1.79769313486231570814527423731704356798070e+309"}),
+				Context: testutils.MustNewStruct(t, map[string]any{"x": "1.79769313486231570814527423731704356798070e+309"}),
 			},
 			model: `
 				model

--- a/pkg/server/commands/reverseexpand/reverse_expand_test.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_test.go
@@ -112,7 +112,7 @@ func TestReverseExpandRespectsContextCancellation(t *testing.T) {
 	defer mockController.Finish()
 
 	var tuples []*openfgav1.Tuple
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		obj := fmt.Sprintf("document:%s", strconv.Itoa(i))
 		tuples = append(tuples, &openfgav1.Tuple{Key: tuple.NewTupleKey(obj, "viewer", "user:maria")})
 	}
@@ -251,7 +251,7 @@ func TestReverseExpandErrorInTuples(t *testing.T) {
 	defer mockController.Finish()
 
 	var tuples []*openfgav1.Tuple
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		obj := fmt.Sprintf("document:%s", strconv.Itoa(i))
 		tuples = append(tuples, &openfgav1.Tuple{Key: tuple.NewTupleKey(obj, "viewer", "user:maria")})
 	}
@@ -323,7 +323,7 @@ func TestReverseExpandSendsAllErrorsThroughChannel(t *testing.T) {
 
 	mockDatastore := mocks.NewMockSlowDataStorage(memory.New(), 1*time.Second)
 
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(1*time.Nanosecond))
 		t.Cleanup(cancel)
 

--- a/pkg/server/commands/v2breaking/v2breaking.go
+++ b/pkg/server/commands/v2breaking/v2breaking.go
@@ -138,7 +138,7 @@ func ExpandReason(typesys *typesystem.TypeSystem, targetObjectType, targetRelati
 // ReasonComputedUsersetSelfObj if any ComputedUserset leaf is present, or
 // ReasonTTUUserset if any TupleToUserset node is present, or "".
 func computedUsersetOrTTUReason(rewrite *openfgav1.Userset) string {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		switch r.GetUserset().(type) {
 		case *openfgav1.Userset_ComputedUserset:
 			return ReasonComputedUsersetSelfObj
@@ -388,7 +388,7 @@ func treeHasAliasedUserset(typesys *typesystem.TypeSystem, targetObjectType, tar
 // rewriteContainsComputedUserset reports whether any ComputedUserset leaf in
 // the rewrite tree references the given relation name.
 func rewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		if cu, ok := r.GetUserset().(*openfgav1.Userset_ComputedUserset); ok && cu.ComputedUserset.GetRelation() == relation {
 			return true
 		}
@@ -402,7 +402,7 @@ func rewriteContainsComputedUserset(rewrite *openfgav1.Userset, relation string)
 // tupleset relation on the target object type is directly related to
 // userObjectType.
 func rewriteContainsTTUForUser(ts *typesystem.TypeSystem, targetObjectType string, rewrite *openfgav1.Userset, userObjectType, userRelation string) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		ttu, ok := r.GetUserset().(*openfgav1.Userset_TupleToUserset)
 		if !ok || ttu.TupleToUserset.GetComputedUserset().GetRelation() != userRelation {
 			return nil
@@ -449,7 +449,7 @@ func usersetAliasesTargetRelation(ts *typesystem.TypeSystem, targetObjectType, t
 // rewriteContainsDifference reports whether the rewrite tree contains any
 // Userset_Difference node.
 func rewriteContainsDifference(rewrite *openfgav1.Userset) bool {
-	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, _ := typesystem.WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		if _, ok := r.GetUserset().(*openfgav1.Userset_Difference); ok {
 			return true
 		}

--- a/pkg/server/commands/write_assertions_test.go
+++ b/pkg/server/commands/write_assertions_test.go
@@ -38,7 +38,7 @@ func TestWriteAssertions(t *testing.T) {
 		contextualTuples := make([]*openfgav1.TupleKey, 0, ctxTuples)
 		assertions := make([]*openfgav1.Assertion, 0, numAssertions)
 
-		for ct := 0; ct < ctxTuples; ct++ {
+		for ct := range ctxTuples {
 			contextualTuples = append(contextualTuples, &openfgav1.TupleKey{
 				Object:   "document:" + strings.Repeat(strconv.Itoa(ct), maxBytesPerObject-len("document:")),
 				Relation: longRelationName,
@@ -46,7 +46,7 @@ func TestWriteAssertions(t *testing.T) {
 			})
 		}
 
-		for a := 0; a < numAssertions; a++ {
+		for a := range numAssertions {
 			assertions = append(assertions, &openfgav1.Assertion{
 				TupleKey: &openfgav1.AssertionTupleKey{
 					Object:   "document:" + strings.Repeat(strconv.Itoa(a), maxBytesPerObject-len("document:")),
@@ -55,7 +55,7 @@ func TestWriteAssertions(t *testing.T) {
 				},
 				Expectation:      true,
 				ContextualTuples: contextualTuples,
-				Context: testutils.MustNewStruct(t, map[string]interface{}{
+				Context: testutils.MustNewStruct(t, map[string]any{
 					"x": 10,
 				}),
 			})
@@ -107,8 +107,8 @@ func TestWriteAssertions(t *testing.T) {
 		modelID := ulid.Make().String()
 		maxBytesPerContextField := 512
 
-		fgaContext := map[string]interface{}{}
-		for index := 0; index < 100; index++ {
+		fgaContext := map[string]any{}
+		for index := range 100 {
 			key := strings.Repeat("a", maxBytesPerContextField) + strconv.Itoa(index)
 			fgaContext[key] = key
 		}
@@ -288,7 +288,7 @@ func TestWriteAssertions(t *testing.T) {
 					{
 						TupleKey:    tuple.NewAssertionTupleKey("repo:test", "can_read", "user:elbuo"),
 						Expectation: false,
-						Context: testutils.MustNewStruct(t, map[string]interface{}{
+						Context: testutils.MustNewStruct(t, map[string]any{
 							"x": 10,
 						}),
 					},
@@ -310,7 +310,7 @@ func TestWriteAssertions(t *testing.T) {
 						Expectation: false,
 						ContextualTuples: []*openfgav1.TupleKey{
 							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
-								testutils.MustNewStruct(t, map[string]interface{}{"x": 0})),
+								testutils.MustNewStruct(t, map[string]any{"x": 0})),
 						},
 					},
 				},
@@ -343,7 +343,7 @@ func TestWriteAssertions(t *testing.T) {
 						Expectation: false,
 						ContextualTuples: []*openfgav1.TupleKey{
 							tuple.NewTupleKeyWithCondition("repo:test", "reader", "user:elbuo", "condX",
-								testutils.MustNewStruct(t, map[string]interface{}{"unknownparam": 0})),
+								testutils.MustNewStruct(t, map[string]any{"unknownparam": 0})),
 						},
 					},
 				},

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -27,7 +27,7 @@ type writeOptionsMatcher struct {
 	expectedOnMissingDelete   storage.OnMissingDelete
 }
 
-func (w *writeOptionsMatcher) Matches(x interface{}) bool {
+func (w *writeOptionsMatcher) Matches(x any) bool {
 	opts, ok := x.([]storage.TupleWriteOption)
 	if !ok || len(opts) != 2 {
 		return false
@@ -52,7 +52,7 @@ func TestWriteCommand(t *testing.T) {
 	)
 
 	items := make([]*openfgav1.TupleKeyWithoutCondition, maxTuplesInWriteOperation+1)
-	for i := 0; i < maxTuplesInWriteOperation+1; i++ {
+	for i := range maxTuplesInWriteOperation + 1 {
 		items[i] = &openfgav1.TupleKeyWithoutCondition{
 			Object:   fmt.Sprintf("document:%d", i),
 			Relation: "viewer",
@@ -87,8 +87,8 @@ func TestWriteCommand(t *testing.T) {
 		param1 == 'ok'
 	}`)
 
-	contextStructGood := testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"})
-	contextStructBad := testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok", "param2": 1})
+	contextStructGood := testutils.MustNewStruct(t, map[string]any{"param1": "ok"})
+	contextStructBad := testutils.MustNewStruct(t, map[string]any{"param1": "ok", "param2": 1})
 	contextStructExceedsLimit := testutils.MustNewStruct(t, map[string]any{
 		"param1": testutils.CreateRandomString(config.DefaultWriteContextByteLimit + 1),
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
+	"slices"
 	"time"
 
 	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -573,7 +573,7 @@ func WithCacheTTLJitterPercentage(pct uint32) OpenFGAServiceV1Option {
 // WithRequestDurationByQueryHistogramBuckets sets the buckets used in labelling the requestDurationByQueryAndDispatchHistogram.
 func WithRequestDurationByQueryHistogramBuckets(buckets []uint) OpenFGAServiceV1Option {
 	return func(s *Server) {
-		sort.Slice(buckets, func(i, j int) bool { return buckets[i] < buckets[j] })
+		slices.Sort(buckets)
 		s.requestDurationByQueryHistogramBuckets = buckets
 	}
 }
@@ -581,7 +581,7 @@ func WithRequestDurationByQueryHistogramBuckets(buckets []uint) OpenFGAServiceV1
 // WithRequestDurationByDispatchCountHistogramBuckets sets the buckets used in labelling the requestDurationByQueryAndDispatchHistogram.
 func WithRequestDurationByDispatchCountHistogramBuckets(buckets []uint) OpenFGAServiceV1Option {
 	return func(s *Server) {
-		sort.Slice(buckets, func(i, j int) bool { return buckets[i] < buckets[j] })
+		slices.Sort(buckets)
 		s.requestDurationByDispatchCountHistogramBuckets = buckets
 	}
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -727,7 +727,7 @@ func TestThreeProngThroughVariousLayers(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			tupleKeys := []*openfgav1.CheckRequestTupleKey{
 				tuple.NewCheckRequestTupleKey("module:a", "viewer", "user:anne"),
@@ -917,7 +917,7 @@ func TestReleasesConnections(t *testing.T) {
 
 	t.Run("list_objects", func(t *testing.T) {
 		tuples := make([]*openfgav1.TupleKey, 0, numTuples)
-		for i := 0; i < numTuples; i++ {
+		for i := range numTuples {
 			tk := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "editor", "user:jon")
 
 			tuples = append(tuples, tk)
@@ -953,7 +953,7 @@ func TestReleasesConnections(t *testing.T) {
 
 	t.Run("list_users", func(t *testing.T) {
 		tuples := make([]*openfgav1.TupleKey, 0, numTuples)
-		for i := 0; i < numTuples; i++ {
+		for i := range numTuples {
 			tk := tuple.NewTupleKey("document:1", "editor", fmt.Sprintf("user:%d", i))
 
 			tuples = append(tuples, tk)

--- a/pkg/server/test/benchmarks/check.go
+++ b/pkg/server/test/benchmarks/check.go
@@ -54,7 +54,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 						define member: [user]`,
 			tupleGenerator: func() []*openfgav1.TupleKey {
 				var tuples []*openfgav1.TupleKey
-				for i := 0; i < 1000; i++ { // add user:anne to many teams
+				for i := range 1000 { // add user:anne to many teams
 					tuples = append(tuples, &openfgav1.TupleKey{
 						Object:   fmt.Sprintf("team:%d", i),
 						Relation: "member",
@@ -94,7 +94,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 						define member: [user]`,
 			tupleGenerator: func() []*openfgav1.TupleKey {
 				var tuples []*openfgav1.TupleKey
-				for i := 0; i < 1000; i++ { // add user:anne to many teams
+				for i := range 1000 { // add user:anne to many teams
 					tuples = append(tuples, &openfgav1.TupleKey{
 						Object:   fmt.Sprintf("team:%d", i),
 						Relation: "member",
@@ -307,7 +307,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 				Object: "doc:x", Relation: "viewer", User: "user:maria",
 			},
 			contextGenerator: func() *structpb.Struct {
-				s, err := structpb.NewStruct(map[string]interface{}{
+				s, err := structpb.NewStruct(map[string]any{
 					"p": "secret",
 				})
 				if err != nil {
@@ -337,7 +337,7 @@ func BenchmarkCheck(b *testing.B, ds storage.OpenFGADatastore) {
 				}
 			},
 			contextGenerator: func() *structpb.Struct {
-				s, err := structpb.NewStruct(map[string]interface{}{
+				s, err := structpb.NewStruct(map[string]any{
 					"b":  true,
 					"s":  "s",
 					"i":  1,
@@ -431,7 +431,7 @@ func benchmarkCheckWithBypassUsersetReads(b *testing.B, ds storage.OpenFGADatast
 
 	// add user to many usersets according to model A
 	var tuples []*openfgav1.TupleKey
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		tuples = append(tuples, &openfgav1.TupleKey{
 			Object:   fmt.Sprintf("group:%d", i),
 			Relation: "member",

--- a/pkg/server/test/benchmarks/list_objects.go
+++ b/pkg/server/test/benchmarks/list_objects.go
@@ -47,7 +47,7 @@ func setupListObjectsBenchmark(b *testing.B, ds storage.OpenFGADatastore, storeI
 	require.NoError(b, err)
 
 	numberObjectsAccesible := 0
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		var tuples []*openfgav1.TupleKey
 
 		for j := 0; j < ds.MaxTuplesPerWrite(); j++ {

--- a/pkg/server/test/benchmarks/list_users.go
+++ b/pkg/server/test/benchmarks/list_users.go
@@ -42,7 +42,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 			tupleGenerator: func() []*openfgav1.TupleKey {
 				// same as the next benchmark, so that later we can compare times.
 				var tuples []*openfgav1.TupleKey
-				for j := 0; j < 1000; j++ {
+				for range 1000 {
 					user := "user:" + ulid.Make().String()
 					// one document accessible by many users
 					tuples = append(tuples, tuple.NewTupleKey("document:1", "viewer", user))
@@ -73,7 +73,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 			tupleGenerator: func() []*openfgav1.TupleKey {
 				// same as the previous benchmark, so that later we can compare times.
 				var tuples []*openfgav1.TupleKey
-				for j := 0; j < 1000; j++ {
+				for range 1000 {
 					user := "user:" + ulid.Make().String()
 					folder := "folder:" + ulid.Make().String()
 					// one document accessible by many users, but this benchmark will incur more reads, so it should take longer and result in less iterations
@@ -110,7 +110,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				}`,
 			tupleGenerator: func() []*openfgav1.TupleKey {
 				var tuples []*openfgav1.TupleKey
-				for j := 0; j < 1000; j++ {
+				for range 1000 {
 					// one document accessible by many users
 					user := "user:" + ulid.Make().String()
 					tuples = append(tuples, tuple.NewTupleKeyWithCondition("document:1", "viewer", user, "condTrue", nil))
@@ -121,7 +121,7 @@ func BenchmarkListUsers(b *testing.B, ds storage.OpenFGADatastore) {
 				Object:      &openfgav1.Object{Type: "document", Id: "1"},
 				Relation:    "can_view_conditional",
 				UserFilters: []*openfgav1.UserTypeFilter{{Type: "user"}},
-				Context:     testutils.MustNewStruct(b, map[string]interface{}{"param": true}),
+				Context:     testutils.MustNewStruct(b, map[string]any{"param": true}),
 			},
 			inputConfigMaxResults: 0, // infinite
 			expectedResults:       1000,

--- a/pkg/server/test/benchmarks/read_changes.go
+++ b/pkg/server/test/benchmarks/read_changes.go
@@ -34,9 +34,9 @@ func BenchmarkReadChanges(b *testing.B, ds storage.OpenFGADatastore) {
 	require.NoError(b, err)
 
 	const numTupleSet = 500
-	for i := 0; i < numTupleSet; i++ {
+	for i := range numTupleSet {
 		tuples := make([]*openfgav1.TupleKey, 40)
-		for j := 0; j < len(tuples); j++ {
+		for j := range tuples {
 			tuples[j] = tuple.NewTupleKey("doc:"+strconv.Itoa(i)+"_"+strconv.Itoa(j), "viewer", "user:maria")
 		}
 		err := ds.Write(ctx, storeID, nil, tuples)

--- a/pkg/server/test/list_objects.go
+++ b/pkg/server/test/list_objects.go
@@ -246,7 +246,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:1",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 					},
 				},
 				{
@@ -255,7 +255,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:2",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "notok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "notok"}),
 					},
 				},
 			},
@@ -293,7 +293,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:1",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 						},
 					},
 					{
@@ -302,7 +302,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:2",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "notok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "notok"}),
 						},
 					},
 				},
@@ -332,7 +332,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:1",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "notok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "notok"}),
 					},
 				},
 				{
@@ -341,7 +341,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:2",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "notok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "notok"}),
 					},
 				},
 			},
@@ -356,7 +356,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:1",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 						},
 					},
 					{
@@ -365,7 +365,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:2",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 						},
 					},
 				},
@@ -395,7 +395,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:1",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 					},
 				},
 				{
@@ -404,14 +404,14 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 					Object:   "document:2",
 					Condition: &openfgav1.RelationshipCondition{
 						Name:    "condition1",
-						Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+						Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 					},
 				},
 			},
 			user:       "user:anne",
 			objectType: "document",
 			relation:   "viewer",
-			context:    testutils.MustNewStruct(t, map[string]interface{}{"param2": "ok"}),
+			context:    testutils.MustNewStruct(t, map[string]any{"param2": "ok"}),
 			contextualTuples: &openfgav1.ContextualTupleKeys{
 				TupleKeys: []*openfgav1.TupleKey{
 					{
@@ -420,7 +420,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:3",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 						},
 					},
 					{
@@ -429,7 +429,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 						Object:   "document:4",
 						Condition: &openfgav1.RelationshipCondition{
 							Name:    "condition1",
-							Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+							Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 						},
 					},
 				},
@@ -466,7 +466,7 @@ func runListObjectsTests(t *testing.T, ds storage.OpenFGADatastore, passedInOpts
 			user:                   "user:jon",
 			objectType:             "document",
 			relation:               "viewer",
-			context:                testutils.MustNewStruct(t, map[string]interface{}{"x": 50}),
+			context:                testutils.MustNewStruct(t, map[string]any{"x": 50}),
 			minimumResultsExpected: 1,
 			allResults:             []string{"document:1"},
 			useCheckCache:          false,

--- a/pkg/storage/cache/keys/pool_test.go
+++ b/pkg/storage/cache/keys/pool_test.go
@@ -120,9 +120,7 @@ func TestPooledBuilder_ConcurrentGetAndClose(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range iterations {
 				b := GetBuilder()
 				b.EncodeString(fmt.Sprintf("goroutine-%d", j))
@@ -130,7 +128,7 @@ func TestPooledBuilder_ConcurrentGetAndClose(t *testing.T) {
 				assert.NotEmpty(t, key.String())
 				b.Close()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }
@@ -141,16 +139,14 @@ func TestPooledDigest_ConcurrentGetAndClose(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range iterations {
 				d := GetDigest()
 				_, _ = fmt.Fprintf(d, "data-%d", j)
 				assert.NotZero(t, d.Sum64())
 				d.Close()
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/storage/cache/keys/xtypes.go
+++ b/pkg/storage/cache/keys/xtypes.go
@@ -57,8 +57,8 @@ func (pbvalue *PbValue) WriteTo(kb *Builder) {
 		case *structpb.Value_ListValue:
 			vals := val.ListValue.GetValues()
 			kb.EncodeArrayHeader(len(vals))
-			for i := len(vals) - 1; i >= 0; i-- {
-				stack = append(stack, frame{value: vals[i]})
+			for _, v := range slices.Backward(vals) {
+				stack = append(stack, frame{value: v})
 			}
 		case *structpb.Value_StructValue:
 			fields := val.StructValue.GetFields()
@@ -69,11 +69,11 @@ func (pbvalue *PbValue) WriteTo(kb *Builder) {
 			slices.Sort(keys)
 
 			kb.EncodeMapHeader(len(keys))
-			for i := len(keys) - 1; i >= 0; i-- {
+			for _, v := range slices.Backward(keys) {
 				stack = append(stack, frame{
-					key:    keys[i],
+					key:    v,
 					hasKey: true,
-					value:  fields[keys[i]],
+					value:  fields[v],
 				})
 			}
 		}

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -213,7 +213,7 @@ func TestJitteredTTL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				result := JitteredTTL(tt.baseTTL, tt.jitterPercentage)
 				require.GreaterOrEqual(t, result, tt.expectedMin, "result %v is less than minimum %v", result, tt.expectedMin)
 				require.LessOrEqual(t, result, tt.expectedMax, "result %v is greater than maximum %v", result, tt.expectedMax)
@@ -225,7 +225,7 @@ func TestJitteredTTL(t *testing.T) {
 		baseTTL := 10 * time.Second
 		jitterPct := uint32(50)
 		results := make(map[time.Duration]struct{})
-		for i := 0; i < 1000; i++ {
+		for range 1000 {
 			results[JitteredTTL(baseTTL, jitterPct)] = struct{}{}
 		}
 		require.Greater(t, len(results), 1, "expected variation in jittered TTL values")
@@ -262,15 +262,15 @@ func BenchmarkInvariantCacheKeyWithContextualTuples(b *testing.B) {
 // BenchmarkInvariantCacheKeyWithContext measures the cost of computing the
 // invariant cache key for a representative request context.
 func BenchmarkInvariantCacheKeyWithContext(b *testing.B) {
-	contextStruct, err := structpb.NewStruct(map[string]interface{}{
+	contextStruct, err := structpb.NewStruct(map[string]any{
 		"boolKey":   true,
 		"stringKey": "hello",
 		"numberKey": 1.2,
 		"nullKey":   nil,
-		"structKey": map[string]interface{}{
+		"structKey": map[string]any{
 			"key1": "value1",
 		},
-		"listKey": []interface{}{"item1", "item2"},
+		"listKey": []any{"item1", "item2"},
 	})
 	require.NoError(b, err)
 

--- a/pkg/storage/keys_test.go
+++ b/pkg/storage/keys_test.go
@@ -715,9 +715,7 @@ func TestCheckCacheKey_ConcurrentUse(t *testing.T) {
 	errs := make(chan keys.Key, goroutines*itersPerG)
 	var wg sync.WaitGroup
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range itersPerG {
 				got := CheckCacheKey("store-x", "doc:1", "viewer", "user:alice", 7)
 				if got != want {
@@ -725,7 +723,7 @@ func TestCheckCacheKey_ConcurrentUse(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -269,10 +269,7 @@ func (s *MemoryBackend) ReadChanges(ctx context.Context, store string, filter st
 		slices.Reverse(allChanges)
 	}
 
-	to := pageSize
-	if len(allChanges) < to {
-		to = len(allChanges)
-	}
+	to := min(len(allChanges), pageSize)
 	if to == 0 {
 		return nil, "", storage.ErrNotFound
 	}

--- a/pkg/storage/memory/memory_test.go
+++ b/pkg/storage/memory/memory_test.go
@@ -110,7 +110,7 @@ func TestStaticTupleIteratorNoRace(t *testing.T) {
 		const numIterator = 50
 
 		tupleRecords := make([]*storage.TupleRecord, numIterator)
-		for i := 0; i < numIterator; i++ {
+		for i := range numIterator {
 			tupleRecords[i] = &storage.TupleRecord{
 				Store:            "store",
 				ObjectType:       "document",
@@ -130,7 +130,7 @@ func TestStaticTupleIteratorNoRace(t *testing.T) {
 
 		var wg errgroup.Group
 
-		for i := 0; i < numIterator; i++ {
+		for range numIterator {
 			wg.Go(func() error {
 				_, err := iter.Head(context.Background())
 				return err
@@ -138,7 +138,7 @@ func TestStaticTupleIteratorNoRace(t *testing.T) {
 		}
 		// important that when we call next, we will have 1 less
 		// element because we don't want to be done.
-		for i := 0; i < numIterator-1; i++ {
+		for range numIterator - 1 {
 			wg.Go(func() error {
 				_, err := iter.Next(context.Background())
 				return err

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -813,7 +813,7 @@ func (s *Datastore) IsReady(ctx context.Context) (storage.ReadinessStatus, error
 
 // HandleSQLError processes an SQL error and converts it into a more
 // specific error type based on the nature of the SQL error.
-func HandleSQLError(err error, args ...interface{}) error {
+func HandleSQLError(err error, args ...any) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
 	}

--- a/pkg/storage/mysql/mysql_test.go
+++ b/pkg/storage/mysql/mysql_test.go
@@ -332,7 +332,7 @@ func TestMySQLDatastore_ReadPageWithUserFiltering(t *testing.T) {
 
 	// Create multiple tuples with same user type for pagination testing
 	var tuples []*openfgav1.TupleKey
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tuples = append(tuples, &openfgav1.TupleKey{
 			Object:   "doc:group1",
 			Relation: "viewer",

--- a/pkg/storage/postgres/pgxpool_iter_query.go
+++ b/pkg/storage/postgres/pgxpool_iter_query.go
@@ -13,7 +13,7 @@ import (
 
 // PgxQuery interface allows Query that returns pgx.Rows.
 type PgxQuery interface {
-	Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 }
 
 // PgxExec interface allows pgx Exec functionality.
@@ -24,14 +24,14 @@ type PgxExec interface {
 // SQLBuilder represents any SQL statement builder that can generate
 // SQL strings with parameterized arguments.
 type SQLBuilder interface {
-	ToSql() (string, []interface{}, error)
+	ToSql() (string, []any, error)
 }
 
 // PgxTxnIterQuery is a helper to run queries using pgxpool when used in sqlcommon iterator.
 type PgxTxnIterQuery struct {
 	txn   PgxQuery
 	query string
-	args  []interface{}
+	args  []any
 }
 
 var _ sqlcommon.SQLIteratorRowGetter = (*PgxTxnIterQuery)(nil)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -441,10 +441,7 @@ func selectAllExistingRowsForUpdate(ctx context.Context,
 	existing := make(map[string]*openfgav1.Tuple, total)
 
 	for start := 0; start < total; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > total {
-			end = total
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, total)
 		keys := lockKeys[start:end]
 
 		if err := selectExistingRowsForWrite(ctx, stbl, txn, store, keys, existing); err != nil {
@@ -459,10 +456,7 @@ func executeDeleteTuples(ctx context.Context, txn PgxExec, store string, deleteC
 	stbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 	for start, totalDeletes := 0, len(deleteConditions); start < totalDeletes; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalDeletes {
-			end = totalDeletes
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalDeletes)
 
 		deleteConditionsBatch := deleteConditions[start:end]
 
@@ -488,14 +482,11 @@ func executeDeleteTuples(ctx context.Context, txn PgxExec, store string, deleteC
 }
 
 // For the prepared writeItems, execute insert writeItems.
-func executeWriteTuples(ctx context.Context, txn PgxExec, writeItems [][]interface{}) error {
+func executeWriteTuples(ctx context.Context, txn PgxExec, writeItems [][]any) error {
 	stbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 	for start, totalWrites := 0, len(writeItems); start < totalWrites; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalWrites {
-			end = totalWrites
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalWrites)
 
 		writesBatch := writeItems[start:end]
 
@@ -537,13 +528,10 @@ func executeWriteTuples(ctx context.Context, txn PgxExec, writeItems [][]interfa
 	return nil
 }
 
-func executeInsertChanges(ctx context.Context, txn PgxExec, changeLogItems [][]interface{}) error {
+func executeInsertChanges(ctx context.Context, txn PgxExec, changeLogItems [][]any) error {
 	stbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 	for start, totalItems := 0, len(changeLogItems); start < totalItems; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalItems {
-			end = totalItems
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalItems)
 
 		changeLogBatch := changeLogItems[start:end]
 
@@ -1379,7 +1367,7 @@ func (s *Datastore) IsReady(ctx context.Context) (storage.ReadinessStatus, error
 //   - [storage.ErrInvalidWriteInput] — on a duplicate-key violation when a [openfgav1.TupleKey] is provided as args[0]
 //   - [storage.ErrCollision] — on a duplicate-key violation with no tuple key argument
 //   - a wrapped "sql error: ..." — for all other unexpected infrastructure errors
-func HandleSQLError(err error, args ...interface{}) error {
+func HandleSQLError(err error, args ...any) error {
 	if errors.Is(err, sql.ErrNoRows) || errors.Is(err, pgx.ErrNoRows) {
 		return storage.ErrNotFound
 	}

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -1078,8 +1078,8 @@ func TestReadFilterWithConditions(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 
-	var writeItems [][]interface{}
-	writeItems = append(writeItems, []interface{}{
+	var writeItems [][]any
+	writeItems = append(writeItems, []any{
 		"store",
 		"folder",
 		"2021-budget",
@@ -1092,7 +1092,7 @@ func TestReadFilterWithConditions(t *testing.T) {
 		sq.Expr("NOW()"),
 	})
 
-	writeItems = append(writeItems, []interface{}{
+	writeItems = append(writeItems, []any{
 		"store",
 		"folder",
 		"2022-budget",
@@ -1743,8 +1743,8 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag("INSERT 1"), nil)
 
-		writeItems := [][]interface{}{}
-		writeItems = append(writeItems, []interface{}{
+		writeItems := [][]any{}
+		writeItems = append(writeItems, []any{
 			"storeID",
 			"objectType1",
 			"objectID1",
@@ -1765,8 +1765,8 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("duplicate key value"))
 
-		writeItems := [][]interface{}{}
-		writeItems = append(writeItems, []interface{}{
+		writeItems := [][]any{}
+		writeItems = append(writeItems, []any{
 			"storeID",
 			"objectType1",
 			"objectID1",
@@ -1787,8 +1787,8 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("error"))
 
-		writeItems := [][]interface{}{}
-		writeItems = append(writeItems, []interface{}{
+		writeItems := [][]any{}
+		writeItems = append(writeItems, []any{
 			"storeID",
 			"objectType1",
 			"objectID1",
@@ -1819,8 +1819,8 @@ func TestExecuteInsertChanges(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag("INSERT 1"), nil)
 
-		writeItems := [][]interface{}{}
-		writeItems = append(writeItems, []interface{}{
+		writeItems := [][]any{}
+		writeItems = append(writeItems, []any{
 			"storeID",
 			"objectType1",
 			"objectID1",
@@ -1842,8 +1842,8 @@ func TestExecuteInsertChanges(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("error"))
 
-		writeItems := [][]interface{}{}
-		writeItems = append(writeItems, []interface{}{
+		writeItems := [][]any{}
+		writeItems = append(writeItems, []any{
 			"storeID",
 			"objectType1",
 			"objectID1",

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -578,7 +578,7 @@ type DBInfo struct {
 	HandleSQLError errorHandlerFn
 }
 
-type errorHandlerFn func(error, ...interface{}) error
+type errorHandlerFn func(error, ...any) error
 
 // NewDBInfo constructs a [DBInfo] object.
 func NewDBInfo(stbl sq.StatementBuilderType, errorHandler errorHandlerFn, dialect string) *DBInfo {
@@ -658,12 +658,12 @@ func MakeTupleLockKeys(deletes storage.Deletes, writes storage.Writes) []TupleLo
 }
 
 // BuildRowConstructorIN builds "((?,?,?,?,?),(?,?,?,?,?),...)" and arg list for row-constructor IN.
-func BuildRowConstructorIN(keys []TupleLockKey) (string, []interface{}) {
+func BuildRowConstructorIN(keys []TupleLockKey) (string, []any) {
 	if len(keys) == 0 {
 		return "", nil
 	}
 	var sb strings.Builder
-	args := make([]interface{}, 0, len(keys)*5)
+	args := make([]any, 0, len(keys)*5)
 	sb.WriteByte('(')
 	for i, k := range keys {
 		if i > 0 {
@@ -708,8 +708,8 @@ func selectExistingRowsForWrite(ctx context.Context, dbInfo *DBInfo, store strin
 func GetDeleteWriteChangelogItems(
 	store string,
 	existing map[string]*openfgav1.Tuple,
-	writeData WriteData) (sq.Or, [][]interface{}, [][]interface{}, error) {
-	changeLogItems := make([][]interface{}, 0, len(writeData.Deletes)+len(writeData.Writes))
+	writeData WriteData) (sq.Or, [][]any, [][]any, error) {
+	changeLogItems := make([][]any, 0, len(writeData.Deletes)+len(writeData.Writes))
 
 	// ensures increasingly unique values within a single thread
 	entropy := ulid.DefaultEntropy()
@@ -753,7 +753,7 @@ func GetDeleteWriteChangelogItems(
 			"user_type":   tupleUtils.GetUserTypeFromUser(tk.GetUser()),
 		})
 
-		changeLogItems = append(changeLogItems, []interface{}{
+		changeLogItems = append(changeLogItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -767,7 +767,7 @@ func GetDeleteWriteChangelogItems(
 		})
 	}
 
-	writeItems := make([][]interface{}, 0, len(writeData.Writes))
+	writeItems := make([][]any, 0, len(writeData.Writes))
 
 	// 2. For writes
 	// a. If on_duplicate: error ( default behavior )
@@ -809,7 +809,7 @@ func GetDeleteWriteChangelogItems(
 			return nil, nil, nil, err
 		}
 
-		writeItems = append(writeItems, []interface{}{
+		writeItems = append(writeItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -822,7 +822,7 @@ func GetDeleteWriteChangelogItems(
 			sq.Expr("NOW()"),
 		})
 
-		changeLogItems = append(changeLogItems, []interface{}{
+		changeLogItems = append(changeLogItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -874,10 +874,7 @@ func Write(
 	// 3. If list compiled in step 2 is not empty, execute SELECT … FOR UPDATE statement
 
 	for start := 0; start < total; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > total {
-			end = total
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, total)
 		keys := lockKeys[start:end]
 
 		if err := selectExistingRowsForWrite(ctx, dbInfo, store, keys, txn, existing); err != nil {
@@ -892,10 +889,7 @@ func Write(
 	}
 
 	for start, totalDeletes := 0, len(deleteConditions); start < totalDeletes; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalDeletes {
-			end = totalDeletes
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalDeletes)
 
 		deleteConditionsBatch := deleteConditions[start:end]
 
@@ -919,10 +913,7 @@ func Write(
 	}
 
 	for start, totalWrites := 0, len(writeItems); start < totalWrites; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalWrites {
-			end = totalWrites
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalWrites)
 
 		writesBatch := writeItems[start:end]
 
@@ -960,10 +951,7 @@ func Write(
 
 	// 5. Execute INSERT changelog statements
 	for start, totalItems := 0, len(changeLogItems); start < totalItems; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalItems {
-			end = totalItems
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalItems)
 
 		changeLogBatch := changeLogItems[start:end]
 

--- a/pkg/storage/sqlcommon/sqlcommon_test.go
+++ b/pkg/storage/sqlcommon/sqlcommon_test.go
@@ -131,7 +131,7 @@ func TestGetDeleteWriteChangelogItems_OperationIsInt32(t *testing.T) {
 
 		opVal := changeLogItems[0][changelogOperationIndex]
 
-		assert.Equal(t, reflect.TypeOf(int32(0)), reflect.TypeOf(opVal),
+		assert.Equal(t, reflect.TypeFor[int32](), reflect.TypeOf(opVal),
 			"operation value must be int32, got %T", opVal)
 		assert.Equal(t, int32(openfgav1.TupleOperation_TUPLE_OPERATION_WRITE), opVal)
 	})
@@ -162,7 +162,7 @@ func TestGetDeleteWriteChangelogItems_OperationIsInt32(t *testing.T) {
 
 		opVal := changeLogItems[0][changelogOperationIndex]
 
-		assert.Equal(t, reflect.TypeOf(int32(0)), reflect.TypeOf(opVal),
+		assert.Equal(t, reflect.TypeFor[int32](), reflect.TypeOf(opVal),
 			"operation value must be int32, got %T", opVal)
 		assert.Equal(t, int32(openfgav1.TupleOperation_TUPLE_OPERATION_DELETE), opVal)
 	})
@@ -194,7 +194,7 @@ func TestGetDeleteWriteChangelogItems_OperationIsInt32(t *testing.T) {
 
 		for i, item := range changeLogItems {
 			opVal := item[changelogOperationIndex]
-			assert.Equal(t, reflect.TypeOf(int32(0)), reflect.TypeOf(opVal),
+			assert.Equal(t, reflect.TypeFor[int32](), reflect.TypeOf(opVal),
 				"changeLogItems[%d] operation must be int32, got %T", i, opVal)
 
 			intVal, ok := opVal.(int32)
@@ -252,7 +252,7 @@ func sqlIterQuerySampleCount(t *testing.T, successVal string) uint64 {
 }
 
 // identityErrHandler passes errors through unchanged (no translation).
-func identityErrHandler(err error, _ ...interface{}) error { return err }
+func identityErrHandler(err error, _ ...any) error { return err }
 
 func TestFetchBufferMetric(t *testing.T) {
 	t.Run("success_records_true_label", func(t *testing.T) {
@@ -274,7 +274,7 @@ func TestFetchBufferMetric(t *testing.T) {
 
 	t.Run("not_found_error_records_true_label", func(t *testing.T) {
 		// errHandler translates the raw error to the storage sentinel, as real backends do.
-		notFoundHandler := func(err error, _ ...interface{}) error { return storage.ErrNotFound }
+		notFoundHandler := func(err error, _ ...any) error { return storage.ErrNotFound }
 		iter := NewSQLTupleIterator(&stubRowGetter{err: errors.New("no rows")}, notFoundHandler)
 		before := sqlIterQuerySampleCount(t, "true")
 		err := iter.fetchBuffer(context.Background())

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -330,12 +330,12 @@ func makeTupleLockKeys(deletes storage.Deletes, writes storage.Writes) []tupleLo
 }
 
 // buildRowConstructorIN builds "((?,?,?,?,?,?,?),(?,?,?,?,?,?,?),...)" and arg list for row-constructor IN.
-func buildRowConstructorIN(keys []tupleLockKey) (string, []interface{}) {
+func buildRowConstructorIN(keys []tupleLockKey) (string, []any) {
 	if len(keys) == 0 {
 		return "", nil
 	}
 	var sb strings.Builder
-	args := make([]interface{}, 0, len(keys)*7)
+	args := make([]any, 0, len(keys)*7)
 	sb.WriteByte('(')
 	for i, k := range keys {
 		if i > 0 {
@@ -420,10 +420,7 @@ func (s *Datastore) write(
 	// 3. If list compiled in step 2 is not empty, execute SELECT … FOR UPDATE statement
 
 	for start := 0; start < total; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > total {
-			end = total
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, total)
 		keys := lockKeys[start:end]
 
 		if err = s.selectExistingRowsForWrite(ctx, store, keys, txn, existing); err != nil {
@@ -431,7 +428,7 @@ func (s *Datastore) write(
 		}
 	}
 
-	changeLogItems := make([][]interface{}, 0, len(deletes)+len(writes))
+	changeLogItems := make([][]any, 0, len(deletes)+len(writes))
 
 	// ensures increasingly unique values within a single thread
 	entropy := ulid.DefaultEntropy()
@@ -478,7 +475,7 @@ func (s *Datastore) write(
 			"user_type":        tupleUtils.GetUserTypeFromUser(tk.GetUser()),
 		})
 
-		changeLogItems = append(changeLogItems, []interface{}{
+		changeLogItems = append(changeLogItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -494,7 +491,7 @@ func (s *Datastore) write(
 		})
 	}
 
-	writeItems := make([][]interface{}, 0, len(writes))
+	writeItems := make([][]any, 0, len(writes))
 
 	// 5. For writes
 	// a. If on_duplicate: error ( default behavior )
@@ -537,7 +534,7 @@ func (s *Datastore) write(
 			return err
 		}
 
-		writeItems = append(writeItems, []interface{}{
+		writeItems = append(writeItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -552,7 +549,7 @@ func (s *Datastore) write(
 			sq.Expr("datetime('subsec')"),
 		})
 
-		changeLogItems = append(changeLogItems, []interface{}{
+		changeLogItems = append(changeLogItems, []any{
 			store,
 			objectType,
 			objectID,
@@ -569,10 +566,7 @@ func (s *Datastore) write(
 	}
 
 	for start, totalDeletes := 0, len(deleteConditions); start < totalDeletes; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalDeletes {
-			end = totalDeletes
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalDeletes)
 
 		deleteConditionsBatch := deleteConditions[start:end]
 
@@ -596,10 +590,7 @@ func (s *Datastore) write(
 	}
 
 	for start, totalWrites := 0, len(writeItems); start < totalWrites; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalWrites {
-			end = totalWrites
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalWrites)
 
 		writesBatch := writeItems[start:end]
 
@@ -639,10 +630,7 @@ func (s *Datastore) write(
 
 	// 6. Execute INSERT changelog statements
 	for start, totalItems := 0, len(changeLogItems); start < totalItems; start += storage.DefaultMaxTuplesPerWrite {
-		end := start + storage.DefaultMaxTuplesPerWrite
-		if end > totalItems {
-			end = totalItems
-		}
+		end := min(start+storage.DefaultMaxTuplesPerWrite, totalItems)
 
 		changeLogBatch := changeLogItems[start:end]
 
@@ -1328,7 +1316,7 @@ func (s *Datastore) IsReady(ctx context.Context) (storage.ReadinessStatus, error
 
 // HandleSQLError processes an SQL error and converts it into a more
 // specific error type based on the nature of the SQL error.
-func HandleSQLError(err error, args ...interface{}) error {
+func HandleSQLError(err error, args ...any) error {
 	if errors.Is(err, sql.ErrNoRows) {
 		return storage.ErrNotFound
 	}

--- a/pkg/storage/sqlite/sqlite_test.go
+++ b/pkg/storage/sqlite/sqlite_test.go
@@ -460,7 +460,7 @@ func TestSQLiteDatastore_ReadPageWithUserFiltering(t *testing.T) {
 
 	// Create multiple tuples with same user type for pagination testing
 	var tuples []*openfgav1.TupleKey
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tuples = append(tuples, &openfgav1.TupleKey{
 			Object:   "doc:group1",
 			Relation: "viewer",

--- a/pkg/storage/sqlite/tuple_iterator.go
+++ b/pkg/storage/sqlite/tuple_iterator.go
@@ -17,7 +17,7 @@ import (
 	"github.com/openfga/openfga/pkg/storage"
 )
 
-type errorHandlerFn func(error, ...interface{}) error
+type errorHandlerFn func(error, ...any) error
 
 // SQLTupleIterator is a struct that implements the storage.TupleIterator
 // interface for iterating over tuples fetched from a SQL database.

--- a/pkg/storage/storagewrappers/cached_datastore.go
+++ b/pkg/storage/storagewrappers/cached_datastore.go
@@ -520,9 +520,7 @@ func (c *cachedIterator) Stop() {
 		return
 	}
 
-	c.wg.Add(1)
-	go func() {
-		defer c.wg.Done()
+	c.wg.Go(func() {
 		defer c.iter.Stop()
 
 		// if cache is already set by another instance, we don't need to drain the iterator
@@ -553,7 +551,7 @@ func (c *cachedIterator) Stop() {
 		}
 
 		// prevent draining on the same iterator across multiple requests
-		_, _, _ = c.sf.Do(c.cacheKey.String(), func() (interface{}, error) {
+		_, _, _ = c.sf.Do(c.cacheKey.String(), func() (any, error) {
 			for {
 				// attempt to drain the iterator to have it ready for subsequent calls
 				t, err := c.iter.Next(c.ctx)
@@ -570,7 +568,7 @@ func (c *cachedIterator) Stop() {
 			}
 			return nil, nil
 		})
-	}()
+	})
 }
 
 // Head see [storage.Iterator].Head.

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -1330,13 +1330,9 @@ func TestCachedIterator(t *testing.T) {
 			logger:            logger.NewNoopLogger(),
 		}
 
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			iter.Stop()
-		}()
+		})
 
 		wg.Wait()
 		iter.wg.Wait()
@@ -1465,13 +1461,9 @@ func TestCachedIterator(t *testing.T) {
 			logger:            logger.NewNoopLogger(),
 		}
 
-		wg.Add(1)
-
-		go func() {
-			defer wg.Done()
-
+		wg.Go(func() {
 			iter.Stop()
-		}()
+		})
 
 		wg.Wait()
 		iter.wg.Wait()
@@ -1486,7 +1478,7 @@ func TestCachedIterator(t *testing.T) {
 		cacheKey := testCacheKey("cache-key")
 		ttl := 5 * time.Hour
 		store := ulid.Make().String()
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			mockController := gomock.NewController(t)
 			defer mockController.Finish()
 

--- a/pkg/storage/storagewrappers/iterator_cache.go
+++ b/pkg/storage/storagewrappers/iterator_cache.go
@@ -331,7 +331,7 @@ func (c *CachingIterator) drainInBackground() {
 
 	// Optimization 3: Use singleflight only for actual draining.
 	// This prevents multiple goroutines from draining the same iterator key concurrently.
-	_, _, _ = c.sf.Do(c.cacheKey.String(), func() (interface{}, error) {
+	_, _, _ = c.sf.Do(c.cacheKey.String(), func() (any, error) {
 		for {
 			// Check for timeout before each iteration
 			if drainCtx.Err() != nil {
@@ -376,8 +376,8 @@ func (c *CachingIterator) drainInBackground() {
 
 // extractObjectID extracts the ID portion from "type:id" format.
 func extractObjectID(object string) string {
-	if idx := strings.IndexByte(object, ':'); idx >= 0 {
-		return object[idx+1:]
+	if _, after, ok := strings.Cut(object, ":"); ok {
+		return after
 	}
 	return object
 }

--- a/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_benchmark_test.go
@@ -36,7 +36,7 @@ var benchSink any
 // createTestTuples generates test tuples for benchmarking.
 func createTestTuples(count int) []*openfgav1.Tuple {
 	tuples := make([]*openfgav1.Tuple, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		tuples[i] = &openfgav1.Tuple{
 			Key: tuple.NewTupleKey(
 				fmt.Sprintf("document:%d", i),
@@ -51,7 +51,7 @@ func createTestTuples(count int) []*openfgav1.Tuple {
 // createMinimalCacheEntries generates MinimalCacheEntry for V2 benchmarks.
 func createMinimalCacheEntries(count int) []MinimalCacheEntry {
 	entries := make([]MinimalCacheEntry, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		entries[i] = MinimalCacheEntry{
 			ObjectID: fmt.Sprintf("%d", i),
 			User:     fmt.Sprintf("user:user%d", i%100),
@@ -63,7 +63,7 @@ func createMinimalCacheEntries(count int) []MinimalCacheEntry {
 // createTupleRecords generates TupleRecord for V1 benchmarks.
 func createTupleRecords(count int) []*storage.TupleRecord {
 	records := make([]*storage.TupleRecord, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		records[i] = &storage.TupleRecord{
 			ObjectID:       fmt.Sprintf("%d", i),
 			ObjectType:     "document",
@@ -270,7 +270,7 @@ func BenchmarkV1vsV2_Memory_CacheEntry(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				records := make([]*storage.TupleRecord, size)
-				for j := 0; j < size; j++ {
+				for j := range size {
 					records[j] = &storage.TupleRecord{
 						ObjectID:       fmt.Sprintf("object-%d", j),
 						ObjectType:     "document",
@@ -293,7 +293,7 @@ func BenchmarkV1vsV2_Memory_CacheEntry(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				entries := make([]MinimalCacheEntry, size)
-				for j := 0; j < size; j++ {
+				for j := range size {
 					entries[j] = MinimalCacheEntry{
 						ObjectID: fmt.Sprintf("object-%d", j),
 						User:     fmt.Sprintf("user:user%d", j%100),
@@ -337,7 +337,7 @@ func BenchmarkV1vsV2_Concurrent_Next(b *testing.B) {
 				var wg sync.WaitGroup
 				wg.Add(numGoroutines)
 
-				for g := 0; g < numGoroutines; g++ {
+				for range numGoroutines {
 					go func() {
 						defer wg.Done()
 						for {
@@ -366,7 +366,7 @@ func BenchmarkV1vsV2_Concurrent_Next(b *testing.B) {
 				var wg sync.WaitGroup
 				wg.Add(numGoroutines)
 
-				for g := 0; g < numGoroutines; g++ {
+				for range numGoroutines {
 					go func() {
 						defer wg.Done()
 						for {
@@ -399,7 +399,7 @@ func BenchmarkV1vsV2_BufferAllocation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			// V1 allocates slice of tuple pointers
 			tuples := make([]*openfgav1.Tuple, 0, size/2)
-			for j := 0; j < size; j++ {
+			for j := range size {
 				tuples = append(tuples, &openfgav1.Tuple{
 					Key: tuple.NewTupleKey(
 						fmt.Sprintf("document:%d", j),
@@ -419,7 +419,7 @@ func BenchmarkV1vsV2_BufferAllocation(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			// V2 now uses same pattern: collect pointers, then transform at flush
 			tuples := make([]*openfgav1.Tuple, 0, size/2)
-			for j := 0; j < size; j++ {
+			for j := range size {
 				tuples = append(tuples, &openfgav1.Tuple{
 					Key: tuple.NewTupleKey(
 						fmt.Sprintf("document:%d", j),

--- a/pkg/storage/storagewrappers/iterator_cache_test.go
+++ b/pkg/storage/storagewrappers/iterator_cache_test.go
@@ -143,7 +143,7 @@ func TestLockFreeCachedIterator_Next_WithCondition(t *testing.T) {
 		goleak.VerifyNone(t)
 	})
 
-	condCtx, _ := structpb.NewStruct(map[string]interface{}{"region": "us-east"})
+	condCtx, _ := structpb.NewStruct(map[string]any{"region": "us-east"})
 	entries := []MinimalCacheEntry{
 		{
 			ObjectID:         "1",
@@ -242,7 +242,7 @@ func TestLockFreeCachedIterator_Concurrent_Next(t *testing.T) {
 	})
 
 	entries := make([]MinimalCacheEntry, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		entries[i] = MinimalCacheEntry{
 			ObjectID: string(rune('a' + i%26)),
 			User:     "user:test",
@@ -256,10 +256,8 @@ func TestLockFreeCachedIterator_Concurrent_Next(t *testing.T) {
 	results := make(chan *openfgav1.Tuple, 200)
 
 	// Start multiple goroutines calling Next concurrently
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			for {
 				t, err := iter.Next(ctx)
 				if err != nil {
@@ -267,7 +265,7 @@ func TestLockFreeCachedIterator_Concurrent_Next(t *testing.T) {
 				}
 				results <- t
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -287,7 +285,7 @@ func TestLockFreeCachedIterator_Concurrent_Stop(t *testing.T) {
 	})
 
 	entries := make([]MinimalCacheEntry, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		entries[i] = MinimalCacheEntry{ObjectID: "1", User: "user:test"}
 	}
 
@@ -297,17 +295,15 @@ func TestLockFreeCachedIterator_Concurrent_Stop(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Start goroutines calling Next
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 5 {
+		wg.Go(func() {
 			for {
 				_, err := iter.Next(ctx)
 				if err != nil {
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	// Stop from another goroutine
@@ -647,7 +643,7 @@ func TestCachingIterator_PopulatesCache(t *testing.T) {
 	// Capture the cache entry
 	var capturedEntry *V2IteratorCacheEntry
 	mockCache.EXPECT().Set(cacheKey, gomock.Any(), ttl).DoAndReturn(
-		func(_ keys.Key, value interface{}, _ time.Duration) {
+		func(_ keys.Key, value any, _ time.Duration) {
 			capturedEntry = value.(*V2IteratorCacheEntry)
 		},
 	)
@@ -825,7 +821,7 @@ func TestCachingIterator_WaitGroup_AddInConstructor(t *testing.T) {
 	// This verifies that even if we create iterators rapidly, the WaitGroup
 	// is properly incremented at construction time (not at Stop time)
 	iterators := make([]*CachingIterator, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		innerIter := storage.NewStaticTupleIterator(tuples)
 		iterators[i] = newCachingIterator(
 			innerIter, mockCache, testCacheKey("test-key-"+strconv.Itoa(i)), 1000, time.Hour, 30*time.Second,
@@ -935,7 +931,7 @@ func TestCachingIterator_ConcurrentNextAndStop(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	// Run multiple iterations to increase chance of detecting race
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		innerIter := storage.NewStaticTupleIterator(tuples)
 		iter := newCachingIterator(
 			innerIter, mockCache, testCacheKey(fmt.Sprintf("test-key-%d", i)), 1000, time.Hour, 30*time.Second,
@@ -997,7 +993,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 
 	// Create tuples - use StaticTupleIterator since background drain uses context.Background()
 	tuples := make([]*openfgav1.Tuple, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
@@ -1014,7 +1010,7 @@ func TestCachingIterator_BackgroundDrainIgnoresRequestContextCancellation(t *tes
 	)
 
 	// Consume just a few tuples (simulating finding a result early)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := iter.Next(requestCtx)
 		require.NoError(t, err)
 	}
@@ -1047,7 +1043,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	tuples := make([]*openfgav1.Tuple, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+string(rune('1'+i)), "viewer", "user:test")}
 	}
 
@@ -1064,7 +1060,7 @@ func TestCachingIterator_BackgroundDrainCompletes_DoesCache(t *testing.T) {
 	)
 
 	// Consume just a few tuples (not all)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := iter.Next(ctx)
 		require.NoError(t, err)
 	}
@@ -1188,7 +1184,7 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 
 	maxSize := 5
 	tuples := make([]*openfgav1.Tuple, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		tuples[i] = &openfgav1.Tuple{Key: tuple.NewTupleKey("document:"+strconv.Itoa(i), "viewer", "user:test")}
 	}
 
@@ -1202,7 +1198,7 @@ func TestCachingIterator_DrainExceedsMaxSize_AbandonsCaching(t *testing.T) {
 	ctx := context.Background()
 
 	// Consume 3 tuples (under maxSize, so tuples is still collecting)
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := iter.Next(ctx)
 		require.NoError(t, err)
 	}
@@ -1259,7 +1255,7 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 
 	// Create 100 tuples for iteration
 	tuples := make([]*openfgav1.Tuple, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		tuples[i] = &openfgav1.Tuple{
 			Key: tuple.NewTupleKey("document:"+string(rune('a'+i%26)), "viewer", "user:test"),
 		}
@@ -1290,7 +1286,7 @@ func BenchmarkCachingIterator_CacheMiss(b *testing.B) {
 func BenchmarkCachingIterator_CacheHit(b *testing.B) {
 	// Create 100 cached entries
 	entries := make([]MinimalCacheEntry, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		entries[i] = MinimalCacheEntry{
 			ObjectID: string(rune('a' + i%26)),
 			User:     "user:test",
@@ -1320,7 +1316,7 @@ func BenchmarkCachingIterator_CacheHit(b *testing.B) {
 func BenchmarkLockFreeCachedIterator_Next(b *testing.B) {
 	// Create 100 cached entries
 	entries := make([]MinimalCacheEntry, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		entries[i] = MinimalCacheEntry{
 			ObjectID:      string(rune('a' + i%26)),
 			User:          "user:test",
@@ -1352,7 +1348,7 @@ func BenchmarkLockFreeCachedIterator_VsStaticIterator(b *testing.B) {
 	// Create data for both iterators
 	entries := make([]MinimalCacheEntry, 100)
 	tuples := make([]*openfgav1.Tuple, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		entries[i] = MinimalCacheEntry{
 			ObjectID: string(rune('a' + i%26)),
 			User:     "user:test",
@@ -1398,7 +1394,7 @@ func BenchmarkMinimalCacheEntry_Memory(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			entries := make([]MinimalCacheEntry, 100)
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				entries[j] = MinimalCacheEntry{
 					ObjectID: "object-" + string(rune('a'+j%26)),
 					User:     "user:test-user",
@@ -1412,7 +1408,7 @@ func BenchmarkMinimalCacheEntry_Memory(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			tuples := make([]*openfgav1.Tuple, 100)
-			for j := 0; j < 100; j++ {
+			for j := range 100 {
 				tuples[j] = &openfgav1.Tuple{
 					Key: tuple.NewTupleKey(
 						"document:object-"+string(rune('a'+j%26)),

--- a/pkg/storage/storagewrappers/model_caching.go
+++ b/pkg/storage/storagewrappers/model_caching.go
@@ -86,7 +86,7 @@ func (c *cachedOpenFGADatastore) ReadAuthorizationModel(ctx context.Context, sto
 
 // FindLatestAuthorizationModel see [storage.AuthorizationModelReadBackend].FindLatestAuthorizationModel.
 func (c *cachedOpenFGADatastore) FindLatestAuthorizationModel(ctx context.Context, storeID string) (*openfgav1.AuthorizationModel, error) {
-	v, err, _ := c.lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (interface{}, error) {
+	v, err, _ := c.lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (any, error) {
 		return c.OpenFGADatastore.FindLatestAuthorizationModel(ctx, storeID)
 	})
 	if err != nil {

--- a/pkg/storage/storagewrappers/model_caching_test.go
+++ b/pkg/storage/storagewrappers/model_caching_test.go
@@ -111,7 +111,7 @@ func TestSingleFlightFindLatestAuthorizationModel(t *testing.T) {
 	)
 
 	var wg errgroup.Group
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Go(func() error {
 			latestModel, err := cachingBackend.FindLatestAuthorizationModel(context.Background(), storeID)
 			if err != nil {

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -218,7 +218,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 
 	// Create test data
 	var tuples []*openfgav1.Tuple
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		tk := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i))
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -262,10 +262,8 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 			for b.Loop() {
 				var wg sync.WaitGroup
 
-				for j := 0; j < concurrency; j++ {
-					wg.Add(1)
-					go func() {
-						defer wg.Done()
+				for range concurrency {
+					wg.Go(func() {
 						start := time.Now()
 						iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 						if err != nil {
@@ -278,7 +276,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 						mu.Unlock()
 
 						iter.Stop()
-					}()
+					})
 				}
 				wg.Wait()
 			}
@@ -289,9 +287,7 @@ func BenchmarkIteratorDatastoreReadLatencyWithDifferentLoads(b *testing.B) {
 			b.ReportMetric(float64(dbCalls.Load()), "db_calls")
 
 			if len(latencies) > 0 {
-				sort.Slice(latencies, func(i, j int) bool {
-					return latencies[i] < latencies[j]
-				})
+				slices.Sort(latencies)
 
 				var total time.Duration
 				for _, lat := range latencies {
@@ -360,7 +356,7 @@ func helperValidateMultipleClients(ctx context.Context, t *testing.T, internalSt
 	}
 
 	require.NotEmpty(t, length(internalStorage))
-	for i := 0; i < len(iterInfos); i++ {
+	for i := range iterInfos {
 		require.NoError(t, iterInfos[i].err)
 		require.NotNil(t, iterInfos[i].iter)
 	}
@@ -452,7 +448,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
 
-		for i := 0; i < numClient; i++ {
+		for i := range numClient {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
@@ -562,7 +558,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
-		for i := 0; i < numClient; i++ {
+		for range numClient {
 			p.Go(func() error {
 				iter, err := ds.Read(ctx, storeID, filter, storage.ReadOptions{})
 				if err != nil {
@@ -732,7 +728,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
 
-		for i := 0; i < numClient; i++ {
+		for i := range numClient {
 			wg.Add(1)
 			go func(i int) {
 				curIter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
@@ -838,7 +834,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
-		for i := 0; i < numClient; i++ {
+		for range numClient {
 			p.Go(func() error {
 				iter, err := ds.ReadUsersetTuples(ctx, storeID, filter, options)
 				if err != nil {
@@ -1008,7 +1004,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		iterInfos := make([]testIteratorInfo, numClient)
 		wg := sync.WaitGroup{}
 
-		for i := 0; i < numClient; i++ {
+		for i := range numClient {
 			wg.Add(1)
 			go func(i int) {
 				curIter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
@@ -1144,7 +1140,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 			}).MaxTimes(numClient)
 		p := pool.New().WithErrors()
 
-		for i := 0; i < numClient; i++ {
+		for range numClient {
 			p.Go(func() error {
 				iter, err := ds.ReadStartingWithUser(ctx, storeID, filter, options)
 				if err != nil {
@@ -1873,7 +1869,7 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 	// Create 150 test tuples
 	const numTuples = bufferSize + 1
 	var tks []*openfgav1.TupleKey
-	for i := 0; i < numTuples; i++ {
+	for i := range numTuples {
 		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
 	}
 

--- a/pkg/storage/test/assertions.go
+++ b/pkg/storage/test/assertions.go
@@ -59,7 +59,7 @@ func AssertionsTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		assertions := make([]*openfgav1.Assertion, 0, numAssertions)
 
 		protoSize := 0
-		for a := 0; a < numAssertions; a++ {
+		for a := range numAssertions {
 			newAssertion := &openfgav1.Assertion{
 				TupleKey: &openfgav1.AssertionTupleKey{
 					Object:   "document:" + strings.Repeat(strconv.Itoa(a), maxBytesPerObject-len("document:")),

--- a/pkg/storage/test/authz_models.go
+++ b/pkg/storage/test/authz_models.go
@@ -73,7 +73,7 @@ func ReadAuthorizationModelsTest(t *testing.T, datastore storage.OpenFGADatastor
 
 	const numOfWrites = 300
 	modelsWritten := make([]*openfgav1.AuthorizationModel, numOfWrites)
-	for i := 0; i < numOfWrites; i++ {
+	for i := range numOfWrites {
 		model := parser.MustTransformDSLToProto(`
 			model
 				schema 1.1

--- a/pkg/storage/test/stores.go
+++ b/pkg/storage/test/stores.go
@@ -42,12 +42,12 @@ func StoreTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	}
 
 	// Create some stores.
-	for i := 0; i < numStores; i++ {
+	for range numStores {
 		stores = append(stores, createStore(testutils.CreateRandomString(10)))
 	}
 
 	// Stores that shares name are created after numStores so we have an easy way to access them.
-	for i := 0; i < numStoresWithSharedName; i++ {
+	for range numStoresWithSharedName {
 		stores = append(stores, createStore(sharedStoreName))
 	}
 

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -46,7 +46,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		storeID := ulid.Make().String()
 
 		var writtenTuples []*openfgav1.TupleKey
-		for i := 0; i < numOfWrites; i++ {
+		for i := range numOfWrites {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
 			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
 			require.NoError(t, err)
@@ -75,7 +75,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		storeID := ulid.Make().String()
 
 		var writtenTuplesBefore, writtenTuplesAfter []*openfgav1.TupleKey
-		for i := 0; i < numOfWrites/2; i++ {
+		for i := range numOfWrites / 2 {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:before")
 			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
 			require.NoError(t, err)
@@ -132,7 +132,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 		filter := "folder"
 
 		var writtenTuples []*openfgav1.TupleKey
-		for i := 0; i < numOfWrites; i++ {
+		for i := range numOfWrites {
 			newTuple1 := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
 			newTuple2 := tuple.NewTupleKey(fmt.Sprintf("%s:%d", filter, i), "viewer", "user:jon")
 			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple1, newTuple2})
@@ -167,7 +167,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "user:anne",
 			Condition: &openfgav1.RelationshipCondition{
 				Name:    "condition",
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 			},
 		}
 		tk1WithoutCond := &openfgav1.TupleKeyWithoutCondition{
@@ -312,7 +312,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 	t.Run("read_changes_returns_deterministic_ordering_and_no_duplicates", func(t *testing.T) {
 		storeID := ulid.Make().String()
 
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			object := fmt.Sprintf("document:%d", i)
 			tuple := []*openfgav1.TupleKey{tuple.NewTupleKey(object, "viewer", "user:jon")}
 			err := datastore.Write(context.Background(), storeID, nil, tuple)
@@ -388,7 +388,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "bill",
 			Condition: &openfgav1.RelationshipCondition{
 				Name:    "condition",
-				Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+				Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 			},
 		}
 
@@ -429,7 +429,7 @@ func ReadChangesTest(t *testing.T, datastore storage.OpenFGADatastore) {
 			User:     "user:jon",
 			Condition: &openfgav1.RelationshipCondition{
 				Name: "mycond",
-				Context: testutils.MustNewStruct(t, map[string]interface{}{
+				Context: testutils.MustNewStruct(t, map[string]any{
 					"x": 10,
 				}),
 			},
@@ -628,7 +628,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 
 		var writtenTuples []*openfgav1.TupleKey
-		for i := 0; i < storage.DefaultPageSize*50; i++ {
+		for i := range storage.DefaultPageSize * 50 {
 			newTuple := tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", "user:jon")
 			err := datastore.Write(context.Background(), storeID, nil, []*openfgav1.TupleKey{newTuple})
 			require.NoError(t, err)
@@ -920,7 +920,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 		tk := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 		}}
 
 		// First write should succeed.
@@ -929,7 +929,7 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 
 		tk2 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 		}}
 		// Second write of the same tuple should not fail.
 		err = datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk2},
@@ -959,11 +959,11 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 		tk1 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 		}}
 		tk2 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition2",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 		}}
 		// First write should succeed.
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
@@ -1000,11 +1000,11 @@ func TupleWritingAndReadingTest(t *testing.T, datastore storage.OpenFGADatastore
 		storeID := ulid.Make().String()
 		tk1 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "ok"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "ok"}),
 		}}
 		tk2 := &openfgav1.TupleKey{Object: "doc:readme", Relation: "owner", User: "10", Condition: &openfgav1.RelationshipCondition{
 			Name:    "condition1",
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"param1": "bad"}),
+			Context: testutils.MustNewStruct(t, map[string]any{"param1": "bad"}),
 		}}
 		// First write should succeed.
 		err := datastore.Write(ctx, storeID, nil, []*openfgav1.TupleKey{tk1})
@@ -1795,7 +1795,7 @@ func WriteTuplesWithMaxTuplesPerWrite(datastore storage.OpenFGADatastore, ctx co
 		// Write a lot of tuples to both stores to ensure that the delete logic is not
 		// affected by the number of tuples in the database.
 		tuplesToWrite := make([]*openfgav1.TupleKey, numTuples)
-		for i := 0; i < numTuples; i++ {
+		for i := range numTuples {
 			tuplesToWrite[i] = &openfgav1.TupleKey{
 				Object:   fmt.Sprintf("doc:readme%d", i),
 				Relation: "owner",
@@ -1813,7 +1813,7 @@ func WriteTuplesWithMaxTuplesPerWrite(datastore storage.OpenFGADatastore, ctx co
 		require.Equal(t, tkLast.GetKey().String(), tuplesToWrite[len(tuplesToWrite)-1].String())
 
 		tuplesToDelete := make([]*openfgav1.TupleKeyWithoutCondition, numTuples)
-		for i := 0; i < numTuples; i++ {
+		for i := range numTuples {
 			tuplesToDelete[i] = tuple.TupleKeyToTupleKeyWithoutCondition(tuplesToWrite[i])
 		}
 		require.NoError(t, datastore.Write(ctx, storeID, tuplesToDelete, nil))

--- a/pkg/storage/tuple_iterators_test.go
+++ b/pkg/storage/tuple_iterators_test.go
@@ -138,7 +138,7 @@ func TestStaticTupleIterator(t *testing.T) {
 	})
 	t.Run("next_and_head_are_thread_safe", func(t *testing.T) {
 		tks := make([]*openfgav1.Tuple, 100)
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			tks[i] = &openfgav1.Tuple{
 				Key:       tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "bill"),
 				Timestamp: timestamppb.New(time.Now()),
@@ -148,7 +148,7 @@ func TestStaticTupleIterator(t *testing.T) {
 		defer iter.Stop()
 
 		var wg errgroup.Group
-		for i := 0; i < 101; i++ {
+		for range 101 {
 			wg.Go(func() error {
 				_, err := iter.Head(context.Background())
 				return err
@@ -158,7 +158,7 @@ func TestStaticTupleIterator(t *testing.T) {
 		err := wg.Wait()
 		require.NoError(t, err)
 
-		for i := 0; i < 101; i++ {
+		for range 101 {
 			wg.Go(func() error {
 				_, err := iter.Next(context.Background())
 				return err
@@ -262,7 +262,7 @@ func TestCombinedIterator(t *testing.T) {
 		iter := NewCombinedIterator(iter1, iter2)
 		defer iter.Stop()
 
-		for i := 0; i < len(expected); i++ {
+		for i := range expected {
 			tk, err := iter.Head(context.Background())
 			require.NoError(t, err)
 			require.Equal(t, expected[i], tk)
@@ -682,7 +682,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 			iter := NewOrderedCombinedIterator(UserMapper(), iter1, iter2)
 			t.Cleanup(iter.Stop)
 
-			for i := 0; i < 5; i++ {
+			for range 5 {
 				got, err := iter.Head(context.Background())
 				require.NoError(t, err)
 
@@ -989,7 +989,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 
 	t.Run("next_and_head_are_thread_safe", func(t *testing.T) {
 		tuples := make([]*openfgav1.TupleKey, 100)
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			tuples[i] = tuple.NewTupleKey("document:doc"+strconv.Itoa(i), "viewer", "user:jon")
 		}
 		iter := NewFilteredTupleKeyIterator(
@@ -1001,7 +1001,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 		defer iter.Stop()
 
 		var wg errgroup.Group
-		for i := 0; i < 101; i++ {
+		for range 101 {
 			wg.Go(func() error {
 				_, err := iter.Head(context.Background())
 				return err
@@ -1011,7 +1011,7 @@ func TestFilteredTupleKeyIterator(t *testing.T) {
 		err := wg.Wait()
 		require.NoError(t, err)
 
-		for i := 0; i < 101; i++ {
+		for range 101 {
 			wg.Go(func() error {
 				_, err := iter.Next(context.Background())
 				return err

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -124,7 +124,7 @@ func CreateRandomString(n int) string {
 	return string(b)
 }
 
-func MustNewStruct(t require.TestingT, v map[string]interface{}) *structpb.Struct {
+func MustNewStruct(t require.TestingT, v map[string]any) *structpb.Struct {
 	conditionContext, err := structpb.NewStruct(v)
 	require.NoError(t, err)
 	return conditionContext
@@ -135,7 +135,7 @@ func MustNewStruct(t require.TestingT, v map[string]interface{}) *structpb.Struc
 func MakeSliceWithGenerator[T any](n uint64, generator func(n uint64) any) []T {
 	s := make([]T, 0, n)
 
-	for i := uint64(0); i < n; i++ {
+	for i := range n {
 		s = append(s, generator(i).(T))
 	}
 
@@ -150,7 +150,7 @@ func NumericalStringGenerator(n uint64) any {
 
 func MakeStringWithRuneset(n uint64, runeSet []rune) string {
 	var sb strings.Builder
-	for i := uint64(0); i < n; i++ {
+	for range n {
 		sb.WriteRune(runeSet[rand.Intn(len(runeSet))])
 	}
 	return sb.String()

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -302,11 +302,11 @@ func StringToUserProto(userKey UserString) *openfgav1.User {
 //  2. "group#member:fga" returns "group#member" and "fga".
 //  3. "anne" returns "" and "anne".
 func SplitObject(object string) (string, string) {
-	ndx := strings.IndexByte(object, ':')
-	if ndx == -1 {
+	before, after, ok := strings.Cut(object, ":")
+	if !ok {
 		return "", object
 	}
-	return object[0:ndx], object[ndx+1:]
+	return before, after
 }
 
 func BuildObject(objectType, objectID string) string {

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -63,7 +63,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		var model *openfgav1.AuthorizationModel
 
 		if modelID == "" {
-			v, err, _ := lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (interface{}, error) {
+			v, err, _ := lookupGroup.Do("FindLatestAuthorizationModel:"+storeID, func() (any, error) {
 				return datastore.FindLatestAuthorizationModel(ctx, storeID)
 			})
 			if err != nil {
@@ -91,7 +91,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 		}
 
 		if model == nil {
-			v, err, _ := lookupGroup.Do(fmt.Sprintf("ReadAuthorizationModel:%s/%s", storeID, modelID), func() (interface{}, error) {
+			v, err, _ := lookupGroup.Do(fmt.Sprintf("ReadAuthorizationModel:%s/%s", storeID, modelID), func() (any, error) {
 				return datastore.ReadAuthorizationModel(ctx, storeID, modelID)
 			})
 			if err != nil {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -830,7 +830,7 @@ func (t *TypeSystem) relationInvolves(objectType, relation string, visited map[s
 
 	rewrite := rel.GetRewrite()
 
-	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		switch rw := r.GetUserset().(type) {
 		case *openfgav1.Userset_ComputedUserset:
 			rewrittenRelation := rw.ComputedUserset.GetRelation()
@@ -1299,7 +1299,7 @@ func (t *TypeSystem) isUsersetRewriteValid(objectType, relation string, rewrite 
 
 		// Tupleset relations must only be direct relationships, no rewrites are allowed on them.
 		tuplesetRewrite := tuplesetRelation.GetRewrite()
-		if reflect.TypeOf(tuplesetRewrite.GetUserset()) != reflect.TypeOf(&openfgav1.Userset_This{}) {
+		if reflect.TypeOf(tuplesetRewrite.GetUserset()) != reflect.TypeFor[*openfgav1.Userset_This]() {
 			return fmt.Errorf("the '%s#%s' relation is referenced in at least one tupleset and thus must be a direct relation", objectType, tupleset)
 		}
 
@@ -1431,7 +1431,7 @@ func (t *TypeSystem) IsDirectlyAssignable(relation *openfgav1.Relation) bool {
 // RewriteContainsSelf returns true if the provided userset rewrite
 // is defined by one or more self referencing definitions.
 func RewriteContainsSelf(rewrite *openfgav1.Userset) bool {
-	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) interface{} {
+	result, err := WalkUsersetRewrite(rewrite, func(r *openfgav1.Userset) any {
 		if _, ok := r.GetUserset().(*openfgav1.Userset_This); ok {
 			return true
 		}
@@ -1626,11 +1626,11 @@ func flattenUserset(relationDef *openfgav1.Userset) []*openfgav1.TupleToUserset 
 // WalkUsersetRewriteHandler is a userset rewrite handler that is applied to a node in a userset rewrite
 // tree. Implementations of the WalkUsersetRewriteHandler should return a non-nil value when the traversal
 // over the rewrite tree should terminate and nil if traversal should proceed to other nodes in the tree.
-type WalkUsersetRewriteHandler func(rewrite *openfgav1.Userset) interface{}
+type WalkUsersetRewriteHandler func(rewrite *openfgav1.Userset) any
 
 // WalkUsersetRewrite recursively walks the provided userset rewrite and invokes the provided WalkUsersetRewriteHandler
 // to each node in the userset rewrite tree until the first non-nil response is encountered.
-func WalkUsersetRewrite(rewrite *openfgav1.Userset, handler WalkUsersetRewriteHandler) (interface{}, error) {
+func WalkUsersetRewrite(rewrite *openfgav1.Userset, handler WalkUsersetRewriteHandler) (any, error) {
 	var children []*openfgav1.Userset
 
 	if result := handler(rewrite); result != nil {

--- a/pkg/typesystem/typesystem_create_test.go
+++ b/pkg/typesystem/typesystem_create_test.go
@@ -384,7 +384,7 @@ func typeSystemEquals(t *testing.T, a, b *TypeSystem) {
 
 			// nil case covered by len check
 			require.Len(t, relationB, len(relationA))
-			for i := 0; i < len(relationA); i++ {
+			for i := range relationA {
 				tupleToUsersetEquals(t, relationA[i], relationB[i])
 			}
 		}

--- a/tests/authzen/authzen_test.go
+++ b/tests/authzen/authzen_test.go
@@ -165,18 +165,18 @@ func (tc *testContext) evaluate(subject, resource, action string) (*authzenv1.Ev
 
 // parseType extracts the type from "type:id" format.
 func parseType(s string) string {
-	idx := strings.Index(s, ":")
-	if idx == -1 {
+	before, _, ok := strings.Cut(s, ":")
+	if !ok {
 		return s
 	}
-	return s[:idx]
+	return before
 }
 
 // parseID extracts the id from "type:id" format.
 func parseID(s string) string {
-	idx := strings.Index(s, ":")
-	if idx == -1 {
+	_, after, ok := strings.Cut(s, ":")
+	if !ok {
 		return s
 	}
-	return s[idx+1:]
+	return after
 }

--- a/tests/authzen/evaluation_test.go
+++ b/tests/authzen/evaluation_test.go
@@ -56,7 +56,7 @@ func TestEvaluation(t *testing.T) {
 		})
 
 		// Test within office hours
-		ctx := testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 10})
+		ctx := testutils.MustNewStruct(t, map[string]any{"current_hour": 10})
 		resp, err := tc.authzenClient.Evaluation(context.Background(), &authzenv1.EvaluationRequest{
 			StoreId:  tc.storeID,
 			Subject:  &authzenv1.Subject{Type: "user", Id: "alice"},
@@ -68,7 +68,7 @@ func TestEvaluation(t *testing.T) {
 		require.True(t, resp.GetDecision())
 
 		// Test outside office hours
-		ctx = testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 22})
+		ctx = testutils.MustNewStruct(t, map[string]any{"current_hour": 22})
 		resp, err = tc.authzenClient.Evaluation(context.Background(), &authzenv1.EvaluationRequest{
 			StoreId:  tc.storeID,
 			Subject:  &authzenv1.Subject{Type: "user", Id: "alice"},
@@ -104,15 +104,15 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Resource: &authzenv1.Resource{
 				Type:       "document",
 				Id:         "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Action: &authzenv1.Action{Name: "reader"},
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"subject_department":  "engineering",
 				"resource_department": "engineering",
 			}),
@@ -126,15 +126,15 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Resource: &authzenv1.Resource{
 				Type:       "document",
 				Id:         "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "sales"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "sales"}),
 			},
 			Action: &authzenv1.Action{Name: "reader"},
-			Context: testutils.MustNewStruct(t, map[string]interface{}{
+			Context: testutils.MustNewStruct(t, map[string]any{
 				"subject_department":  "engineering",
 				"resource_department": "sales",
 			}),
@@ -341,7 +341,7 @@ func TestEvaluation(t *testing.T) {
 		})
 
 		// Alice is an admin - should have access regardless of level
-		ctx := testutils.MustNewStruct(t, map[string]interface{}{
+		ctx := testutils.MustNewStruct(t, map[string]any{
 			"user_level":     1,
 			"required_level": 5,
 			"is_admin":       true,
@@ -357,7 +357,7 @@ func TestEvaluation(t *testing.T) {
 		require.True(t, resp.GetDecision())
 
 		// Bob has sufficient level
-		ctx = testutils.MustNewStruct(t, map[string]interface{}{
+		ctx = testutils.MustNewStruct(t, map[string]any{
 			"user_level":     7,
 			"required_level": 5,
 			"is_admin":       false,
@@ -373,7 +373,7 @@ func TestEvaluation(t *testing.T) {
 		require.True(t, resp.GetDecision())
 
 		// Bob with insufficient level
-		ctx = testutils.MustNewStruct(t, map[string]interface{}{
+		ctx = testutils.MustNewStruct(t, map[string]any{
 			"user_level":     3,
 			"required_level": 5,
 			"is_admin":       false,
@@ -415,12 +415,12 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Resource: &authzenv1.Resource{
 				Type:       "document",
 				Id:         "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Action: &authzenv1.Action{Name: "reader"},
 		})
@@ -433,12 +433,12 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "engineering"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "engineering"}),
 			},
 			Resource: &authzenv1.Resource{
 				Type:       "document",
 				Id:         "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"department": "sales"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"department": "sales"}),
 			},
 			Action: &authzenv1.Action{Name: "reader"},
 		})
@@ -471,11 +471,11 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"level": 1}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"level": 1}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
-			Context:  testutils.MustNewStruct(t, map[string]interface{}{"subject_level": 10}),
+			Context:  testutils.MustNewStruct(t, map[string]any{"subject_level": 10}),
 		})
 		require.NoError(t, err)
 		require.True(t, resp.GetDecision(), "Expected permit because context overrides properties")
@@ -486,7 +486,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"level": 1}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"level": 1}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -521,7 +521,7 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action: &authzenv1.Action{
 				Name:       "reader",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"method": "GET"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"method": "GET"}),
 			},
 		})
 		require.NoError(t, err)
@@ -534,7 +534,7 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action: &authzenv1.Action{
 				Name:       "reader",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"method": "POST"}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"method": "POST"}),
 			},
 		})
 		require.NoError(t, err)
@@ -566,7 +566,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"roles": []interface{}{"admin", "viewer"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"roles": []any{"admin", "viewer"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -580,7 +580,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"roles": []interface{}{"editor"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"roles": []any{"editor"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -594,7 +594,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"roles": []interface{}{"viewer", "guest"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"roles": []any{"viewer", "guest"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -628,8 +628,8 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type: "user",
 				Id:   "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"metadata": map[string]any{
 						"role":       "admin",
 						"department": "engineering",
 					},
@@ -647,8 +647,8 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type: "user",
 				Id:   "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"metadata": map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"metadata": map[string]any{
 						"role":       "viewer",
 						"department": "sales",
 					},
@@ -687,8 +687,8 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{
 				Type: "document",
 				Id:   "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"limits": map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"limits": map[string]any{
 						"max_views":     float64(50),
 						"max_downloads": float64(10),
 					},
@@ -706,8 +706,8 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{
 				Type: "document",
 				Id:   "doc1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"limits": map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"limits": map[string]any{
 						"max_views":     float64(200),
 						"max_downloads": float64(10),
 					},
@@ -744,7 +744,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"permissions": []interface{}{"read", "write", "delete"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"permissions": []any{"read", "write", "delete"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -758,7 +758,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"permissions": []interface{}{"read"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"permissions": []any{"read"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -793,11 +793,11 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{
 				Type:       "server",
 				Id:         "prod-1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"allowed_ports": []interface{}{float64(80), float64(443), float64(8080)}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"allowed_ports": []any{float64(80), float64(443), float64(8080)}}),
 			},
 			Action: &authzenv1.Action{
 				Name:       "can_connect",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"port": float64(443)}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"port": float64(443)}),
 			},
 		})
 		require.NoError(t, err)
@@ -810,11 +810,11 @@ func TestEvaluation(t *testing.T) {
 			Resource: &authzenv1.Resource{
 				Type:       "server",
 				Id:         "prod-1",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"allowed_ports": []interface{}{float64(80), float64(443), float64(8080)}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"allowed_ports": []any{float64(80), float64(443), float64(8080)}}),
 			},
 			Action: &authzenv1.Action{
 				Name:       "can_connect",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"port": float64(22)}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"port": float64(22)}),
 			},
 		})
 		require.NoError(t, err)
@@ -846,20 +846,20 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type: "user",
 				Id:   "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"tags": []interface{}{"vip", "verified"},
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"tags": []any{"vip", "verified"},
 				}),
 			},
 			Resource: &authzenv1.Resource{
 				Type: "folder",
 				Id:   "shared",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"allowed_users": []interface{}{"alice", "bob", "charlie"},
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"allowed_users": []any{"alice", "bob", "charlie"},
 				}),
 			},
 			Action: &authzenv1.Action{
 				Name: "can_upload",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
 					"max_size": float64(10485760),
 				}),
 			},
@@ -873,20 +873,20 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type: "user",
 				Id:   "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"tags": []interface{}{"vip", "guest"},
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"tags": []any{"vip", "guest"},
 				}),
 			},
 			Resource: &authzenv1.Resource{
 				Type: "folder",
 				Id:   "shared",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
-					"allowed_users": []interface{}{"alice", "bob"},
+				Properties: testutils.MustNewStruct(t, map[string]any{
+					"allowed_users": []any{"alice", "bob"},
 				}),
 			},
 			Action: &authzenv1.Action{
 				Name: "can_upload",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{
+				Properties: testutils.MustNewStruct(t, map[string]any{
 					"max_size": float64(10485760),
 				}),
 			},
@@ -920,7 +920,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"roles": []interface{}{}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"roles": []any{}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},
@@ -934,7 +934,7 @@ func TestEvaluation(t *testing.T) {
 			Subject: &authzenv1.Subject{
 				Type:       "user",
 				Id:         "alice",
-				Properties: testutils.MustNewStruct(t, map[string]interface{}{"roles": []interface{}{"admin"}}),
+				Properties: testutils.MustNewStruct(t, map[string]any{"roles": []any{"admin"}}),
 			},
 			Resource: &authzenv1.Resource{Type: "document", Id: "doc1"},
 			Action:   &authzenv1.Action{Name: "reader"},

--- a/tests/authzen/evaluations_test.go
+++ b/tests/authzen/evaluations_test.go
@@ -514,7 +514,7 @@ func TestEvaluations(t *testing.T) {
 			StoreId: tc.storeID,
 			Subject: &authzenv1.Subject{Type: "user", Id: "alice"},
 			Action:  &authzenv1.Action{Name: "reader"},
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 10}),
+			Context: testutils.MustNewStruct(t, map[string]any{"current_hour": 10}),
 			Evaluations: []*authzenv1.EvaluationsItemRequest{
 				{Resource: &authzenv1.Resource{Type: "document", Id: "doc1"}},
 				{Resource: &authzenv1.Resource{Type: "document", Id: "doc2"}},
@@ -530,7 +530,7 @@ func TestEvaluations(t *testing.T) {
 			StoreId: tc.storeID,
 			Subject: &authzenv1.Subject{Type: "user", Id: "alice"},
 			Action:  &authzenv1.Action{Name: "reader"},
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 22}),
+			Context: testutils.MustNewStruct(t, map[string]any{"current_hour": 22}),
 			Evaluations: []*authzenv1.EvaluationsItemRequest{
 				{Resource: &authzenv1.Resource{Type: "document", Id: "doc1"}},
 				{Resource: &authzenv1.Resource{Type: "document", Id: "doc2"}},
@@ -568,12 +568,12 @@ func TestEvaluations(t *testing.T) {
 			StoreId: tc.storeID,
 			Subject: &authzenv1.Subject{Type: "user", Id: "alice"},
 			Action:  &authzenv1.Action{Name: "reader"},
-			Context: testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 22}), // Default: outside hours
+			Context: testutils.MustNewStruct(t, map[string]any{"current_hour": 22}), // Default: outside hours
 			Evaluations: []*authzenv1.EvaluationsItemRequest{
 				{Resource: &authzenv1.Resource{Type: "document", Id: "doc1"}}, // Uses default context
 				{
 					Resource: &authzenv1.Resource{Type: "document", Id: "doc2"},
-					Context:  testutils.MustNewStruct(t, map[string]interface{}{"current_hour": 10}), // Override: within hours
+					Context:  testutils.MustNewStruct(t, map[string]any{"current_hour": 10}), // Override: within hours
 				},
 			},
 		})

--- a/tests/authzen/search_test.go
+++ b/tests/authzen/search_test.go
@@ -60,7 +60,7 @@ func TestSubjectSearch(t *testing.T) {
 
 		// Create 10 users with reader access
 		tuples := make([]*openfgav1.TupleKey, 10)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			tuples[i] = &openfgav1.TupleKey{
 				User:     fmt.Sprintf("user:user%02d", i),
 				Relation: "reader",
@@ -89,7 +89,7 @@ func TestSubjectSearch(t *testing.T) {
 		for _, s := range resp.GetResults() {
 			subjectIDs[s.GetId()] = true
 		}
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			require.True(t, subjectIDs[fmt.Sprintf("user%02d", i)])
 		}
 	})
@@ -251,7 +251,7 @@ func TestResourceSearch(t *testing.T) {
 
 		// Create 10 documents with alice as reader
 		tuples := make([]*openfgav1.TupleKey, 10)
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			tuples[i] = &openfgav1.TupleKey{
 				User:     "user:alice",
 				Relation: "reader",
@@ -280,7 +280,7 @@ func TestResourceSearch(t *testing.T) {
 		for _, r := range resp.GetResults() {
 			resourceIDs[r.GetId()] = true
 		}
-		for i := 0; i < 10; i++ {
+		for i := range 10 {
 			require.True(t, resourceIDs[fmt.Sprintf("doc%02d", i)])
 		}
 	})

--- a/tests/check/check_test.go
+++ b/tests/check/check_test.go
@@ -168,7 +168,7 @@ func TestServerLogs(t *testing.T) {
 		grpcReq         *openfgav1.CheckRequest
 		httpReqBody     io.Reader
 		expectedError   bool
-		expectedContext map[string]interface{}
+		expectedContext map[string]any
 	}
 
 	tests := []test{
@@ -180,7 +180,7 @@ func TestServerLogs(t *testing.T) {
 				StoreId:              storeID,
 				TupleKey:             tuple.NewCheckRequestTupleKey("document:1", "viewer", "user:anne"),
 			},
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service":                "openfga.v1.OpenFGAService",
 				"grpc_method":                 "Check",
 				"grpc_type":                   "unary",
@@ -205,7 +205,7 @@ func TestServerLogs(t *testing.T) {
   },
   "authorization_model_id": "` + authorizationModelID + `"
 }`),
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service":                "openfga.v1.OpenFGAService",
 				"grpc_method":                 "Check",
 				"grpc_type":                   "unary",
@@ -228,7 +228,7 @@ func TestServerLogs(t *testing.T) {
 				TupleKey:             tuple.NewCheckRequestTupleKey("", "viewer", "user:anne"),
 			},
 			expectedError: true,
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service": "openfga.v1.OpenFGAService",
 				"grpc_method":  "Check",
 				"grpc_type":    "unary",
@@ -250,7 +250,7 @@ func TestServerLogs(t *testing.T) {
   "authorization_model_id": "` + authorizationModelID + `"
 }`),
 			expectedError: true,
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service": "openfga.v1.OpenFGAService",
 				"grpc_method":  "Check",
 				"grpc_type":    "unary",
@@ -271,7 +271,7 @@ func TestServerLogs(t *testing.T) {
   "authorization_model_id": "` + authorizationModelID + `"
 }`),
 			expectedError: false,
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service":                "openfga.v1.OpenFGAService",
 				"grpc_method":                 "StreamedListObjects",
 				"grpc_type":                   "server_stream",

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -88,7 +88,7 @@ func TestGRPCMaxMessageSize(t *testing.T) {
 			Relation: "viewer",
 			User:     "user:jon",
 		},
-		Context: testutils.MustNewStruct(t, map[string]interface{}{
+		Context: testutils.MustNewStruct(t, map[string]any{
 			"s": testutils.CreateRandomString(config.DefaultMaxRPCMessageSizeInBytes + 1),
 		}),
 	})
@@ -516,7 +516,7 @@ func GRPCWriteTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 
 func writeTuples(client openfgav1.OpenFGAServiceClient, storeID string, modelID string, count int, user string) (*openfgav1.WriteResponse, error) {
 	tupleKeys := make([]*openfgav1.TupleKey, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		tupleKeys[i] = tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", user)
 	}
 	return client.Write(context.Background(), &openfgav1.WriteRequest{
@@ -1364,7 +1364,7 @@ func GRPCListObjectsTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 
 func GRPCListUsersValidationTest(t *testing.T, client openfgav1.OpenFGAServiceClient) {
 	_101tuples := make([]*openfgav1.TupleKey, 101)
-	for i := 0; i < 101; i++ {
+	for i := range 101 {
 		_101tuples[i] = tuple.NewTupleKey(
 			fmt.Sprintf("document:%d", i), "user", fmt.Sprintf("user:%d", i),
 		)

--- a/tests/listusers/listusers_test.go
+++ b/tests/listusers/listusers_test.go
@@ -144,7 +144,7 @@ func TestListUsersLogs(t *testing.T) {
 		grpcReq         *openfgav1.ListUsersRequest
 		httpReqBody     io.Reader
 		expectedError   bool
-		expectedContext map[string]interface{}
+		expectedContext map[string]any
 	}
 
 	tests := []test{
@@ -160,7 +160,7 @@ func TestListUsersLogs(t *testing.T) {
 				},
 				UserFilters: []*openfgav1.UserTypeFilter{{Type: "user"}},
 			},
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service":           "openfga.v1.OpenFGAService",
 				"grpc_method":            "ListUsers",
 				"grpc_type":              "unary",
@@ -180,7 +180,7 @@ func TestListUsersLogs(t *testing.T) {
 		  "object":{"type":"document","id":"1"},
 		  "user_filters":[{"type":"user"}]
 		}`),
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service":           "openfga.v1.OpenFGAService",
 				"grpc_method":            "ListUsers",
 				"grpc_type":              "unary",
@@ -202,7 +202,7 @@ func TestListUsersLogs(t *testing.T) {
 				UserFilters: []*openfgav1.UserTypeFilter{{Type: "user"}},
 			},
 			expectedError: true,
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service": "openfga.v1.OpenFGAService",
 				"grpc_method":  "ListUsers",
 				"grpc_type":    "unary",
@@ -221,7 +221,7 @@ func TestListUsersLogs(t *testing.T) {
 				"user_filters":[{"type":"user"}]
 			  }`),
 			expectedError: true,
-			expectedContext: map[string]interface{}{
+			expectedContext: map[string]any{
 				"grpc_service": "openfga.v1.OpenFGAService",
 				"grpc_method":  "ListUsers",
 				"grpc_type":    "unary",

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"slices"
 	"testing"
 
 	"google.golang.org/grpc"
@@ -54,15 +55,12 @@ func StartServerWithContext(t testing.TB, cfg *serverconfig.Config, serverCtx *r
 	grpcPort, grpcPortReleaser := testutils.TCPRandomPort()
 	cfg.GRPC.Addr = fmt.Sprintf("localhost:%d", grpcPort)
 	if cfg.Authzen.BaseURL == "" {
-		for _, exp := range cfg.Experimentals {
-			if exp == serverconfig.ExperimentalAuthZen {
-				scheme := "http"
-				if cfg.HTTP.TLS != nil && cfg.HTTP.TLS.Enabled {
-					scheme = "https"
-				}
-				cfg.Authzen.BaseURL = scheme + "://" + cfg.HTTP.Addr
-				break
+		if slices.Contains(cfg.Experimentals, serverconfig.ExperimentalAuthZen) {
+			scheme := "http"
+			if cfg.HTTP.TLS != nil && cfg.HTTP.TLS.Enabled {
+				scheme = "https"
 			}
+			cfg.Authzen.BaseURL = scheme + "://" + cfg.HTTP.Addr
 		}
 	}
 


### PR DESCRIPTION
## Description

Adds the `modernize` linter, so the code is always "modern".

#### What problem is being solved?

Significantly simplifies code using the newest Go features.

#### What changes are made to solve it?

```
golangci-lint run --enable-only modernize --fix
```

## References

#598

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized concurrency and iteration patterns across server execution and internal pipelines to improve goroutine orchestration.
  * Updated request parsing/serialization and request-context merging with more idiomatic Go utilities.
  * Streamlined histogram bucket sorting, storage batching bounds, and token/context handling.

* **Tests**
  * Updated tests and benchmarks for consistent `any` usage and range-based iteration.
  * Refreshed expected context/map shapes where applicable.

* **Chores**
  * Added and applied a “modernize” linter cleanup in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->