### PR TITLE
chore(lint): Add `spancheck` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,6 +6,7 @@ run:
   allow-parallel-runners: true
 linters:
   enable:
+    # List of enabled linters, sorted alphabetically.
     - bodyclose
     - copyloopvar
     - errname
@@ -19,8 +20,9 @@ linters:
     - misspell
     - perfsprint
     - protogetter
-    - revive
     - recvcheck
+    - revive
+    - spancheck
     - staticcheck
     - tagalign
     - testifylint

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -14,7 +14,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -30,8 +29,19 @@ import (
 
 var tracer = otel.Tracer("openfga/pkg/storage/mysql")
 
-func startTrace(ctx context.Context, name string) (context.Context, trace.Span) {
-	return tracer.Start(ctx, "mysql."+name)
+// startTrace creates an OpenTelemetry span and returns a context containing the span, along with a closure to end it.
+func startTrace(ctx context.Context, name string) (context.Context, func()) {
+	ctx, span := tracer.Start(ctx, "mysql."+name)
+
+	// Return the tracer's context and a function that ends the span when called.
+	//
+	// Note: Returning the span directly and calling `span.End()` at the caller causes the `spancheck` linter to report
+	// a false positive. Since the span object escapes this function, the linter cannot reliably track it across the
+	// function boundary (i.e., it is no longer the same local reference). Wrapping `span.End()` in a closure keeps the
+	// span local and allows `spancheck` to detect that it is properly ended.
+	return ctx, func() {
+		span.End()
+	}
 }
 
 // Datastore provides a MySQL based implementation of [storage.OpenFGADatastore].
@@ -140,16 +150,16 @@ func (s *Datastore) Read(
 	filter storage.ReadFilter,
 	_ storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Read")
+	defer spanEnd()
 
 	return s.read(ctx, store, filter, nil)
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
 func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.ReadFilter, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
-	ctx, span := startTrace(ctx, "ReadPage")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadPage")
+	defer spanEnd()
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
@@ -161,8 +171,8 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*sqlcommon.SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "read")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select(
@@ -221,8 +231,8 @@ func (s *Datastore) Write(
 	writes storage.Writes,
 	opts ...storage.TupleWriteOption,
 ) error {
-	ctx, span := startTrace(ctx, "Write")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Write")
+	defer spanEnd()
 
 	return sqlcommon.Write(ctx, s.dbInfo, s.db, store,
 		sqlcommon.WriteData{
@@ -235,8 +245,8 @@ func (s *Datastore) Write(
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
 func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter storage.ReadUserTupleFilter, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
-	ctx, span := startTrace(ctx, "ReadUserTuple")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadUserTuple")
+	defer spanEnd()
 
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
 	userType := tupleUtils.GetUserTypeFromUser(filter.User)
@@ -300,8 +310,8 @@ func (s *Datastore) ReadUsersetTuples(
 	filter storage.ReadUsersetTuplesFilter,
 	_ storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadUsersetTuples")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadUsersetTuples")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select(
@@ -353,8 +363,8 @@ func (s *Datastore) ReadStartingWithUser(
 	filter storage.ReadStartingWithUserFilter,
 	_ storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadStartingWithUser")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadStartingWithUser")
+	defer spanEnd()
 
 	var targetUsersArg []string
 	for _, u := range filter.UserFilter {
@@ -395,16 +405,16 @@ func (s *Datastore) MaxTuplesPerWrite() int {
 
 // ReadAuthorizationModel see [storage.AuthorizationModelReadBackend].ReadAuthorizationModel.
 func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, modelID string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModel")
+	defer spanEnd()
 
 	return sqlcommon.ReadAuthorizationModel(ctx, s.dbInfo, store, modelID)
 }
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
 func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModels")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModels")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select("authorization_model_id").
@@ -467,8 +477,8 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 // FindLatestAuthorizationModel see [storage.AuthorizationModelReadBackend].FindLatestAuthorizationModel.
 func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "FindLatestAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "FindLatestAuthorizationModel")
+	defer spanEnd()
 
 	return sqlcommon.FindLatestAuthorizationModel(ctx, s.dbInfo, store)
 }
@@ -480,16 +490,16 @@ func (s *Datastore) MaxTypesPerAuthorizationModel() int {
 
 // WriteAuthorizationModel see [storage.TypeDefinitionWriteBackend].WriteAuthorizationModel.
 func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, model *openfgav1.AuthorizationModel) error {
-	ctx, span := startTrace(ctx, "WriteAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAuthorizationModel")
+	defer spanEnd()
 
 	return sqlcommon.WriteAuthorizationModel(ctx, s.dbInfo, store, model)
 }
 
 // CreateStore adds a new store to storage.
 func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "CreateStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "CreateStore")
+	defer spanEnd()
 
 	var id, name string
 	var createdAt, updatedAt time.Time
@@ -538,8 +548,8 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 // GetStore retrieves the details of a specific store using its storeID.
 func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "GetStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "GetStore")
+	defer spanEnd()
 
 	row := s.stbl.
 		Select("id", "name", "created_at", "updated_at").
@@ -570,8 +580,8 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 
 // ListStores provides a paginated list of all stores present in the storage.
 func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
-	ctx, span := startTrace(ctx, "ListStores")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ListStores")
+	defer spanEnd()
 
 	whereClause := sq.And{
 		sq.Eq{"deleted_at": nil},
@@ -636,8 +646,8 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 // DeleteStore removes a store from storage.
 func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
-	ctx, span := startTrace(ctx, "DeleteStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "DeleteStore")
+	defer spanEnd()
 
 	_, err := s.stbl.
 		Update("store").
@@ -653,8 +663,8 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 
 // WriteAssertions see [storage.AssertionsBackend].WriteAssertions.
 func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgav1.Assertion) error {
-	ctx, span := startTrace(ctx, "WriteAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAssertions")
+	defer spanEnd()
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
@@ -676,8 +686,8 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 // ReadAssertions see [storage.AssertionsBackend].ReadAssertions.
 func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgav1.Assertion, error) {
-	ctx, span := startTrace(ctx, "ReadAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAssertions")
+	defer spanEnd()
 
 	var marshalledAssertions []byte
 	err := s.stbl.
@@ -707,8 +717,8 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 
 // ReadChanges see [storage.ChangelogBackend].ReadChanges.
 func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
-	ctx, span := startTrace(ctx, "ReadChanges")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadChanges")
+	defer spanEnd()
 
 	objectTypeFilter := filter.ObjectType
 	horizonOffset := filter.HorizonOffset

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -24,7 +24,6 @@ import (
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -40,8 +39,19 @@ import (
 
 var tracer = otel.Tracer("openfga/pkg/storage/postgres")
 
-func startTrace(ctx context.Context, name string) (context.Context, trace.Span) {
-	return tracer.Start(ctx, "postgres."+name)
+// startTrace creates an OpenTelemetry span and returns a context containing the span, along with a closure to end it.
+func startTrace(ctx context.Context, name string) (context.Context, func()) {
+	ctx, span := tracer.Start(ctx, "postgres."+name)
+
+	// Return the tracer's context and a function that ends the span when called.
+	//
+	// Note: Returning the span directly and calling `span.End()` at the caller causes the `spancheck` linter to report
+	// a false positive. Since the span object escapes this function, the linter cannot reliably track it across the
+	// function boundary (i.e., it is no longer the same local reference). Wrapping `span.End()` in a closure keeps the
+	// span local and allows `spancheck` to detect that it is properly ended.
+	return ctx, func() {
+		span.End()
+	}
 }
 
 // Datastore provides a PostgreSQL based implementation of [storage.OpenFGADatastore].
@@ -338,8 +348,8 @@ func (s *Datastore) Read(
 	filter storage.ReadFilter,
 	options storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Read")
+	defer spanEnd()
 
 	readPool := s.getPgxPool(options.Consistency.Preference)
 	return s.read(ctx, store, filter, nil, readPool)
@@ -347,8 +357,8 @@ func (s *Datastore) Read(
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
 func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.ReadFilter, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
-	ctx, span := startTrace(ctx, "ReadPage")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadPage")
+	defer spanEnd()
 
 	readPool := s.getPgxPool(options.Consistency.Preference)
 	iter, err := s.read(ctx, store, filter, &options, readPool)
@@ -361,8 +371,8 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions, db *pgxpool.Pool) (*sqlcommon.SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "read")
+	defer spanEnd()
 
 	sb := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
 		Select(
@@ -425,8 +435,8 @@ func (s *Datastore) Write(
 	writes storage.Writes,
 	opts ...storage.TupleWriteOption,
 ) error {
-	ctx, span := startTrace(ctx, "Write")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Write")
+	defer spanEnd()
 	return s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 }
 
@@ -650,8 +660,8 @@ func (s *Datastore) write(
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
 func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter storage.ReadUserTupleFilter, options storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
-	ctx, span := startTrace(ctx, "ReadUserTuple")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadUserTuple")
+	defer spanEnd()
 
 	readStbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
@@ -722,8 +732,8 @@ func (s *Datastore) ReadUsersetTuples(
 	filter storage.ReadUsersetTuplesFilter,
 	options storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadUsersetTuples")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadUsersetTuples")
+	defer spanEnd()
 
 	db := s.getPgxPool(options.Consistency.Preference)
 	sb := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
@@ -781,8 +791,8 @@ func (s *Datastore) ReadStartingWithUser(
 	filter storage.ReadStartingWithUserFilter,
 	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadStartingWithUser")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadStartingWithUser")
+	defer spanEnd()
 
 	db := s.getPgxPool(options.Consistency.Preference)
 	readStbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
@@ -829,8 +839,8 @@ func (s *Datastore) MaxTuplesPerWrite() int {
 
 // ReadAuthorizationModel see [storage.AuthorizationModelReadBackend].ReadAuthorizationModel.
 func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, modelID string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModel")
+	defer spanEnd()
 
 	db := s.getPgxPool(openfgav1.ConsistencyPreference_MINIMIZE_LATENCY)
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
@@ -859,8 +869,8 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
 func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModels")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModels")
+	defer spanEnd()
 
 	db := s.getPgxPool(openfgav1.ConsistencyPreference_MINIMIZE_LATENCY)
 
@@ -930,8 +940,8 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 // FindLatestAuthorizationModel see [storage.AuthorizationModelReadBackend].FindLatestAuthorizationModel.
 func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "FindLatestAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "FindLatestAuthorizationModel")
+	defer spanEnd()
 
 	db := s.getPgxPool(openfgav1.ConsistencyPreference_MINIMIZE_LATENCY)
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
@@ -962,8 +972,8 @@ func (s *Datastore) MaxTypesPerAuthorizationModel() int {
 
 // WriteAuthorizationModel see [storage.TypeDefinitionWriteBackend].WriteAuthorizationModel.
 func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, model *openfgav1.AuthorizationModel) error {
-	ctx, span := startTrace(ctx, "WriteAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAuthorizationModel")
+	defer spanEnd()
 
 	schemaVersion := model.GetSchemaVersion()
 	typeDefinitions := model.GetTypeDefinitions()
@@ -995,8 +1005,8 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 // CreateStore adds a new store to storage.
 func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "CreateStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "CreateStore")
+	defer spanEnd()
 
 	var id, name string
 	var createdAt, updatedAt time.Time
@@ -1028,8 +1038,8 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 // GetStore retrieves the details of a specific store using its storeID.
 func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "GetStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "GetStore")
+	defer spanEnd()
 
 	db := s.getPgxPool(openfgav1.ConsistencyPreference_MINIMIZE_LATENCY)
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
@@ -1063,8 +1073,8 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 
 // ListStores provides a paginated list of all stores present in the storage.
 func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
-	ctx, span := startTrace(ctx, "ListStores")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ListStores")
+	defer spanEnd()
 
 	whereClause := sq.And{
 		sq.Eq{"deleted_at": nil},
@@ -1135,8 +1145,8 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 // DeleteStore removes a store from storage.
 func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
-	ctx, span := startTrace(ctx, "DeleteStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "DeleteStore")
+	defer spanEnd()
 
 	db := s.primaryDB
 	stmt, args, err := sq.StatementBuilder.PlaceholderFormat(sq.Dollar).
@@ -1157,8 +1167,8 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 
 // WriteAssertions see [storage.AssertionsBackend].WriteAssertions.
 func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgav1.Assertion) error {
-	ctx, span := startTrace(ctx, "WriteAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAssertions")
+	defer spanEnd()
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
@@ -1186,8 +1196,8 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 // ReadAssertions see [storage.AssertionsBackend].ReadAssertions.
 func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgav1.Assertion, error) {
-	ctx, span := startTrace(ctx, "ReadAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAssertions")
+	defer spanEnd()
 
 	var marshalledAssertions []byte
 	db := s.getPgxPool(openfgav1.ConsistencyPreference_MINIMIZE_LATENCY)
@@ -1223,8 +1233,8 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 
 // ReadChanges see [storage.ChangelogBackend].ReadChanges.
 func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
-	ctx, span := startTrace(ctx, "ReadChanges")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadChanges")
+	defer spanEnd()
 
 	objectTypeFilter := filter.ObjectType
 	horizonOffset := filter.HorizonOffset

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -32,8 +31,19 @@ import (
 
 var tracer = otel.Tracer("openfga/pkg/storage/sqlite")
 
-func startTrace(ctx context.Context, name string) (context.Context, trace.Span) {
-	return tracer.Start(ctx, "sqlite."+name)
+// startTrace creates an OpenTelemetry span and returns a context containing the span, along with a closure to end it.
+func startTrace(ctx context.Context, name string) (context.Context, func()) {
+	ctx, span := tracer.Start(ctx, "sqlite."+name)
+
+	// Return the tracer's context and a function that ends the span when called.
+	//
+	// Note: Returning the span directly and calling `span.End()` at the caller causes the `spancheck` linter to report
+	// a false positive. Since the span object escapes this function, the linter cannot reliably track it across the
+	// function boundary (i.e., it is no longer the same local reference). Wrapping `span.End()` in a closure keeps the
+	// span local and allows `spancheck` to detect that it is properly ended.
+	return ctx, func() {
+		span.End()
+	}
 }
 
 var tupleColumns = []string{
@@ -154,16 +164,16 @@ func (s *Datastore) Read(
 	filter storage.ReadFilter,
 	_ storage.ReadOptions,
 ) (storage.TupleIterator, error) {
-	ctx, span := startTrace(ctx, "Read")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Read")
+	defer spanEnd()
 
 	return s.read(ctx, store, filter, nil)
 }
 
 // ReadPage see [storage.RelationshipTupleReader].ReadPage.
 func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.ReadFilter, options storage.ReadPageOptions) ([]*openfgav1.Tuple, string, error) {
-	ctx, span := startTrace(ctx, "ReadPage")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadPage")
+	defer spanEnd()
 
 	iter, err := s.read(ctx, store, filter, &options)
 	if err != nil {
@@ -175,8 +185,8 @@ func (s *Datastore) ReadPage(ctx context.Context, store string, filter storage.R
 }
 
 func (s *Datastore) read(ctx context.Context, store string, filter storage.ReadFilter, options *storage.ReadPageOptions) (*SQLTupleIterator, error) {
-	_, span := startTrace(ctx, "read")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "read")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select(
@@ -245,8 +255,8 @@ func (s *Datastore) Write(
 	writes storage.Writes,
 	opts ...storage.TupleWriteOption,
 ) error {
-	ctx, span := startTrace(ctx, "Write")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "Write")
+	defer spanEnd()
 
 	return s.write(ctx, store, deletes, writes, storage.NewTupleWriteOptions(opts...), time.Now().UTC())
 }
@@ -685,8 +695,8 @@ func (s *Datastore) write(
 
 // ReadUserTuple see [storage.RelationshipTupleReader].ReadUserTuple.
 func (s *Datastore) ReadUserTuple(ctx context.Context, store string, filter storage.ReadUserTupleFilter, _ storage.ReadUserTupleOptions) (*openfgav1.Tuple, error) {
-	ctx, span := startTrace(ctx, "ReadUserTuple")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadUserTuple")
+	defer spanEnd()
 
 	objectType, objectID := tupleUtils.SplitObject(filter.Object)
 	userType := tupleUtils.GetUserTypeFromUser(filter.User)
@@ -755,8 +765,8 @@ func (s *Datastore) ReadUsersetTuples(
 	filter storage.ReadUsersetTuplesFilter,
 	_ storage.ReadUsersetTuplesOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadUsersetTuples")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadUsersetTuples")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select(
@@ -811,8 +821,8 @@ func (s *Datastore) ReadStartingWithUser(
 	filter storage.ReadStartingWithUserFilter,
 	_ storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
-	_, span := startTrace(ctx, "ReadStartingWithUser")
-	defer span.End()
+	_, spanEnd := startTrace(ctx, "ReadStartingWithUser")
+	defer spanEnd()
 
 	var targetUsersArg sq.Or
 	for _, u := range filter.UserFilter {
@@ -885,8 +895,8 @@ func constructAuthorizationModelFromSQLRows(rows *sql.Rows) (*openfgav1.Authoriz
 
 // ReadAuthorizationModel see [storage.AuthorizationModelReadBackend].ReadAuthorizationModel.
 func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, modelID string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModel")
+	defer spanEnd()
 
 	rows, err := s.stbl.
 		Select("authorization_model_id", "schema_version", "serialized_protobuf").
@@ -906,8 +916,8 @@ func (s *Datastore) ReadAuthorizationModel(ctx context.Context, store string, mo
 
 // ReadAuthorizationModels see [storage.AuthorizationModelReadBackend].ReadAuthorizationModels.
 func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, options storage.ReadAuthorizationModelsOptions) ([]*openfgav1.AuthorizationModel, string, error) {
-	ctx, span := startTrace(ctx, "ReadAuthorizationModels")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAuthorizationModels")
+	defer spanEnd()
 
 	sb := s.stbl.
 		Select("authorization_model_id", "schema_version", "serialized_protobuf").
@@ -962,8 +972,8 @@ func (s *Datastore) ReadAuthorizationModels(ctx context.Context, store string, o
 
 // FindLatestAuthorizationModel see [storage.AuthorizationModelReadBackend].FindLatestAuthorizationModel.
 func (s *Datastore) FindLatestAuthorizationModel(ctx context.Context, store string) (*openfgav1.AuthorizationModel, error) {
-	ctx, span := startTrace(ctx, "FindLatestAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "FindLatestAuthorizationModel")
+	defer spanEnd()
 
 	rows, err := s.stbl.
 		Select("authorization_model_id", "schema_version", "serialized_protobuf").
@@ -987,8 +997,8 @@ func (s *Datastore) MaxTypesPerAuthorizationModel() int {
 
 // WriteAuthorizationModel see [storage.TypeDefinitionWriteBackend].WriteAuthorizationModel.
 func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, model *openfgav1.AuthorizationModel) error {
-	ctx, span := startTrace(ctx, "WriteAuthorizationModel")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAuthorizationModel")
+	defer spanEnd()
 
 	schemaVersion := model.GetSchemaVersion()
 	typeDefinitions := model.GetTypeDefinitions()
@@ -1019,8 +1029,8 @@ func (s *Datastore) WriteAuthorizationModel(ctx context.Context, store string, m
 
 // CreateStore adds a new store to storage.
 func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "CreateStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "CreateStore")
+	defer spanEnd()
 
 	var id, name string
 	var createdAt, updatedAt time.Time
@@ -1048,8 +1058,8 @@ func (s *Datastore) CreateStore(ctx context.Context, store *openfgav1.Store) (*o
 
 // GetStore retrieves the details of a specific store using its storeID.
 func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, error) {
-	ctx, span := startTrace(ctx, "GetStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "GetStore")
+	defer spanEnd()
 
 	row := s.stbl.
 		Select("id", "name", "created_at", "updated_at").
@@ -1080,8 +1090,8 @@ func (s *Datastore) GetStore(ctx context.Context, id string) (*openfgav1.Store, 
 
 // ListStores provides a paginated list of all stores present in the storage.
 func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOptions) ([]*openfgav1.Store, string, error) {
-	ctx, span := startTrace(ctx, "ListStores")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ListStores")
+	defer spanEnd()
 
 	whereClause := sq.And{
 		sq.Eq{"deleted_at": nil},
@@ -1146,8 +1156,8 @@ func (s *Datastore) ListStores(ctx context.Context, options storage.ListStoresOp
 
 // DeleteStore removes a store from storage.
 func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
-	ctx, span := startTrace(ctx, "DeleteStore")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "DeleteStore")
+	defer spanEnd()
 
 	_, err := s.stbl.
 		Update("store").
@@ -1163,8 +1173,8 @@ func (s *Datastore) DeleteStore(ctx context.Context, id string) error {
 
 // WriteAssertions see [storage.AssertionsBackend].WriteAssertions.
 func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, assertions []*openfgav1.Assertion) error {
-	ctx, span := startTrace(ctx, "WriteAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "WriteAssertions")
+	defer spanEnd()
 
 	marshalledAssertions, err := proto.Marshal(&openfgav1.Assertions{Assertions: assertions})
 	if err != nil {
@@ -1189,8 +1199,8 @@ func (s *Datastore) WriteAssertions(ctx context.Context, store, modelID string, 
 
 // ReadAssertions see [storage.AssertionsBackend].ReadAssertions.
 func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) ([]*openfgav1.Assertion, error) {
-	ctx, span := startTrace(ctx, "ReadAssertions")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadAssertions")
+	defer spanEnd()
 
 	var marshalledAssertions []byte
 	err := s.stbl.
@@ -1220,8 +1230,8 @@ func (s *Datastore) ReadAssertions(ctx context.Context, store, modelID string) (
 
 // ReadChanges see [storage.ChangelogBackend].ReadChanges.
 func (s *Datastore) ReadChanges(ctx context.Context, store string, filter storage.ReadChangesFilter, options storage.ReadChangesOptions) ([]*openfgav1.TupleChange, string, error) {
-	ctx, span := startTrace(ctx, "ReadChanges")
-	defer span.End()
+	ctx, spanEnd := startTrace(ctx, "ReadChanges")
+	defer spanEnd()
 
 	objectTypeFilter := filter.ObjectType
 	horizonOffset := filter.HorizonOffset


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Add the `spancheck` linter.

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Added the `spancheck` linter to detect OpenTelemetry spans that are not properly ended. This helps prevent span leaks by ensuring spans returned from `tracer.Start` are properly ended.

#### How is it being solved?

By adding the `spancheck` linter to the GolangCI-Lint configuration so `make lint` validates that OpenTelemetry spans are properly ended.

#### What changes are made to solve it?

- Added the `spancheck` linter to the GolangCI-Lint configuration. Also sorted the list of enabled linters for better readability.
- Moved `span.End()` to the same scope as its corresponding `tracer.Start()` call in the MySQL, PostgreSQL, and SQLite packages to fix the existing `spancheck` linter violations.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

Related-to: #598 

> [!NOTE]
> Not closing #598 with this PR, as additional linters will be added in follow-up PRs.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
  - [x] Not applicable. This PR only adds a linter and does not introduce any user-facing changes.
- [ ] The correct base branch is being used, if not `main`
  - [x] Not applicable. This PR targets `main`.
- [ ] I have added tests to validate that the change in functionality is working as expected
  - [x] Not applicable. The refactored `startTrace()` helper in the MySQL, PostgreSQL, and SQLite packages is already covered by existing unit tests, so no additional tests are required.


## Testing

The refactored `startTrace()` helper in all three packages (MySQL, PostgreSQL, and SQLite) is already covered by existing unit tests, so no additional tests are required.

Run the linter and verify that `spancheck` is enabled and that there are no linting errors.
<img width="1870" height="769" alt="image" src="https://github.com/user-attachments/assets/1093210e-c0af-4058-945d-1a925c36aaf2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tracing behavior across MySQL, PostgreSQL, and SQLite storage operations.
  * Improved consistency when tracking datastore reads, writes, and administrative actions.

* **Chores**
  * Updated code-quality checks with an additional linter and refreshed linter configuration.
  * No changes to public APIs or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->