### PR TITLE
feat(server): support tracer provider injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 
 ## [Unreleased]
 ### Added
+- Added a `WithTracerProvider` server option for embedded OpenFGA users to supply an OpenTelemetry tracer provider to the server, typesystem resolver, and authorization graph. It defaults to the global provider for backward compatibility and can be set to a no-op provider to suppress spans from those layers. [#3274](https://github.com/openfga/openfga/issues/3274)
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
 
 ### Fixed

--- a/internal/graph/check.go
+++ b/internal/graph/check.go
@@ -54,6 +54,7 @@ type LocalChecker struct {
 	upstreamTimeout      time.Duration
 	planner              planner.Manager
 	logger               logger.Logger
+	tracer               trace.Tracer
 	optimizationsEnabled bool
 	maxResolutionDepth   uint32
 }
@@ -85,6 +86,16 @@ func WithLocalCheckerLogger(logger logger.Logger) LocalCheckerOption {
 	}
 }
 
+// WithTracerProvider sets the OpenTelemetry tracer provider used by the checker.
+func WithTracerProvider(tracerProvider trace.TracerProvider) LocalCheckerOption {
+	return func(d *LocalChecker) {
+		if tracerProvider == nil {
+			return
+		}
+		d.tracer = tracerProvider.Tracer("internal/graph/check")
+	}
+}
+
 func WithMaxResolutionDepth(depth uint32) LocalCheckerOption {
 	return func(d *LocalChecker) {
 		d.maxResolutionDepth = depth
@@ -109,6 +120,7 @@ func NewLocalChecker(opts ...LocalCheckerOption) *LocalChecker {
 		upstreamTimeout:    serverconfig.DefaultRequestTimeout,
 		logger:             logger.NewNoopLogger(),
 		planner:            planner.NewNoopPlanner(),
+		tracer:             tracer,
 	}
 	// by default, a LocalChecker delegates/dispatches subproblems to itself (e.g. local dispatch) unless otherwise configured.
 	checker.delegate = checker
@@ -400,7 +412,7 @@ func (c *LocalChecker) ResolveCheck(
 		return nil, ctx.Err()
 	}
 
-	ctx, span := tracer.Start(ctx, "ResolveCheck", trace.WithAttributes(
+	ctx, span := c.tracer.Start(ctx, "ResolveCheck", trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreID()),
 		attribute.String("resolver_type", "LocalChecker"),
 		attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(req.GetTupleKey())),
@@ -495,7 +507,7 @@ func (c *LocalChecker) checkPublicAssignable(ctx context.Context, req *ResolveCh
 	userType := tuple.GetType(reqTupleKey.GetUser())
 	wildcardRelationReference := typesystem.WildcardRelationReference(userType)
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkPublicAssignable")
+		ctx, span := c.tracer.Start(ctx, "checkPublicAssignable")
 		defer span.End()
 
 		response := &ResolveCheckResponse{
@@ -550,7 +562,7 @@ func (c *LocalChecker) checkDirectUserTuple(ctx context.Context, req *ResolveChe
 	reqTupleKey := req.GetTupleKey()
 
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkDirectUserTuple",
+		ctx, span := c.tracer.Start(ctx, "checkDirectUserTuple",
 			trace.WithAttributes(attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(reqTupleKey))))
 		defer span.End()
 
@@ -650,7 +662,7 @@ func (c *LocalChecker) checkDirectUsersetTuples(ctx context.Context, req *Resolv
 	reqTupleKey := req.GetTupleKey()
 
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkDirectUsersetTuples", trace.WithAttributes(
+		ctx, span := c.tracer.Start(ctx, "checkDirectUsersetTuples", trace.WithAttributes(
 			attribute.String("userset", tuple.ToObjectRelationString(reqTupleKey.GetObject(), reqTupleKey.GetRelation())),
 		))
 		defer span.End()
@@ -798,7 +810,7 @@ func (c *LocalChecker) checkDirectUsersetTuples(ctx context.Context, req *Resolv
 // related to it.
 func (c *LocalChecker) checkDirect(parentctx context.Context, req *ResolveCheckRequest) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkDirect", trace.WithAttributes(
+		ctx, span := c.tracer.Start(ctx, "checkDirect", trace.WithAttributes(
 			attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(req.GetTupleKey())),
 		))
 		defer span.End()
@@ -848,7 +860,7 @@ func (c *LocalChecker) checkComputedUserset(_ context.Context, req *ResolveCheck
 	childRequest.TupleKey = rewrittenTupleKey
 
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkComputedUserset", trace.WithAttributes(
+		ctx, span := c.tracer.Start(ctx, "checkComputedUserset", trace.WithAttributes(
 			attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(rewrittenTupleKey)),
 		))
 		defer span.End()
@@ -861,7 +873,7 @@ func (c *LocalChecker) checkComputedUserset(_ context.Context, req *ResolveCheck
 // of them evaluates the computed userset of the TTU rewrite rule for them.
 func (c *LocalChecker) checkTTU(parentctx context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "checkTTU", trace.WithAttributes(
+		ctx, span := c.tracer.Start(ctx, "checkTTU", trace.WithAttributes(
 			attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(req.GetTupleKey())),
 		))
 		defer span.End()
@@ -1020,7 +1032,7 @@ func (c *LocalChecker) checkSetOperation(
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
 		var err error
 		var resp *ResolveCheckResponse
-		ctx, span := tracer.Start(ctx, reducerKey, trace.WithAttributes(
+		ctx, span := c.tracer.Start(ctx, reducerKey, trace.WithAttributes(
 			attribute.String("tuple_key", tuple.TupleKeyWithConditionToString(req.GetTupleKey())),
 		))
 		defer func() {

--- a/internal/graph/default_resolver.go
+++ b/internal/graph/default_resolver.go
@@ -64,7 +64,7 @@ type dispatchMsg struct {
 // This is the slow path as it requires dispatch on all its children.
 func (c *LocalChecker) defaultUserset(_ context.Context, req *ResolveCheckRequest, _ []*openfgav1.RelationReference, iter storage.TupleKeyIterator, selectedStrategy string) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "defaultUserset")
+		ctx, span := c.tracer.Start(ctx, "defaultUserset")
 		defer span.End()
 		dispatchChan := make(chan dispatchMsg, c.concurrencyLimit)
 
@@ -132,7 +132,7 @@ func (c *LocalChecker) produceUsersetDispatches(ctx context.Context, req *Resolv
 // resort to dispatch check on its children.
 func (c *LocalChecker) defaultTTU(_ context.Context, req *ResolveCheckRequest, rewrite *openfgav1.Userset, iter storage.TupleKeyIterator, selectedStrategy string) CheckHandlerFunc {
 	return func(ctx context.Context) (*ResolveCheckResponse, error) {
-		ctx, span := tracer.Start(ctx, "defaultTTU")
+		ctx, span := c.tracer.Start(ctx, "defaultTTU")
 		defer span.End()
 		computedRelation := rewrite.GetTupleToUserset().GetComputedUserset().GetRelation()
 

--- a/internal/graph/recursive_resolver.go
+++ b/internal/graph/recursive_resolver.go
@@ -80,7 +80,7 @@ func (c *LocalChecker) recursiveTTU(_ context.Context, req *ResolveCheckRequest,
 }
 
 func (c *LocalChecker) recursiveFastPath(ctx context.Context, req *ResolveCheckRequest, iter storage.TupleKeyIterator, mapping *recursiveMapping, objectProvider objectProvider) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "recursiveFastPath")
+	ctx, span := c.tracer.Start(ctx, "recursiveFastPath")
 	defer span.End()
 	usersetFromUser := hashset.New()
 	usersetFromObject := hashset.New()
@@ -201,7 +201,7 @@ func buildRecursiveMapper(ctx context.Context, req *ResolveCheckRequest, mapping
 }
 
 func (c *LocalChecker) recursiveMatchUserUserset(ctx context.Context, req *ResolveCheckRequest, mapping *recursiveMapping, currentLevelFromObject *hashset.Set, usersetFromUser *hashset.Set) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "recursiveMatchUserUserset", trace.WithAttributes(
+	ctx, span := c.tracer.Start(ctx, "recursiveMatchUserUserset", trace.WithAttributes(
 		attribute.Int("first_level_size", currentLevelFromObject.Size()),
 		attribute.Int("terminal_type_size", usersetFromUser.Size()),
 	))

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -106,7 +106,7 @@ func (c *LocalChecker) weight2TTU(ctx context.Context, req *ResolveCheckRequest,
 // Left channel is the result set of ReadStartingWithUser of User/Relation that yields Object's ObjectID.
 // From the perspective of the model, the left hand side of a TTU is the computed relationship being expanded.
 func (c *LocalChecker) weight2(ctx context.Context, leftChans []<-chan *iterator.Msg, iter storage.TupleMapper) (*ResolveCheckResponse, error) {
-	ctx, span := tracer.Start(ctx, "weight2")
+	ctx, span := c.tracer.Start(ctx, "weight2")
 	defer span.End()
 	cancellableCtx, cancel := context.WithCancel(ctx)
 	leftChan := iterator.FanInIteratorChannels(cancellableCtx, leftChans)

--- a/pkg/server/assertions.go
+++ b/pkg/server/assertions.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Server) WriteAssertions(ctx context.Context, req *openfgav1.WriteAssertionsRequest) (*openfgav1.WriteAssertionsResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.WriteAssertions.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.WriteAssertions.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()
@@ -65,7 +65,7 @@ func (s *Server) WriteAssertions(ctx context.Context, req *openfgav1.WriteAssert
 }
 
 func (s *Server) ReadAssertions(ctx context.Context, req *openfgav1.ReadAssertionsRequest) (*openfgav1.ReadAssertionsResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.ReadAssertions.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ReadAssertions.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()

--- a/pkg/server/authorization_models.go
+++ b/pkg/server/authorization_models.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.ReadAuthorizationModelRequest) (*openfgav1.ReadAuthorizationModelResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.ReadAuthorizationModel.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ReadAuthorizationModel.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: authorizationModelIDKey, Value: attribute.StringValue(req.GetId())},
 	))
@@ -47,7 +47,7 @@ func (s *Server) ReadAuthorizationModel(ctx context.Context, req *openfgav1.Read
 }
 
 func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.WriteAuthorizationModelRequest) (*openfgav1.WriteAuthorizationModelResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.WriteAuthorizationModel.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.WriteAuthorizationModel.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()
@@ -83,7 +83,7 @@ func (s *Server) WriteAuthorizationModel(ctx context.Context, req *openfgav1.Wri
 }
 
 func (s *Server) ReadAuthorizationModels(ctx context.Context, req *openfgav1.ReadAuthorizationModelsRequest) (*openfgav1.ReadAuthorizationModelsResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.ReadAuthorizationModels.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ReadAuthorizationModels.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()

--- a/pkg/server/authzen.go
+++ b/pkg/server/authzen.go
@@ -117,7 +117,7 @@ func (s *Server) prepareAuthZenRequest(ctx context.Context, method string, req a
 		return ctx, func() {}, err
 	}
 
-	ctx, span := tracer.Start(ctx, method)
+	ctx, span := s.getTracer().Start(ctx, method)
 
 	ctx, err := s.initAuthZenRequest(ctx, method, req)
 	if err != nil {

--- a/pkg/server/batch_check.go
+++ b/pkg/server/batch_check.go
@@ -31,7 +31,7 @@ import (
 func (s *Server) BatchCheck(ctx context.Context, req *openfgav1.BatchCheckRequest) (*openfgav1.BatchCheckResponse, error) {
 	startTime := time.Now()
 
-	ctx, span := tracer.Start(ctx, apimethod.BatchCheck.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.BatchCheck.String(), trace.WithAttributes(
 		attribute.KeyValue{Key: "store_id", Value: attribute.StringValue(req.GetStoreId())},
 		attribute.KeyValue{Key: "batch_size", Value: attribute.IntValue(len(req.GetChecks()))},
 		attribute.KeyValue{Key: "consistency", Value: attribute.StringValue(req.GetConsistency().String())},

--- a/pkg/server/check.go
+++ b/pkg/server/check.go
@@ -40,7 +40,7 @@ func (s *Server) Check(ctx context.Context, req *openfgav1.CheckRequest) (*openf
 	startTime := time.Now()
 
 	tk := req.GetTupleKey()
-	ctx, span := tracer.Start(ctx, apimethod.Check.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.Check.String(), trace.WithAttributes(
 		attribute.KeyValue{Key: "store_id", Value: attribute.StringValue(req.GetStoreId())},
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},
@@ -328,7 +328,7 @@ func (s *Server) shadowV2Check(ctx context.Context, req *openfgav1.CheckRequest,
 		defer cancel()
 		// Inject the original span context so shadow spans share the same trace ID.
 		newCtx = trace.ContextWithSpanContext(newCtx, originalSpanCtx)
-		newCtx, shadowSpan := tracer.Start(newCtx, "shadowV2Check", trace.WithAttributes(
+		newCtx, shadowSpan := s.getTracer().Start(newCtx, "shadowV2Check", trace.WithAttributes(
 			attribute.String("store_id", req.GetStoreId()),
 		))
 		defer shadowSpan.End()
@@ -393,7 +393,7 @@ func (s *Server) v2Check(
 	storeID := req.GetStoreId()
 	tk := req.GetTupleKey()
 
-	ctx, span := tracer.Start(ctx, commands.V2CheckMethodName, trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, commands.V2CheckMethodName, trace.WithAttributes(
 		attribute.String("store_id", storeID),
 		attribute.String("object", tk.GetObject()),
 		attribute.String("relation", tk.GetRelation()),
@@ -463,12 +463,14 @@ func (s *Server) getCheckResolverBuilder(storeID string) *graph.CheckResolverOrd
 			graph.WithPlanner(s.planner),
 			graph.WithUpstreamTimeout(s.requestTimeout),
 			graph.WithLocalCheckerLogger(s.logger),
+			graph.WithTracerProvider(s.tracerProvider),
 		}...),
 		graph.WithLocalShadowCheckerOpts([]graph.LocalCheckerOption{
 			graph.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
 			graph.WithOptimizations(true), // shadow checker always uses optimizations
 			graph.WithMaxResolutionDepth(s.resolveNodeLimit),
 			graph.WithPlanner(s.planner),
+			graph.WithTracerProvider(s.tracerProvider),
 		}...),
 		graph.WithShadowResolverEnabled(s.featureFlagClient.Boolean(serverconfig.ExperimentalShadowCheck, storeID)),
 		graph.WithShadowResolverOpts([]graph.ShadowResolverOpt{

--- a/pkg/server/expand.go
+++ b/pkg/server/expand.go
@@ -19,7 +19,7 @@ import (
 
 func (s *Server) Expand(ctx context.Context, req *openfgav1.ExpandRequest) (*openfgav1.ExpandResponse, error) {
 	tk := req.GetTupleKey()
-	ctx, span := tracer.Start(ctx, apimethod.Expand.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.Expand.String(), trace.WithAttributes(
 		attribute.KeyValue{Key: "store_id", Value: attribute.StringValue(req.GetStoreId())},
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},

--- a/pkg/server/list_objects.go
+++ b/pkg/server/list_objects.go
@@ -35,7 +35,7 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	targetObjectType := req.GetType()
 	storeID := req.GetStoreId()
 
-	ctx, span := tracer.Start(ctx, apimethod.ListObjects.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ListObjects.String(), trace.WithAttributes(
 		attribute.String("store_id", storeID),
 		attribute.String("object_type", targetObjectType),
 		attribute.String("relation", req.GetRelation()),
@@ -216,7 +216,7 @@ func (s *Server) StreamedListObjects(req *openfgav1.StreamedListObjectsRequest, 
 	ctx := srv.Context()
 	storeID := req.GetStoreId()
 
-	ctx, span := tracer.Start(ctx, apimethod.StreamedListObjects.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.StreamedListObjects.String(), trace.WithAttributes(
 		attribute.String("store_id", storeID),
 		attribute.String("object_type", req.GetType()),
 		attribute.String("relation", req.GetRelation()),
@@ -354,6 +354,7 @@ func (s *Server) getListObjectsCheckResolverBuilder(storeID string) *graph.Check
 			graph.WithResolveNodeBreadthLimit(s.resolveNodeBreadthLimit),
 			graph.WithOptimizations(s.featureFlagClient.Boolean(serverconfig.ExperimentalCheckOptimizations, storeID)),
 			graph.WithMaxResolutionDepth(s.resolveNodeLimit),
+			graph.WithTracerProvider(s.tracerProvider),
 		}...),
 		graph.WithCachedCheckResolverOpts(s.cacheSettings.ShouldCacheCheckQueries(), checkCacheOptions...),
 		graph.WithDispatchThrottlingCheckResolverOpts(s.checkDispatchThrottlingEnabled, checkDispatchThrottlingOptions...),

--- a/pkg/server/list_users.go
+++ b/pkg/server/list_users.go
@@ -39,7 +39,7 @@ func (s *Server) ListUsers(
 ) (*openfgav1.ListUsersResponse, error) {
 	start := time.Now()
 	storeID := req.GetStoreId()
-	ctx, span := tracer.Start(ctx, apimethod.ListUsers.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ListUsers.String(), trace.WithAttributes(
 		attribute.String("store_id", storeID),
 		attribute.String("object", tuple.BuildObject(req.GetObject().GetType(), req.GetObject().GetId())),
 		attribute.String("relation", req.GetRelation()),

--- a/pkg/server/read.go
+++ b/pkg/server/read.go
@@ -18,7 +18,7 @@ import (
 
 func (s *Server) Read(ctx context.Context, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
 	tk := req.GetTupleKey()
-	ctx, span := tracer.Start(ctx, apimethod.Read.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.Read.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: "object", Value: attribute.StringValue(tk.GetObject())},
 		attribute.KeyValue{Key: "relation", Value: attribute.StringValue(tk.GetRelation())},

--- a/pkg/server/read_changes.go
+++ b/pkg/server/read_changes.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (s *Server) ReadChanges(ctx context.Context, req *openfgav1.ReadChangesRequest) (*openfgav1.ReadChangesResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.ReadChanges.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.ReadChanges.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 		attribute.KeyValue{Key: "type", Value: attribute.StringValue(req.GetType())},
 	))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,7 +55,7 @@ const (
 	throttleTypeDispatch  = "dispatch"
 )
 
-var tracer = otel.Tracer("openfga/pkg/server")
+var defaultServerTracer = otel.Tracer("openfga/pkg/server")
 
 var (
 	dispatchCountHistogramName = "dispatch_count"
@@ -169,6 +169,8 @@ type Server struct {
 	authzenv1.UnimplementedAuthZenServiceServer
 
 	logger                           logger.Logger
+	tracerProvider                   trace.TracerProvider
+	tracer                           trace.Tracer
 	datastore                        storage.OpenFGADatastore
 	tokenSerializer                  encoder.ContinuationTokenSerializer
 	encoder                          encoder.Encoder
@@ -260,6 +262,13 @@ type Server struct {
 
 type OpenFGAServiceV1Option func(s *Server)
 
+func (s *Server) getTracer() trace.Tracer {
+	if s.tracer != nil {
+		return s.tracer
+	}
+	return defaultServerTracer
+}
+
 // WithDatastore passes a datastore to the Server.
 // You must call [storage.OpenFGADatastore.Close] on it after you have stopped using it.
 func WithDatastore(ds storage.OpenFGADatastore) OpenFGAServiceV1Option {
@@ -298,6 +307,14 @@ func WithTypesystemCacheSize(maxTypesystemCacheSize int) OpenFGAServiceV1Option 
 func WithLogger(l logger.Logger) OpenFGAServiceV1Option {
 	return func(s *Server) {
 		s.logger = l
+	}
+}
+
+// WithTracerProvider sets the OpenTelemetry tracer provider used by the server,
+// typesystem resolver, and authorization graph.
+func WithTracerProvider(tracerProvider trace.TracerProvider) OpenFGAServiceV1Option {
+	return func(s *Server) {
+		s.tracerProvider = tracerProvider
 	}
 }
 
@@ -884,6 +901,7 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 	s := &Server{
 		ctx:                              context.Background(),
 		logger:                           logger.NewNoopLogger(),
+		tracerProvider:                   otel.GetTracerProvider(),
 		encoder:                          encoder.NewBase64Encoder(),
 		transport:                        gateway.NewNoopTransport(),
 		changelogHorizonOffset:           serverconfig.DefaultChangelogHorizonOffset,
@@ -955,6 +973,12 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		return nil, fmt.Errorf("server cannot be started with nil context")
 	}
 
+	if s.tracerProvider == nil {
+		return nil, fmt.Errorf("tracer provider must not be nil")
+	}
+
+	s.tracer = s.tracerProvider.Tracer("openfga/pkg/server")
+
 	if len(s.requestDurationByQueryHistogramBuckets) == 0 {
 		return nil, fmt.Errorf("request duration datastore count buckets must not be empty")
 	}
@@ -1021,7 +1045,11 @@ func NewServerWithOpts(opts ...OpenFGAServiceV1Option) (*Server, error) {
 		s.listUsersDispatchThrottler = throttler.NewConstantRateThrottler(s.listUsersDispatchThrottlingFrequency, "list_users_dispatch_throttle")
 	}
 
-	s.typesystemResolver, s.typesystemResolverStop, err = typesystem.MemoizedTypesystemResolverFunc(s.datastore, s.maxTypesystemCacheSize)
+	s.typesystemResolver, s.typesystemResolverStop, err = typesystem.MemoizedTypesystemResolverFuncWithOpts(
+		s.datastore,
+		s.maxTypesystemCacheSize,
+		typesystem.WithTracerProvider(s.tracerProvider),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/stores.go
+++ b/pkg/server/stores.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Server) CreateStore(ctx context.Context, req *openfgav1.CreateStoreRequest) (*openfgav1.CreateStoreResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.CreateStore.String())
+	ctx, span := s.getTracer().Start(ctx, apimethod.CreateStore.String())
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {
@@ -51,7 +51,7 @@ func (s *Server) CreateStore(ctx context.Context, req *openfgav1.CreateStoreRequ
 }
 
 func (s *Server) DeleteStore(ctx context.Context, req *openfgav1.DeleteStoreRequest) (*openfgav1.DeleteStoreResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.DeleteStore.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.DeleteStore.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()
@@ -84,7 +84,7 @@ func (s *Server) DeleteStore(ctx context.Context, req *openfgav1.DeleteStoreRequ
 }
 
 func (s *Server) GetStore(ctx context.Context, req *openfgav1.GetStoreRequest) (*openfgav1.GetStoreResponse, error) {
-	ctx, span := tracer.Start(ctx, apimethod.GetStore.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.GetStore.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()
@@ -111,7 +111,7 @@ func (s *Server) GetStore(ctx context.Context, req *openfgav1.GetStoreRequest) (
 
 func (s *Server) ListStores(ctx context.Context, req *openfgav1.ListStoresRequest) (*openfgav1.ListStoresResponse, error) {
 	method := "ListStores"
-	ctx, span := tracer.Start(ctx, method)
+	ctx, span := s.getTracer().Start(ctx, method)
 	defer span.End()
 
 	if !validator.RequestIsValidatedFromContext(ctx) {

--- a/pkg/server/tracer_test.go
+++ b/pkg/server/tracer_test.go
@@ -67,10 +67,12 @@ func TestWithTracerProviderIsInstanceScoped(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(firstRecorder.Ended()), firstSpanCount)
 	require.Len(t, secondRecorder.Ended(), secondSpanCount)
+	firstSpanCountAfterFirst := len(firstRecorder.Ended())
 
 	_, err = secondServer.Check(context.Background(), secondRequest)
 	require.NoError(t, err)
 	require.Greater(t, len(secondRecorder.Ended()), secondSpanCount)
+	require.Len(t, firstRecorder.Ended(), firstSpanCountAfterFirst)
 }
 
 func TestWithTracerProviderRejectsNil(t *testing.T) {

--- a/pkg/server/tracer_test.go
+++ b/pkg/server/tracer_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/openfga/openfga/pkg/storage/memory"
+)
+
+func TestTracerProviderDefaultsToGlobal(t *testing.T) {
+	datastore := memory.New()
+	t.Cleanup(datastore.Close)
+
+	s := MustNewServerWithOpts(WithDatastore(datastore))
+	t.Cleanup(s.Close)
+
+	require.Equal(t, otel.GetTracerProvider(), s.tracerProvider)
+}
+
+func TestWithTracerProvider(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tracerProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		require.NoError(t, tracerProvider.Shutdown(context.Background()))
+	})
+
+	s, req := setupCheckServer(t, "", nil, WithTracerProvider(tracerProvider))
+
+	_, err := s.Check(context.Background(), req)
+	require.NoError(t, err)
+
+	instrumentationScopes := make(map[string]struct{})
+	for _, span := range spanRecorder.Ended() {
+		instrumentationScopes[span.InstrumentationScope().Name] = struct{}{}
+	}
+
+	require.Contains(t, instrumentationScopes, "openfga/pkg/server")
+	require.Contains(t, instrumentationScopes, "openfga/pkg/typesystem")
+	require.Contains(t, instrumentationScopes, "internal/graph/check")
+}
+
+func TestWithTracerProviderIsInstanceScoped(t *testing.T) {
+	firstRecorder := tracetest.NewSpanRecorder()
+	firstProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(firstRecorder))
+	t.Cleanup(func() {
+		require.NoError(t, firstProvider.Shutdown(context.Background()))
+	})
+
+	secondRecorder := tracetest.NewSpanRecorder()
+	secondProvider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(secondRecorder))
+	t.Cleanup(func() {
+		require.NoError(t, secondProvider.Shutdown(context.Background()))
+	})
+
+	firstServer, firstRequest := setupCheckServer(t, "", nil, WithTracerProvider(firstProvider))
+	secondServer, secondRequest := setupCheckServer(t, "", nil, WithTracerProvider(secondProvider))
+
+	firstSpanCount := len(firstRecorder.Ended())
+	secondSpanCount := len(secondRecorder.Ended())
+
+	_, err := firstServer.Check(context.Background(), firstRequest)
+	require.NoError(t, err)
+	require.Greater(t, len(firstRecorder.Ended()), firstSpanCount)
+	require.Len(t, secondRecorder.Ended(), secondSpanCount)
+
+	_, err = secondServer.Check(context.Background(), secondRequest)
+	require.NoError(t, err)
+	require.Greater(t, len(secondRecorder.Ended()), secondSpanCount)
+}
+
+func TestWithTracerProviderRejectsNil(t *testing.T) {
+	datastore := memory.New()
+	t.Cleanup(datastore.Close)
+
+	_, err := NewServerWithOpts(
+		WithDatastore(datastore),
+		WithTracerProvider(nil),
+	)
+
+	require.EqualError(t, err, "tracer provider must not be nil")
+}

--- a/pkg/server/write.go
+++ b/pkg/server/write.go
@@ -22,7 +22,7 @@ import (
 func (s *Server) Write(ctx context.Context, req *openfgav1.WriteRequest) (*openfgav1.WriteResponse, error) {
 	start := time.Now()
 
-	ctx, span := tracer.Start(ctx, apimethod.Write.String(), trace.WithAttributes(
+	ctx, span := s.getTracer().Start(ctx, apimethod.Write.String(), trace.WithAttributes(
 		attribute.String("store_id", req.GetStoreId()),
 	))
 	defer span.End()

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -25,6 +25,23 @@ const (
 
 type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (*TypeSystem, error)
 
+type typesystemResolverConfig struct {
+	tracer trace.Tracer
+}
+
+// TypesystemResolverOption configures a memoized typesystem resolver.
+type TypesystemResolverOption func(*typesystemResolverConfig)
+
+// WithTracerProvider sets the OpenTelemetry tracer provider used by the resolver.
+func WithTracerProvider(tracerProvider trace.TracerProvider) TypesystemResolverOption {
+	return func(config *typesystemResolverConfig) {
+		if tracerProvider == nil {
+			return
+		}
+		config.tracer = tracerProvider.Tracer("openfga/pkg/typesystem")
+	}
+}
+
 // MemoizedTypesystemResolverFunc does several things.
 //
 // If given a model ID: validates the model ID, and tries to fetch it from the cache.
@@ -33,7 +50,19 @@ type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (
 // If not given a model ID: fetches the latest model ID from the datastore, then sees if the model ID is in the cache.
 // If it is, returns it. Else, validates it and returns it.
 func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBackend, maxSize int) (TypesystemResolverFunc, func(), error) {
+	return MemoizedTypesystemResolverFuncWithOpts(datastore, maxSize)
+}
+
+// MemoizedTypesystemResolverFuncWithOpts is like MemoizedTypesystemResolverFunc
+// but accepts options that customize the resolver.
+func MemoizedTypesystemResolverFuncWithOpts(datastore storage.AuthorizationModelReadBackend, maxSize int, opts ...TypesystemResolverOption) (TypesystemResolverFunc, func(), error) {
 	lookupGroup := singleflight.Group{}
+	config := &typesystemResolverConfig{
+		tracer: tracer,
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
 
 	// cache holds models that have already been validated.
 	cache, err := storage.NewInMemoryLRUCache[*TypeSystem](
@@ -44,7 +73,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 	}
 
 	return func(ctx context.Context, storeID, modelID string) (*TypeSystem, error) {
-		ctx, span := tracer.Start(ctx, "resolveTypesystem", trace.WithAttributes(
+		ctx, span := config.tracer.Start(ctx, "resolveTypesystem", trace.WithAttributes(
 			attribute.String("store_id", storeID),
 		))
 		defer func() {
@@ -105,7 +134,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 			model = v.(*openfgav1.AuthorizationModel)
 		}
 
-		typesys, err := NewAndValidate(ctx, model)
+		typesys, err := newAndValidate(ctx, model, config.tracer)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrInvalidModel, err)
 		}

--- a/pkg/typesystem/resolver.go
+++ b/pkg/typesystem/resolver.go
@@ -25,16 +25,17 @@ const (
 
 type TypesystemResolverFunc func(ctx context.Context, storeID, modelID string) (*TypeSystem, error)
 
-type typesystemResolverConfig struct {
+// TypesystemResolverConfig configures a memoized typesystem resolver.
+type TypesystemResolverConfig struct {
 	tracer trace.Tracer
 }
 
 // TypesystemResolverOption configures a memoized typesystem resolver.
-type TypesystemResolverOption func(*typesystemResolverConfig)
+type TypesystemResolverOption func(*TypesystemResolverConfig)
 
 // WithTracerProvider sets the OpenTelemetry tracer provider used by the resolver.
 func WithTracerProvider(tracerProvider trace.TracerProvider) TypesystemResolverOption {
-	return func(config *typesystemResolverConfig) {
+	return func(config *TypesystemResolverConfig) {
 		if tracerProvider == nil {
 			return
 		}
@@ -57,7 +58,7 @@ func MemoizedTypesystemResolverFunc(datastore storage.AuthorizationModelReadBack
 // but accepts options that customize the resolver.
 func MemoizedTypesystemResolverFuncWithOpts(datastore storage.AuthorizationModelReadBackend, maxSize int, opts ...TypesystemResolverOption) (TypesystemResolverFunc, func(), error) {
 	lookupGroup := singleflight.Group{}
-	config := &typesystemResolverConfig{
+	config := &TypesystemResolverConfig{
 		tracer: tracer,
 	}
 	for _, opt := range opts {

--- a/pkg/typesystem/typesystem.go
+++ b/pkg/typesystem/typesystem.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/emirpasic/gods/sets/hashset"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/language/pkg/go/graph"
@@ -1168,7 +1169,11 @@ func hasEntrypoints(
 //     b) For a type#relation this means checking that this type with this relation is in the *TypeSystem
 //  4. Check that a relation is assignable if and only if it has a non-zero list of types
 func NewAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel) (*TypeSystem, error) {
-	_, span := tracer.Start(ctx, "typesystem.NewAndValidate")
+	return newAndValidate(ctx, model, tracer)
+}
+
+func newAndValidate(ctx context.Context, model *openfgav1.AuthorizationModel, typesystemTracer trace.Tracer) (*TypeSystem, error) {
+	_, span := typesystemTracer.Start(ctx, "typesystem.NewAndValidate")
 	defer span.End()
 
 	// Build the TypeSystem without constructing the graphs, so validation can run before the


### PR DESCRIPTION
Closes #3274

Add per-server OpenTelemetry tracer provider injection and route the provider through the server, typesystem resolver, and authorization graph.

---

Changes: preserves the global provider as the default; retains existing exported resolver signatures through a compatibility wrapper; rejects a nil server provider while keeping lower-level options nil-safe; adds span-routing, default-provider, nil-provider, and two-Server isolation tests. Local verification completed before adoption: focused tracer tests passed; pkg/typesystem and internal/graph tests passed; all repository packages compiled with go test ./... -run ^$; go vet passed for all affected packages; golangci-lint reported 0 new issues relative to origin/main. The Windows host lacks gcc, so race mode is left to the required Linux CI job. The change was implemented with OpenAI Codex assistance and the final diff was independently reviewed.

Verified with `git diff --check HEAD^ HEAD`.

Areas for careful review:
- No known behavior changes outside the reported bug.

Implementation assistance: an external coding workspace was used to prepare the change and its
tests. `ShinyHero666` reviewed the final diff, understands it, and takes responsibility
for this contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom OpenTelemetry tracer provider for embedded OpenFGA servers.
  * Applied tracing configuration consistently across server requests, authorization checks, and type system operations.
  * Servers use the global OpenTelemetry provider by default, with support for no-op providers to suppress spans.
  * Added validation to reject nil tracer providers.

* **Documentation**
  * Documented the new tracer provider server option in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->