### PR TITLE
fix: use releaser app token for helm-charts release PR

### DIFF
--- a/.github/workflows/create-helm-release-pr.yaml
+++ b/.github/workflows/create-helm-release-pr.yaml
@@ -58,16 +58,27 @@ jobs:
           fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
+      # helm-charts must be in the releaser app's installed repositories, and
+      # the app needs contents:write + pull_requests:write there.
+      - name: Generate token for helm-charts
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RELEASER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: helm-charts
+
       - name: Checkout helm-charts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: openfga/helm-charts
-          token: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: helm-charts
 
       - name: Update Chart.yaml and create PR
         env:
-          GH_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
           cd helm-charts


### PR DESCRIPTION
The helm-charts PR step authenticated with the GORELEASER_GITHUB_TOKEN PAT, which can push branches but lacks pull_requests:write on helm-charts, so gh pr create fails with a 403 on createPullRequest. Mint a releaser app token scoped to helm-charts (the mechanism the SDK sync workflow already uses) and use it for the checkout push and the PR creation.

Requires openfga/helm-charts to be in the releaser app's installed repositories.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated Helm release process to use a short-lived authentication token.
  * Improved access handling when checking out chart files and creating release pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->