### PR TITLE
chore: remove github.com/tidwall/gjson dependency

### DIFF
--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -19,6 +19,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -31,7 +32,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tidwall/gjson"
 	"go.uber.org/goleak"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -1154,6 +1154,99 @@ func TestPlaygroundEnabled(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status code received from server")
 }
 
+// jsonVal is a minimal accessor over values decoded by encoding/json,
+// used to query the config JSON schema in tests via dotted paths.
+type jsonVal struct {
+	v      any
+	exists bool
+}
+
+func parseJSON(t *testing.T, data []byte) jsonVal {
+	t.Helper()
+	var root any
+	require.NoError(t, json.Unmarshal(data, &root))
+	return jsonVal{v: root, exists: true}
+}
+
+// Get traverses a dot-separated path, e.g. "properties.grpc.properties.addr.default".
+func (j jsonVal) Get(path string) jsonVal {
+	cur := j.v
+	for key := range strings.SplitSeq(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return jsonVal{}
+		}
+		v, ok := m[key]
+		if !ok {
+			return jsonVal{}
+		}
+		cur = v
+	}
+	return jsonVal{v: cur, exists: true}
+}
+
+func (j jsonVal) Exists() bool { return j.exists }
+
+func (j jsonVal) String() string {
+	switch v := j.v.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(v)
+	default:
+		return ""
+	}
+}
+
+func (j jsonVal) Bool() bool {
+	switch v := j.v.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true" || v == "1"
+	default:
+		return false
+	}
+}
+
+func (j jsonVal) Int() int64 {
+	switch v := j.v.(type) {
+	case float64:
+		return int64(v)
+	case string:
+		n, _ := strconv.ParseInt(v, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func (j jsonVal) Uint() uint64 {
+	switch v := j.v.(type) {
+	case float64:
+		return uint64(v)
+	case string:
+		n, _ := strconv.ParseUint(v, 10, 64)
+		return n
+	default:
+		return 0
+	}
+}
+
+func (j jsonVal) Array() []jsonVal {
+	arr, ok := j.v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]jsonVal, len(arr))
+	for i, v := range arr {
+		out[i] = jsonVal{v: v, exists: true}
+	}
+	return out
+}
+
 func TestDefaultConfig(t *testing.T) {
 	cfg, err := ReadConfig()
 	require.NoError(t, err)
@@ -1162,7 +1255,7 @@ func TestDefaultConfig(t *testing.T) {
 	jsonSchema, err := os.ReadFile(path.Join(filepath.Dir(basepath), "..", "..", ".config-schema.json"))
 	require.NoError(t, err)
 
-	res := gjson.ParseBytes(jsonSchema)
+	res := parseJSON(t, jsonSchema)
 
 	val := res.Get("properties.datastore.properties.engine.default")
 	require.True(t, val.Exists())

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/tidwall/gjson v1.19.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
 	go.opentelemetry.io/otel v1.44.0
@@ -118,8 +117,6 @@ require (
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	github.com/tidwall/match v1.1.1 // indirect
-	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,12 +278,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
-github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
-github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
-github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
-github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
-github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Remove the `github.com/tidwall/gjson` dependency.

## Description

Replace the `github.com/tidwall/gjson` dependency, its only usage with the stdlib package `encoding/json`.

#### What problem is being solved?

`github.com/tidwall/gjson` was pulled in as a dependency solely for a single test `TestDefaultConfig`. It provided no production functionality, yet added three modules to the dependency graph. Fewer dependencies means a smaller supply-chain surface and less to keep updated.

#### How is it being solved?

The single test's JSON-schema lookups are re-implemented using the standard `encoding/json` package plus a small local helper, so the third-party library can be dropped entirely.

#### What changes are made to solve it?

Added a minimal `jsonVal` helper type in cmd/run/run_test.go backed by `encoding/json`:
  - `parseJSON` unmarshals the schema into any.
  - Get traverses dot-separated paths.
  - Typed accessors `Exists/String/Bool/Int/Uint/Array` mirror gjson's coercion.
- Swapped `gjson.ParseBytes` for `parseJSON`; the 84 existing `res.Get(...)` call sites are unchanged.
- Removed the `github.com/tidwall/gjson` import and ran `go mod tidy`.

## References

N/A

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved configuration validation coverage by switching to a built-in JSON accessor for default config checks.
  * Added support for reading nested values, checking existence, and verifying typed values during test validation.

* **Chores**
  * Removed an unused JSON parsing dependency and related transitive packages from the module requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->