### PR TITLE
fix(postgres): apply secondary datastore credentials

### DIFF
--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -59,30 +59,33 @@ type Datastore struct {
 // Ensures that Datastore implements the OpenFGADatastore interface.
 var _ storage.OpenFGADatastore = (*Datastore)(nil)
 
-func parseConfig(uri string, override bool, cfg *sqlcommon.Config) (*pgxpool.Config, error) {
+// parseConfig builds a pool config for uri, applying username and password when
+// they are set. Each datastore passes its own credentials: the secondary has a
+// separate pair and must not inherit the primary's.
+func parseConfig(uri string, username, password string, cfg *sqlcommon.Config) (*pgxpool.Config, error) {
 	c, err := pgxpool.ParseConfig(uri)
 	if err != nil {
 		return nil, fmt.Errorf("pgxpool parse postgres connection uri: %w", err)
 	}
 
-	if override {
+	if username != "" || password != "" {
 		parsed, err := url.Parse(uri)
 		if err != nil {
 			return nil, fmt.Errorf("url parse postgres connection uri: %w", err)
 		}
 
-		if cfg.Username != "" {
-			c.ConnConfig.User = cfg.Username
+		if username != "" {
+			c.ConnConfig.User = username
 		} else if parsed.User != nil {
 			c.ConnConfig.User = parsed.User.Username()
 		}
 
 		switch {
-		case cfg.Password != "":
-			c.ConnConfig.Password = cfg.Password
+		case password != "":
+			c.ConnConfig.Password = password
 		case parsed.User != nil:
-			if password, ok := parsed.User.Password(); ok {
-				c.ConnConfig.Password = password
+			if pw, ok := parsed.User.Password(); ok {
+				c.ConnConfig.Password = pw
 			}
 		}
 	}
@@ -210,9 +213,9 @@ func createBeforeConnect(logger logger.Logger, provider PassfileProvider) func(c
 	}
 }
 
-// initDB initializes a new postgres database connection.
-func initDB(uri string, override bool, cfg *sqlcommon.Config) (*pgxpool.Pool, error) {
-	c, err := parseConfig(uri, override, cfg)
+// initDB initializes a new postgres database connection with the given credentials.
+func initDB(uri string, username, password string, cfg *sqlcommon.Config) (*pgxpool.Pool, error) {
+	c, err := parseConfig(uri, username, password, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -227,14 +230,14 @@ func initDB(uri string, override bool, cfg *sqlcommon.Config) (*pgxpool.Pool, er
 
 // New creates a new [Datastore] storage.
 func New(uri string, cfg *sqlcommon.Config) (*Datastore, error) {
-	primaryDB, err := initDB(uri, cfg.Username != "" || cfg.Password != "", cfg)
+	primaryDB, err := initDB(uri, cfg.Username, cfg.Password, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("initialize postgres connection: %w", err)
 	}
 
 	var secondaryDB *pgxpool.Pool
 	if cfg.SecondaryURI != "" {
-		secondaryDB, err = initDB(cfg.SecondaryURI, cfg.SecondaryUsername != "" || cfg.SecondaryPassword != "", cfg)
+		secondaryDB, err = initDB(cfg.SecondaryURI, cfg.SecondaryUsername, cfg.SecondaryPassword, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("initialize postgres connection: %w", err)
 		}

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -126,7 +126,7 @@ func TestWriteWithSimpleProtocol(t *testing.T) {
 
 	// Build the pool config the same way New() does, then override the query
 	// execution mode to SimpleProtocol to mimic PgBouncer transaction-pooling mode.
-	poolCfg, err := parseConfig(uri, false, cfg)
+	poolCfg, err := parseConfig(uri, "", "", cfg)
 	require.NoError(t, err)
 	poolCfg.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 
@@ -191,6 +191,31 @@ func TestPostgresDatastoreStatusWithSecondaryDB(t *testing.T) {
 	cfg.ExportMetrics = true
 
 	ds, err := New(primaryURI, cfg)
+	require.NoError(t, err)
+	defer ds.Close()
+
+	status, err := ds.IsReady(context.Background())
+	require.NoError(t, err)
+	require.True(t, status.IsReady)
+	require.Equal(t, "primary: ready, secondary: ready", status.Message)
+}
+
+// Regression test for #3256. Both URIs are supplied WITHOUT credentials, and the
+// credentials are provided only through the config, exactly as they are when set
+// via OPENFGA_DATASTORE_* / OPENFGA_DATASTORE_SECONDARY_* environment variables.
+// Before the fix the secondary pool was built with the primary's credentials.
+func TestPostgresSecondaryUsesSecondaryCredentials(t *testing.T) {
+	primaryDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+	require.NoError(t, primaryDatastore.CreateSecondary(t))
+
+	cfg := sqlcommon.NewConfig()
+	cfg.Username = primaryDatastore.GetUsername()
+	cfg.Password = primaryDatastore.GetPassword()
+	cfg.SecondaryURI = primaryDatastore.GetSecondaryConnectionURI(false)
+	cfg.SecondaryUsername = primaryDatastore.GetUsername()
+	cfg.SecondaryPassword = primaryDatastore.GetPassword()
+
+	ds, err := New(primaryDatastore.GetConnectionURI(false), cfg)
 	require.NoError(t, err)
 	defer ds.Close()
 
@@ -358,7 +383,7 @@ func TestParseConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, err := parseConfig(tt.uri, tt.override, &tt.cfg)
+			parsed, err := parseConfig(tt.uri, tt.cfg.Username, tt.cfg.Password, &tt.cfg)
 			if tt.expectedErr {
 				require.Error(t, err)
 			} else {
@@ -1858,4 +1883,96 @@ func TestExecuteInsertChanges(t *testing.T) {
 		err := executeInsertChanges(context.Background(), mockPgxExec, writeItems)
 		require.ErrorContains(t, err, "sql error: error")
 	})
+}
+
+// Regression tests for #3256: the secondary datastore connected with the primary
+// credentials, because parseConfig always read cfg.Username / cfg.Password
+// regardless of which datastore it was being asked to build.
+
+// The secondary pool must use the secondary credentials.
+func TestParseConfigAppliesSecondaryCredentials(t *testing.T) {
+	cfg := &sqlcommon.Config{
+		Username:          "primary_user",
+		Password:          "primary_password",
+		SecondaryUsername: "secondary_user",
+		SecondaryPassword: "secondary_password",
+		SecondaryURI:      "postgres://replica:5432/defaultdb",
+	}
+
+	c, err := parseConfig(cfg.SecondaryURI, cfg.SecondaryUsername, cfg.SecondaryPassword, cfg)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+
+	if got := c.ConnConfig.User; got != cfg.SecondaryUsername {
+		t.Errorf("secondary user = %q, want %q", got, cfg.SecondaryUsername)
+	}
+	if got := c.ConnConfig.Password; got != cfg.SecondaryPassword {
+		t.Errorf("secondary password = %q, want %q", got, cfg.SecondaryPassword)
+	}
+}
+
+// The primary pool must still use the primary credentials.
+func TestParseConfigAppliesPrimaryCredentials(t *testing.T) {
+	cfg := &sqlcommon.Config{
+		Username:          "primary_user",
+		Password:          "primary_password",
+		SecondaryUsername: "secondary_user",
+		SecondaryPassword: "secondary_password",
+	}
+
+	c, err := parseConfig("postgres://primary:5432/defaultdb", cfg.Username, cfg.Password, cfg)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+
+	if got := c.ConnConfig.User; got != cfg.Username {
+		t.Errorf("primary user = %q, want %q", got, cfg.Username)
+	}
+	if got := c.ConnConfig.Password; got != cfg.Password {
+		t.Errorf("primary password = %q, want %q", got, cfg.Password)
+	}
+}
+
+// With no explicit secondary credentials, the ones embedded in the secondary URI
+// must be kept rather than replaced by the primary's.
+func TestParseConfigSecondaryFallsBackToURICredentials(t *testing.T) {
+	cfg := &sqlcommon.Config{
+		Username:     "primary_user",
+		Password:     "primary_password",
+		SecondaryURI: "postgres://uri_user:uri_pass@replica:5432/defaultdb",
+	}
+
+	c, err := parseConfig(cfg.SecondaryURI, cfg.SecondaryUsername, cfg.SecondaryPassword, cfg)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+
+	if got := c.ConnConfig.User; got != "uri_user" {
+		t.Errorf("secondary user = %q, want uri_user", got)
+	}
+	if got := c.ConnConfig.Password; got != "uri_pass" {
+		t.Errorf("secondary password = %q, want uri_pass", got)
+	}
+}
+
+// When only a password is configured, the username must still come from the URI
+// rather than being dropped.
+func TestParseConfigPasswordOnlyKeepsURIUsername(t *testing.T) {
+	cfg := &sqlcommon.Config{
+		SecondaryURI:      "postgres://uri_user:uri_pass@replica:5432/defaultdb",
+		SecondaryPassword: "explicit_pass",
+	}
+
+	c, err := parseConfig(cfg.SecondaryURI, cfg.SecondaryUsername, cfg.SecondaryPassword, cfg)
+	if err != nil {
+		t.Fatalf("parseConfig: %v", err)
+	}
+
+	if got := c.ConnConfig.User; got != "uri_user" {
+		t.Errorf("user = %q, want uri_user (from URI)", got)
+	}
+	if got := c.ConnConfig.Password; got != "explicit_pass" {
+		t.Errorf("password = %q, want explicit_pass", got)
+	}
 }

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -200,20 +200,47 @@ func TestPostgresDatastoreStatusWithSecondaryDB(t *testing.T) {
 	require.Equal(t, "primary: ready, secondary: ready", status.Message)
 }
 
-// Regression test for #3256. Both URIs are supplied WITHOUT credentials, and the
-// credentials are provided only through the config, exactly as they are when set
-// via OPENFGA_DATASTORE_* / OPENFGA_DATASTORE_SECONDARY_* environment variables.
-// Before the fix the secondary pool was built with the primary's credentials.
+// Regression test for #3256. Both URIs are supplied WITHOUT credentials, so the
+// credentials can only come from the config, exactly as they do when set via
+// OPENFGA_DATASTORE_* / OPENFGA_DATASTORE_SECONDARY_* environment variables.
+//
+// The secondary is given a DISTINCT role. A physical replica shares the primary's
+// roles, so the role is created on the primary before the base backup is taken and
+// then replicates to the standby. That is what makes this test fail before the fix:
+// the secondary pool would connect as the primary user, which is not what the
+// secondary credentials name.
 func TestPostgresSecondaryUsesSecondaryCredentials(t *testing.T) {
 	primaryDatastore := storagefixtures.RunDatastoreTestContainer(t, "postgres")
+
+	const (
+		secondaryUser     = "openfga_secondary"
+		secondaryPassword = "secondary_password"
+	)
+
+	// Create the secondary role on the primary BEFORE the replica is cloned, so it
+	// is carried over by the base backup. It needs read access to the same tables
+	// the readiness check touches.
+	primaryURI := primaryDatastore.GetConnectionURI(true)
+	adminPool, err := pgxpool.New(context.Background(), primaryURI)
+	require.NoError(t, err)
+	for _, stmt := range []string{
+		fmt.Sprintf("CREATE ROLE %s LOGIN PASSWORD '%s'", secondaryUser, secondaryPassword),
+		fmt.Sprintf("GRANT USAGE ON SCHEMA public TO %s", secondaryUser),
+		fmt.Sprintf("GRANT SELECT ON ALL TABLES IN SCHEMA public TO %s", secondaryUser),
+	} {
+		_, err = adminPool.Exec(context.Background(), stmt)
+		require.NoError(t, err, "stmt: %s", stmt)
+	}
+	adminPool.Close()
+
 	require.NoError(t, primaryDatastore.CreateSecondary(t))
 
 	cfg := sqlcommon.NewConfig()
 	cfg.Username = primaryDatastore.GetUsername()
 	cfg.Password = primaryDatastore.GetPassword()
 	cfg.SecondaryURI = primaryDatastore.GetSecondaryConnectionURI(false)
-	cfg.SecondaryUsername = primaryDatastore.GetUsername()
-	cfg.SecondaryPassword = primaryDatastore.GetPassword()
+	cfg.SecondaryUsername = secondaryUser
+	cfg.SecondaryPassword = secondaryPassword
 
 	ds, err := New(primaryDatastore.GetConnectionURI(false), cfg)
 	require.NoError(t, err)
@@ -223,6 +250,14 @@ func TestPostgresSecondaryUsesSecondaryCredentials(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, status.IsReady)
 	require.Equal(t, "primary: ready, secondary: ready", status.Message)
+
+	// Confirm the secondary really connected as the secondary role, rather than
+	// merely being reachable.
+	var connectedAs string
+	require.NoError(t, ds.secondaryDB.QueryRow(
+		context.Background(), "SELECT current_user").Scan(&connectedAs))
+	require.Equal(t, secondaryUser, connectedAs,
+		"secondary pool must authenticate as the configured secondary user")
 }
 
 func TestPostgresDatastoreAfterCloseIsNotReady(t *testing.T) {


### PR DESCRIPTION
## Description

`parseConfig` always read `cfg.Username` / `cfg.Password`, regardless of which datastore it was building. The secondary pool is created from the same `*sqlcommon.Config`, so it inherited the primary's credentials and `OPENFGA_DATASTORE_SECONDARY_USERNAME` / `_PASSWORD` had no effect.

`postgres.go` before this change:

```go
primaryDB, err := initDB(uri, cfg.Username != "" || cfg.Password != "", cfg)
...
secondaryDB, err = initDB(cfg.SecondaryURI, cfg.SecondaryUsername != "" || cfg.SecondaryPassword != "", cfg)
```

Both call sites correctly *detected* their own credentials, but only passed a `bool`. `parseConfig` then applied the primary pair either way.

The fix passes the credentials themselves instead of a flag. The `override` parameter becomes redundant, since both call sites derived it from exactly the values now being passed.

## Verification

Reproduced first, against `parseConfig` as it is actually called for the secondary:

```
secondary connection built with user="primary_user" password="primary_password"
    secondary user = "primary_user", want "secondary_user"
    secondary password = "primary_password", want "secondary_password"
--- FAIL: TestSecondaryCredentialsAreNotApplied
--- PASS: TestPrimaryCredentialsAreApplied     <- control, primary was never broken
```

After the change, all of `TestParseConfig`'s existing 5 subtests still pass, plus 4 new ones covering: secondary uses secondary credentials, primary still uses primary credentials, secondary with no explicit credentials keeps the ones embedded in its URI, and password-only leaves the URI's username intact.

I also added `TestPostgresSecondaryUsesSecondaryCredentials`, which runs `New()` against a real primary + streaming replica via the existing test containers, with **both URIs supplied without credentials** so they can only come from config. That is the shape described in the issue. It passes (~31s locally with Docker).

## Notes for reviewers

Two things I want to flag rather than leave for you to find:

1. **The integration test cannot distinguish this bug on its own.** The replica is a physical `pg_basebackup` copy, so it shares the primary's roles. Swapping the credentials is therefore invisible to it. I verified this: reverting the secondary call site alone keeps that test green. The unit tests are what actually pin the behaviour. Genuinely covering the call site would need a fixture where the replica has a distinct role, which felt out of scope here — happy to add it if you'd prefer.

2. **`else if parsed.User != nil` is dead code**, both before and after this change. `pgxpool.ParseConfig` has already populated `User` and `Password` from the URI by that point, so the branch never changes anything. I confirmed it directly rather than assuming. I left it alone to keep the diff focused, but it could be removed separately.

Closes #3256

---

Generative AI was used to help investigate and prepare this change, under the Linux Foundation Generative AI policy referenced in the contributing guide. All results quoted above were executed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL connections so primary and secondary databases use their configured credentials independently.
  * Preserved credentials embedded in database URIs when explicit values are not provided.
  * Improved handling of partial credential configuration, such as password-only overrides.

* **Tests**
  * Added coverage verifying credential selection for primary and secondary database connections.
  * Added regression testing to confirm both database pools become ready with separate credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->