### PR TITLE
fix: validate tuple condition against the correct type-restriction facet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Tuple condition validation now checks that a condition is bound to the specific type-restriction facet (concrete user, typed wildcard, or userset) that matches the tuple's user, not just the user type and condition name. Previously a relation such as `define viewer: [user, user:* with cond]` would accept a tuple like `document:1#viewer@user:alice` carrying `cond`, even though `cond` is only defined on the `user:*` facet. Because this validation also runs when reading tuples during query resolution, such tuples are now consistently rejected across Check and ListObjects. See `internal/validation/validation.go`. [#3217](https://github.com/openfga/openfga/pull/3217)
+
 ### Added
 - Extended experimental `weighted_graph_check` diagnostic logging to cover the `wildcard_with_exclusion` and `userset_with_exclusion` shapes: the log now fires when v2 Check rejects one of these shapes and Check falls back to v1, and when v2 Check is skipped entirely because the weighted graph fails to build. These logs surface authorization models that may be affected by a future v1 deprecation, and no operator action is required. [#3204](https://github.com/openfga/openfga/pull/3204)
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -233,10 +233,27 @@ func validateCondition(typesys *typesystem.TypeSystem, tk *openfgav1.TupleKey) e
 
 	validCondition := false
 	for _, directlyRelatedType := range typeRestrictions {
-		if directlyRelatedType.GetType() == userType && directlyRelatedType.GetCondition() == tk.GetCondition().GetName() {
-			validCondition = true
-			break
+		if directlyRelatedType.GetType() != userType || directlyRelatedType.GetCondition() != tk.GetCondition().GetName() {
+			continue
 		}
+
+		// The restriction's facet (concrete / typed-wildcard / userset) must also match the
+		// tuple's user shape. Otherwise a condition bound to one facet (e.g. `user:* with C`)
+		// would wrongly validate a tuple for a different facet (e.g. `user:alice with C`).
+		if directlyRelatedType.GetRelationOrWildcard() != nil {
+			if directlyRelatedType.GetRelation() != "" && directlyRelatedType.GetRelation() != userRelation {
+				continue
+			}
+
+			if directlyRelatedType.GetWildcard() != nil && !tuple.IsTypedWildcard(tk.GetUser()) {
+				continue
+			}
+		} else if tuple.IsTypedWildcard(tk.GetUser()) {
+			continue
+		}
+
+		validCondition = true
+		break
 	}
 
 	if !validCondition {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	parser "github.com/openfga/language/pkg/go/transformer"
 
 	"github.com/openfga/openfga/pkg/testutils"
 	"github.com/openfga/openfga/pkg/tuple"
@@ -762,6 +764,116 @@ func TestValidateTupleForWrite(t *testing.T) {
 			if test.expectedError != nil {
 				require.ErrorIs(t, err, test.expectedError)
 				require.Equal(t, err.Error(), test.expectedError.Error())
+			}
+		})
+	}
+}
+
+func TestValidateConditionFacetMismatch(t *testing.T) {
+	// isOk is bound to different facets depending on the model. A conditioned tuple must
+	// only be accepted when the matching restriction's facet (concrete / typed-wildcard /
+	// userset) also matches the tuple's user shape.
+	condCtx, err := structpb.NewStruct(map[string]interface{}{"ok": true})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		model   string
+		tuple   *openfgav1.TupleKey
+		wantErr bool
+	}{
+		{
+			name: "wildcard_user_borrows_concrete_facet_condition",
+			// concrete user is conditioned; wildcard is not.
+			model: `model
+  schema 1.1
+type user
+type document
+  relations
+    define b0: [user with isOk, user:*]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "user:*", "isOk", condCtx),
+			wantErr: true,
+		},
+		{
+			name: "concrete_user_borrows_wildcard_facet_condition",
+			// wildcard is conditioned; concrete user is not.
+			model: `model
+  schema 1.1
+type user
+type document
+  relations
+    define b0: [user, user:* with isOk]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "user:alice", "isOk", condCtx),
+			wantErr: true,
+		},
+		{
+			name: "concrete_user_borrows_userset_facet_condition",
+			// userset facet is conditioned; concrete user is not.
+			model: `model
+  schema 1.1
+type user
+type group
+  relations
+    define member: [user]
+type document
+  relations
+    define b0: [user, group#member with isOk]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "user:alice", "isOk", condCtx),
+			wantErr: true,
+		},
+		{
+			name: "valid_wildcard_condition_on_wildcard_facet",
+			model: `model
+  schema 1.1
+type user
+type document
+  relations
+    define b0: [user, user:* with isOk]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "user:*", "isOk", condCtx),
+			wantErr: false,
+		},
+		{
+			name: "valid_concrete_condition_on_concrete_facet",
+			model: `model
+  schema 1.1
+type user
+type document
+  relations
+    define b0: [user with isOk, user:*]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "user:alice", "isOk", condCtx),
+			wantErr: false,
+		},
+		{
+			name: "valid_userset_condition_on_userset_facet",
+			model: `model
+  schema 1.1
+type user
+type group
+  relations
+    define member: [user]
+type document
+  relations
+    define b0: [user, group#member with isOk]
+condition isOk(ok: bool) { ok }`,
+			tuple:   tuple.NewTupleKeyWithCondition("document:1", "b0", "group:eng#member", "isOk", condCtx),
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ts, err := typesystem.New(parser.MustTransformDSLToProto(test.model))
+			require.NoError(t, err)
+			err = ValidateTupleForWrite(ts, test.tuple)
+			if test.wantErr {
+				require.ErrorContains(t, err, "invalid condition for type restriction")
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

#### What problem is being solved?

`validateCondition` in `internal/validation/validation.go` decides whether a conditioned relationship tuple is permitted by the authorization model. When a relation is directly assignable by the same user type under more than one facet — a concrete user (`user`), a typed wildcard (`user:*`), or a userset (`group#member`) — and only one of those facets carries a condition, the validator only compared the tuple's user type and the condition name. It did not compare the facet.

As a result, for a relation such as `define viewer: [user, user:* with cond]`, a tuple like `document:1#viewer@user:alice` carrying `cond` was accepted even though `cond` is only defined on the `user:*` facet. The no-condition branch of the same function already screens the facet; the conditioned branch did not.

Because this validation also runs when reading tuples during query resolution (`ValidateTupleForRead` / `FilterInvalidTuples`), the mismatch could also cause Check and ListObjects to treat such a tuple inconsistently. Applying the facet check makes both write-time validation and read-time filtering reject these tuples consistently.

This change:
- Makes the conditioned branch of `validateCondition` screen the wildcard/userset facet, matching the existing no-condition branch.
- Adds `TestValidateConditionFacetMismatch` covering concrete↔wildcard mismatches in both directions, the userset facet, and the valid cases.

## References

<!-- none -->

## Review Checklist
- [x] I have clicked on "allow edits by maintainers".
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to openfga.dev
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected