### PR TITLE
fix(server): BatchCheck emits v1→v2 divergence telemetry (was blind)

### DIFF
--- a/pkg/server/batch_check.go
+++ b/pkg/server/batch_check.go
@@ -154,23 +154,21 @@ func (s *Server) BatchCheck(ctx context.Context, req *openfgav1.BatchCheckReques
 	// maxChecksPerBatchCheck per request). Shape filters may over-report on
 	// per-check v1 fallback but never miss a real divergence.
 	if v2Enabled && !v2GraphResolveFailed {
-		if typesys, tsErr := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId()); tsErr == nil {
-			requestID := requestid.GetRequestIDFromContext(ctx)
-			for _, check := range req.GetChecks() {
-				outcome, ok := result[commands.CorrelationID(check.GetCorrelationId())]
-				tk := check.GetTupleKey()
-				if !ok || outcome.Err != nil || outcome.Allowed || !tuple.IsObjectRelation(tk.GetUser()) {
-					continue
-				}
-				if reason := v2breaking.CheckReason(typesys, tk); reason != "" {
-					s.logger.WarnWithContext(ctx, "potential v2 BatchCheck resolution breaking change",
-						zap.String("store_id", storeID),
-						zap.String("model_id", req.GetAuthorizationModelId()),
-						zap.String("request_id", requestID),
-						zap.String("correlation_id", check.GetCorrelationId()),
-						zap.String("reason", reason),
-					)
-				}
+		requestID := requestid.GetRequestIDFromContext(ctx)
+		for _, check := range req.GetChecks() {
+			outcome, ok := result[commands.CorrelationID(check.GetCorrelationId())]
+			tk := check.GetTupleKey()
+			if !ok || outcome.Err != nil || outcome.Allowed || !tuple.IsObjectRelation(tk.GetUser()) {
+				continue
+			}
+			if reason := v2breaking.CheckReason(typesys, tk); reason != "" {
+				s.logger.WarnWithContext(ctx, "potential v2 BatchCheck resolution breaking change",
+					zap.String("store_id", storeID),
+					zap.String("model_id", req.GetAuthorizationModelId()),
+					zap.String("request_id", requestID),
+					zap.String("correlation_id", check.GetCorrelationId()),
+					zap.String("reason", reason),
+				)
 			}
 		}
 	}

--- a/pkg/server/batch_check.go
+++ b/pkg/server/batch_check.go
@@ -19,10 +19,13 @@ import (
 	"github.com/openfga/openfga/internal/telemetry"
 	"github.com/openfga/openfga/internal/utils"
 	"github.com/openfga/openfga/internal/utils/apimethod"
+	"github.com/openfga/openfga/pkg/middleware/requestid"
 	"github.com/openfga/openfga/pkg/middleware/validator"
 	"github.com/openfga/openfga/pkg/server/commands"
+	"github.com/openfga/openfga/pkg/server/commands/v2breaking"
 	"github.com/openfga/openfga/pkg/server/config"
 	serverErrors "github.com/openfga/openfga/pkg/server/errors"
+	"github.com/openfga/openfga/pkg/tuple"
 )
 
 func (s *Server) BatchCheck(ctx context.Context, req *openfgav1.BatchCheckRequest) (*openfgav1.BatchCheckResponse, error) {
@@ -143,6 +146,33 @@ func (s *Server) BatchCheck(ctx context.Context, req *openfgav1.BatchCheckReques
 		}
 
 		return nil, err
+	}
+
+	// Emit the same v1→v2 divergence telemetry that Check provides (check.go);
+	// the batch path had none, so stores rolling out the weighted-graph resolver
+	// got no per-request signal for checks carried by BatchCheck (up to
+	// maxChecksPerBatchCheck per request). Shape filters may over-report on
+	// per-check v1 fallback but never miss a real divergence.
+	if v2Enabled && !v2GraphResolveFailed {
+		if typesys, tsErr := s.resolveTypesystem(ctx, storeID, req.GetAuthorizationModelId()); tsErr == nil {
+			requestID := requestid.GetRequestIDFromContext(ctx)
+			for _, check := range req.GetChecks() {
+				outcome, ok := result[commands.CorrelationID(check.GetCorrelationId())]
+				tk := check.GetTupleKey()
+				if !ok || outcome.Err != nil || outcome.Allowed || !tuple.IsObjectRelation(tk.GetUser()) {
+					continue
+				}
+				if reason := v2breaking.CheckReason(typesys, tk); reason != "" {
+					s.logger.WarnWithContext(ctx, "potential v2 BatchCheck resolution breaking change",
+						zap.String("store_id", storeID),
+						zap.String("model_id", req.GetAuthorizationModelId()),
+						zap.String("request_id", requestID),
+						zap.String("correlation_id", check.GetCorrelationId()),
+						zap.String("reason", reason),
+					)
+				}
+			}
+		}
 	}
 
 	methodName := "batchcheck"

--- a/pkg/server/batch_check_test.go
+++ b/pkg/server/batch_check_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 
@@ -17,6 +19,7 @@ import (
 	"github.com/openfga/openfga/internal/condition"
 	"github.com/openfga/openfga/internal/graph"
 	"github.com/openfga/openfga/pkg/featureflags"
+	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/server/commands"
 	"github.com/openfga/openfga/pkg/server/config"
 	"github.com/openfga/openfga/pkg/testutils"
@@ -402,6 +405,93 @@ func TestBatchCheckV2UsedWhenFlagEnabled(t *testing.T) {
 	v2Fallback, ok := tags["v2_fallback_count"]
 	require.True(t, ok, "v2_fallback_count should be set in context tags")
 	require.EqualValues(t, uint32(0), v2Fallback)
+}
+
+// TestBatchCheckV2BreakingChangeLog verifies that BatchCheck emits the same v1→v2
+// divergence telemetry Check provides: a denied userset check matching a known
+// divergence shape logs a warning with the reason and correlation ID, while
+// allowed checks and non-userset denials stay silent.
+func TestBatchCheckV2BreakingChangeLog(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	_, ds, _ := util.MustBootstrapDatastore(t, "memory")
+
+	core, logs := observer.New(zap.WarnLevel)
+	testLogger := &logger.ZapLogger{Logger: zap.New(core)}
+
+	s := MustNewServerWithOpts(
+		WithDatastore(ds),
+		WithLogger(testLogger),
+		WithFeatureFlagClient(featureflags.NewDefaultClient([]string{config.ExperimentalWeightedGraphCheck})),
+	)
+	t.Cleanup(s.Close)
+
+	ctx := context.Background()
+
+	createStoreResp, err := s.CreateStore(ctx, &openfgav1.CreateStoreRequest{Name: "test"})
+	require.NoError(t, err)
+	storeID := createStoreResp.GetId()
+
+	model := testutils.MustTransformDSLToProtoWithID(`
+		model
+			schema 1.1
+		type user
+		type document
+			relations
+				define viewer: [user]
+	`)
+	writeModelResp, err := s.WriteAuthorizationModel(ctx, &openfgav1.WriteAuthorizationModelRequest{
+		StoreId:         storeID,
+		SchemaVersion:   model.GetSchemaVersion(),
+		TypeDefinitions: model.GetTypeDefinitions(),
+	})
+	require.NoError(t, err)
+	modelID := writeModelResp.GetAuthorizationModelId()
+
+	_, err = s.Write(ctx, &openfgav1.WriteRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Writes: &openfgav1.WriteRequestWrites{
+			TupleKeys: []*openfgav1.TupleKey{
+				tuple.NewTupleKey("document:1", "viewer", "user:alice"),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := s.BatchCheck(ctx, &openfgav1.BatchCheckRequest{
+		StoreId:              storeID,
+		AuthorizationModelId: modelID,
+		Checks: []*openfgav1.BatchCheckItem{
+			{
+				// self_referential_userset divergence shape: v2 answers false
+				TupleKey:      &openfgav1.CheckRequestTupleKey{Object: "document:1", Relation: "viewer", User: "document:1#viewer"},
+				CorrelationId: "divergent",
+			},
+			{
+				// denied, but user is not a userset — no divergence shape
+				TupleKey:      &openfgav1.CheckRequestTupleKey{Object: "document:1", Relation: "viewer", User: "user:bob"},
+				CorrelationId: "plain-deny",
+			},
+			{
+				// allowed — never logged
+				TupleKey:      &openfgav1.CheckRequestTupleKey{Object: "document:1", Relation: "viewer", User: "user:alice"},
+				CorrelationId: "allow",
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.False(t, resp.GetResult()["divergent"].GetAllowed())
+	require.False(t, resp.GetResult()["plain-deny"].GetAllowed())
+	require.True(t, resp.GetResult()["allow"].GetAllowed())
+
+	breakingLogs := logs.FilterMessage("potential v2 BatchCheck resolution breaking change")
+	require.Equal(t, 1, breakingLogs.Len())
+	fields := fieldMap(breakingLogs.All()[0].Context)
+	require.Equal(t, "divergent", fields["correlation_id"])
+	require.Equal(t, "self_referential_userset", fields["reason"])
 }
 
 // TestBatchCheckV2FallbackCountWhenGraphParseFails verifies that when ExperimentalWeightedGraphCheck


### PR DESCRIPTION
## Summary

- `Check` warns (`potential v2 Check resolution breaking change`, with a `v2breaking` reason) when a denied userset request matches a known v1→v2 divergence shape — the rollout guardrail for the weighted-graph resolver.
- `BatchCheck` routes through the same v2 checker but emitted **no divergence telemetry at all** — only aggregate `v2_check_count`/`v2_fallback_count` counters. A batch of 50 checks with divergence-shaped denials produced zero signal during rollout.
- Mirror the Check gate in the batch path: for each check where v2 answered `false` and the user is a userset, evaluate `v2breaking.CheckReason` and warn with `reason` + `correlation_id`. Same "may over-report on fallback, never miss" semantics as the existing package contract.

## Impact if unsolved

Operators migrating stores to the weighted-graph resolver use this telemetry to find models that will break at cutover. Divergences arriving via BatchCheck — typically the bulk of production traffic — were invisible, so a store could look clean on dashboards while its batch traffic silently resolved differently under v2.

## Test plan

- New `TestBatchCheckV2BreakingChangeLog`: a self-referential-userset check logs exactly one warning with `correlation_id` and `reason=self_referential_userset`; a plain deny and an allow stay silent.
- Full `TestBatchCheck*` suite passes.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added warning diagnostics for BatchCheck results that may resolve differently between v1 and v2.
  - Warnings include relevant request and correlation details, along with the detected reason.

- **Bug Fixes**
  - Improved visibility into denied checks involving self-referential userset resolution while avoiding warnings for ordinary denials and allowed checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->