### PR TITLE
fix: enforce deadline on sql tuple iterator to prevent goroutine leaks

### DIFF
--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -392,14 +392,29 @@ func (p *rowGetter) GetRows(ctx context.Context) (Rows, error) {
 		return nil, err
 	}
 
-	ctx = context.WithoutCancel(ctx)
+	queryCtx := context.WithoutCancel(ctx)
+	var cancel context.CancelFunc = func() {}
+	if deadline, ok := ctx.Deadline(); ok {
+		queryCtx, cancel = context.WithDeadline(queryCtx, deadline)
+	}
 
-	rows, err := conn.Query(ctx, p.statement, p.args...)
+	rows, err := conn.Query(queryCtx, p.statement, p.args...)
 	if err != nil {
+		cancel()
 		conn.Close()
 		return nil, err
 	}
-	return rows, nil
+	return &rowsWithCancel{Rows: rows, cancel: cancel}, nil
+}
+
+type rowsWithCancel struct {
+	Rows
+	cancel context.CancelFunc
+}
+
+func (r *rowsWithCancel) Close() error {
+	r.cancel()
+	return r.Rows.Close()
 }
 
 func NewRowGetter(connector Connector, builder SQLBuilder) (SQLIteratorRowGetter, error) {


### PR DESCRIPTION
Fixes #3098

### Description
In PR #2508, `context.WithoutCancel` was introduced in [fetchBuffer](cci:1://file:///e:/opensource/cncf/go/openfga/openfga/pkg/storage/sqlcommon/sqlcommon.go:509:0-523:1) to prevent premature tearing down of database connections during short-circuited concurrent requests. However, `context.WithoutCancel` implicitly drops the original context's deadline, effectively running the database query without a timeout. This leads to leaked goroutines and stranded PostgreSQL connections when a database lock or hang occurs, as the `pgx` driver never receives a timeout cancellation.

This PR correctly isolates the concerns. It retains the `WithoutCancel` behavior to insulate the query from manual parent `cancel()` short-circuit signals, while correctly extracting and re-attaching the hard deadline into the query context using `context.WithDeadline()`. 

To prevent memory leaks stemming from the `WithDeadline` background timer, [Rows](cci:2://file:///e:/opensource/cncf/go/openfga/openfga/pkg/storage/sqlcommon/sqlcommon.go:454:0-459:1) has been elegantly wrapped to ensure the timer is safely halted (`cancel()`) immediately upon `Rows.Close()`.

### Testing
- Validated via database lock simulation testing. Requests are now properly aborted on the database driver level precisely when the request deadline strikes, cleanly recovering the connection/goroutine.
- Passes all existing datastore and integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database query cleanup when requests are canceled.
  * Ensured query deadlines remain enforced while results are being processed.
  * Prevented connections and result sets from remaining open after query errors or closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->