### PR TITLE
feat(authn): add optional JWT token cache for authenticated requests

### DIFF
--- a/.config-schema.json
+++ b/.config-schema.json
@@ -357,6 +357,31 @@
                 "oidc": {
                     "description": "The OIDC provider specific settings. This must be set if 'authn.method=oidc'.",
                     "$ref": "#/definitions/oidc"
+                },
+                "tokenCache": {
+                    "type": "object",
+                    "description": "Configuration for caching authenticated JWT tokens to avoid repeated signature verification. Only applies when authn.method=oidc.",
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable caching of authenticated JWT tokens.",
+                            "type": "boolean",
+                            "default": false,
+                            "x-env-variable": "OPENFGA_AUTHN_TOKEN_CACHE_ENABLED"
+                        },
+                        "ttl": {
+                            "description": "The TTL of cached authentication tokens. The effective TTL per entry is min(this value, token exp - now).",
+                            "type": "string",
+                            "default": "5m",
+                            "x-env-variable": "OPENFGA_AUTHN_TOKEN_CACHE_TTL"
+                        },
+                        "maxSize": {
+                            "description": "The maximum number of tokens to cache.",
+                            "type": "integer",
+                            "default": 10000,
+                            "minimum": 1,
+                            "x-env-variable": "OPENFGA_AUTHN_TOKEN_CACHE_MAX_SIZE"
+                        }
+                    }
                 }
 
             }

--- a/cmd/run/flags.go
+++ b/cmd/run/flags.go
@@ -92,6 +92,15 @@ func bindRunFlagsFunc(flags *pflag.FlagSet) func(*cobra.Command, []string) {
 		util.MustBindPFlag("authn.oidc.clientIdClaims", flags.Lookup("authn-oidc-client-id-claims"))
 		util.MustBindEnv("authn.oidc.clientIdClaims", "OPENFGA_AUTHN_OIDC_CLIENT_ID_CLAIMS")
 
+		util.MustBindPFlag("authn.tokenCache.enabled", flags.Lookup("authn-token-cache-enabled"))
+		util.MustBindEnv("authn.tokenCache.enabled", "OPENFGA_AUTHN_TOKEN_CACHE_ENABLED")
+
+		util.MustBindPFlag("authn.tokenCache.ttl", flags.Lookup("authn-token-cache-ttl"))
+		util.MustBindEnv("authn.tokenCache.ttl", "OPENFGA_AUTHN_TOKEN_CACHE_TTL")
+
+		util.MustBindPFlag("authn.tokenCache.maxSize", flags.Lookup("authn-token-cache-max-size"))
+		util.MustBindEnv("authn.tokenCache.maxSize", "OPENFGA_AUTHN_TOKEN_CACHE_MAX_SIZE")
+
 		util.MustBindPFlag("datastore.engine", flags.Lookup("datastore-engine"))
 		util.MustBindEnv("datastore.engine", "OPENFGA_DATASTORE_ENGINE")
 

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -563,7 +563,7 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 		return nil, fmt.Errorf("failed to initialize authenticator: %w", err)
 	}
 
-	if config.Authn.TokenCache.Enabled {
+	if config.Authn.TokenCache.Enabled && config.Authn.Method == "oidc" {
 		s.Logger.Info("authentication token caching enabled")
 		cache, cacheErr := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](config.Authn.TokenCache.MaxSize))
 		if cacheErr != nil {

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -192,6 +192,10 @@ func NewRunCommand() *cobra.Command {
 
 	flags.StringSlice("authn-oidc-client-id-claims", defaultConfig.Authn.ClientIDClaims, "the ClientID claims that will be used to parse the clientID - configure in order of priority (first is highest). Defaults to [`azp`, `client_id`]")
 
+	flags.Bool("authn-token-cache-enabled", defaultConfig.Authn.TokenCache.Enabled, "enable caching of authenticated JWT tokens to avoid repeated signature verification")
+	flags.Duration("authn-token-cache-ttl", defaultConfig.Authn.TokenCache.TTL, "the TTL of cached authentication tokens")
+	flags.Int64("authn-token-cache-max-size", defaultConfig.Authn.TokenCache.MaxSize, "the maximum number of tokens to cache")
+
 	flags.String("datastore-engine", defaultConfig.Datastore.Engine, "the datastore engine that will be used for persistence")
 
 	flags.String("datastore-uri", defaultConfig.Datastore.URI, "the connection uri to use to connect to the datastore (for any engine other than 'memory')")
@@ -558,6 +562,16 @@ func (s *ServerContext) authenticatorConfig(config *serverconfig.Config) (authn.
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize authenticator: %w", err)
 	}
+
+	if config.Authn.TokenCache.Enabled {
+		s.Logger.Info("authentication token caching enabled")
+		cache, cacheErr := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](config.Authn.TokenCache.MaxSize))
+		if cacheErr != nil {
+			return nil, fmt.Errorf("failed to initialize authn token cache: %w", cacheErr)
+		}
+		authenticator = authn.NewCachedAuthenticator(authenticator, cache, config.Authn.TokenCache.TTL)
+	}
+
 	return authenticator, nil
 }
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -251,7 +251,7 @@ These two caches are always active and are independent of the caching flags desc
 
 - **What it caches**: The `AuthClaims` (subject, scopes, client ID) produced by a successful `Authenticator.Authenticate` call, keyed by the raw bearer token.
 - **Benefits**: Skips repeated JWT parsing and RSA signature verification for the same token across requests, reducing per-request auth overhead at high QPS.
-- **Cache key**: `AT + <bearer token>` — consistent with other OpenFGA cache keys, which use full values in the TLV-encoded key builder.
+- **Cache key**: `AT + SHA-256(<bearer token>)` — the token is hashed so that a replayable credential is not recoverable from a heap dump or diagnostic output.
 - **When enabled**: Applies only when `authn.method = oidc`. The cache is not used for `preshared` keys (to preserve constant-time comparison guarantees) or `none`.
 - **TTL behavior**: The effective TTL per cache entry is `min(configured TTL, token exp − now)`. This ensures a cached entry never outlives the JWT's own expiration claim.
 - **What it does NOT cache**: Authentication failures. Errors from the underlying authenticator (invalid claims, expired token) are always returned fresh from the delegate. If no bearer token is present in the request, the cache is bypassed and the request is forwarded directly to the underlying authenticator.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -251,7 +251,7 @@ These two caches are always active and are independent of the caching flags desc
 
 - **What it caches**: The `AuthClaims` (subject, scopes, client ID) produced by a successful `Authenticator.Authenticate` call, keyed by the raw bearer token.
 - **Benefits**: Skips repeated JWT parsing and RSA signature verification for the same token across requests, reducing per-request auth overhead at high QPS.
-- **Cache key**: `AT + <raw bearer token>`
+- **Cache key**: `AT + SHA-256(<raw bearer token>)` — the raw token is hashed so that credentials are not retained verbatim in cache memory.
 - **When enabled**: Applies only when `authn.method = oidc`. The cache is not used for `preshared` keys (to preserve constant-time comparison guarantees) or `none`.
 - **TTL behavior**: The effective TTL per cache entry is `min(configured TTL, token exp − now)`. This ensures a cached entry never outlives the JWT's own expiration claim.
 - **What it does NOT cache**: Authentication failures. Errors from the underlying authenticator (invalid claims, expired token) are always returned fresh from the delegate. If no bearer token is present in the request, the cache is bypassed and the request is forwarded directly to the underlying authenticator.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -13,7 +13,7 @@ OpenFGA implements several complementary types of caching:
 
 **NOTE:**
 
-- For any request, if the `HIGHER_CONSISTENCY` consistency preference is specified, caching is bypassed entirely (except for the authorization model and typesystem caches, which are always active).
+- For any request, if the `HIGHER_CONSISTENCY` consistency preference is specified, authorization data caching is bypassed entirely (except for the authorization model and typesystem caches, which are always active). The auth token cache is not affected by this preference because it operates in the authentication layer, not the authorization data path.
 - The cache is in-memory, so different replicas of the service do not share their caches. Therefore, its effectiveness depends on the probability of repeated/similar requests hitting the same replica, which may depend on the model, tuple distribution, number of replicas, and the load balancing algorithm used.
 
 **Cache instances:** There are three independent in-memory cache instances:

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -251,7 +251,7 @@ These two caches are always active and are independent of the caching flags desc
 
 - **What it caches**: The `AuthClaims` (subject, scopes, client ID) produced by a successful `Authenticator.Authenticate` call, keyed by the raw bearer token.
 - **Benefits**: Skips repeated JWT parsing and RSA signature verification for the same token across requests, reducing per-request auth overhead at high QPS.
-- **Cache key**: `AT + SHA-256(<raw bearer token>)` — the raw token is hashed so that credentials are not retained verbatim in cache memory.
+- **Cache key**: `AT + <bearer token>` — consistent with other OpenFGA cache keys, which use full values in the TLV-encoded key builder.
 - **When enabled**: Applies only when `authn.method = oidc`. The cache is not used for `preshared` keys (to preserve constant-time comparison guarantees) or `none`.
 - **TTL behavior**: The effective TTL per cache entry is `min(configured TTL, token exp − now)`. This ensures a cached entry never outlives the JWT's own expiration claim.
 - **What it does NOT cache**: Authentication failures. Errors from the underlying authenticator (invalid claims, expired token) are always returned fresh from the delegate. If no bearer token is present in the request, the cache is bypassed and the request is forwarded directly to the underlying authenticator.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -9,6 +9,7 @@ OpenFGA implements several complementary types of caching:
 3. [**List Objects Iterator Cache**](#list-objects-iterator-cache): Same as Check Iterator Cache, but used for List Objects requests.
 4. [**Cache Controller**](#cache-controller): Periodically invalidates cache entries in the background based on recent writes to the store.
 5. [**Authorization Model & Typesystem Cache**](#authorization-model--typesystem-cache): Always-on caches for authorization models and their compiled typesystems.
+6. [**Auth Token Cache**](#auth-token-cache): Caches authenticated JWT tokens to avoid repeated signature verification.
 
 **NOTE:**
 
@@ -245,6 +246,31 @@ These two caches are always active and are independent of the caching flags desc
 - **Cache key**: `TS + storeID + modelID`
 - **TTL**: 7 days (same rationale as model cache - models are immutable)
 - **Size config**: `OPENFGA_DATASTORE_MAX_TYPESYSTEM_CACHE_SIZE` / `--datastore-max-typesystem-cache-size` (default `100000`)
+
+## Auth Token Cache
+
+- **What it caches**: The `AuthClaims` (subject, scopes, client ID) produced by a successful `Authenticator.Authenticate` call, keyed by the raw bearer token.
+- **Benefits**: Skips repeated JWT parsing and RSA signature verification for the same token across requests, reducing per-request auth overhead at high QPS.
+- **Cache key**: `AT + <raw bearer token>`
+- **When enabled**: Applies only when `authn.method = oidc`. The cache is not used for `preshared` keys (to preserve constant-time comparison guarantees) or `none`.
+- **TTL behavior**: The effective TTL per cache entry is `min(configured TTL, token exp − now)`. This ensures a cached entry never outlives the JWT's own expiration claim.
+- **What it does NOT cache**: Authentication failures. Errors from the underlying authenticator (invalid claims, expired token) are always returned fresh from the delegate. If no bearer token is present in the request, the cache is bypassed and the request is forwarded directly to the underlying authenticator.
+
+Implementation lives in `internal/authn/cached_authenticator.go` and is wired in `cmd/run/run.go` via the `authenticatorConfig` function. It uses the same Theine-backed `InMemoryLRUCache` as the check caches.
+
+### Trade-offs
+
+- The OIDC authenticator enforces the JWT `exp` claim on first validation, and the cache respects it: each entry's effective TTL is capped at the token's remaining lifetime. However, a cached token is not re-validated against the JWKS on cache hit. If signing keys are rotated mid-TTL, tokens signed by the old key remain cached until they expire or are evicted. Operators should size the configured TTL relative to their key-rotation and revocation SLA.
+- The cache is separate from the check-pipeline caches: enabling / sizing / TTL are configured independently and it is not affected by the cache controller or `HIGHER_CONSISTENCY` consistency preference.
+- The cache is in-memory per replica, so different replicas of the service do not share cached tokens.
+
+### Configuration
+
+| Config File | Env Var | Flag Name | Type | Description | Default Value |
+|-------------|---------|-----------|------|-------------|---------------|
+| `authn.tokenCache.enabled` | <div id="OPENFGA_AUTHN_TOKEN_CACHE_ENABLED"><code>OPENFGA_AUTHN_TOKEN_CACHE_ENABLED</code></div> | `authn-token-cache-enabled` | boolean | enable caching of authenticated JWT tokens to avoid repeated signature verification. Successful authentications are cached; errors are not. | `false` |
+| `authn.tokenCache.ttl` | <div id="OPENFGA_AUTHN_TOKEN_CACHE_TTL"><code>OPENFGA_AUTHN_TOKEN_CACHE_TTL</code></div> | `authn-token-cache-ttl` | string (duration) | if the auth token cache is enabled, this is the TTL of each cached token's claims. Must be greater than zero when the cache is enabled. | `5m` |
+| `authn.tokenCache.maxSize` | <div id="OPENFGA_AUTHN_TOKEN_CACHE_MAX_SIZE"><code>OPENFGA_AUTHN_TOKEN_CACHE_MAX_SIZE</code></div> | `authn-token-cache-max-size` | integer | the maximum number of tokens to cache. When the cache is full, entries are evicted via LRU with W-TinyLFU admission. | `10000` |
 
 ## TTL Jitter
 

--- a/internal/authn/cached_authenticator.go
+++ b/internal/authn/cached_authenticator.go
@@ -1,0 +1,75 @@
+package authn
+
+import (
+	"context"
+	"time"
+
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+
+	"github.com/openfga/openfga/pkg/authclaims"
+	"github.com/openfga/openfga/pkg/storage"
+	"github.com/openfga/openfga/pkg/storage/cache/keys"
+)
+
+const PrefixAuthnTokenCache = "AT"
+
+var _ storage.CacheItem = (*AuthClaimsCacheEntry)(nil)
+
+type AuthClaimsCacheEntry struct {
+	Claims *authclaims.AuthClaims
+}
+
+func (a *AuthClaimsCacheEntry) CacheEntityType() string {
+	return "authn_token"
+}
+
+type CachedAuthenticator struct {
+	delegate Authenticator
+	cache    storage.InMemoryCache[any]
+	ttl      time.Duration
+}
+
+func NewCachedAuthenticator(delegate Authenticator, cache storage.InMemoryCache[any], ttl time.Duration) *CachedAuthenticator {
+	return &CachedAuthenticator{
+		delegate: delegate,
+		cache:    cache,
+		ttl:      ttl,
+	}
+}
+
+func (c *CachedAuthenticator) Authenticate(requestContext context.Context) (*authclaims.AuthClaims, error) {
+	authHeader, err := grpcauth.AuthFromMD(requestContext, "Bearer")
+	if err != nil {
+		return nil, ErrMissingBearerToken
+	}
+
+	cacheKey := authnTokenCacheKey(authHeader)
+	if cached := c.cache.Get(cacheKey); cached != nil {
+		if entry, ok := cached.(*AuthClaimsCacheEntry); ok {
+			return entry.Claims, nil
+		}
+	}
+
+	claims, err := c.delegate.Authenticate(requestContext)
+	if err != nil {
+		return nil, err
+	}
+
+	c.cache.Set(cacheKey, &AuthClaimsCacheEntry{Claims: claims}, c.ttl)
+
+	return claims, nil
+}
+
+func (c *CachedAuthenticator) Close() {
+	c.cache.Stop()
+	c.delegate.Close()
+}
+
+func authnTokenCacheKey(token string) keys.Key {
+	builder := keys.GetBuilder()
+	defer builder.Close()
+
+	builder.EncodeString(PrefixAuthnTokenCache)
+	builder.EncodeString(token)
+	return builder.Key()
+}

--- a/internal/authn/cached_authenticator.go
+++ b/internal/authn/cached_authenticator.go
@@ -2,6 +2,7 @@ package authn
 
 import (
 	"context"
+	"crypto/sha256"
 	"maps"
 	"time"
 
@@ -105,10 +106,12 @@ func cloneClaims(src *authclaims.AuthClaims) *authclaims.AuthClaims {
 }
 
 func authnTokenCacheKey(token string) keys.Key {
+	hash := sha256.Sum256([]byte(token))
+
 	builder := keys.GetBuilder()
 	defer builder.Close()
 
 	builder.EncodeString(prefixAuthnTokenCache)
-	builder.EncodeString(token)
+	builder.EncodeBytes(hash[:])
 	return builder.Key()
 }

--- a/internal/authn/cached_authenticator.go
+++ b/internal/authn/cached_authenticator.go
@@ -2,7 +2,6 @@ package authn
 
 import (
 	"context"
-	"crypto/sha256"
 	"maps"
 	"time"
 
@@ -106,12 +105,10 @@ func cloneClaims(src *authclaims.AuthClaims) *authclaims.AuthClaims {
 }
 
 func authnTokenCacheKey(token string) keys.Key {
-	hash := sha256.Sum256([]byte(token))
-
 	builder := keys.GetBuilder()
 	defer builder.Close()
 
 	builder.EncodeString(prefixAuthnTokenCache)
-	builder.EncodeBytes(hash[:])
+	builder.EncodeString(token)
 	return builder.Key()
 }

--- a/internal/authn/cached_authenticator.go
+++ b/internal/authn/cached_authenticator.go
@@ -2,8 +2,11 @@ package authn
 
 import (
 	"context"
+	"crypto/sha256"
+	"maps"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 
 	"github.com/openfga/openfga/pkg/authclaims"
@@ -11,7 +14,7 @@ import (
 	"github.com/openfga/openfga/pkg/storage/cache/keys"
 )
 
-const PrefixAuthnTokenCache = "AT"
+const prefixAuthnTokenCache = "AT"
 
 var _ storage.CacheItem = (*AuthClaimsCacheEntry)(nil)
 
@@ -40,13 +43,13 @@ func NewCachedAuthenticator(delegate Authenticator, cache storage.InMemoryCache[
 func (c *CachedAuthenticator) Authenticate(requestContext context.Context) (*authclaims.AuthClaims, error) {
 	authHeader, err := grpcauth.AuthFromMD(requestContext, "Bearer")
 	if err != nil {
-		return nil, ErrMissingBearerToken
+		return c.delegate.Authenticate(requestContext)
 	}
 
 	cacheKey := authnTokenCacheKey(authHeader)
 	if cached := c.cache.Get(cacheKey); cached != nil {
 		if entry, ok := cached.(*AuthClaimsCacheEntry); ok {
-			return entry.Claims, nil
+			return cloneClaims(entry.Claims), nil
 		}
 	}
 
@@ -55,7 +58,10 @@ func (c *CachedAuthenticator) Authenticate(requestContext context.Context) (*aut
 		return nil, err
 	}
 
-	c.cache.Set(cacheKey, &AuthClaimsCacheEntry{Claims: claims}, c.ttl)
+	ttl := c.effectiveTTL(authHeader)
+	if ttl > 0 {
+		c.cache.Set(cacheKey, &AuthClaimsCacheEntry{Claims: cloneClaims(claims)}, ttl)
+	}
 
 	return claims, nil
 }
@@ -65,11 +71,47 @@ func (c *CachedAuthenticator) Close() {
 	c.delegate.Close()
 }
 
+// effectiveTTL returns min(configured TTL, time until JWT expiry).
+// If the token is not a JWT or has no exp claim, the configured TTL is used.
+func (c *CachedAuthenticator) effectiveTTL(rawToken string) time.Duration {
+	parser := jwt.NewParser()
+	token, _, err := parser.ParseUnverified(rawToken, jwt.MapClaims{})
+	if err != nil {
+		return c.ttl
+	}
+
+	exp, err := token.Claims.GetExpirationTime()
+	if err != nil || exp == nil {
+		return c.ttl
+	}
+
+	remaining := time.Until(exp.Time)
+	if remaining <= 0 {
+		return 0
+	}
+
+	if remaining < c.ttl {
+		return remaining
+	}
+
+	return c.ttl
+}
+
+func cloneClaims(src *authclaims.AuthClaims) *authclaims.AuthClaims {
+	return &authclaims.AuthClaims{
+		Subject:  src.Subject,
+		ClientID: src.ClientID,
+		Scopes:   maps.Clone(src.Scopes),
+	}
+}
+
 func authnTokenCacheKey(token string) keys.Key {
+	hash := sha256.Sum256([]byte(token))
+
 	builder := keys.GetBuilder()
 	defer builder.Close()
 
-	builder.EncodeString(PrefixAuthnTokenCache)
-	builder.EncodeString(token)
+	builder.EncodeString(prefixAuthnTokenCache)
+	builder.EncodeBytes(hash[:])
 	return builder.Key()
 }

--- a/internal/authn/cached_authenticator_test.go
+++ b/internal/authn/cached_authenticator_test.go
@@ -30,11 +30,16 @@ func contextWithBearer(token string) context.Context {
 	return metadata.NewIncomingContext(context.Background(), md)
 }
 
-func TestCachedAuthenticator_CachesSuccessfulAuth(t *testing.T) {
+func newTestCache(t *testing.T) storage.InMemoryCache[any] {
+	t.Helper()
 	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
 	require.NoError(t, err)
-	defer cache.Stop()
+	t.Cleanup(cache.Stop)
+	return cache
+}
 
+func TestCachedAuthenticator_CachesSuccessfulAuth(t *testing.T) {
+	cache := newTestCache(t)
 	delegate := &mockAuthenticator{
 		claims: &authclaims.AuthClaims{
 			Subject:  "user:alice",
@@ -44,17 +49,14 @@ func TestCachedAuthenticator_CachesSuccessfulAuth(t *testing.T) {
 	}
 
 	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
-
 	ctx := contextWithBearer("test-token-123")
 
-	// First call should hit the delegate
 	claims, err := cached.Authenticate(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "user:alice", claims.Subject)
 	require.Equal(t, "my-client", claims.ClientID)
 	require.Equal(t, 1, delegate.callCount)
 
-	// Second call with same token should use cache
 	claims, err = cached.Authenticate(ctx)
 	require.NoError(t, err)
 	require.Equal(t, "user:alice", claims.Subject)
@@ -62,19 +64,14 @@ func TestCachedAuthenticator_CachesSuccessfulAuth(t *testing.T) {
 }
 
 func TestCachedAuthenticator_DifferentTokensNotCached(t *testing.T) {
-	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
-	require.NoError(t, err)
-	defer cache.Stop()
-
+	cache := newTestCache(t)
 	delegate := &mockAuthenticator{
-		claims: &authclaims.AuthClaims{
-			Subject: "user:alice",
-		},
+		claims: &authclaims.AuthClaims{Subject: "user:alice"},
 	}
 
 	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
 
-	_, err = cached.Authenticate(contextWithBearer("token-a"))
+	_, err := cached.Authenticate(contextWithBearer("token-a"))
 	require.NoError(t, err)
 	require.Equal(t, 1, delegate.callCount)
 
@@ -84,36 +81,88 @@ func TestCachedAuthenticator_DifferentTokensNotCached(t *testing.T) {
 }
 
 func TestCachedAuthenticator_DoesNotCacheErrors(t *testing.T) {
-	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
-	require.NoError(t, err)
-	defer cache.Stop()
-
-	delegate := &mockAuthenticator{
-		err: ErrUnauthenticated,
-	}
+	cache := newTestCache(t)
+	delegate := &mockAuthenticator{err: ErrUnauthenticated}
 
 	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
 	ctx := contextWithBearer("bad-token")
 
-	_, err = cached.Authenticate(ctx)
+	_, err := cached.Authenticate(ctx)
 	require.Error(t, err)
 	require.Equal(t, 1, delegate.callCount)
 
-	// Should try again (not cached)
 	_, err = cached.Authenticate(ctx)
 	require.Error(t, err)
 	require.Equal(t, 2, delegate.callCount)
 }
 
-func TestCachedAuthenticator_MissingBearerToken(t *testing.T) {
-	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
-	require.NoError(t, err)
-	defer cache.Stop()
+func TestCachedAuthenticator_MissingBearerDelegatesToUnderlying(t *testing.T) {
+	cache := newTestCache(t)
+	delegate := &mockAuthenticator{
+		claims: &authclaims.AuthClaims{Subject: ""},
+	}
 
-	delegate := &mockAuthenticator{}
 	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
 
-	_, err = cached.Authenticate(context.Background())
-	require.ErrorIs(t, err, ErrMissingBearerToken)
-	require.Equal(t, 0, delegate.callCount)
+	claims, err := cached.Authenticate(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, claims)
+	require.Equal(t, 1, delegate.callCount)
+}
+
+func TestCachedAuthenticator_CacheHitReturnsCopy(t *testing.T) {
+	cache := newTestCache(t)
+	delegate := &mockAuthenticator{
+		claims: &authclaims.AuthClaims{
+			Subject: "user:alice",
+			Scopes:  map[string]bool{"read": true},
+		},
+	}
+
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+	ctx := contextWithBearer("token-scopes")
+
+	first, err := cached.Authenticate(ctx)
+	require.NoError(t, err)
+
+	first.Scopes["write"] = true
+
+	second, err := cached.Authenticate(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, second.Scopes, "write", "mutating returned claims must not affect cached entry")
+	require.Equal(t, 1, delegate.callCount)
+}
+
+func TestCachedAuthenticator_NilClaimsFromDelegate(t *testing.T) {
+	cache := newTestCache(t)
+	delegate := &mockAuthenticator{claims: nil, err: ErrUnauthenticated}
+
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+
+	_, err := cached.Authenticate(contextWithBearer("nil-token"))
+	require.Error(t, err)
+	require.Equal(t, 1, delegate.callCount)
+}
+
+func TestAuthnTokenCacheKey_DifferentTokensDifferentKeys(t *testing.T) {
+	keyA := authnTokenCacheKey("token-a")
+	keyB := authnTokenCacheKey("token-b")
+	require.NotEqual(t, keyA, keyB)
+}
+
+func TestAuthnTokenCacheKey_SameTokenSameKey(t *testing.T) {
+	key1 := authnTokenCacheKey("same-token")
+	key2 := authnTokenCacheKey("same-token")
+	require.Equal(t, key1, key2)
+}
+
+func TestEffectiveTTL_NonJWTToken(t *testing.T) {
+	cached := &CachedAuthenticator{ttl: 5 * time.Minute}
+	require.Equal(t, 5*time.Minute, cached.effectiveTTL("not-a-jwt"))
+}
+
+func TestEffectiveTTL_JWTWithFarExpiry(t *testing.T) {
+	cached := &CachedAuthenticator{ttl: 5 * time.Minute}
+	// effectiveTTL uses ParseUnverified, so we don't need a valid signature
+	require.Equal(t, 5*time.Minute, cached.effectiveTTL("not-a-jwt"))
 }

--- a/internal/authn/cached_authenticator_test.go
+++ b/internal/authn/cached_authenticator_test.go
@@ -1,0 +1,119 @@
+package authn
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/openfga/openfga/pkg/authclaims"
+	"github.com/openfga/openfga/pkg/storage"
+)
+
+type mockAuthenticator struct {
+	callCount int
+	claims    *authclaims.AuthClaims
+	err       error
+}
+
+func (m *mockAuthenticator) Authenticate(_ context.Context) (*authclaims.AuthClaims, error) {
+	m.callCount++
+	return m.claims, m.err
+}
+
+func (m *mockAuthenticator) Close() {}
+
+func contextWithBearer(token string) context.Context {
+	md := metadata.Pairs("authorization", "Bearer "+token)
+	return metadata.NewIncomingContext(context.Background(), md)
+}
+
+func TestCachedAuthenticator_CachesSuccessfulAuth(t *testing.T) {
+	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	delegate := &mockAuthenticator{
+		claims: &authclaims.AuthClaims{
+			Subject:  "user:alice",
+			ClientID: "my-client",
+			Scopes:   map[string]bool{"read": true},
+		},
+	}
+
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+
+	ctx := contextWithBearer("test-token-123")
+
+	// First call should hit the delegate
+	claims, err := cached.Authenticate(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "user:alice", claims.Subject)
+	require.Equal(t, "my-client", claims.ClientID)
+	require.Equal(t, 1, delegate.callCount)
+
+	// Second call with same token should use cache
+	claims, err = cached.Authenticate(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "user:alice", claims.Subject)
+	require.Equal(t, 1, delegate.callCount)
+}
+
+func TestCachedAuthenticator_DifferentTokensNotCached(t *testing.T) {
+	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	delegate := &mockAuthenticator{
+		claims: &authclaims.AuthClaims{
+			Subject: "user:alice",
+		},
+	}
+
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+
+	_, err = cached.Authenticate(contextWithBearer("token-a"))
+	require.NoError(t, err)
+	require.Equal(t, 1, delegate.callCount)
+
+	_, err = cached.Authenticate(contextWithBearer("token-b"))
+	require.NoError(t, err)
+	require.Equal(t, 2, delegate.callCount)
+}
+
+func TestCachedAuthenticator_DoesNotCacheErrors(t *testing.T) {
+	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	delegate := &mockAuthenticator{
+		err: ErrUnauthenticated,
+	}
+
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+	ctx := contextWithBearer("bad-token")
+
+	_, err = cached.Authenticate(ctx)
+	require.Error(t, err)
+	require.Equal(t, 1, delegate.callCount)
+
+	// Should try again (not cached)
+	_, err = cached.Authenticate(ctx)
+	require.Error(t, err)
+	require.Equal(t, 2, delegate.callCount)
+}
+
+func TestCachedAuthenticator_MissingBearerToken(t *testing.T) {
+	cache, err := storage.NewInMemoryLRUCache[any](storage.WithMaxCacheSize[any](100))
+	require.NoError(t, err)
+	defer cache.Stop()
+
+	delegate := &mockAuthenticator{}
+	cached := NewCachedAuthenticator(delegate, cache, 5*time.Minute)
+
+	_, err = cached.Authenticate(context.Background())
+	require.ErrorIs(t, err, ErrMissingBearerToken)
+	require.Equal(t, 0, delegate.callCount)
+}

--- a/internal/authn/cached_authenticator_test.go
+++ b/internal/authn/cached_authenticator_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	jwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
@@ -163,6 +164,33 @@ func TestEffectiveTTL_NonJWTToken(t *testing.T) {
 
 func TestEffectiveTTL_JWTWithFarExpiry(t *testing.T) {
 	cached := &CachedAuthenticator{ttl: 5 * time.Minute}
-	// effectiveTTL uses ParseUnverified, so we don't need a valid signature
-	require.Equal(t, 5*time.Minute, cached.effectiveTTL("not-a-jwt"))
+	token := buildUnsignedJWT(t, time.Now().Add(1*time.Hour))
+	ttl := cached.effectiveTTL(token)
+	require.Equal(t, 5*time.Minute, ttl)
+}
+
+func TestEffectiveTTL_JWTWithNearExpiry(t *testing.T) {
+	cached := &CachedAuthenticator{ttl: 5 * time.Minute}
+	token := buildUnsignedJWT(t, time.Now().Add(30*time.Second))
+	ttl := cached.effectiveTTL(token)
+	require.True(t, ttl > 0 && ttl <= 30*time.Second,
+		"expected TTL capped at ~30s, got %v", ttl)
+}
+
+func TestEffectiveTTL_JWTAlreadyExpired(t *testing.T) {
+	cached := &CachedAuthenticator{ttl: 5 * time.Minute}
+	token := buildUnsignedJWT(t, time.Now().Add(-10*time.Second))
+	ttl := cached.effectiveTTL(token)
+	require.Equal(t, time.Duration(0), ttl)
+}
+
+func buildUnsignedJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, jwt.MapClaims{
+		"exp": exp.Unix(),
+		"sub": "test",
+	})
+	s, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	return s
 }

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -58,6 +58,10 @@ const (
 	DefaultCacheControllerConfigEnabled = false
 	DefaultCacheControllerConfigTTL     = 10 * time.Second
 
+	DefaultAuthnTokenCacheEnabled  = false
+	DefaultAuthnTokenCacheTTL      = 5 * time.Minute
+	DefaultAuthnTokenCacheMaxSize  = 10000
+
 	DefaultShadowCheckResolverTimeout = 1 * time.Second
 
 	DefaultShadowListObjectsQueryTimeout       = 1 * time.Second
@@ -218,6 +222,14 @@ type AuthnConfig struct {
 	Method                   string
 	*AuthnOIDCConfig         `mapstructure:"oidc"`
 	*AuthnPresharedKeyConfig `mapstructure:"preshared"`
+	TokenCache               AuthnTokenCacheConfig `mapstructure:"tokenCache"`
+}
+
+// AuthnTokenCacheConfig defines configuration for caching authenticated JWT tokens.
+type AuthnTokenCacheConfig struct {
+	Enabled bool
+	TTL     time.Duration
+	MaxSize int64
 }
 
 // AuthnOIDCConfig defines configurations for the 'oidc' method of authentication.
@@ -795,6 +807,9 @@ func (cfg *Config) verifyCacheConfig() error {
 	if cfg.CacheTTLJitterPercentage > 100 {
 		return errors.New("'cacheTTLJitterPercentage' must be between 0 and 100")
 	}
+	if cfg.Authn.TokenCache.Enabled && cfg.Authn.TokenCache.TTL <= 0 {
+		return errors.New("'authn.tokenCache.ttl' must be greater than zero")
+	}
 	return nil
 }
 
@@ -908,6 +923,11 @@ func DefaultConfig() *Config {
 			Method:                  "none",
 			AuthnPresharedKeyConfig: &AuthnPresharedKeyConfig{},
 			AuthnOIDCConfig:         &AuthnOIDCConfig{},
+			TokenCache: AuthnTokenCacheConfig{
+				Enabled: DefaultAuthnTokenCacheEnabled,
+				TTL:     DefaultAuthnTokenCacheTTL,
+				MaxSize: DefaultAuthnTokenCacheMaxSize,
+			},
 		},
 		Log: LogConfig{
 			Format:          "text",

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -807,8 +807,13 @@ func (cfg *Config) verifyCacheConfig() error {
 	if cfg.CacheTTLJitterPercentage > 100 {
 		return errors.New("'cacheTTLJitterPercentage' must be between 0 and 100")
 	}
-	if cfg.Authn.TokenCache.Enabled && cfg.Authn.TokenCache.TTL <= 0 {
-		return errors.New("'authn.tokenCache.ttl' must be greater than zero")
+	if cfg.Authn.TokenCache.Enabled {
+		if cfg.Authn.TokenCache.TTL <= 0 {
+			return errors.New("'authn.tokenCache.ttl' must be greater than zero")
+		}
+		if cfg.Authn.TokenCache.MaxSize <= 0 {
+			return errors.New("'authn.tokenCache.maxSize' must be greater than zero")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

Every authenticated request in OpenFGA re-parses and re-verifies the incoming JWT bearer token from scratch. While the JWK signing keys are already cached (refreshed every 24-48h), the RSA signature verification and claims validation still runs on every single call, costing roughly 0.1–0.5 ms per request. 
At high QPS this becomes a measurable share of the authentication path, even though the same tokens are re-presented repeatedly by the same clients within a short window.

#### How is it being solved?

Introduce an opt-in in-memory cache in front of the Authenticator interface that stores the successfully-parsed `AuthClaims` keyed by the raw bearer token. On a cache hit, we skip signature verification and claims parsing entirely and return the previously validated claims. On a cache miss or on any authentication error, we fall through to the underlying authenticator; errors are never cached so revocation/expiry paths continue to work as before.

Trade-off: while the cache is warm, a token remains valid up to TTL past any external revocation. Since JWTs are already non-revocable without a denylist, this only widens the pre-existing revocation lag by at most TTL, operators should size TTL against their acceptable revocation window.

#### What changes are made to solve it?

- `internal/authn/cached_authenticator.go` (new): `CachedAuthenticator` wraps any `Authenticator `(works transparently with oidc, preshared, or noop). Successful claims are cached under the key AT + <bearer token>; errors bypass the cache.
- `internal/authn/cached_authenticator_test.go` (new): Unit tests covering cache hits, distinct-token isolation, error non-caching, and missing bearer token.
- `pkg/server/config/config.go`: New `AuthnTokenCacheConfig` struct (Enabled, TTL, MaxSize) on `AuthnConfig`, defaults (false, 5m, 10000), and validation (TTL > 0 when enabled) in `verifyCacheConfig`.
- `cmd/run/run.go`: New flags -`-authn-token-cache-enabled`, `--authn-token-cache-ttl`, `--authn-token-cache-max-size`; `authenticatorConfig` now wraps the constructed authenticator with `CachedAuthenticator` when the flag is enabled.
- `cmd/run/flags.go`: Bound the three new flags to config keys and environment variables (`OPENFGA_AUTHN_TOKEN_CACHE_ENABLED`, `OPENFGA_AUTHN_TOKEN_CACHE_TTL`, `OPENFGA_AUTHN_TOKEN_CACHE_MAX_SIZE`).
- `docs/caching.md`: New "Auth Token Cache" section with description, cache key, trade-offs, and the standard configuration table; added to the top-level overview list.

Co-authored-by: Claude noreply@anthropic.com

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional authentication token caching for OIDC authentication.
  * Added configuration options, command-line flags, and environment variables for enabling caching, setting duration, and limiting cache size.

* **Bug Fixes**
  * Cache duration now respects each token’s expiration time.
  * Expired tokens and authentication failures are not cached.
  * Improved handling of requests without bearer tokens and protected cached credentials.

* **Documentation**
  * Documented token caching behavior, configuration, bypass conditions, and expiration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->