### PR TITLE
fix: start listusers union/intersection consumers before producers to prevent deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 ### Added
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
 
+### Fixed
+- Fixed a deadlock in ListUsers that caused a timeout with partial results when the number of union/intersection operands exceeded `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` and the operands each resolved to more than one user. [#3284](https://github.com/openfga/openfga/pull/3284)
+
 ## [1.19.0] - 2026-08-24
 ### Added
 - Adds configurable pipeline optimization for weight-one difference subtract edges with high cardinality on wildcard leaves. For now, this configuration is internal only. [#3267](https://github.com/openfga/openfga/pull/3267)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
 
 ### Fixed
-- Fixed a deadlock in ListUsers that caused a timeout with partial results when the number of union/intersection operands exceeded `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` and the operands each resolved to more than one user. [#3284](https://github.com/openfga/openfga/pull/3284)
+- Fixed a deadlock in ListUsers that caused a timeout with partial results when the number of union/intersection operands exceeded `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT` and the operands each resolved to more than one user. Thank you to [@fabianluque](https://github.com/fabianluque) for the discovery and detailed report! [#3284](https://github.com/openfga/openfga/pull/3284)
 
 ## [1.19.0] - 2026-08-24
 ### Added

--- a/pkg/server/commands/listusers/list_users_rpc.go
+++ b/pkg/server/commands/listusers/list_users_rpc.go
@@ -573,24 +573,9 @@ func (l *listUsersQuery) expandIntersection(
 
 	childOperands := rewrite.Intersection.GetChild()
 	intersectionFoundUsersChans := make([]chan foundUser, len(childOperands))
-	for i, rewrite := range childOperands {
+	for i := range childOperands {
 		intersectionFoundUsersChans[i] = make(chan foundUser, 1)
-		pool.Go(func(ctx context.Context) error {
-			resp := l.expandRewrite(ctx, req, rewrite, intersectionFoundUsersChans[i])
-			return resp.err
-		})
 	}
-
-	errChan := make(chan error, 1)
-
-	go func() {
-		err := pool.Wait()
-		for i := range intersectionFoundUsersChans {
-			close(intersectionFoundUsersChans[i])
-		}
-		errChan <- err
-		close(errChan)
-	}()
 
 	var mu sync.Mutex
 
@@ -601,6 +586,9 @@ func (l *listUsersQuery) expandIntersection(
 	wildcardKey := tuple.TypedPublicWildcard(req.GetUserFilters()[0].GetType())
 	foundUsersCountMap := make(map[string]uint32, 0)
 	excludedUsersMap := make(map[string]struct{}, 0)
+	// Consumers must start before the producer pool below: a producer blocks on
+	// its second send into a size-1 channel until drained, so if the bounded
+	// pool fills before consumers run, the submit loop deadlocks.
 	for _, foundUsersChan := range intersectionFoundUsersChans {
 		go func(foundUsersChan chan foundUser) {
 			defer wg.Done()
@@ -637,6 +625,25 @@ func (l *listUsersQuery) expandIntersection(
 			}
 		}(foundUsersChan)
 	}
+
+	for i, rewrite := range childOperands {
+		pool.Go(func(ctx context.Context) error {
+			resp := l.expandRewrite(ctx, req, rewrite, intersectionFoundUsersChans[i])
+			return resp.err
+		})
+	}
+
+	errChan := make(chan error, 1)
+
+	go func() {
+		err := pool.Wait()
+		for i := range intersectionFoundUsersChans {
+			close(intersectionFoundUsersChans[i])
+		}
+		errChan <- err
+		close(errChan)
+	}()
+
 	wg.Wait()
 
 	excludedUsers := []*openfgav1.User{}
@@ -680,24 +687,9 @@ func (l *listUsersQuery) expandUnion(
 
 	childOperands := rewrite.Union.GetChild()
 	unionFoundUsersChans := make([]chan foundUser, len(childOperands))
-	for i, rewrite := range childOperands {
+	for i := range childOperands {
 		unionFoundUsersChans[i] = make(chan foundUser, 1)
-		pool.Go(func(ctx context.Context) error {
-			resp := l.expandRewrite(ctx, req, rewrite, unionFoundUsersChans[i])
-			return resp.err
-		})
 	}
-
-	errChan := make(chan error, 1)
-
-	go func() {
-		err := pool.Wait()
-		for i := range unionFoundUsersChans {
-			close(unionFoundUsersChans[i])
-		}
-		errChan <- err
-		close(errChan)
-	}()
 
 	var mu sync.Mutex
 
@@ -706,6 +698,9 @@ func (l *listUsersQuery) expandUnion(
 
 	foundUsersMap := make(map[string]struct{}, 0)
 	excludedUsersCountMap := make(map[string]uint32, 0)
+	// Consumers must start before the producer pool below: a producer blocks on
+	// its second send into a size-1 channel until drained, so if the bounded
+	// pool fills before consumers run, the submit loop deadlocks.
 	for _, foundUsersChan := range unionFoundUsersChans {
 		go func(foundUsersChan chan foundUser) {
 			defer wg.Done()
@@ -727,6 +722,25 @@ func (l *listUsersQuery) expandUnion(
 			}
 		}(foundUsersChan)
 	}
+
+	for i, rewrite := range childOperands {
+		pool.Go(func(ctx context.Context) error {
+			resp := l.expandRewrite(ctx, req, rewrite, unionFoundUsersChans[i])
+			return resp.err
+		})
+	}
+
+	errChan := make(chan error, 1)
+
+	go func() {
+		err := pool.Wait()
+		for i := range unionFoundUsersChans {
+			close(unionFoundUsersChans[i])
+		}
+		errChan <- err
+		close(errChan)
+	}()
+
 	wg.Wait()
 
 	excludedUsers := []*openfgav1.User{}

--- a/pkg/server/commands/listusers/list_users_rpc_test.go
+++ b/pkg/server/commands/listusers/list_users_rpc_test.go
@@ -4349,3 +4349,87 @@ func TestListUsersDatastoreThrottler(t *testing.T) {
 		require.False(t, resp.GetMetadata().WasDatastoreThrottled.Load(), "Should not be throttled when threshold is zero")
 	})
 }
+
+// TestListUsersOperandsExceedingBreadthLimit verifies that a union or
+// intersection whose number of child operands exceeds resolveNodeBreadthLimit
+// is still expanded completely. Each operand resolves to more than one user, so
+// the whole result set must be returned regardless of how operand expansion is
+// scheduled against the breadth limit.
+func TestListUsersOperandsExceedingBreadthLimit(t *testing.T) {
+	// A breadth limit of 1 is smaller than the 2 operands in each model below.
+	const breadthLimit = 1
+
+	// r1 and r2 each resolve to more than one user; user:a and user:b belong to
+	// both, so the intersection is non-empty.
+	tuples := []*openfgav1.TupleKey{
+		tuple.NewTupleKey("doc:1", "r1", "user:a"),
+		tuple.NewTupleKey("doc:1", "r1", "user:b"),
+		tuple.NewTupleKey("doc:1", "r1", "user:c"),
+		tuple.NewTupleKey("doc:1", "r2", "user:a"),
+		tuple.NewTupleKey("doc:1", "r2", "user:b"),
+		tuple.NewTupleKey("doc:1", "r2", "user:d"),
+	}
+
+	tests := map[string]struct {
+		model    string
+		expected []string
+	}{
+		"union": {
+			model: `
+				model
+					schema 1.1
+				type user
+				type doc
+					relations
+						define r1: [user]
+						define r2: [user]
+						define viewer: r1 or r2`,
+			expected: []string{"user:a", "user:b", "user:c", "user:d"},
+		},
+		"intersection": {
+			model: `
+				model
+					schema 1.1
+				type user
+				type doc
+					relations
+						define r1: [user]
+						define r2: [user]
+						define viewer: r1 and r2`,
+			expected: []string{"user:a", "user:b"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ds := memory.New()
+			t.Cleanup(ds.Close)
+
+			model := testutils.MustTransformDSLToProtoWithID(tc.model)
+			storeID := ulid.Make().String()
+			require.NoError(t, ds.WriteAuthorizationModel(ctx, storeID, model))
+			require.NoError(t, ds.Write(ctx, storeID, nil, tuples))
+
+			typesys, err := typesystem.NewAndValidate(ctx, model)
+			require.NoError(t, err)
+			ctx = typesystem.ContextWithTypesystem(ctx, typesys)
+
+			res, err := NewListUsersQuery(ds, nil,
+				WithResolveNodeBreadthLimit(breadthLimit),
+			).ListUsers(ctx, &openfgav1.ListUsersRequest{
+				StoreId:     storeID,
+				Object:      &openfgav1.Object{Type: "doc", Id: "1"},
+				Relation:    "viewer",
+				UserFilters: []*openfgav1.UserTypeFilter{{Type: "user"}},
+			})
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(res.GetUsers()))
+			for _, u := range res.GetUsers() {
+				got = append(got, tuple.UserProtoToString(u))
+			}
+			require.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description

<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

When ListUsers processes a union or intersection, it creates a pool of size `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`:
https://github.com/openfga/openfga/blob/c3da9133d9f7edd3d4625ed8740d6bbbdf44fafc/pkg/server/commands/listusers/list_users_rpc.go#L679

It synchronously starts pooled goroutines for each operand of the union/intersection:
https://github.com/openfga/openfga/blob/c3da9133d9f7edd3d4625ed8740d6bbbdf44fafc/pkg/server/commands/listusers/list_users_rpc.go#L683-L686

^ notice that they're each passed a buffered channel of size 1. Each pooled goroutine is a producer which sends matching users to that channel. If there's >1 matching user, the goroutine is stuck waiting to send until a consumer pulls the first user from the channel.

If there are more pooled goroutines running than the set limit, `pool.Go` will block. However, the consumers are not created until further below:
https://github.com/openfga/openfga/blob/c3da9133d9f7edd3d4625ed8740d6bbbdf44fafc/pkg/server/commands/listusers/list_users_rpc.go#L709-L713

So if each producer gets >1 user from each operand, they are all stuck waiting on sending to their buffered channel, but if the number of these waiting producers exceeds `OPENFGA_RESOLVE_NODE_BREADTH_LIMIT`, nothing is consuming since the `pool.Go` blocks. I.e., deadlock.

#### How is it being solved?

Start the producers after the consumers (consumers run in goroutines, guarded by a waitgroup).

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected

