### PR TITLE
feat(authz): support client ids containing tuple-reserved characters

### DIFF
--- a/internal/authz/authz.go
+++ b/internal/authz/authz.go
@@ -68,8 +68,10 @@ func (s StoreIDType) String() string {
 
 type ClientIDType string
 
+// String sanitizes c with tuple.SanitizeUserID before building the tuple
+// user. Any tuple granting a client access must use the same sanitized id.
 func (c ClientIDType) String() string {
-	return fmt.Sprintf("%s:%s", ApplicationType, string(c))
+	return fmt.Sprintf("%s:%s", ApplicationType, tuple.SanitizeUserID(string(c)))
 }
 
 type ModuleIDType string

--- a/internal/authz/authz_test.go
+++ b/internal/authz/authz_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openfga/openfga/pkg/authclaims"
 	"github.com/openfga/openfga/pkg/logger"
 	"github.com/openfga/openfga/pkg/testutils"
+	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
 
@@ -85,6 +86,18 @@ func TestGetStoreID(t *testing.T) {
 
 		authorizer := NewAuthorizer(nil, mockServer, logger.NewNoopLogger())
 		require.Empty(t, authorizer.AccessControlStoreID())
+	})
+}
+
+func TestClientIDType_String(t *testing.T) {
+	t.Run("plain_client_id_is_unchanged", func(t *testing.T) {
+		require.Equal(t, "application:test-client", ClientIDType("test-client").String())
+	})
+	t.Run("kubernetes_serviceaccount_subject_is_sanitized", func(t *testing.T) {
+		clientID := ClientIDType("system:serviceaccount:openfga:permissions-deployer")
+		result := clientID.String()
+		require.Equal(t, "application:system_serviceaccount_openfga_permissions-deployer", result)
+		require.True(t, tuple.IsValidUser(result))
 	})
 }
 

--- a/pkg/tuple/tuple.go
+++ b/pkg/tuple/tuple.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 	"unsafe"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -472,6 +473,33 @@ func IsValidUserID(s string) bool {
 		}
 	}
 	return count > 0
+}
+
+// SanitizeUserID replaces every character IsValidUserID rejects (a Unicode
+// control character, '#', ':', or ' ') with '_'. Invalid UTF-8 passes through
+// unchanged, and for any non-empty s, IsValidUserID(SanitizeUserID(s)) is true.
+func SanitizeUserID(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	for i := 0; i < len(s); {
+		chr, size := utf8.DecodeRuneInString(s[i:])
+		if chr == utf8.RuneError && size == 1 {
+			b.WriteByte(s[i])
+			i++
+			continue
+		}
+
+		switch {
+		case unicode.IsControl(chr), chr == '#', chr == ':', chr == ' ':
+			b.WriteByte('_')
+		default:
+			b.WriteRune(chr)
+		}
+		i += size
+	}
+
+	return b.String()
 }
 
 func IsValidUserset(s string) bool {

--- a/pkg/tuple/tuple_test.go
+++ b/pkg/tuple/tuple_test.go
@@ -380,6 +380,17 @@ func BenchmarkIsValidUserID(b *testing.B) {
 	outcome = result
 }
 
+func BenchmarkSanitizeUserID(b *testing.B) {
+	value := "system:serviceaccount:openfga:permissions-deployer"
+
+	var result string
+
+	for b.Loop() {
+		result = SanitizeUserID(value)
+	}
+	outcome = result
+}
+
 func BenchmarkIsValidUserset(b *testing.B) {
 	value := "group:1#member"
 
@@ -511,6 +522,31 @@ func FuzzIsValidUserID(f *testing.F) {
 
 		require.Equal(t, result, IsValidUserID(value), "failed idempotence: '%s' -- '%X'", value, value)
 		require.Equal(t, userIDRegex.MatchString(value), result, "failed accuracy: '%s' -- '%X'", value, value)
+	})
+}
+
+func FuzzSanitizeUserID(f *testing.F) {
+	f.Add("")
+	f.Add(" ")
+	f.Add("\x00")
+	f.Add("fo o:bar")
+	f.Add("system:serviceaccount:openfga:permissions-deployer")
+	f.Add("some_identifier")
+	f.Add("👽:🙀")
+
+	f.Fuzz(func(t *testing.T, value string) {
+		result := SanitizeUserID(value)
+
+		if value == "" {
+			require.Empty(t, result)
+			return
+		}
+
+		require.True(t, IsValidUserID(result), "sanitized value must be a valid user id: %q -> %q", value, result)
+
+		if IsValidUserID(value) {
+			require.Equal(t, value, result, "sanitizing an already-valid user id must be a no-op")
+		}
 	})
 }
 


### PR DESCRIPTION
Sanitize claim-sourced client ids so they form valid tuple users, unblocking Kubernetes ServiceAccount subjects as access-control clients.

## Description

#### What problem is being solved?

The [access control](https://openfga.dev/docs/getting-started/setup-openfga/access-control#04-grant-access-to-a-store) feature grants an OIDC client access by writing an `application:<client_id>` tuple, where `<client_id>` comes straight from a claim (`azp`/`client_id` by default, or any claim named via `--authn-oidc-client-id-claims`). `tuple.IsValidUser` allows at most one `:` in a tuple user, but `ClientIDType.String()` builds `application:<client_id>` with no validation or transformation of the raw claim. A client id claim with more than one colon makes every access-control check for that client fail with "invalid tuple 'user' field format".

This is exactly the shape of a Kubernetes ServiceAccount token subject, the standard identity for an in-cluster workload calling another in-cluster service: `system:serviceaccount:<namespace>:<name>`, three colons. A cluster's own service identities can't be used as access-control clients today.

#### How is it being solved?

`ClientIDType.String()` now sanitizes the client id before building the tuple user, replacing every character `tuple.IsValidUser` rejects (`:`, `#`, space, or a Unicode control character) with `_`. `system:serviceaccount:openfga:my-service` becomes `system_serviceaccount_openfga_my-service`, so `application:system_serviceaccount_openfga_my-service` is a valid tuple user.

This can only change behavior for client ids that don't work today. Every consumer of `ClientIDType.String()`'s output is a `Check` request's `User` field (`ListAuthorizedStores` and `individualAuthorize`), so any claim value already containing one of these characters was already producing an invalid tuple and failing every check.

#### What changes are made to solve it?

- `pkg/tuple/tuple.go`: new exported `SanitizeUserID(s string) string`, next to the `IsValidUserID` it's built against.
- `pkg/tuple/tuple_test.go`: `FuzzSanitizeUserID`, mirroring `FuzzIsValidUserID`'s style, asserting `IsValidUserID(SanitizeUserID(s))` holds for any non-empty `s` and that sanitizing an already-valid id is a no-op; `BenchmarkSanitizeUserID`.
- `internal/authz/authz.go`: `ClientIDType.String()` calls `tuple.SanitizeUserID`.
- `internal/authz/authz_test.go`: `TestClientIDType_String`, covering a plain client id (unchanged) and a Kubernetes ServiceAccount subject (sanitized).

#### Notes for reviewers

Sanitization only runs where the client id is read (`ClientIDType.String()`), not where access is granted. Any tuple written to grant a client access, most importantly the [bootstrap admin tuple](https://openfga.dev/docs/modeling/access-control#bootstrapping-access-control), must use the same sanitized id (e.g. `application:system_serviceaccount_openfga_my-service`), not the raw claim value. `tuple.SanitizeUserID` is exported so operator tooling can compute the exact sanitized form before writing that tuple.

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev)
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sanitizing client IDs before using them in access-control tuples.
  * Invalid user-ID characters are replaced with underscores, including support for Unicode and invalid UTF-8 input.

* **Bug Fixes**
  * Client IDs such as Kubernetes service-account subjects now produce valid, consistently formatted application tuples.

* **Tests**
  * Added coverage for plain, Unicode, invalid, and already-valid client IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->