### PR TITLE
chore(lint): Add `prealloc` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - mirror
     - misspell
     - perfsprint
+    - prealloc
     - protogetter
     - revive
     - recvcheck

--- a/cmd/run/run_test.go
+++ b/cmd/run/run_test.go
@@ -1065,9 +1065,8 @@ func testServerMetricsReporting(t *testing.T, engine string, connectionMetricNam
 		"openfga_condition_evaluation_cost",
 		"openfga_condition_compilation_duration_ms",
 		"openfga_condition_evaluation_duration_ms",
+		connectionMetricName,
 	}
-
-	expectedMetrics = append(expectedMetrics, connectionMetricName)
 
 	for _, metric := range expectedMetrics {
 		count, err := testutil.GatherAndCount(prometheus.DefaultGatherer, metric)

--- a/internal/authn/oidc/oidc.go
+++ b/internal/authn/oidc/oidc.go
@@ -95,11 +95,13 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 		return nil, authn.ErrMissingBearerToken
 	}
 
-	options := []jwt.ParserOption{
+	// Preallocate space for 4 options to avoid reallocations, as recommended by the `prealloc` linter.
+	options := make([]jwt.ParserOption, 0, 4)
+	options = append(options,
 		jwt.WithValidMethods([]string{"RS256"}),
 		jwt.WithIssuedAt(),
 		jwt.WithExpirationRequired(),
-	}
+	)
 
 	// constructor enforces non-empty Audience; unconditional to make the invariant explicit
 	options = append(options, jwt.WithAudience(oidc.Audience))
@@ -118,9 +120,10 @@ func (oidc *RemoteOidcAuthenticator) Authenticate(requestContext context.Context
 		return nil, errInvalidClaims
 	}
 
-	validIssuers := []string{
-		oidc.MainIssuer,
-	}
+	// Preallocate space for the main issuer and all issuer aliases to avoid reallocations, as recommended by the
+	// `prealloc` linter.
+	validIssuers := make([]string, 0, 1+len(oidc.IssuerAliases))
+	validIssuers = append(validIssuers, oidc.MainIssuer)
 	validIssuers = append(validIssuers, oidc.IssuerAliases...)
 
 	ok = slices.ContainsFunc(validIssuers, func(issuer string) bool {

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -212,7 +212,7 @@ func TestAuthorize(t *testing.T) {
 		defer mockController.Finish()
 
 		errorMessage := fmt.Errorf("error")
-		modules := []string{}
+		modules := make([]string, 0, MaxModulesInRequest)
 
 		for moduleIndex := range MaxModulesInRequest {
 			modules = append(modules, fmt.Sprintf("module%d", moduleIndex+1))
@@ -304,7 +304,7 @@ func TestAuthorize(t *testing.T) {
 		mockController, mockServer, authorizer := setupAuthorizerAndController(t, storeID, modelID)
 		defer mockController.Finish()
 
-		modules := []string{}
+		modules := make([]string, 0, MaxModulesInRequest)
 		for moduleIndex := range MaxModulesInRequest {
 			modules = append(modules, fmt.Sprintf("module%d", moduleIndex))
 		}

--- a/internal/check/bottom_up_test.go
+++ b/internal/check/bottom_up_test.go
@@ -585,7 +585,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 1)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
 		producer := make(chan *iterator.Msg, 1)
@@ -612,7 +612,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -839,7 +839,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -870,7 +870,7 @@ func TestBottomUpResolveUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("obj:0", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -911,7 +911,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 1)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
 		producer := make(chan *iterator.Msg, 1)
@@ -937,7 +937,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -1164,7 +1164,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -1192,7 +1192,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("obj:0", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1230,7 +1230,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1265,7 +1265,7 @@ func TestBottomUpResolveIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		// this is to simulate successful remove of item 1
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("obj:1", nil)
@@ -1307,7 +1307,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -1341,7 +1341,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -1527,7 +1527,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -1605,7 +1605,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1638,7 +1638,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1673,7 +1673,7 @@ func TestBottomUpResolveDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]storage.Iterator[string], 0)
+		producers := make([]storage.Iterator[string], 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
 		close(producer1)

--- a/internal/condition/types/ipaddress.go
+++ b/internal/condition/types/ipaddress.go
@@ -26,7 +26,7 @@ func IPAddressEnvOption() cel.EnvOption {
 }
 
 func (ip IPAddress) CompileOptions() []cel.EnvOption {
-	options := []cel.EnvOption{}
+	options := make([]cel.EnvOption, 0, len(ipaddrLibraryDecls))
 	for name, overloads := range ipaddrLibraryDecls {
 		options = append(options, cel.Function(name, overloads...))
 	}

--- a/internal/condition/types/ipaddress_test.go
+++ b/internal/condition/types/ipaddress_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"testing"
 
+	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/stretchr/testify/require"
@@ -90,6 +91,60 @@ func TestIPaddressCELBinaryBinding(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			val := ipaddressCELBinaryBinding(test.lhs, test.rhs)
 			require.Equal(t, test.result, val)
+		})
+	}
+}
+
+func TestIPAddressWithCompileOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		expression      string
+		isErrorExpected bool
+	}{
+		{
+			name:            "valid_ipaddress_function",
+			expression:      `ipaddress("192.168.1.1")`,
+			isErrorExpected: false,
+		},
+		{
+			name:            "invalid_ipaddress_function",
+			expression:      `ipaddress("not-an-ip")`,
+			isErrorExpected: true,
+		},
+	}
+
+	// Construct a CEL environment using only the compile options exposed by the IP address library. This verifies that
+	// the library registers the declarations required for the `ipaddress` function to compile.
+	env, err := cel.NewCustomEnv(ipaddrLib.CompileOptions()...)
+	require.NoError(t, err)
+
+	// With the CEL environment successfully constructed, verify that each test expression can be compiled, converted
+	// into an executable CEL program, and evaluated.
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Ensure the expression successfully compiles. Validation of the runtime behavior of `ipaddress` is covered
+			// by the evaluation below.
+			ast, issues := env.Compile(test.expression)
+			require.NoError(t, issues.Err())
+
+			// Ensure the compiled expression can be converted into an executable CEL program using only the compile
+			// options exposed by the IP address library.
+			prg, err := env.Program(ast)
+			require.NoError(t, err)
+
+			// Evaluate the compiled program and verify whether evaluation succeeds or fails as expected.
+			_, _, err = prg.Eval(map[string]any{})
+			if test.isErrorExpected {
+				require.Error(t, err)
+
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/graph/weight_two_resolver_test.go
+++ b/internal/graph/weight_two_resolver_test.go
@@ -179,7 +179,7 @@ func TestFastPathUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 1)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
 		producer := make(chan *iterator.Msg, 1)
@@ -205,7 +205,7 @@ func TestFastPathUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -430,7 +430,7 @@ func TestFastPathUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -458,7 +458,7 @@ func TestFastPathUnion(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("obj:0", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -498,7 +498,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 1)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
 		producer := make(chan *iterator.Msg, 1)
@@ -524,7 +524,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -751,7 +751,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -779,7 +779,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("obj:0", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -814,7 +814,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("obj:1", nil)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -849,7 +849,7 @@ func TestFastPathIntersection(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		// the first two times of Head() is to remove the first item (1)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(2).Return("obj:1", nil)
@@ -893,7 +893,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -927,7 +927,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
 		iter1.EXPECT().Stop().MaxTimes(1)
@@ -1113,7 +1113,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Err: fmt.Errorf("mock error")}
 		close(producer1)
@@ -1191,7 +1191,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).AnyTimes().Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1223,7 +1223,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		iter1 := mocks.NewMockIterator[string](ctrl)
 		iter1.EXPECT().Head(gomock.Any()).AnyTimes().Return("obj:1", nil)
 		iter1.EXPECT().Next(gomock.Any()).MaxTimes(1).Return("", errors.New("boom"))
@@ -1255,7 +1255,7 @@ func TestFastPathDifference(t *testing.T) {
 		defer ctrl.Finish()
 
 		res := make(chan *iterator.Msg)
-		producers := make([]*iterator.Stream, 0)
+		producers := make([]*iterator.Stream, 0, 2)
 		producer1 := make(chan *iterator.Msg, 1)
 		producer1 <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"obj:2"})}
 		close(producer1)

--- a/internal/listobjects/pipeline/pipeline_test.go
+++ b/internal/listobjects/pipeline/pipeline_test.go
@@ -108,12 +108,10 @@ func TestPipeline_Shutdown(t *testing.T) {
 	const user string = "user:bob"
 	const nestLevel int = 100
 
-	var tuples []string
-
 	var child string
 	var parent string
-
-	var documents []string
+	tuples := make([]string, 0, nestLevel*24)
+	documents := make([]string, 0, nestLevel)
 
 	for i := range nestLevel {
 		if i%2 == 0 {

--- a/internal/listobjects/pipeline/store_test.go
+++ b/internal/listobjects/pipeline/store_test.go
@@ -453,7 +453,7 @@ func TestReaderRead(t *testing.T) {
 
 		reader := pipeline.NewValidatingStore(store, "store-1")
 
-		var got []string
+		got := make([]string, 0, 1)
 		receiver := reader.Read(context.Background(), pipeline.ObjectQuery{
 			ObjectType: "document",
 			Relation:   "viewer",

--- a/internal/test/listusers/listusers.go
+++ b/internal/test/listusers/listusers.go
@@ -30,7 +30,7 @@ func (t *TestListUsersRequest) ToString() string {
 }
 
 func FromUsersProto(r []*openfgav1.User) []string {
-	var users []string
+	users := make([]string, 0, len(r))
 	for _, user := range r {
 		users = append(users, tuple.UserProtoToString(user))
 	}
@@ -38,7 +38,7 @@ func FromUsersProto(r []*openfgav1.User) []string {
 }
 
 func (t *TestListUsersRequest) ToProtoRequest() *openfgav1.ListUsersRequest {
-	var userTypeFilters []*openfgav1.UserTypeFilter
+	userTypeFilters := make([]*openfgav1.UserTypeFilter, 0, len(t.Filters))
 
 	for _, filterString := range t.Filters {
 		userTypeFilters = append(userTypeFilters, toProtoUserTypeFilter(filterString))

--- a/pkg/server/check_test.go
+++ b/pkg/server/check_test.go
@@ -131,9 +131,8 @@ func setupCheckServer(t *testing.T, modelDSL string, tuples []*openfgav1.TupleKe
 
 	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
 
-	defaultOpts := []OpenFGAServiceV1Option{
-		WithDatastore(ds),
-	}
+	defaultOpts := make([]OpenFGAServiceV1Option, 0, 1+len(opts))
+	defaultOpts = append(defaultOpts, WithDatastore(ds))
 	defaultOpts = append(defaultOpts, opts...)
 
 	s := MustNewServerWithOpts(defaultOpts...)

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -639,7 +639,7 @@ func (l *listUsersQuery) expandIntersection(
 	}
 	wg.Wait()
 
-	excludedUsers := []*openfgav1.User{}
+	excludedUsers := make([]*openfgav1.User, 0, len(excludedUsersMap))
 	for key := range excludedUsersMap {
 		excludedUsers = append(excludedUsers, tuple.StringToUserProto(key))
 	}

--- a/pkg/server/server_authz_test.go
+++ b/pkg/server/server_authz_test.go
@@ -82,9 +82,10 @@ const (
 
 func testStoreModelWithModule() []*openfgav1.TypeDefinition {
 	// Add a module to the test store
-	typeDefs := []*openfgav1.TypeDefinition{{
+	typeDefs := make([]*openfgav1.TypeDefinition, 0, 1+(authz.MaxModulesInRequest+1))
+	typeDefs = append(typeDefs, &openfgav1.TypeDefinition{
 		Type: "user",
-	}}
+	})
 
 	// Add as many modules as necessary (we do this dynamically in case the max modules changes)
 	for moduleIndex := range authz.MaxModulesInRequest + 1 {
@@ -502,7 +503,7 @@ func TestWrite(t *testing.T) {
 		})
 
 		t.Run("errors_when_not_authorized_for_all_modules", func(t *testing.T) {
-			tuples := []*openfgav1.TupleKey{}
+			tuples := make([]*openfgav1.TupleKey, 0, authz.MaxModulesInRequest)
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: clientID})
 
 			for index := range authz.MaxModulesInRequest {
@@ -525,7 +526,7 @@ func TestWrite(t *testing.T) {
 		})
 
 		t.Run("successfully_call_write_for_modules", func(t *testing.T) {
-			tuples := []*openfgav1.TupleKey{}
+			tuples := make([]*openfgav1.TupleKey, 0, authz.MaxModulesInRequest)
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: clientID})
 
 			for index := range authz.MaxModulesInRequest {
@@ -543,7 +544,7 @@ func TestWrite(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			tuplesInDelete := []*openfgav1.TupleKeyWithoutCondition{}
+			tuplesInDelete := make([]*openfgav1.TupleKeyWithoutCondition, 0, len(tuples))
 			for _, tuple := range tuples {
 				tuplesInDelete = append(tuplesInDelete, &openfgav1.TupleKeyWithoutCondition{
 					User:     tuple.GetUser(),
@@ -563,7 +564,7 @@ func TestWrite(t *testing.T) {
 		})
 
 		t.Run("errors_when_sending_more_than_max_modules", func(t *testing.T) {
-			tuples := []*openfgav1.TupleKey{}
+			tuples := make([]*openfgav1.TupleKey, 0, authz.MaxModulesInRequest+1)
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: clientID})
 
 			for index := range authz.MaxModulesInRequest + 1 {
@@ -582,7 +583,7 @@ func TestWrite(t *testing.T) {
 
 			require.ErrorIs(t, err, authz.ErrUnauthorizedResponse)
 
-			tuplesInDelete := []*openfgav1.TupleKeyWithoutCondition{}
+			tuplesInDelete := make([]*openfgav1.TupleKeyWithoutCondition, 0, len(tuples))
 			for _, tuple := range tuples {
 				tuplesInDelete = append(tuplesInDelete, &openfgav1.TupleKeyWithoutCondition{
 					User:     tuple.GetUser(),
@@ -603,7 +604,7 @@ func TestWrite(t *testing.T) {
 		})
 
 		t.Run("success_when_sending_more_than_max_modules_with_store_level_write_permission", func(t *testing.T) {
-			tuples := []*openfgav1.TupleKey{}
+			tuples := make([]*openfgav1.TupleKey, 0, authz.MaxModulesInRequest+1)
 			ctx := authclaims.ContextWithAuthClaims(context.Background(), &authclaims.AuthClaims{ClientID: clientID})
 
 			// grant access to the store
@@ -623,7 +624,7 @@ func TestWrite(t *testing.T) {
 
 			require.NoError(t, err)
 
-			tuplesInDelete := []*openfgav1.TupleKeyWithoutCondition{}
+			tuplesInDelete := make([]*openfgav1.TupleKeyWithoutCondition, 0, len(tuples))
 			for _, tuple := range tuples {
 				tuplesInDelete = append(tuplesInDelete, &openfgav1.TupleKeyWithoutCondition{
 					User:     tuple.GetUser(),

--- a/pkg/storage/mysql/mysql.go
+++ b/pkg/storage/mysql/mysql.go
@@ -356,7 +356,7 @@ func (s *Datastore) ReadStartingWithUser(
 	_, span := startTrace(ctx, "ReadStartingWithUser")
 	defer span.End()
 
-	var targetUsersArg []string
+	targetUsersArg := make([]string, 0, len(filter.UserFilter))
 	for _, u := range filter.UserFilter {
 		targetUser := u.GetObject()
 		if u.GetRelation() != "" {

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -786,7 +786,7 @@ func (s *Datastore) ReadStartingWithUser(
 
 	db := s.getPgxPool(options.Consistency.Preference)
 	readStbl := sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
-	var targetUsersArg []string
+	targetUsersArg := make([]string, 0, len(filter.UserFilter))
 	for _, u := range filter.UserFilter {
 		targetUser := u.GetObject()
 		if u.GetRelation() != "" {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -884,7 +884,7 @@ func TestPostgresDatastore_ReadPageWithUserFiltering(t *testing.T) {
 	store := ulid.Make().String()
 
 	// Create multiple tuples with same user type for pagination testing
-	var tuples []*openfgav1.TupleKey
+	tuples := make([]*openfgav1.TupleKey, 0, 20)
 	for i := range 10 {
 		tuples = append(tuples, &openfgav1.TupleKey{
 			Object:   "doc:group1",
@@ -1078,7 +1078,7 @@ func TestReadFilterWithConditions(t *testing.T) {
 	require.NoError(t, err)
 	defer ds.Close()
 
-	var writeItems [][]interface{}
+	writeItems := make([][]interface{}, 0, 2)
 	writeItems = append(writeItems, []interface{}{
 		"store",
 		"folder",
@@ -1743,7 +1743,7 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag("INSERT 1"), nil)
 
-		writeItems := [][]interface{}{}
+		writeItems := make([][]interface{}, 0, 1)
 		writeItems = append(writeItems, []interface{}{
 			"storeID",
 			"objectType1",
@@ -1765,7 +1765,7 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("duplicate key value"))
 
-		writeItems := [][]interface{}{}
+		writeItems := make([][]interface{}, 0, 1)
 		writeItems = append(writeItems, []interface{}{
 			"storeID",
 			"objectType1",
@@ -1787,7 +1787,7 @@ func TestExecuteWriteTuples(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("error"))
 
-		writeItems := [][]interface{}{}
+		writeItems := make([][]interface{}, 0, 1)
 		writeItems = append(writeItems, []interface{}{
 			"storeID",
 			"objectType1",
@@ -1819,7 +1819,7 @@ func TestExecuteInsertChanges(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag("INSERT 1"), nil)
 
-		writeItems := [][]interface{}{}
+		writeItems := make([][]interface{}, 0, 1)
 		writeItems = append(writeItems, []interface{}{
 			"storeID",
 			"objectType1",
@@ -1842,7 +1842,7 @@ func TestExecuteInsertChanges(t *testing.T) {
 		mockPgxExec := mocks.NewMockPgxExec(ctrl)
 		mockPgxExec.EXPECT().Exec(gomock.Any(), gomock.Any(), gomock.Any()).Return(pgconn.NewCommandTag(""), fmt.Errorf("error"))
 
-		writeItems := [][]interface{}{}
+		writeItems := make([][]interface{}, 0, 1)
 		writeItems = append(writeItems, []interface{}{
 			"storeID",
 			"objectType1",

--- a/pkg/storage/sqlite/sqlite.go
+++ b/pkg/storage/sqlite/sqlite.go
@@ -814,7 +814,7 @@ func (s *Datastore) ReadStartingWithUser(
 	_, span := startTrace(ctx, "ReadStartingWithUser")
 	defer span.End()
 
-	var targetUsersArg sq.Or
+	targetUsersArg := make(sq.Or, 0, len(filter.UserFilter))
 	for _, u := range filter.UserFilter {
 		userObjectType, userObjectID, userRelation := tupleUtils.ToUserPartsFromObjectRelation(u)
 		targetUser := sq.Eq{

--- a/pkg/storage/storagewrappers/cached_datastore_test.go
+++ b/pkg/storage/storagewrappers/cached_datastore_test.go
@@ -178,8 +178,8 @@ func TestReadStartingWithUser(t *testing.T) {
 		tuple.NewTupleKey("document:4", "viewer", "user:4"),
 		tuple.NewTupleKey("document:5", "viewer", "user:*"),
 	}
-	var tuples []*openfgav1.Tuple
-	var cachedTuples []*storage.TupleRecord
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
+	cachedTuples := make([]*storage.TupleRecord, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -443,8 +443,8 @@ func TestReadUsersetTuples(t *testing.T) {
 		tuple.NewTupleKey("document:1", "viewer", "user:*"),
 		tuple.NewTupleKey("document:1", "viewer", "company:1#viewer"),
 	}
-	var tuples []*openfgav1.Tuple
-	var cachedTuples []*storage.TupleRecord
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
+	cachedTuples := make([]*storage.TupleRecord, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -652,8 +652,8 @@ func TestRead(t *testing.T) {
 		tuple.NewTupleKey("license:1", "owner", "company:1"),
 		tuple.NewTupleKey("license:1", "owner", "company:2"),
 	}
-	var tuples []*openfgav1.Tuple
-	var cachedTuples []*storage.TupleRecord
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
+	cachedTuples := make([]*storage.TupleRecord, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})

--- a/pkg/storage/storagewrappers/combinedtuplereader.go
+++ b/pkg/storage/storagewrappers/combinedtuplereader.go
@@ -162,7 +162,7 @@ func (c *CombinedTupleReader) ReadStartingWithUser(
 	filter storage.ReadStartingWithUserFilter,
 	options storage.ReadStartingWithUserOptions,
 ) (storage.TupleIterator, error) {
-	var userFilters []string
+	userFilters := make([]string, 0, len(filter.UserFilter))
 	for _, u := range filter.UserFilter {
 		uf := u.GetObject()
 		if u.GetRelation() != "" {

--- a/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
+++ b/pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
@@ -55,7 +55,7 @@ func BenchmarkSharedIteratorWithStaticIterator(b *testing.B) {
 		tuple.NewTupleKey("document:5", "viewer", "user:5"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -108,7 +108,7 @@ func BenchmarkSharedIteratorConcurrentAccess(b *testing.B) {
 		tuple.NewTupleKey("document:5", "viewer", "user:5"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -159,7 +159,7 @@ func BenchmarkSharedIteratorVsDirectAccess(b *testing.B) {
 		tuple.NewTupleKey("document:5", "viewer", "user:5"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -407,7 +407,7 @@ func TestSharedIteratorDatastore_Read(t *testing.T) {
 		tuple.NewTupleKey("license:1", "owner", "company:3"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -686,7 +686,7 @@ func TestSharedIteratorDatastore_ReadUsersetTuples(t *testing.T) {
 		tuple.NewTupleKey("document:1", "viewer", "company:1#viewer"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -961,7 +961,7 @@ func TestSharedIteratorDatastore_ReadStartingWithUser(t *testing.T) {
 		tuple.NewTupleKey("document:5", "viewer", "user:*"),
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	for _, tk := range tks {
 		ts := timestamppb.New(time.Now())
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})
@@ -1877,7 +1877,7 @@ func TestSharedIterator_ManyTuples(t *testing.T) {
 		tks = append(tks, tuple.NewTupleKey(fmt.Sprintf("document:%d", i), "viewer", fmt.Sprintf("user:%d", i)))
 	}
 
-	var tuples []*openfgav1.Tuple
+	tuples := make([]*openfgav1.Tuple, 0, len(tks))
 	ts := timestamppb.New(time.Now())
 	for _, tk := range tks {
 		tuples = append(tuples, &openfgav1.Tuple{Key: tk, Timestamp: ts})

--- a/pkg/storage/test/tuples.go
+++ b/pkg/storage/test/tuples.go
@@ -2039,7 +2039,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		require.NoError(t, err)
 
 		tuples := iterateThroughAllTuples(t, tupleIterator)
-		var actualObjectIDs []string
+		actualObjectIDs := make([]string, 0, len(tuples))
 		for _, item := range tuples {
 			_, objectID := tuple.SplitObject(item.GetObject())
 			actualObjectIDs = append(actualObjectIDs, objectID)
@@ -2086,7 +2086,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		require.NoError(t, err)
 
 		tuples := iterateThroughAllTuples(t, tupleIterator)
-		var actualObjectIDs []string
+		actualObjectIDs := make([]string, 0, len(tuples))
 		for _, item := range tuples {
 			_, objectID := tuple.SplitObject(item.GetObject())
 			actualObjectIDs = append(actualObjectIDs, objectID)
@@ -2136,7 +2136,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		require.NoError(t, err)
 
 		tuples := iterateThroughAllTuples(t, tupleIterator)
-		var actualObjectIDs []string
+		actualObjectIDs := make([]string, 0, len(tuples))
 		for _, item := range tuples {
 			_, objectID := tuple.SplitObject(item.GetObject())
 			actualObjectIDs = append(actualObjectIDs, objectID)
@@ -2192,7 +2192,7 @@ func ReadStartingWithUserTest(t *testing.T, datastore storage.OpenFGADatastore) 
 		require.NoError(t, err)
 
 		tuples := iterateThroughAllTuples(t, tupleIterator)
-		var actualObjectIDs []string
+		actualObjectIDs := make([]string, 0, len(tuples))
 		for _, item := range tuples {
 			_, objectID := tuple.SplitObject(item.GetObject())
 			actualObjectIDs = append(actualObjectIDs, objectID)

--- a/pkg/storage/tuple_iterators_test.go
+++ b/pkg/storage/tuple_iterators_test.go
@@ -617,7 +617,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 					t.Run(name, func(t *testing.T) {
 						mapper := combinedTest.mapper
 
-						var iters []TupleIterator
+						iters := make([]TupleIterator, 0, len(tc.iter))
 						for _, curIter := range tc.iter {
 							iters = append(iters, NewStaticTupleIterator(curIter))
 						}
@@ -698,7 +698,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 						t.Run(name, func(t *testing.T) {
 							mapper := combinedTest.mapper
 
-							var iters []TupleIterator
+							iters := make([]TupleIterator, 0, len(tc.iter))
 							for _, curIter := range tc.iter {
 								iters = append(iters, NewStaticTupleIterator(curIter))
 							}
@@ -738,7 +738,7 @@ func TestOrderedCombinedIterator(t *testing.T) {
 						t.Run(name, func(t *testing.T) {
 							mapper := combinedTest.mapper
 
-							var iters []TupleIterator
+							iters := make([]TupleIterator, 0, len(tc.iter))
 							for _, curIter := range tc.iter {
 								iters = append(iters, NewStaticTupleIterator(curIter))
 							}

--- a/pkg/testutils/testutils.go
+++ b/pkg/testutils/testutils.go
@@ -171,10 +171,11 @@ func MustTransformDSLToProtoWithID(s string) *openfgav1.AuthorizationModel {
 func CreateGrpcConnection(t *testing.T, grpcAddress string, opts ...grpc.DialOption) *grpc.ClientConn {
 	t.Helper()
 
-	defaultOptions := []grpc.DialOption{
+	defaultOptions := make([]grpc.DialOption, 0, 2+len(opts))
+	defaultOptions = append(defaultOptions,
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: grpcbackoff.DefaultConfig}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	}
+	)
 
 	defaultOptions = append(defaultOptions, opts...)
 

--- a/pkg/typesystem/weighted_graph_test.go
+++ b/pkg/typesystem/weighted_graph_test.go
@@ -819,7 +819,7 @@ func TestConstructUserset(t *testing.T) {
 		innerUnionUserset := innerUnion.Union
 		require.NotNil(t, innerUnionUserset)
 		require.Len(t, innerUnionUserset.GetChild(), 2)
-		var relationName []string
+		relationName := make([]string, 0, len(innerUnionUserset.GetChild()))
 		for _, child := range innerUnionUserset.GetChild() {
 			cu := child.GetUserset()
 			require.NotNil(t, cu)
@@ -870,7 +870,7 @@ func TestConstructUserset(t *testing.T) {
 		innerIntersectionUserset := innerIntersection.Intersection
 		require.NotNil(t, innerIntersectionUserset)
 		require.Len(t, innerIntersectionUserset.GetChild(), 2)
-		var relationName []string
+		relationName := make([]string, 0, len(innerIntersectionUserset.GetChild()))
 		for _, child := range innerIntersectionUserset.GetChild() {
 			cu := child.GetUserset()
 			require.NotNil(t, cu)

--- a/tests/check/check.go
+++ b/tests/check/check.go
@@ -61,25 +61,36 @@ func RunAllTests(t *testing.T, client tests.ClientInterface) {
 }
 
 func runTests(t *testing.T, params testParams) {
-	files := []string{
-		"tests/consolidated_1_1_tests.yaml",
-		"tests/abac_tests.yaml",
+	testFiles := []struct {
+		name string
+		// Keep the test count for each test file up to date here so variable `allTestCases` can be preallocated
+		// with a fixed capacity, as recommended by the `prealloc` linter.
+		count int
+	}{
+		{
+			name:  "tests/consolidated_1_1_tests.yaml",
+			count: 137,
+		},
+		{
+			name:  "tests/abac_tests.yaml",
+			count: 23,
+		},
 	}
+	allTestCases := make([]individualTest, 0, 137+23)
 
-	var allTestCases []individualTest
-
-	for _, file := range files {
+	for _, file := range testFiles {
 		var b []byte
 		var err error
 		schemaVersion := params.schemaVersion
 		if schemaVersion == typesystem.SchemaVersion1_1 {
-			b, err = assets.EmbedTests.ReadFile(file)
+			b, err = assets.EmbedTests.ReadFile(file.name)
 		}
 		require.NoError(t, err)
 
 		var testCases checkTests
 		err = yaml.Unmarshal(b, &testCases)
 		require.NoError(t, err)
+		require.Len(t, testCases.Tests, file.count)
 
 		allTestCases = append(allTestCases, testCases.Tests...)
 	}

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -990,8 +990,7 @@ func TestGRPCListStores(t *testing.T) {
 
 	require.NotEmpty(t, response1.GetContinuationToken())
 
-	var received []*openfgav1.Store
-	received = append(received, response1.GetStores()...)
+	require.Len(t, response1.GetStores(), 1)
 
 	response2, err := client.ListStores(context.Background(), &openfgav1.ListStoresRequest{
 		PageSize:          wrapperspb.Int32(2),
@@ -1001,9 +1000,7 @@ func TestGRPCListStores(t *testing.T) {
 
 	require.Empty(t, response2.GetContinuationToken())
 
-	received = append(received, response2.GetStores()...)
-
-	require.Len(t, received, 2)
+	require.Len(t, response2.GetStores(), 1)
 	// todo: add assertions on received Store objects
 }
 

--- a/tests/listobjects/listobjects.go
+++ b/tests/listobjects/listobjects.go
@@ -83,25 +83,36 @@ func RunAllTests(t *testing.T, client tests.ClientInterface) {
 }
 
 func runTests(t *testing.T, params testParams) {
-	files := []string{
-		"tests/consolidated_1_1_tests.yaml",
-		"tests/abac_tests.yaml",
+	testFiles := []struct {
+		name string
+		// Keep the test count for each test file up to date here so variable `allTestCases` can be preallocated
+		// with a fixed capacity, as recommended by the `prealloc` linter.
+		count int
+	}{
+		{
+			name:  "tests/consolidated_1_1_tests.yaml",
+			count: 137,
+		},
+		{
+			name:  "tests/abac_tests.yaml",
+			count: 23,
+		},
 	}
+	allTestCases := make([]individualTest, 0, 137+23)
 
-	var allTestCases []individualTest
-
-	for _, file := range files {
+	for _, file := range testFiles {
 		var b []byte
 		var err error
 		schemaVersion := params.schemaVersion
 		if schemaVersion == typesystem.SchemaVersion1_1 {
-			b, err = assets.EmbedTests.ReadFile(file)
+			b, err = assets.EmbedTests.ReadFile(file.name)
 		}
 		require.NoError(t, err)
 
 		var testCases listObjectTests
 		err = yaml.Unmarshal(b, &testCases)
 		require.NoError(t, err)
+		require.Len(t, testCases.Tests, file.count)
 
 		allTestCases = append(allTestCases, testCases.Tests...)
 	}

--- a/tests/listusers/listusers.go
+++ b/tests/listusers/listusers.go
@@ -44,22 +44,33 @@ func RunAllTests(t *testing.T, client tests.ClientInterface) {
 	t.Run("RunAll", func(t *testing.T) {
 		t.Run("ListUsers", func(t *testing.T) {
 			t.Parallel()
-			files := []string{
-				"tests/consolidated_1_1_tests.yaml",
-				"tests/abac_tests.yaml",
+			testFiles := []struct {
+				name string
+				// Keep the test count for each test file up to date here so variable `allTestCases` can be preallocated
+				// with a fixed capacity, as recommended by the `prealloc` linter.
+				count int
+			}{
+				{
+					name:  "tests/consolidated_1_1_tests.yaml",
+					count: 137,
+				},
+				{
+					name:  "tests/abac_tests.yaml",
+					count: 23,
+				},
 			}
+			allTestCases := make([]individualTest, 0, 137+23)
 
-			var allTestCases []individualTest
-
-			for _, file := range files {
+			for _, file := range testFiles {
 				var b []byte
 				var err error
-				b, err = assets.EmbedTests.ReadFile(file)
+				b, err = assets.EmbedTests.ReadFile(file.name)
 				require.NoError(t, err)
 
 				var testCases listUsersTests
 				err = yaml.Unmarshal(b, &testCases)
 				require.NoError(t, err)
+				require.Len(t, testCases.Tests, file.count)
 
 				allTestCases = append(allTestCases, testCases.Tests...)
 			}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

Add the `prealloc` linter.

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Added the `prealloc` linter to detect slices that can be preallocated to avoid unnecessary memory allocations. This helps improve performance by ensuring slices are initialized with an appropriate capacity when the final size is known.

#### How is it being solved?

By adding the `prealloc` linter to the GolangCI-Lint configuration so `make lint` validates that slices are preallocated to avoid unnecessary memory allocations.

#### What changes are made to solve it?

- Added the `prealloc` linter to detect slices that can be preallocated to avoid unnecessary memory allocations. This helps improve performance by ensuring slices are initialized with an appropriate capacity when the final size is known.
- Added the unit test `TestIPAddressWithCompileOptions` to verify that the changes in `internal/condition/types/ipaddress.go` did not introduce any regressions. The test is not specific to the `prealloc` changes, but provides additional confidence that the refactoring preserves existing behavior.

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

Related-to: #598 

> [!NOTE]
> Not closing #598 with this PR, as additional linters will be added in follow-up PRs.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
  - [x] Not applicable. This PR only adds a linter and does not introduce any user-facing changes.
- [ ] The correct base branch is being used, if not `main`
  - [x] Not applicable. This PR targets `main`.
- [x] I have added tests to validate that the change in functionality is working as expected
  - [x] Only 1 new unit test was added. All other changes are already covered by existing unit, storage integration, or matrix integration tests, or are included in the existing unit test coverage.


## Testing

<details>
<summary>Changes-to-Tests Summary</summary>

- Current PR changes in the following files are directly part of existing unit tests:
  1. cmd/run/run_test.go
  1. internal/authz/authz_test.go
  1. internal/check/bottom_up_test.go
  1. internal/graph/weight_two_resolver_test.go
  1. internal/listobjects/pipeline/pipeline_test.go
  1. internal/listobjects/pipeline/store_test.go
  1. pkg/server/check_test.go
  1. pkg/server/server_authz_test.go
  1. pkg/storage/postgres/postgres_test.go
  1. pkg/storage/storagewrappers/cached_datastore_test.go
  1. pkg/storage/storagewrappers/sharediterator/shared_iterator_datastore_test.go
  1. pkg/storage/tuple_iterators_test.go
  1. pkg/typesystem/weighted_graph_test.go

- Current PR changes in the following files already has unit test coverage:
  1. internal/authn/oidc/oidc.go
  1. pkg/server/commands/listusers/list_users_rpc.go
  1. pkg/storage/mysql/mysql.go
  1. pkg/storage/postgres/postgres.go
  1. pkg/storage/sqlite/sqlite.go
  1. pkg/storage/storagewrappers/combinedtuplereader.go

- This PR adds a new unit test to cover the changes in the following file. Note: The test is not specific to the `prealloc` changes, but provides additional confidence that the refactoring did not introduce any regressions.
  1. internal/condition/types/ipaddress.go

- Current PR changes in the following files are directly covered part of matrix integration tests:
  1. internal/test/listusers/listusers.go
  1. pkg/testutils/testutils.go
  1. tests/check/check.go
  1. tests/functional_test.go
  1. tests/listobjects/listobjects.go
  1. tests/listusers/listusers.go

- Current PR changes in the following file are directly covered part of storage integration tests:
  1. pkg/storage/test/tuples.go
</details>

Run the following to validate the changes:

### Linter

```bash
make lint
```
<details>
<summary>Screenshot</summary>
<img width="1870" height="752" alt="image" src="https://github.com/user-attachments/assets/c297fe86-9e46-4a66-8c44-4ffedb438315" />
</details>

### Unit Tests

```bash
make test-unit
```
<details>
<summary>Screenshot</summary>
<img width="1142" height="1111" alt="image" src="https://github.com/user-attachments/assets/656f8411-600e-4433-8d3a-950ba5368da7" />
</details>

### Storage Integration Tests

> **Note:** Changes in `pkg/storage/test/tuples.go` affect all storage backends (in-memory, MySQL, PostgreSQL, and SQLite), so run the entire storage test suite.

```bash
make test-storage
```
<details>
<summary>Screenshot</summary>
<img width="859" height="177" alt="image" src="https://github.com/user-attachments/assets/309c1875-9641-4572-8278-c9a107fa2fd2" />
</details>

### Matrix Integration tests

<details>
<summary>Steps</summary>

#### 1. Test the current changes from `tests/functional_test.go`

Terminal 1:
```bash
DATASTORE="mysql" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestGRPCListStores" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/
```
<details>
<summary>Screenshot</summary>
<img width="808" height="323" alt="image" src="https://github.com/user-attachments/assets/b71eb1ce-1208-4e68-aeea-17c445dea28a" />
</details>

#### 2. Test the current changes from `tests/check/check.go`

##### 2.1. In-memory

Terminal 1:
```bash
DATASTORE="in-memory" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestMatrixMemory" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/check/
```
<details>
<summary>Screenshot</summary>
<img width="1801" height="1110" alt="image" src="https://github.com/user-attachments/assets/a9d65902-3fe9-43c1-9906-4c4bab62d166" />
</details>

##### 2.2. MySQL

Terminal 1:
```bash
DATASTORE="mysql" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestMatrixMysql" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/check/
```
<details>
<summary>Screenshot</summary>
<img width="1871" height="1110" alt="image" src="https://github.com/user-attachments/assets/bb69ebe2-2562-4e81-804b-3e1d35fcbd9e" />
</details>

##### 2.3. PostgreSQL

Terminal 1:
```bash
DATASTORE="postgres" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestMatrixPostgres" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/check/
```
<details>
<summary>Screenshot</summary>
<img width="1834" height="1110" alt="image" src="https://github.com/user-attachments/assets/cc161b72-ee45-4132-a799-bcb8c4161b63" />
</details>

##### 2.4. SQLite

> **Note:** SQLite is currently disabled in `tests/check/check_test.go`.

#### 3. Test the current changes from `tests/listobjects/listobjects.go`

##### 3.1. In-memory

Terminal 1:
```bash
DATASTORE="in-memory" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListObjectsMemory" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listobjects/
```
<details>
<summary>Screenshot</summary>
<img width="1437" height="1110" alt="image" src="https://github.com/user-attachments/assets/fae80e77-d72d-489e-9fdd-4805ac067d89" />
</details>

##### 3.2. MySQL

Terminal 1:
```bash
DATASTORE="mysql" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListObjectsMySQL" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listobjects/
```
<details>
<summary>Screenshot</summary>
<img width="1386" height="1110" alt="image" src="https://github.com/user-attachments/assets/db9f7c23-8733-4da9-8341-b06c085c326a" />
</details>

##### 3.3. PostgreSQL

Terminal 1:
```bash
DATASTORE="postgres" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListObjectsPostgres" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listobjects/
```
<details>
<summary>Screenshot</summary>
<img width="1340" height="1110" alt="image" src="https://github.com/user-attachments/assets/1a3e2391-4a2b-410d-8314-4430d5c8e327" />
</details>

##### 3.4. SQLite

Terminal 1:
```bash
DATASTORE="sqlite" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListObjectsSQLite" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listobjects/
```
<details>
<summary>Screenshot</summary>
<img width="1350" height="1110" alt="image" src="https://github.com/user-attachments/assets/910b873a-25fb-4cd5-98a6-87f7414af268" />
</details>

#### 4. Test the current changes from `tests/listusers/listusers.go`

##### 4.1. In-memory

Terminal 1:
```bash
DATASTORE="in-memory" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListUsersMemory" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listusers/
```
<details>
<summary>Screenshot</summary>
<img width="1316" height="1110" alt="image" src="https://github.com/user-attachments/assets/dc3798a1-c3cf-475e-b969-14a8191af15a" />
</details>

##### 4.2. MySQL

Terminal 1:
```bash
DATASTORE="mysql" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListUsersMySQL" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listusers/
```
<details>
<summary>Screenshot</summary>
<img width="1401" height="1110" alt="image" src="https://github.com/user-attachments/assets/2f501ae0-ee51-479f-92e0-997e0dad52fa" />
</details>

##### 4.3. PostgreSQL

Terminal 1:
```bash
DATASTORE="postgres" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListUsersPostgres" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listusers/
```
<details>
<summary>Screenshot</summary>
<img width="1413" height="1110" alt="image" src="https://github.com/user-attachments/assets/4fa59f0d-59e3-429d-af31-6aadcf6d30fe" />
</details>

##### 4.4. SQLite

Terminal 1:
```bash
DATASTORE="sqlite" make dev-run
```

Terminal 2:
```bash
go test -race \
  -run "TestListUsersSQLite" \
  -count=1 \
  -timeout=10m \
  -v \
  ./tests/listusers/
```
<details>
<summary>Screenshot</summary>
<img width="1232" height="1110" alt="image" src="https://github.com/user-attachments/assets/e1b07675-694f-4431-96be-d45c30a90e1b" />
</details>


</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved memory allocation efficiency by preallocating slices and option lists across request handling, authentication, storage queries, and test utilities.

* **Bug Fixes**
  * Improved handling of empty user filters when constructing datastore query parameters.

* **Tests**
  * Added coverage for IP address CEL compilation and evaluation.
  * Strengthened test loading by validating expected YAML test-case counts.
  * Refined metrics and pagination assertions to be more precise.

* **Chores**
  * Enabled an additional code-quality check to catch avoidable allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->