### PR TITLE
preserve error chain in reverse expand weighted handlers

### DIFF
--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -695,7 +695,7 @@ func (c *ReverseExpandQuery) intersectionHandler(
 	// when the intersection node has a weight to the sourceUserType then it means all the group edges has weight to the sourceUserType
 	intersectionEdges, err := typesystem.GetEdgesForIntersection(edges, sourceUserType)
 	if err != nil {
-		return fmt.Errorf("%w: operation: intersection: %s", ErrLowestWeightFail, err.Error())
+		return fmt.Errorf("%w: operation: intersection: %w", ErrLowestWeightFail, err)
 	}
 
 	// note that we should never see a case where no edges to call LO
@@ -716,7 +716,7 @@ func (c *ReverseExpandQuery) intersectionHandler(
 		userset, err := c.typesystem.ConstructUserset(intersectEdge, sourceUserType)
 		if err != nil {
 			// this should never happen
-			return fmt.Errorf("%w: operation: intersection: %s", ErrConstructUsersetFail, err.Error())
+			return fmt.Errorf("%w: operation: intersection: %w", ErrConstructUsersetFail, err)
 		}
 		usersets = append(usersets, userset)
 		var intersectRelation string
@@ -772,7 +772,7 @@ func (c *ReverseExpandQuery) exclusionHandler(
 
 	edges, err := typesystem.GetEdgesForExclusion(exclusionEdges, sourceUserType)
 	if err != nil {
-		return fmt.Errorf("%w: operation: exclusion: %s", ErrLowestWeightFail, err.Error())
+		return fmt.Errorf("%w: operation: exclusion: %w", ErrLowestWeightFail, err)
 	}
 
 	// This means the exclusion edge does not have a path to the terminal type.
@@ -780,7 +780,7 @@ func (c *ReverseExpandQuery) exclusionHandler(
 	if edges.ExcludedEdge == nil {
 		baseEdges, err := c.typesystem.GetInternalEdges(edges.BaseEdge, sourceUserType)
 		if err != nil {
-			return fmt.Errorf("%w: operation: exclusion: failed to get base edges: %s", ErrLowestWeightFail, err.Error())
+			return fmt.Errorf("%w: operation: exclusion: failed to get base edges: %w", ErrLowestWeightFail, err)
 		}
 
 		newReq := req.clone()
@@ -801,7 +801,7 @@ func (c *ReverseExpandQuery) exclusionHandler(
 	userset, err := c.typesystem.ConstructUserset(edges.ExcludedEdge, sourceUserType)
 	if err != nil {
 		// This should never happen.
-		return fmt.Errorf("%w: operation: exclusion: %s", ErrConstructUsersetFail, err.Error())
+		return fmt.Errorf("%w: operation: exclusion: %w", ErrConstructUsersetFail, err)
 	}
 
 	// Concurrently find candidates and call check on them as they are found


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when reverse expansion encounters failures while retrieving weighted edges or constructing usersets.
  * Preserved underlying error details to support more reliable error diagnosis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->