### PR TITLE
docs: fix typos in code comments

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -638,7 +638,7 @@ func (q *ListObjectsQuery) Execute(
 		p.Close() // ensure that the pipeline is closed after any early loop exits
 
 		if err := p.Err(); err != nil {
-			// current list objects behavior is to elide context cancelation errors
+			// current list objects behavior is to elide context cancellation errors
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				return nil, serverErrors.HandleError("", err)
 			}

--- a/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
+++ b/pkg/server/commands/reverseexpand/reverse_expand_weighted.go
@@ -495,7 +495,7 @@ func buildUserFilter(
 
 			filter = &openfgav1.ObjectRelation{Object: tuple.BuildObject(toNode.GetUniqueLabel(), userID)}
 
-		case weightedGraph.SpecificTypeWildcard: // Wildcard Referece To() -> "user:*"
+		case weightedGraph.SpecificTypeWildcard: // Wildcard Reference To() -> "user:*"
 			filter = &openfgav1.ObjectRelation{Object: toNode.GetUniqueLabel()}
 		}
 	}

--- a/pkg/server/config/config.go
+++ b/pkg/server/config/config.go
@@ -153,7 +153,7 @@ type DatastoreConfig struct {
 	MinOpenConns int
 
 	// MaxIdleConns is the maximum number of connections to the datastore in the idle connection
-	// pool. This is only used for some datastore engines (non-PostgresSQL that uses sql.DB).
+	// pool. This is only used for some datastore engines (non-PostgreSQL that uses sql.DB).
 	MaxIdleConns int
 
 	// MinIdleConns is the minimum number of connections to the datastore in the idle connection

--- a/pkg/storage/sqlcommon/sqlcommon.go
+++ b/pkg/storage/sqlcommon/sqlcommon.go
@@ -133,7 +133,7 @@ func WithMaxOpenConns(c int) DatastoreOption {
 // WithMinOpenConns returns a DatastoreOption that sets the
 // minimum number of open connections in the Config.
 // This is only used by some SQL drivers (e.g., pgxpool that is used
-// in PostgresSQL).
+// in PostgreSQL).
 func WithMinOpenConns(c int) DatastoreOption {
 	return func(cfg *Config) {
 		cfg.MinOpenConns = c
@@ -151,7 +151,7 @@ func WithMaxIdleConns(c int) DatastoreOption {
 // WithMinIdleConns returns a DatastoreOption that sets the
 // minimum number of idle connections in the Config.
 // This is only used by some SQL drivers (e.g., pgxpool that is used
-// in PostgresSQL).
+// in PostgreSQL).
 func WithMinIdleConns(c int) DatastoreOption {
 	return func(cfg *Config) {
 		cfg.MinIdleConns = c


### PR DESCRIPTION
Comment-only typo fixes I noticed while reading through the list-objects and sqlcommon code:

- `Referece` -> `Reference`
- `cancelation` -> `cancellation`
- `PostgresSQL` -> `PostgreSQL` (3x)

No functional change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling and terminology in developer-facing comments related to pipeline cancellation, references, PostgreSQL configuration, and database connection settings.
  - No user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->