### PR TITLE
chore: bump Go toolchain to 1.26.6 for stdlib security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
-### Security
-- Build with Go 1.26.6 so released binaries and container images pick up the Go standard library security fixes published for go1.26.5 (CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56853, CVE-2026-56858/59/60/62).
-
 ### Added
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
+
+### Security
+- Build with Go 1.26.6 so released binaries and container images pick up the Go standard library security fixes published for go1.26.5 (CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56853, CVE-2026-56858/59/60/62).
 
 ## [1.19.0] - 2026-08-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Security
+- Build with Go 1.26.6 so released binaries and container images pick up the Go standard library security fixes published for go1.26.5 (CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56853, CVE-2026-56858/59/60/62).
+
 ### Added
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openfga/openfga
 
 go 1.25.7
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/IBM/pgxpoolprometheus v1.1.3


### PR DESCRIPTION
## Description

Bumps the Go toolchain from `go1.26.5` to `go1.26.6`.

Container image and binary scanners (Trivy, Grype, Wiz) flag the released `openfga/openfga` images because they are built with go1.26.5, whose standard library is affected by a set of fixed vulnerabilities: CVE-2026-33818, CVE-2026-39821, CVE-2026-46600, CVE-2026-56853, CVE-2026-56858, CVE-2026-56859, CVE-2026-56860 and CVE-2026-56862 (all HIGH, all fixed in go1.26.6).

Since CI and the release pipeline resolve the Go version via `go-version-file: './go.mod'`, updating the `toolchain` directive is enough for the next release's binaries and images to be built with the patched standard library.

## References

- https://go.dev/doc/devel/release (go1.26.6)
- v1.19.0 image scan currently reports the stdlib findings above.

## Review Checklist

- [x] Changelog entry added under `Unreleased` (validated with `npx keep-a-changelog`)
- [x] Commits signed off (DCO)
- [ ] N/A — no functional code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated released binaries and container images to include the latest Go standard library security fixes.

* **Documentation**
  * Added release notes documenting the security update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->