### PR TITLE
lint: enable makezero and fix existing violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - gocyclo
     - godot
     - importas
+    - makezero
     - mirror
     - misspell
     - perfsprint

--- a/internal/containers/mpmc/queue_test.go
+++ b/internal/containers/mpmc/queue_test.go
@@ -227,10 +227,9 @@ func TestQueue(t *testing.T) {
 					require.Equal(t, expected, actual)
 				}
 
-				expected = make([]int, 0, tc.capacity)
 				for i := tc.capacity; i > 0; i-- {
 					p.Send(context.Background(), i)
-					expected = append(expected, i)
+					expected[tc.capacity-i] = i
 				}
 
 				p.Close()

--- a/internal/listobjects/pipeline/internal/worker/core.go
+++ b/internal/listobjects/pipeline/internal/worker/core.go
@@ -356,7 +356,7 @@ func (c *Core) send(ctx context.Context, buffer []string) {
 func (c *Core) Broadcast(ctx context.Context, values Receiver[string]) {
 	buffer, ok := ctx.Value(BufferKey).([]string)
 	if !ok || buffer == nil {
-		buffer = make([]string, c.ChunkSize)
+		buffer = make([]string, 0, c.ChunkSize)
 	}
 	buffer = buffer[:0]
 

--- a/pkg/server/commands/list_objects_test.go
+++ b/pkg/server/commands/list_objects_test.go
@@ -786,7 +786,6 @@ func createRecursiveRelations(b *testing.B, ctx context.Context, datastore stora
 				obj := "org:" + strconv.Itoa(objID)
 				tk := tuple.NewTupleKey(obj, "recursive", "user:justin")
 				tuples[j] = tk
-				tuples = append(tuples, tk)
 				objID++
 				continue
 			}

--- a/pkg/storage/memory/memory.go
+++ b/pkg/storage/memory/memory.go
@@ -297,10 +297,9 @@ func (s *MemoryBackend) read(ctx context.Context, store string, filter storage.R
 	s.mutexTuples.RLock()
 	defer s.mutexTuples.RUnlock()
 
-	var matches []*storage.TupleRecord
+	matches := make([]*storage.TupleRecord, 0, len(s.tuples[store]))
 	if filter.Object == "" && filter.Relation == "" && filter.User == "" {
-		matches = make([]*storage.TupleRecord, len(s.tuples[store]))
-		copy(matches, s.tuples[store])
+		matches = append(matches, s.tuples[store]...)
 	} else {
 		for _, t := range s.tuples[store] {
 			if match(t, &openfgav1.TupleKey{


### PR DESCRIPTION
## Summary
- Enable the `makezero` linter.
- Fix the four existing violations.
- Preallocate zero-length slices without introducing zero-value prefixes before append operations.
- Remove a duplicate append in the recursive benchmark helper.

## Validation
- Full makezero run: 0 issues
- Tests for all affected packages pass
- Lint on the diff from `origin/main`: 0 issues

Fixes #598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted queue test expectations to reflect the descending send/receive order.
  * Improved internal batching buffer allocation behavior during broadcasts.
  * Refined in-memory list/storage “no filters” matching to build results efficiently.
* **Chores**
  * Enabled an additional linter to strengthen code quality checks.
  * Updated benchmark data generation to write directly into the preallocated tuple results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->