### PR TITLE
fix(graph): stop selecting on closed producer channels in the fast paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Try to keep listed changes to a concise bulleted list of simple explanations of changes. Aim for the amount of information needed so that readers can understand where they would look in the codebase to investigate the changes' implementation, or where they would look in the documentation to understand how to make use of the change in practice - better yet, link directly to the docs and provide detailed information there. Only elaborate if doing so is required to avoid breaking changes or experimental features from ruining someone's day.
 
 ## [Unreleased]
+### Fixed
+- Fixed `recursiveFastPath` and `weight2` in Check spinning at full CPU on a closed producer channel until the other producer finished, which also made the planner avoid the `weight2` strategy. [#3299](https://github.com/openfga/openfga/issues/3299)
 
 ## [1.20.0] - 2026-09-08
 ### Added

--- a/internal/graph/recursive_resolver.go
+++ b/internal/graph/recursive_resolver.go
@@ -129,6 +129,7 @@ func (c *LocalChecker) recursiveFastPath(ctx context.Context, req *ResolveCheckR
 		case userToUsersetMessage, ok := <-userToUsersetMessageChan:
 			if !ok {
 				userToUsersetDone = true
+				userToUsersetMessageChan = nil
 				if usersetFromUser.Size() == 0 {
 					return res, ctx.Err()
 				}
@@ -145,6 +146,7 @@ func (c *LocalChecker) recursiveFastPath(ctx context.Context, req *ResolveCheckR
 			if !ok {
 				// usersetFromObject must not be empty because we would have caught it earlier.
 				objectToUsersetDone = true
+				objectToUsersetMessageChan = nil
 				break
 			}
 			if objectToUsersetMessage.err != nil {

--- a/internal/graph/recursive_resolver_test.go
+++ b/internal/graph/recursive_resolver_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/emirpasic/gods/sets/hashset"
 	"github.com/oklog/ulid/v2"
@@ -491,6 +492,56 @@ type group
 		result, err := checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), storage.NewStaticTupleKeyIterator(tupleKeys), "recursive")(ctx)
 		require.Nil(t, result)
 		require.Equal(t, ErrResolutionDepthExceeded, err)
+	})
+
+	t.Run("waits_for_the_user_side_without_spinning_once_the_object_side_has_closed", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		storeID := ulid.Make().String()
+		release := make(chan struct{})
+		time.AfterFunc(blockedProducerDelay, func() { close(release) })
+
+		blockUntilReleased := func(ctx context.Context) (*openfgav1.Tuple, error) {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-release:
+				return nil, storage.ErrIteratorDone
+			}
+		}
+		blockedIter := mocks.NewMockIterator[*openfgav1.Tuple](ctrl)
+		blockedIter.EXPECT().Head(gomock.Any()).MaxTimes(1).DoAndReturn(blockUntilReleased)
+		blockedIter.EXPECT().Next(gomock.Any()).MaxTimes(1).DoAndReturn(blockUntilReleased)
+		blockedIter.EXPECT().IsOrdered().MaxTimes(1).Return(true)
+		blockedIter.EXPECT().Stop().MaxTimes(1)
+
+		mockDatastore := mocks.NewMockRelationshipTupleReader(ctrl)
+		mockDatastore.EXPECT().ReadStartingWithUser(gomock.Any(), storeID, gomock.Any(), gomock.Any()).MaxTimes(1).Return(blockedIter, nil)
+		mockDatastore.EXPECT().Read(gomock.Any(), storeID, gomock.Any(), gomock.Any()).AnyTimes().Return(storage.NewStaticTupleIterator(nil), nil)
+
+		req := &ResolveCheckRequest{
+			StoreID:              storeID,
+			AuthorizationModelID: ulid.Make().String(),
+			TupleKey:             tuple.NewTupleKey("group:1", "member", "user:maria"),
+			RequestMetadata:      NewCheckRequestMetadata(),
+		}
+		ctx := setRequestContext(context.Background(), ts, mockDatastore, nil)
+		checker := NewLocalChecker()
+		parents := storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+			tuple.NewTupleKey("group:1", "parent", "group:2"),
+		})
+
+		var (
+			result   *ResolveCheckResponse
+			checkErr error
+		)
+
+		requireNoSpin(t, func() {
+			result, checkErr = checker.recursiveTTU(ctx, req, typesystem.TupleToUserset("parent", "member"), parents, "recursive")(ctx)
+		})
+		require.NoError(t, checkErr)
+		require.False(t, result.GetAllowed())
 	})
 }
 

--- a/internal/graph/weight_two_resolver.go
+++ b/internal/graph/weight_two_resolver.go
@@ -154,6 +154,7 @@ ConsumerLoop:
 		case msg, ok := <-leftChan:
 			if !ok {
 				leftOpen = false
+				leftChan = nil
 				if leftSet.Size() == 0 {
 					if ctx.Err() != nil {
 						lastErr = ctx.Err()
@@ -186,6 +187,7 @@ ConsumerLoop:
 		case msg, ok := <-rightChan:
 			if !ok {
 				rightOpen = false
+				rightChan = nil
 				break
 			}
 			if msg.err != nil {

--- a/internal/graph/weight_two_resolver_test.go
+++ b/internal/graph/weight_two_resolver_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
+	"runtime/metrics"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
@@ -25,6 +28,28 @@ import (
 	"github.com/openfga/openfga/pkg/tuple"
 	"github.com/openfga/openfga/pkg/typesystem"
 )
+
+const (
+	blockedProducerDelay = 300 * time.Millisecond
+	spinCPUBudget        = 100 * time.Millisecond
+)
+
+func processUserCPUTime() time.Duration {
+	runtime.GC()
+	samples := []metrics.Sample{{Name: "/cpu/classes/user:cpu-seconds"}}
+	metrics.Read(samples)
+	return time.Duration(samples[0].Value.Float64() * float64(time.Second))
+}
+
+func requireNoSpin(t *testing.T, run func()) {
+	t.Helper()
+
+	before := processUserCPUTime()
+	run()
+	spent := processUserCPUTime() - before
+
+	require.Less(t, spent, spinCPUBudget, "process burned %s of CPU while one producer was blocked for %s", spent, blockedProducerDelay)
+}
 
 // setRequestContext creates the correct storage wrappers in the request. NOTE: "ds" can be a mock.
 func setRequestContext(ctx context.Context, ts *typesystem.TypeSystem, ds storage.RelationshipTupleReader, ctxTuples []*openfgav1.TupleKey) context.Context {
@@ -1303,6 +1328,35 @@ func TestFastPathOperationSetup(t *testing.T) {
 		outcome := <-outChan
 		require.ErrorContains(t, outcome.Err, errMessage)
 		require.ErrorIs(t, outcome.Err, ErrPanic)
+	})
+}
+
+func TestWeight2(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(t)
+	})
+
+	t.Run("waits_for_the_left_side_without_spinning_once_the_right_side_has_closed", func(t *testing.T) {
+		leftChan := make(chan *iterator.Msg, 1)
+		time.AfterFunc(blockedProducerDelay, func() {
+			leftChan <- &iterator.Msg{Iter: storage.NewStaticIterator[string]([]string{"group:2#member"})}
+			close(leftChan)
+		})
+
+		right := storage.WrapIterator(storage.UsersetKind, storage.NewStaticTupleKeyIterator([]*openfgav1.TupleKey{
+			tuple.NewTupleKey("document:1", "viewer", "group:1#member"),
+		}))
+
+		var (
+			result   *ResolveCheckResponse
+			checkErr error
+		)
+
+		requireNoSpin(t, func() {
+			result, checkErr = NewLocalChecker().weight2(context.Background(), []<-chan *iterator.Msg{leftChan}, right)
+		})
+		require.NoError(t, checkErr)
+		require.False(t, result.GetAllowed())
 	})
 }
 


### PR DESCRIPTION
`recursiveFastPath` and `weight2` keep a channel in their `select` after it has closed. A closed channel is always ready, so the loop spins at full CPU until the other producer finishes.

## Description
#### What problem is being solved?

`recursiveFastPath` (`internal/graph/recursive_resolver.go`) and `weight2` (`internal/graph/weight_two_resolver.go`) drain two producer channels in one `select` loop. When one channel closes, the loop marks that side done but keeps receiving from the closed channel. A closed channel is always ready, so every iteration takes that case immediately and the loop burns a core until the other producer delivers or the context ends. Both sides normally finish within the same few milliseconds, which is why this never showed; once one side returns instantly the spin lasts as long as the slow side and starves the goroutines that would let it finish.

Measured on the model and data in #3299 (25 concurrent `Check` calls per round, in-process server, memory datastore, Apple M3, go1.27.1):

| per round | v1.20.0 | this change |
|---|---|---|
| p50 | 2.6 to 2.8 s | 26 to 28 ms |
| p99 | 4.5 to 5.2 s | 30 to 83 ms |
| user CPU | 20 to 24 s | 0.17 to 0.25 s |
| dispatches | 2400 | 2400 |
| allowed | 5 | 5 |

CPU profile on v1.20.0 has `recursiveFastPath` at 96% of samples, 65% of them in `runtime.selectgo`. On a flatter shape (`[team#member]` without nested teams) the spin also inflates `weight2` wall time enough that the planner keeps choosing `default`; there dispatches per round drop from 2690 to 1470 once the spin is gone, with no other change.

#### How is it being solved?

Nil the channel when it closes so the `select` waits on the live producer and on context cancellation only. A nil channel is never ready in a `select`. The loop conditions already exit once both sides are done, and `weight2` guards its deferred drain with `leftOpen`, which flips in the same branch as the nil assignment, so nothing reads the nil channel afterwards. If one producer never closes and the context never ends, the old code spun forever and the new code blocks forever, so no new hang is introduced.

#### What changes are made to solve it?

- `internal/graph/recursive_resolver.go`: set `userToUsersetMessageChan` and `objectToUsersetMessageChan` to nil when each closes.
- `internal/graph/weight_two_resolver.go`: set `leftChan` and `rightChan` to nil when each closes.
- Regression tests: a new subtest in `TestRecursiveTTU` (`recursive_resolver_test.go`) and a new `TestWeight2` (`weight_two_resolver_test.go`), sharing a `requireNoSpin` helper next to `setRequestContext`. Each blocks one producer for 300ms and requires the process to burn less than 100ms of user CPU meanwhile. They read the `runtime/metrics` CPU counters after a forced GC, since those counters are only refreshed at the end of a GC cycle, so no build tag or rusage is needed. Both fail on v1.20.0 with about 300ms burned and pass with the change, including under `-race`.
- `CHANGELOG.md`: entry under Unreleased.

Verified on this branch alone: `internal/graph` under `-race`, `pkg/server/...`, and the `tests/check` matrix.

## References

- Closes https://github.com/openfga/openfga/issues/3299

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [x] I have added tests to validate that the change in functionality is working as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed authorization checks that could consume excessive CPU while waiting for an active producer after another producer had finished.
  - Restored proper planner use of the `weight2` strategy in affected scenarios.

- **Tests**
  - Added coverage confirming that recursive and weighted checks wait efficiently without busy-spinning when one input closes before the other.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->