### PR TITLE
fix: retry write when on_duplicate:ignore hits a first-time insert race

### DIFF
--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -20,6 +20,13 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
+// maxWriteConflictRetries bounds how many times Execute re-attempts a write that failed with
+// storage.ErrWriteConflictOnInsert under on_duplicate:ignore. Because the conflicting transaction
+// has already committed by the time the uniqueness violation surfaces, a single retry is enough
+// to observe the committed row and ignore it; the extra attempts are a safety margin for
+// datastores with weaker insert-time blocking.
+const maxWriteConflictRetries = 3
+
 // WriteCommand is used to Write and Delete tuples. Instances may be safely shared by multiple goroutines.
 type WriteCommand struct {
 	logger                    logger.Logger
@@ -93,14 +100,31 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 		return nil, err
 	}
 
-	err = c.datastore.Write(
-		ctx,
-		req.GetStoreId(),
-		req.GetDeletes().GetTupleKeys(),
-		req.GetWrites().GetTupleKeys(),
-		storage.WithOnMissingDelete(onEmptyDelete),
-		storage.WithOnDuplicateInsert(onDuplicateInsert),
-	)
+	write := func() error {
+		return c.datastore.Write(
+			ctx,
+			req.GetStoreId(),
+			req.GetDeletes().GetTupleKeys(),
+			req.GetWrites().GetTupleKeys(),
+			storage.WithOnMissingDelete(onEmptyDelete),
+			storage.WithOnDuplicateInsert(onDuplicateInsert),
+		)
+	}
+
+	err = write()
+
+	// With on_duplicate:ignore, concurrent first-time inserts of the same tuple can still collide
+	// at INSERT time: the datastore locks tuples with SELECT ... FOR UPDATE, which cannot lock a
+	// row that does not yet exist, so every racing transaction attempts the INSERT and all but one
+	// fail the uniqueness constraint with ErrWriteConflictOnInsert. Retrying lets the losers observe
+	// the now-committed row and ignore it (or surface a condition conflict if it was written with a
+	// different condition).
+	for retries := 0; onDuplicateInsert == storage.OnDuplicateInsertIgnore &&
+		errors.Is(err, storage.ErrWriteConflictOnInsert) &&
+		retries < maxWriteConflictRetries; retries++ {
+		err = write()
+	}
+
 	if err != nil {
 		if errors.Is(err, storage.ErrTransactionalWriteFailed) {
 			return nil, status.Error(codes.Aborted, err.Error())

--- a/pkg/server/commands/write.go
+++ b/pkg/server/commands/write.go
@@ -20,11 +20,10 @@ import (
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
-// maxWriteConflictRetries bounds how many times Execute re-attempts a write that failed with
-// storage.ErrWriteConflictOnInsert under on_duplicate:ignore. Because the conflicting transaction
-// has already committed by the time the uniqueness violation surfaces, a single retry is enough
-// to observe the committed row and ignore it; the extra attempts are a safety margin for
-// datastores with weaker insert-time blocking.
+// maxWriteConflictRetries bounds how many times Execute re-attempts an insert or delete conflict
+// when the corresponding operation is configured to ignore an existing or missing tuple. Retrying
+// allows the command to observe the state committed by the conflicting transaction and apply the
+// requested ignore behavior.
 const maxWriteConflictRetries = 3
 
 // WriteCommand is used to Write and Delete tuples. Instances may be safely shared by multiple goroutines.
@@ -95,7 +94,7 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 		return nil, err
 	}
 
-	onEmptyDelete, err := parseOptionOnMissing(req.GetDeletes())
+	onMissingDelete, err := parseOptionOnMissing(req.GetDeletes())
 	if err != nil {
 		return nil, err
 	}
@@ -106,22 +105,21 @@ func (c *WriteCommand) Execute(ctx context.Context, req *openfgav1.WriteRequest)
 			req.GetStoreId(),
 			req.GetDeletes().GetTupleKeys(),
 			req.GetWrites().GetTupleKeys(),
-			storage.WithOnMissingDelete(onEmptyDelete),
+			storage.WithOnMissingDelete(onMissingDelete),
 			storage.WithOnDuplicateInsert(onDuplicateInsert),
 		)
 	}
 
 	err = write()
 
-	// With on_duplicate:ignore, concurrent first-time inserts of the same tuple can still collide
-	// at INSERT time: the datastore locks tuples with SELECT ... FOR UPDATE, which cannot lock a
-	// row that does not yet exist, so every racing transaction attempts the INSERT and all but one
-	// fail the uniqueness constraint with ErrWriteConflictOnInsert. Retrying lets the losers observe
-	// the now-committed row and ignore it (or surface a condition conflict if it was written with a
-	// different condition).
-	for retries := 0; onDuplicateInsert == storage.OnDuplicateInsertIgnore &&
-		errors.Is(err, storage.ErrWriteConflictOnInsert) &&
-		retries < maxWriteConflictRetries; retries++ {
+	shouldRetry := func(err error) bool {
+		return (onDuplicateInsert == storage.OnDuplicateInsertIgnore &&
+			errors.Is(err, storage.ErrWriteConflictOnInsert)) ||
+			(onMissingDelete == storage.OnMissingDeleteIgnore &&
+				errors.Is(err, storage.ErrWriteConflictOnDelete))
+	}
+
+	for retries := 0; shouldRetry(err) && retries < maxWriteConflictRetries; retries++ {
 		err = write()
 	}
 

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -989,6 +989,43 @@ func TestWriteCommand(t *testing.T) {
 			},
 			expectedError: "rpc error: code = Aborted desc = transactional write failed due to conflict",
 		},
+		{
+			name: "deletes_with_ignore_option_retries_write_conflict_then_succeeds",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {
+				gomock.InOrder(
+					mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+						NewWriteOptsMatcher(storage.OnDuplicateInsertError, storage.OnMissingDeleteIgnore)).Return(storage.ErrWriteConflictOnDelete),
+					mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+						NewWriteOptsMatcher(storage.OnDuplicateInsertError, storage.OnMissingDeleteIgnore)).Return(nil),
+				)
+			},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:maria",
+				}},
+				OnMissing: "ignore",
+			},
+			expectedResponse: &openfgav1.WriteResponse{},
+		},
+		{
+			name: "deletes_with_ignore_option_returns_conflict_after_exhausting_retries",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {
+				mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+					NewWriteOptsMatcher(storage.OnDuplicateInsertError, storage.OnMissingDeleteIgnore)).
+					Times(maxWriteConflictRetries + 1).Return(storage.ErrWriteConflictOnDelete)
+			},
+			deletes: &openfgav1.WriteRequestDeletes{
+				TupleKeys: []*openfgav1.TupleKeyWithoutCondition{{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:maria",
+				}},
+				OnMissing: "ignore",
+			},
+			expectedError: "rpc error: code = Aborted desc = transactional write failed due to conflict",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/server/commands/write_test.go
+++ b/pkg/server/commands/write_test.go
@@ -946,6 +946,49 @@ func TestWriteCommand(t *testing.T) {
 			},
 			expectedResponse: &openfgav1.WriteResponse{},
 		},
+		{
+			// With on_duplicate:ignore, a concurrent first-time insert of the same tuple can fail
+			// with ErrWriteConflictOnInsert; Execute retries so the now-committed row is ignored.
+			name: "writes_with_ignore_option_retries_write_conflict_then_succeeds",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {
+				mockDatastore.EXPECT().ReadAuthorizationModel(gomock.Any(), storeID, modelID).Return(model, nil)
+				gomock.InOrder(
+					mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+						NewWriteOptsMatcher(storage.OnDuplicateInsertIgnore, storage.OnMissingDeleteError)).Return(storage.ErrWriteConflictOnInsert),
+					mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+						NewWriteOptsMatcher(storage.OnDuplicateInsertIgnore, storage.OnMissingDeleteError)).Return(nil),
+				)
+			},
+			writes: &openfgav1.WriteRequestWrites{
+				TupleKeys: []*openfgav1.TupleKey{{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:maria",
+				}},
+				OnDuplicate: "ignore",
+			},
+			expectedResponse: &openfgav1.WriteResponse{},
+		},
+		{
+			// A persistent write conflict under on_duplicate:ignore is retried a bounded number of
+			// times and then surfaced as a 409 Conflict.
+			name: "writes_with_ignore_option_returns_conflict_after_exhausting_retries",
+			setMock: func(mockDatastore *mockstorage.MockOpenFGADatastore) {
+				mockDatastore.EXPECT().ReadAuthorizationModel(gomock.Any(), storeID, modelID).Return(model, nil)
+				mockDatastore.EXPECT().Write(gomock.Any(), storeID, gomock.Any(), gomock.Any(),
+					NewWriteOptsMatcher(storage.OnDuplicateInsertIgnore, storage.OnMissingDeleteError)).
+					Times(maxWriteConflictRetries + 1).Return(storage.ErrWriteConflictOnInsert)
+			},
+			writes: &openfgav1.WriteRequestWrites{
+				TupleKeys: []*openfgav1.TupleKey{{
+					Object:   "document:1",
+					Relation: "viewer",
+					User:     "user:maria",
+				}},
+				OnDuplicate: "ignore",
+			},
+			expectedError: "rpc error: code = Aborted desc = transactional write failed due to conflict",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -166,9 +166,16 @@ func TestWriteWithSimpleProtocol(t *testing.T) {
 }
 
 func TestWriteCommandConcurrentDuplicateIgnore(t *testing.T) {
+	const (
+		concurrentWrites = 5
+		advisoryLockKey  = 424242
+	)
+
 	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
 
-	ds, err := New(testDatastore.GetConnectionURI(true), sqlcommon.NewConfig())
+	ds, err := New(testDatastore.GetConnectionURI(true), sqlcommon.NewConfig(
+		sqlcommon.WithMaxOpenConns(concurrentWrites+2),
+	))
 	require.NoError(t, err)
 	defer ds.Close()
 
@@ -183,11 +190,6 @@ func TestWriteCommandConcurrentDuplicateIgnore(t *testing.T) {
 				define viewer: [user]
 	`)
 	require.NoError(t, ds.WriteAuthorizationModel(ctx, storeID, model))
-
-	const (
-		concurrentWrites = 5
-		advisoryLockKey  = 424242
-	)
 
 	// Hold every transaction immediately before its INSERT so all concurrent commands first
 	// observe that the tuple is absent. Releasing the lock then deterministically exercises the

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"testing/iotest"
 	"time"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/openfga/openfga/internal/mocks"
 	"github.com/openfga/openfga/pkg/logger"
+	"github.com/openfga/openfga/pkg/server/commands"
 	"github.com/openfga/openfga/pkg/storage"
 	"github.com/openfga/openfga/pkg/storage/sqlcommon"
 	"github.com/openfga/openfga/pkg/storage/test"
@@ -161,6 +163,134 @@ func TestWriteWithSimpleProtocol(t *testing.T) {
 	}, storage.ReadUserTupleOptions{})
 	require.NoError(t, err)
 	require.Equal(t, "document:2", tk.GetKey().GetObject())
+}
+
+func TestWriteCommandConcurrentDuplicateIgnore(t *testing.T) {
+	testDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	ds, err := New(testDatastore.GetConnectionURI(true), sqlcommon.NewConfig())
+	require.NoError(t, err)
+	defer ds.Close()
+
+	ctx := t.Context()
+	storeID := ulid.Make().String()
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+		type user
+		type document
+			relations
+				define viewer: [user]
+	`)
+	require.NoError(t, ds.WriteAuthorizationModel(ctx, storeID, model))
+
+	const (
+		concurrentWrites = 5
+		advisoryLockKey  = 424242
+	)
+
+	// Hold every transaction immediately before its INSERT so all concurrent commands first
+	// observe that the tuple is absent. Releasing the lock then deterministically exercises the
+	// uniqueness-conflict path instead of relying on goroutine scheduling to reproduce the race.
+	_, err = ds.primaryDB.Exec(ctx, `
+		CREATE FUNCTION block_tuple_insert() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(424242);
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+
+		CREATE TRIGGER block_tuple_insert
+		BEFORE INSERT ON tuple
+		FOR EACH ROW EXECUTE FUNCTION block_tuple_insert();`)
+	require.NoError(t, err)
+	defer func() {
+		_, err := ds.primaryDB.Exec(context.Background(), `
+			DROP TRIGGER block_tuple_insert ON tuple;
+			DROP FUNCTION block_tuple_insert();`)
+		require.NoError(t, err)
+	}()
+
+	barrierConn, err := ds.primaryDB.Acquire(ctx)
+	require.NoError(t, err)
+	defer barrierConn.Release()
+
+	_, err = barrierConn.Exec(ctx, "SELECT pg_advisory_lock($1)", advisoryLockKey)
+	require.NoError(t, err)
+	locked := true
+	defer func() {
+		if !locked {
+			return
+		}
+		err := barrierConn.QueryRow(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockKey).Scan(&locked)
+		require.NoError(t, err)
+		require.True(t, locked)
+	}()
+
+	cmd := commands.NewWriteCommand(ds)
+	start := make(chan struct{})
+	var ready sync.WaitGroup
+	ready.Add(concurrentWrites)
+	errs := make(chan error, concurrentWrites)
+
+	for range concurrentWrites {
+		go func() {
+			ready.Done()
+			<-start
+
+			_, err := cmd.Execute(ctx, &openfgav1.WriteRequest{
+				StoreId:              storeID,
+				AuthorizationModelId: model.GetId(),
+				Writes: &openfgav1.WriteRequestWrites{
+					TupleKeys: []*openfgav1.TupleKey{{
+						Object:   "document:1",
+						Relation: "viewer",
+						User:     "user:anne",
+					}},
+					OnDuplicate: "ignore",
+				},
+			})
+			errs <- err
+		}()
+	}
+
+	ready.Wait()
+	close(start)
+	require.Eventually(t, func() bool {
+		var waitingTransactions int
+		err := ds.primaryDB.QueryRow(ctx, `
+			SELECT COUNT(*)
+			FROM pg_locks
+			WHERE locktype = 'advisory' AND objid = $1 AND NOT granted`, advisoryLockKey).Scan(&waitingTransactions)
+		return err == nil && waitingTransactions == concurrentWrites
+	}, 5*time.Second, 10*time.Millisecond)
+
+	err = barrierConn.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockKey).Scan(&locked)
+	require.NoError(t, err)
+	require.True(t, locked)
+	locked = false
+
+	for range concurrentWrites {
+		require.NoError(t, <-errs)
+	}
+
+	var tupleCount int
+	err = ds.primaryDB.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM tuple
+		WHERE store = $1 AND object_type = $2 AND object_id = $3 AND relation = $4 AND _user = $5`,
+		storeID, "document", "1", "viewer", "user:anne").Scan(&tupleCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, tupleCount)
+
+	var changeCount int
+	err = ds.primaryDB.QueryRow(ctx, `
+		SELECT COUNT(*)
+		FROM changelog
+		WHERE store = $1 AND object_type = $2 AND object_id = $3 AND relation = $4 AND _user = $5`,
+		storeID, "document", "1", "viewer", "user:anne").Scan(&changeCount)
+	require.NoError(t, err)
+	require.Equal(t, 1, changeCount)
 }
 
 func TestPostgresDatastoreStartup(t *testing.T) {


### PR DESCRIPTION
Fixes #3201.

`on_duplicate: "ignore"` works fine once a tuple exists — but for a brand new tuple, concurrent writes race each other and all but one come back 409 instead of being ignored.

We lock existing rows with `SELECT ... FOR UPDATE` before insert, but that can't lock a row that isn't there yet. So under READ COMMITTED, concurrent first-time inserts all pass the check, all try to insert, one wins, the rest hit the unique constraint and get turned into a 409 regardless of `on_duplicate`.

Fix: retry the write (max 3x) when `ignore` is set and we hit that specific conflict. By then the winning transaction has committed, so the retry sees the row and skips it like it should have. Non-ignore writes and real condition conflicts aren't retried.

Did this in the command layer instead of all three storage backends — felt like a retry-policy call rather than a storage concern, but open to moving it if preferred.

Added two tests (retry-then-succeed, retries-then-409), and confirmed against real Postgres using the repro from the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved writes using the “ignore duplicates” option by automatically retrying transient insert conflicts.
  * Improved deletes using the “ignore missing” option by automatically retrying transient delete conflicts.
  * Added bounded retry behavior for persistent conflicts, returning a clear aborted failure after the limit is reached.
* **Tests**
  * Added table-driven coverage for both “ignore duplicates” and “ignore missing” retry behavior.
  * Added a regression test for concurrent “ignore duplicates” to verify only one tuple and one changelog entry are created under contention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->