### PR TITLE
release: update changelog for release `v1.20.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Try to keep listed changes to a concise bulleted list of simple explanations of 
 - Scope context-cancelation stripping to query execution only. No longer can deadlock on saturated connection pool. [#3255](https://github.com/openfga/openfga/pull/3255)
 - Updated v2 resolution diagnostic logging in `Check` and `ListUsers` to gate on InfoLevel log level. Removed diagnostic logging from `Expand` whose resolution will not change. [#3254](https://github.com/openfga/openfga/pull/3254)
 
+### Security
+- Fixed [GHSA-5278-rrxc-mgf7](https://github.com/openfga/openfga/security/advisories/GHSA-5278-rrxc-mgf7), where StreamedListObjects could return a result that should have been excluded during an error. Thank you to [@yxshwanth](https://github.com/yxshwanth) for the detailed report and fix.
+
 ## [1.18.3] - 2026-08-05
 ### Fixed
 - Fixed experimental `weighted_graph_check` intermittently returning `false` when evaluating relations that cross two or more distinct recursive TTUs which share the same tupleset relation. [#3244](https://github.com/openfga/openfga/pull/3244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+
+## [1.20.0] - 2026-09-08
 ### Added
 - Added `WithServiceName` server option to allow embedders to override the `serviceName` field used for the `grpc_service` label on OpenFGA's package-level Prometheus metrics and `telemetry.RPCInfo.Service`. This enables multiple `Server` instances in the same process to emit separate metric series. Note it does not rename the standard gRPC server metrics (e.g. `grpc_server_handled_total`), whose labels are derived from the registered gRPC service. Use stable, low-cardinality names, as the value becomes a metric label. Defaults to `openfgav1.OpenFGAService_ServiceDesc.ServiceName` when omitted (backward compatible). [#3265](https://github.com/openfga/openfga/pull/3265)
 
@@ -1734,7 +1736,8 @@ Re-release of `v0.3.5` because the go module proxy cached a prior commit of the 
 - Memory storage adapter implementation
 - Early support for preshared key or OIDC authentication methods
 
-[Unreleased]: https://github.com/openfga/openfga/compare/v1.19.0...HEAD
+[Unreleased]: https://github.com/openfga/openfga/compare/v1.20.0...HEAD
+[1.20.0]: https://github.com/openfga/openfga/compare/v1.19.0...v1.20.0
 [1.19.0]: https://github.com/openfga/openfga/compare/v1.18.3...v1.19.0
 [1.18.3]: https://github.com/openfga/openfga/compare/v1.18.2...v1.18.3
 [1.18.2]: https://github.com/openfga/openfga/compare/v1.18.1...v1.18.2


### PR DESCRIPTION
## Description
This PR updates the changelog in preparation for releasing `v1.20.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added the 1.20.0 release entry dated September 8, 2026.
  - Updated changelog comparison links for Unreleased and 1.20.0.
  - Documented a security fix addressing cases where streamed list results could include items that should have been excluded during an error.
  - Added security advisory details for the affected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->