### PR TITLE
fix: validate object and relation format in Write delete requests

### DIFF
--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -167,7 +167,24 @@ func (c *WriteCommand) validateWriteRequest(ctx context.Context, req *openfgav1.
 	}
 
 	for _, tk := range deletes {
-		// TODO validate relation format and object format
+		if ok := tupleUtils.IsValidObject(tk.GetObject()); !ok {
+			return serverErrors.ValidationError(
+				&tupleUtils.InvalidTupleError{
+					Cause:    fmt.Errorf("the 'object' field is malformed"),
+					TupleKey: tk,
+				},
+			)
+		}
+
+		if ok := tupleUtils.IsValidRelation(tk.GetRelation()); !ok {
+			return serverErrors.ValidationError(
+				&tupleUtils.InvalidTupleError{
+					Cause:    fmt.Errorf("the 'relation' field is malformed"),
+					TupleKey: tk,
+				},
+			)
+		}
+
 		if ok := tupleUtils.IsValidUser(tk.GetUser()); !ok {
 			return serverErrors.ValidationError(
 				&tupleUtils.InvalidTupleError{

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -451,6 +451,54 @@ func TestWriteCommand(t *testing.T) {
 			expectedResponse: &openfgav1.WriteResponse{},
 		},
 		{
+			name:    "delete_failure_with_invalid_object",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "invalid",
+					Relation: "viewer",
+					User:     "user:1",
+				}},
+			},
+			expectedError: "rpc error: code = Code(2000) desc = Invalid tuple 'invalid#viewer@user:1'. Reason: the 'object' field is malformed",
+		},
+		{
+			name:    "delete_failure_with_empty_object",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "",
+					Relation: "viewer",
+					User:     "user:1",
+				}},
+			},
+			expectedError: "rpc error: code = Code(2000) desc = Invalid tuple '#viewer@user:1'. Reason: the 'object' field is malformed",
+		},
+		{
+			name:    "delete_failure_with_invalid_relation",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "document:1",
+					Relation: "",
+					User:     "user:1",
+				}},
+			},
+			expectedError: "rpc error: code = Code(2000) desc = Invalid tuple 'document:1#@user:1'. Reason: the 'relation' field is malformed",
+		},
+		{
+			name:    "delete_failure_with_relation_containing_special_chars",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "document:1",
+					Relation: "view#er",
+					User:     "user:1",
+				}},
+			},
+			expectedError: "rpc error: code = Code(2000) desc = Invalid tuple 'document:1#view#er@user:1'. Reason: the 'relation' field is malformed",
+		},
+		{
 			name:    "delete_failure_with_invalid_user",
 			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {},
 			deletes: &openfgav1.WriteRequestDeletes{


### PR DESCRIPTION
## Summary

Adds format validation for `object` and `relation` fields in Write delete requests, resolving a long-standing TODO.

## Problem

The Write endpoint validates all three fields (object, relation, user) for **write** operations via `ValidateTupleForWrite`, but only validates the `user` field for **delete** operations (marked with a TODO since initial implementation).

A malformed delete tuple (e.g., object without `:` separator, or relation containing `#`) passes validation, reaches the storage layer, matches no rows, and returns a misleading `ErrWriteConflictOnDelete` instead of a clear validation error.

## Solution

Added `IsValidObject()` and `IsValidRelation()` checks to the delete validation loop, using the same utility functions already used in the write path's deeper validation.

**Design note:** This is intentionally format-only validation. Deletes do NOT load the authorization model, so tuples referencing types/relations that no longer exist in the model can still be deleted (by design). This preserves the existing behavior confirmed by tests like `delete_of_tuple_with_object_type_not_in_model_should_succeed`.

## Tests

Added 4 new test cases:
- `delete_failure_with_invalid_object` — missing colon separator
- `delete_failure_with_empty_object` — empty string
- `delete_failure_with_invalid_relation` — empty relation
- `delete_failure_with_relation_containing_special_chars` — relation with `#`

All existing tests pass, including the intentional design tests:
- `delete_of_tuple_with_object_type_not_in_model_should_succeed` ✅
- `delete_of_tuple_with_relation_not_in_model_should_succeed` ✅
- `delete_of_implicit_tuple_should_succeed` ✅

## Checklist

- [x] Resolves TODO at `pkg/server/commands/write.go`
- [x] Unit tests added and passing
- [x] No breaking changes (better error messages, same rejection semantics)
- [x] Follows existing code patterns and error message format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for delete requests with malformed object or relation fields.
  * Delete operations now return clear validation errors for invalid, empty, or improperly formatted tuple fields.

* **Tests**
  * Added coverage for invalid delete tuple objects and relations, including special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->