### PR TITLE
Warn the caller when ListObjects results are truncated by the deadline

### DIFF
--- a/pkg/server/commands/list_objects.go
+++ b/pkg/server/commands/list_objects.go
@@ -110,6 +110,12 @@ type ListObjectsResolutionMetadata struct {
 	// DatastoreThrottled indicates whether the request was throttled by the Datastore.
 	DatastoreThrottled atomic.Bool
 
+	// DeadlineExceeded indicates that resolution stopped early because the
+	// ListObjects deadline was reached, so Objects holds whatever was found up
+	// to that point rather than the full set. Callers that surface results to a
+	// client should tell it the list is partial.
+	DeadlineExceeded atomic.Bool
+
 	// WasWeightedGraphUsed indicates whether the weighted graph was used as the algorithm for the ListObjects request.
 	WasWeightedGraphUsed atomic.Bool
 
@@ -486,7 +492,9 @@ func (q *ListObjectsQuery) evaluate(
 			if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 				resultsChan <- ListObjectsResult{Err: err}
 			}
-			// TODO set header to indicate "deadline exceeded"
+			if errors.Is(err, context.DeadlineExceeded) {
+				resolutionMetadata.DeadlineExceeded.Store(true)
+			}
 		}
 		close(resultsChan)
 		dsMeta := ds.GetMetadata()
@@ -644,6 +652,9 @@ func (q *ListObjectsQuery) Execute(
 			// current list objects behavior is to elide context cancelation errors
 			if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				return nil, serverErrors.HandleError("", err)
+			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				res.ResolutionMetadata.DeadlineExceeded.Store(true)
 			}
 		}
 
@@ -841,6 +852,10 @@ func (q *ListObjectsQuery) ExecuteStreamed(ctx context.Context, req *openfgav1.S
 			}
 		}
 		p.Close() // ensure that the pipeline is closed after any early loop exits
+
+		if errors.Is(errRx, context.DeadlineExceeded) {
+			resolutionMetadata.DeadlineExceeded.Store(true)
+		}
 
 		if errRx != nil && !errors.Is(errRx, context.Canceled) && !errors.Is(errRx, context.DeadlineExceeded) {
 			if errors.Is(errRx, condition.ErrEvaluationFailed) {

--- a/pkg/server/list_objects.go
+++ b/pkg/server/list_objects.go
@@ -170,6 +170,15 @@ func (s *Server) ListObjects(ctx context.Context, req *openfgav1.ListObjectsRequ
 	wasDatastoreThrottled := result.ResolutionMetadata.DatastoreThrottled.Load()
 	grpc_ctxtags.Extract(ctx).Set("request.datastore_throttled", wasDatastoreThrottled)
 
+	// Resolution that stops at the deadline still returns 200 with whatever it
+	// found, so without this the caller cannot tell a truncated list from an
+	// exhaustive one.
+	deadlineExceeded := result.ResolutionMetadata.DeadlineExceeded.Load()
+	grpc_ctxtags.Extract(ctx).Set("request.deadline_exceeded", deadlineExceeded)
+	if deadlineExceeded {
+		s.transport.SetHeader(ctx, WarningHeader, deadlineExceededWarning)
+	}
+
 	wasWeightedGraphUsed := result.ResolutionMetadata.WasWeightedGraphUsed.Load()
 	grpc_ctxtags.Extract(ctx).Set("request.weighted_graph", wasWeightedGraphUsed)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -49,6 +49,13 @@ const (
 	AuthorizationModelIDHeader = "Openfga-Authorization-Model-Id"
 	authorizationModelIDKey    = "authorization_model_id"
 
+	// WarningHeader carries a non-fatal notice about a successful response.
+	WarningHeader = "X-Openfga-Warning"
+
+	// deadlineExceededWarning tells the caller a ListObjects response is
+	// partial because resolution stopped at the configured deadline.
+	deadlineExceededWarning = "deadline-exceeded"
+
 	allowedLabel = "allowed"
 
 	throttleTypeDatastore = "datastore"

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1946,6 +1946,29 @@ func TestIsAuthZenEnabled(t *testing.T) {
 	})
 }
 
+// recordingTransport captures the response headers a request sets, so a test can
+// assert on them without a real gRPC stream.
+type recordingTransport struct {
+	mu      sync.Mutex
+	headers map[string]string
+}
+
+func newRecordingTransport() *recordingTransport {
+	return &recordingTransport{headers: map[string]string{}}
+}
+
+func (r *recordingTransport) SetHeader(_ context.Context, key, value string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.headers[key] = value
+}
+
+func (r *recordingTransport) get(key string) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.headers[key]
+}
+
 func TestServer_ThrottleUntilDeadline(t *testing.T) {
 	t.Cleanup(func() {
 		goleak.VerifyNone(t)
@@ -1981,8 +2004,11 @@ func TestServer_ThrottleUntilDeadline(t *testing.T) {
 
 	deadline := 50 * time.Millisecond
 
+	transport := newRecordingTransport()
+
 	s := MustNewServerWithOpts(
 		WithDatastore(ds),
+		WithTransport(transport),
 
 		WithListObjectsPipelineEnabled(false),
 		WithDispatchThrottlingCheckResolverEnabled(true),
@@ -2034,6 +2060,10 @@ func TestServer_ThrottleUntilDeadline(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.LessOrEqual(t, len(resp.GetObjects()), 1) // race condition of context cancellation
+
+		// The response is a 200 carrying a partial list, so the only thing that
+		// can tell the caller it was truncated is the warning header.
+		require.Equal(t, deadlineExceededWarning, transport.get(WarningHeader))
 	})
 }
 


### PR DESCRIPTION
Closes #3276.

When resolution hits `--listObjects-deadline`, `evaluate` deliberately swallows `context.DeadlineExceeded` so the partial results survive, and the request returns 200 with whatever was found. There has been a `// TODO set header to indicate "deadline exceeded"` sitting next to that for a while. Without it a truncated list is indistinguishable from an exhaustive one, so a consumer treats a short answer as the complete set.

Rather than reach for `grpc.SetHeader` inside the command, which would put transport concerns into `pkg/server/commands`, the fact travels back the way the throttling flags already do. `ListObjectsResolutionMetadata` gains `DeadlineExceeded atomic.Bool` alongside `DispatchThrottled` and `DatastoreThrottled`, it is set at each of the three places the deadline error is elided (the legacy `evaluate` handler, the pipeline path, and the streamed pipeline path), and `pkg/server/list_objects.go` sets the header through `s.transport`, which is what the other response headers here already use. It also lands in `grpc_ctxtags` as `request.deadline_exceeded`, so it shows up in request logs next to the throttling tags.

The header is `X-Openfga-Warning: deadline-exceeded`, the name the issue proposes.

Verified by extending `TestServer_ThrottleUntilDeadline`, which already forces the deadline reliably. The server is given a recording transport, and the ListObjects subtest asserts the header. Dropping just the `SetHeader` call gives:

    expected: "deadline-exceeded"
    actual  : ""

`./pkg/server/commands/...` is green. `./pkg/server/` has six failures, all of them `TestServerWithPostgresDatastore`, `TestServerWithMySQLDatastore`, `TestServerNotReadyDueToDatastoreRevision` and `TestReleasesConnections`, which want database containers I do not have here. They fail identically on `main` without this branch; I checked both ways rather than assuming.

Two things I deliberately left alone, happy to take direction on either. `StreamedListObjects` now records the flag but does not emit a header, since on a stream the headers go out with the first message and by the time the deadline trips objects have usually been sent already. And the header is a warning rather than an error because the current contract is to return partial results with a 200; changing that is a bigger decision than this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ListObjects responses now indicate when resolution stops at the configured deadline.
  - Partial results include a warning header so clients can distinguish them from complete result sets.
  - Deadline-related status is recorded consistently across supported ListObjects execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->